### PR TITLE
chore(init): add serial startup timestamps and pre-generate SSH host keys

### DIFF
--- a/src/smolvm/facade.py
+++ b/src/smolvm/facade.py
@@ -38,7 +38,7 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Literal
 
-from smolvm.backends import BACKEND_FIRECRACKER, BACKEND_QEMU, resolve_backend
+from smolvm.backends import BACKEND_QEMU, resolve_backend
 from smolvm.env import inject_env_vars, read_env_vars, remove_env_vars
 from smolvm.exceptions import (
     CommandExecutionUnavailableError,
@@ -817,54 +817,19 @@ class SmolVM:
         # to let standard SSH retries handle it.
         return candidates[0]
 
-    def _prefer_direct_guest_ssh_endpoint(self) -> bool:
-        """Return ``True`` when guest IP should be the first SSH candidate.
-
-        Firecracker VMs on Linux generally have the guest IP reachable directly,
-        so preferring ``guest_ip:22`` avoids localhost forwarding/NAT jitter on
-        readiness checks. QEMU keeps localhost first for compatibility.
-        """
-        backend: str | None = None
-
-        config_backend = getattr(getattr(self._info, "config", None), "backend", None)
-        if isinstance(config_backend, str) and config_backend.strip():
-            backend = config_backend
-
-        if backend is None:
-            sdk_backend = getattr(self._sdk, "backend", None)
-            if isinstance(sdk_backend, str) and sdk_backend.strip():
-                backend = sdk_backend
-
-        if backend is None:
-            return False
-
-        try:
-            resolved = resolve_backend(backend)
-        except ValueError:
-            return False
-
-        return resolved == BACKEND_FIRECRACKER
-
     def _ssh_endpoints(self) -> list[tuple[str, int]]:
-        """Return SSH endpoint candidates in backend-aware preferred order."""
+        """Return SSH endpoint candidates in preferred order."""
         if self._info.network is None:
             raise SmolVMError(
                 "VM has no network configuration",
                 {"vm_id": self._vm_id},
             )
 
-        guest_endpoint = (self._info.network.guest_ip, 22)
-        endpoints: list[tuple[str, int]] = [guest_endpoint]
+        endpoints: list[tuple[str, int]] = []
         ssh_host_port = self._info.network.ssh_host_port
-
-        if self._prefer_direct_guest_ssh_endpoint():
-            if isinstance(ssh_host_port, int):
-                endpoints.append(("127.0.0.1", ssh_host_port))
-        else:
-            endpoints = []
-            if isinstance(ssh_host_port, int):
-                endpoints.append(("127.0.0.1", ssh_host_port))
-            endpoints.append(guest_endpoint)
+        if isinstance(ssh_host_port, int):
+            endpoints.append(("127.0.0.1", ssh_host_port))
+        endpoints.append((self._info.network.guest_ip, 22))
 
         unique: list[tuple[str, int]] = []
         for endpoint in endpoints:

--- a/tests/test_facade.py
+++ b/tests/test_facade.py
@@ -542,7 +542,6 @@ class TestVMRun:
         mock_info.status = VMState.RUNNING
         mock_info.network = mock_network
         mock_info.config.boot_args = "console=ttyS0 reboot=k panic=1 pci=off init=/init"
-        mock_info.config.backend = "qemu"
 
         mock_sdk = MagicMock()
         mock_sdk.create.return_value = MagicMock(vm_id="vm001", status=VMState.CREATED)
@@ -569,45 +568,6 @@ class TestVMRun:
 
     @patch("smolvm.facade.SSHClient")
     @patch("smolvm.facade.SmolVMManager")
-    def test_run_prefers_guest_ip_first_for_firecracker(
-        self,
-        mock_sdk_cls: MagicMock,
-        mock_ssh_cls: MagicMock,
-        sample_config: VMConfig,
-    ) -> None:
-        """run() should try guest_ip:22 first on Firecracker VMs."""
-        mock_network = MagicMock()
-        mock_network.guest_ip = "172.16.0.2"
-        mock_network.ssh_host_port = 2200
-
-        mock_info = MagicMock()
-        mock_info.vm_id = "vm001"
-        mock_info.status = VMState.RUNNING
-        mock_info.network = mock_network
-        mock_info.config.boot_args = "console=ttyS0 reboot=k panic=1 pci=off init=/init"
-        mock_info.config.backend = "firecracker"
-
-        mock_sdk = MagicMock()
-        mock_sdk.create.return_value = MagicMock(vm_id="vm001", status=VMState.CREATED)
-        mock_sdk.get.return_value = mock_info
-        mock_sdk_cls.return_value = mock_sdk
-
-        guest_client = MagicMock()
-        guest_client.run.return_value = MagicMock(exit_code=0, stdout="ok\n", stderr="")
-        mock_ssh_cls.return_value = guest_client
-
-        vm = SmolVM(sample_config)
-        result = vm.run("echo ok")
-
-        assert result.exit_code == 0
-        mock_ssh_cls.assert_called_once()
-        assert mock_ssh_cls.call_args.kwargs["host"] == "172.16.0.2"
-        assert mock_ssh_cls.call_args.kwargs["port"] == 22
-        guest_client.wait_for_ssh.assert_called_once()
-        guest_client.run.assert_called_once_with("echo ok", timeout=30, shell="login")
-
-    @patch("smolvm.facade.SSHClient")
-    @patch("smolvm.facade.SmolVMManager")
     def test_wait_for_ssh_falls_back_to_guest_ip_when_localhost_unreachable(
         self,
         mock_sdk_cls: MagicMock,
@@ -624,7 +584,6 @@ class TestVMRun:
         mock_info.status = VMState.RUNNING
         mock_info.network = mock_network
         mock_info.config.boot_args = "console=ttyS0 reboot=k panic=1 pci=off init=/init"
-        mock_info.config.backend = "qemu"
 
         mock_sdk = MagicMock()
         mock_sdk.create.return_value = MagicMock(vm_id="vm001", status=VMState.CREATED)
@@ -1228,7 +1187,7 @@ class TestVMEnvInjection:
         """start() should fallback to guest IP for env injection if localhost SSH fails."""
         mock_sdk = MagicMock()
         config_with_env = sample_config.model_copy(
-            update={"env_vars": {"FOO": "bar"}, "boot_args": "init=/init", "backend": "qemu"}
+            update={"env_vars": {"FOO": "bar"}, "boot_args": "init=/init"}
         )
 
         created_info = MagicMock(vm_id="vm001", status=VMState.CREATED)


### PR DESCRIPTION
## Summary
This PR keeps the SSH readiness instrumentation work and removes the endpoint-ordering experiment.

### Included
- Add `SMOLVM_TS` timestamp markers in `/init` to profile guest boot stages from serial logs.
- Generate SSH host keys at image build time for key-only images (Alpine/Debian).
- In `/init`, only run `ssh-keygen -A` when host keys are missing.

### Explicitly not included
- No Firecracker guest-IP-first endpoint preference change (reverted).

## Why
Latest Ubuntu benchmarks showed no material TTFC improvement from endpoint-order changes.
Keeping this PR focused on observability + low-risk boot hygiene provides useful profiling data without changing connection semantics.

## Notes
To apply build-time host-key generation for existing environments, rebuild cached images (or clear image cache) before benchmarking.
