### PR TITLE
Default to isolated per-VM disks with optional shared mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,19 @@ vm = VM.from_id("vm-abcdef12")
 print(f"Status: {vm.status}")
 ```
 
+### 4.1 Disk isolation defaults
+
+SmolVM now defaults to **isolated per-VM disks** (`disk_mode="isolated"`),
+so each VM gets its own writable rootfs clone (sandbox-by-default).
+
+If you intentionally want shared/persistent image behavior across VMs, set:
+
+```python
+from smolvm import VMConfig
+
+config = VMConfig(..., disk_mode="shared")
+```
+
 ### 5. Port Forwarding
 
 Expose a guest application to your local machine securely. `expose_local` prefers host-local iptables forwarding and automatically falls back to an SSH tunnel when needed.

--- a/src/smolvm/types.py
+++ b/src/smolvm/types.py
@@ -16,7 +16,7 @@
 
 from enum import Enum
 from pathlib import Path
-from typing import Annotated
+from typing import Annotated, Literal
 from uuid import uuid4
 
 from pydantic import BaseModel, Field, field_validator
@@ -48,8 +48,13 @@ class VMConfig(BaseModel):
         rootfs_path: Path to the root filesystem image.
         boot_args: Kernel boot arguments.
         backend: Optional runtime backend override ("firecracker" or "qemu").
+        disk_mode: Disk lifecycle mode:
+            - ``"isolated"`` (default): clone rootfs per VM for sandbox isolation.
+            - ``"shared"``: boot directly from ``rootfs_path``.
+        retain_disk_on_delete: Keep isolated VM disk after delete, so a later
+            create with the same VM ID can reuse prior state.
         env_vars: Environment variables to inject into the guest
-            after boot via SSH.  Keys must be valid shell identifiers.
+            after boot via SSH. Keys must be valid shell identifiers.
     """
 
     vm_id: Annotated[
@@ -65,6 +70,8 @@ class VMConfig(BaseModel):
     rootfs_path: Path
     boot_args: str = "console=ttyS0 reboot=k panic=1 pci=off"
     backend: str | None = None
+    disk_mode: Literal["isolated", "shared"] = "isolated"
+    retain_disk_on_delete: bool = False
     env_vars: dict[str, str] = {}
 
     @field_validator("vm_id", mode="before")

--- a/src/smolvm/vm.py
+++ b/src/smolvm/vm.py
@@ -22,6 +22,7 @@ import os
 import platform
 import pwd
 import shlex
+import shutil
 import signal
 import subprocess
 import time
@@ -161,11 +162,14 @@ class SmolVM:
         self.data_dir = resolve_data_dir(data_dir)
         self.socket_dir = socket_dir or DEFAULT_SOCKET_DIR
         self.backend = resolve_backend(backend)
+        self.disk_dir = self.data_dir / "disks"
+        self.disk_dir.mkdir(parents=True, exist_ok=True)
 
         # Under sudo, keep the chosen user-state path owned by the real user.
         owner = _get_sudo_user_info()
         if owner is not None:
             self._ensure_path_owner(self.data_dir, owner.pw_uid, owner.pw_gid)
+            self._ensure_path_owner(self.disk_dir, owner.pw_uid, owner.pw_gid)
 
         # Initialize managers
         db_path = self.data_dir / "smolvm.db"
@@ -262,6 +266,51 @@ class SmolVM:
         if vm_info.config.backend:
             return self._resolve_vm_backend(vm_info.config.backend)
         return self.backend
+
+    def _instance_disk_path(self, vm_id: str) -> Path:
+        """Return managed isolated disk path for a VM ID."""
+        return self.disk_dir / f"{vm_id}.ext4"
+
+    def _materialize_rootfs(self, config: VMConfig) -> VMConfig:
+        """Materialize the effective rootfs path for a VM create request.
+
+        In ``isolated`` mode, clones the configured ``rootfs_path`` into a
+        per-VM disk file under ``data_dir/disks`` (or reuses an existing one
+        for the same VM ID). In ``shared`` mode, uses ``rootfs_path`` directly.
+        """
+        if config.disk_mode == "shared":
+            return config
+
+        instance_rootfs = self._instance_disk_path(config.vm_id)
+        if not instance_rootfs.exists():
+            logger.info(
+                "Creating isolated disk for VM %s from %s -> %s",
+                config.vm_id,
+                config.rootfs_path,
+                instance_rootfs,
+            )
+            shutil.copy2(config.rootfs_path, instance_rootfs)
+        else:
+            logger.info(
+                "Reusing isolated disk for VM %s at %s",
+                config.vm_id,
+                instance_rootfs,
+            )
+
+        return config.model_copy(update={"rootfs_path": instance_rootfs})
+
+    def _managed_disk_for_vm(self, vm_info: VMInfo | None) -> Path | None:
+        """Return the managed isolated disk path for a VM if applicable."""
+        if vm_info is None:
+            return None
+        if vm_info.config.disk_mode != "isolated":
+            return None
+
+        expected = self._instance_disk_path(vm_info.vm_id).resolve()
+        actual = vm_info.config.rootfs_path.resolve()
+        if actual != expected:
+            return None
+        return expected
 
     def _qemu_binary_candidates(self) -> list[str]:
         """Return architecture-aware qemu-system binary candidates."""
@@ -369,9 +418,16 @@ class SmolVM:
         backend = self._backend_for_config(config)
         effective_config = config
         if effective_config.backend != backend:
-            effective_config = config.model_copy(update={"backend": backend})
+            effective_config = effective_config.model_copy(update={"backend": backend})
 
-        logger.info("Creating VM: %s (backend=%s)", effective_config.vm_id, backend)
+        effective_config = self._materialize_rootfs(effective_config)
+
+        logger.info(
+            "Creating VM: %s (backend=%s, disk_mode=%s)",
+            effective_config.vm_id,
+            backend,
+            effective_config.disk_mode,
+        )
 
         # Create VM record
         vm_info = self.state.create_vm(effective_config)
@@ -1128,6 +1184,19 @@ class SmolVM:
                 if fh is not None:
                     with suppress(Exception):
                         fh.close()
+
+            managed_disk = self._managed_disk_for_vm(vm_info)
+            if managed_disk and managed_disk.exists():
+                if vm_info.config.retain_disk_on_delete:
+                    logger.info(
+                        "Retaining isolated disk for VM %s at %s",
+                        vm_id,
+                        managed_disk,
+                    )
+                else:
+                    with suppress(Exception):
+                        managed_disk.unlink()
+                        logger.info("Removed isolated disk for VM %s: %s", vm_id, managed_disk)
 
         except Exception as e:
             logger.warning("Error during cleanup for %s: %s", vm_id, e)

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -257,6 +257,33 @@ class TestVMConfig:
                 env_vars={"A=B": "value"},
             )
 
+    def test_disk_mode_defaults_to_isolated(self, tmp_path: Path) -> None:
+        """Test default disk mode is isolated for sandbox-by-default behavior."""
+        kernel = tmp_path / "vmlinux"
+        rootfs = tmp_path / "rootfs.ext4"
+        kernel.touch()
+        rootfs.touch()
+
+        config = VMConfig(vm_id="vm001", kernel_path=kernel, rootfs_path=rootfs)
+
+        assert config.disk_mode == "isolated"
+        assert config.retain_disk_on_delete is False
+
+    def test_invalid_disk_mode_rejected(self, tmp_path: Path) -> None:
+        """Test unsupported disk_mode values are rejected."""
+        kernel = tmp_path / "vmlinux"
+        rootfs = tmp_path / "rootfs.ext4"
+        kernel.touch()
+        rootfs.touch()
+
+        with pytest.raises(ValidationError):
+            VMConfig(  # type: ignore[arg-type]
+                vm_id="vm001",
+                kernel_path=kernel,
+                rootfs_path=rootfs,
+                disk_mode="snapshot",
+            )
+
 
 class TestVMState:
     """Tests for VMState enum."""

--- a/tests/test_vm.py
+++ b/tests/test_vm.py
@@ -20,6 +20,7 @@ from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
 import pytest
+
 from smolvm.exceptions import (
     SmolVMError,
     VMAlreadyExistsError,
@@ -126,6 +127,121 @@ class TestSmolVMCreate:
         # VM should not exist after rollback
         with pytest.raises(VMNotFoundError):
             smol_vm.get("vm001")
+
+
+class TestSmolVMDiskLifecycle:
+    """Tests for per-VM disk materialization and cleanup."""
+
+    @patch("smolvm.vm.NetworkManager")
+    def test_create_materializes_isolated_disk(
+        self,
+        mock_network_class: MagicMock,
+        smol_vm: SmolVM,
+        sample_config: VMConfig,
+    ) -> None:
+        """Isolated mode should clone rootfs into data_dir/disks per VM."""
+        mock_network = MagicMock()
+        mock_network.host_ip = "172.16.0.1"
+        mock_network.generate_mac.return_value = "AA:FC:00:00:00:01"
+        mock_network_class.return_value = mock_network
+        smol_vm.network = mock_network
+
+        vm_info = smol_vm.create(sample_config)
+
+        expected_disk = smol_vm.data_dir / "disks" / "vm001.ext4"
+        assert vm_info.config.rootfs_path == expected_disk
+        assert expected_disk.exists()
+
+    @patch("smolvm.vm.NetworkManager")
+    def test_shared_disk_mode_uses_original_rootfs(
+        self,
+        mock_network_class: MagicMock,
+        smol_vm: SmolVM,
+        sample_config: VMConfig,
+    ) -> None:
+        """Shared disk mode should use the caller-provided rootfs path directly."""
+        mock_network = MagicMock()
+        mock_network.host_ip = "172.16.0.1"
+        mock_network.generate_mac.return_value = "AA:FC:00:00:00:01"
+        mock_network_class.return_value = mock_network
+        smol_vm.network = mock_network
+
+        config = sample_config.model_copy(update={"disk_mode": "shared"})
+        vm_info = smol_vm.create(config)
+
+        assert vm_info.config.rootfs_path == sample_config.rootfs_path
+        assert not (smol_vm.data_dir / "disks" / "vm001.ext4").exists()
+
+    @patch("smolvm.vm.NetworkManager")
+    def test_delete_removes_isolated_disk_by_default(
+        self,
+        mock_network_class: MagicMock,
+        smol_vm: SmolVM,
+        sample_config: VMConfig,
+    ) -> None:
+        """Deleting a VM removes its isolated disk unless retention is enabled."""
+        mock_network = MagicMock()
+        mock_network.host_ip = "172.16.0.1"
+        mock_network.generate_mac.return_value = "AA:FC:00:00:00:01"
+        mock_network_class.return_value = mock_network
+        smol_vm.network = mock_network
+
+        smol_vm.create(sample_config)
+        disk_path = smol_vm.data_dir / "disks" / "vm001.ext4"
+        assert disk_path.exists()
+
+        smol_vm.delete("vm001")
+
+        assert not disk_path.exists()
+
+    @patch("smolvm.vm.NetworkManager")
+    def test_delete_retains_isolated_disk_when_enabled(
+        self,
+        mock_network_class: MagicMock,
+        smol_vm: SmolVM,
+        sample_config: VMConfig,
+    ) -> None:
+        """retain_disk_on_delete preserves isolated disk for later reuse."""
+        mock_network = MagicMock()
+        mock_network.host_ip = "172.16.0.1"
+        mock_network.generate_mac.return_value = "AA:FC:00:00:00:01"
+        mock_network_class.return_value = mock_network
+        smol_vm.network = mock_network
+
+        retained_config = sample_config.model_copy(update={"retain_disk_on_delete": True})
+        smol_vm.create(retained_config)
+        disk_path = smol_vm.data_dir / "disks" / "vm001.ext4"
+        assert disk_path.exists()
+
+        smol_vm.delete("vm001")
+
+        assert disk_path.exists()
+
+    @patch("smolvm.vm.NetworkManager")
+    def test_create_reuses_retained_disk_for_same_vm_id(
+        self,
+        mock_network_class: MagicMock,
+        smol_vm: SmolVM,
+        sample_config: VMConfig,
+    ) -> None:
+        """A retained isolated disk should be reused for a recreated VM ID."""
+        mock_network = MagicMock()
+        mock_network.host_ip = "172.16.0.1"
+        mock_network.generate_mac.return_value = "AA:FC:00:00:00:01"
+        mock_network_class.return_value = mock_network
+        smol_vm.network = mock_network
+
+        retained_config = sample_config.model_copy(update={"retain_disk_on_delete": True})
+        smol_vm.create(retained_config)
+        disk_path = smol_vm.data_dir / "disks" / "vm001.ext4"
+        original_mtime = disk_path.stat().st_mtime_ns
+
+        smol_vm.delete("vm001")
+        assert disk_path.exists()
+
+        recreated = smol_vm.create(retained_config)
+        assert recreated.config.rootfs_path == disk_path
+        assert disk_path.stat().st_mtime_ns == original_mtime
 
 
 class TestSmolVMGet:


### PR DESCRIPTION
This PR changes SmolVM disk semantics to be sandbox-first by default.                                                                                                        
                                                                                                                                                                            
Previously, VMs booted directly from the configured `rootfs_path`, which could unintentionally share writable state across multiple VMs.                                       
Now, SmolVM defaults to isolated per-VM disks while still allowing explicit shared behavior when desired.     

## What changed                                                                                                                                                                 
                                                                                                                                                                              
 ### 1) New VMConfig disk controls                                                                                                                                            
                                                                                                                                                                              
 - Added disk_mode: Literal["isolated", "shared"] = "isolated"                                                                                                                
 - Added retain_disk_on_delete: bool = False                                                                                                                                  
                                                                                                                                                                              
 ### 2) Per-VM disk materialization in SmolVM.create()                                                                                                                        
                                                                                                                                                                              
 - isolated (default):                                                                                                                                                        
     - clones configured rootfs_path to:                                                                                                                                      
           - <data_dir>/disks/<vm_id>.ext4                                                                                                                                    
     - VM runs on this per-VM disk                                                                                                                                            
 - shared:                                                                                                                                                                    
     - uses configured rootfs_path directly (previous behavior)                                                                                                               
                                                                                                                                                                              
 ### 3) Cleanup/retention behavior                                                                                                                                            
                                                                                                                                                                              
 - On VM delete/cleanup:                                                                                                                                                      
     - isolated managed disk is removed by default                                                                                                                            
     - if retain_disk_on_delete=True, disk is preserved                                                                                                                       
 - Recreating the same VM ID with retained disk reuses existing <data_dir>/disks/<vm_id>.ext4           


## Why                                                                                                                                                                          
                                                                                                                                                                              
 - Enforces sandbox isolation by default                                                                                                                                      
 - Prevents accidental cross-VM state contamination                                                                                                                           
 - Keeps a pragmatic escape hatch for performance/dev workflows (disk_mode="shared")                                                                                          
 - Supports restore-like workflows via retained disk + same VM ID      