### PR TITLE
Follow-up: exclude `ui/` from Hatch package artifacts

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,6 +54,11 @@ smolvm-cleanup = "smolvm.cleanup:main"
 [tool.hatch.build.targets.wheel]
 packages = ["src/smolvm"]
 
+[tool.hatch.build]
+exclude = [
+    "/ui",
+]
+
 [tool.hatch.version]
 path = "src/smolvm/__init__.py"
 


### PR DESCRIPTION
### Motivation
- Prevent non-Python frontend assets in `ui/` from being included in Python distribution artifacts to keep published packages small and focused on runtime code.

### Description
- Add a `[tool.hatch.build]` section to `pyproject.toml` with `exclude = ["/ui"]` so Hatch omits the repository-level `ui/` directory from sdist and wheel builds.

### Testing
- Built sdist and wheel with `python -m build`, which completed successfully.
- Verified there are zero `ui/` entries in the produced artifacts by inspecting `dist/*.tar.gz` and `dist/*.whl` with a Python script that checks for `ui/` paths.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6999a85ed79c832884edfe5989b53a84)