### PR TITLE
docs: add minimal issue + PR templates for clear contributor workflows

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,59 @@
+name: Bug report
+description: Report a reproducible problem
+title: "[Bug]: "
+labels:
+  - bug
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for reporting this. Please share enough detail for us to reproduce quickly.
+  - type: textarea
+    id: what_happened
+    attributes:
+      label: What happened?
+      description: Include the error and actual behavior.
+      placeholder: A clear description of the bug.
+    validations:
+      required: true
+  - type: textarea
+    id: steps
+    attributes:
+      label: Steps to reproduce
+      description: Short, numbered steps.
+      placeholder: |
+        1. ...
+        2. ...
+        3. ...
+    validations:
+      required: true
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected behavior
+      placeholder: What you expected to happen.
+    validations:
+      required: true
+  - type: input
+    id: smolvm_version
+    attributes:
+      label: SmolVM version or commit
+      placeholder: e.g. v0.3.2 or main@<commit>
+    validations:
+      required: true
+  - type: dropdown
+    id: environment
+    attributes:
+      label: Environment
+      options:
+        - Linux + Firecracker
+        - macOS + QEMU
+        - Other
+    validations:
+      required: true
+  - type: textarea
+    id: logs
+    attributes:
+      label: Relevant logs or output
+      description: Paste any traceback or `smolvm doctor --json --strict` output.
+      render: shell

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Security vulnerability report
+    url: https://github.com/CelestoAI/SmolVM/security/advisories/new
+    about: Please report suspected vulnerabilities privately.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,36 @@
+name: Feature request
+description: Suggest an improvement
+title: "[Feature]: "
+labels:
+  - enhancement
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Please describe the problem first, then the proposed solution.
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem statement
+      description: What is hard today? Who is affected?
+      placeholder: A clear description of the pain point.
+    validations:
+      required: true
+  - type: textarea
+    id: proposal
+    attributes:
+      label: Proposed solution
+      description: What should change?
+      placeholder: Describe the API, behavior, or UX you want.
+    validations:
+      required: true
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered
+      placeholder: Other approaches you considered.
+  - type: textarea
+    id: context
+    attributes:
+      label: Additional context
+      description: Links, examples, or constraints.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,22 @@
+## Summary
+
+Briefly describe what changed and why.
+
+## Related Issues
+
+- Closes #
+
+## Testing
+
+List what you ran locally (or write "not run" with reason).
+
+- `uv run pytest`
+- `uv run ruff check .`
+- `uv run mypy src`
+
+## Checklist
+
+- [ ] Scope is focused and limited to this change
+- [ ] Tests added/updated for behavior changes
+- [ ] Docs updated for user-visible changes
+- [ ] No secrets or sensitive data included


### PR DESCRIPTION
Add minimal GitHub templates to make issue reporting and PR submissions clearer and more consistent.

## Changes
- Added `.github/ISSUE_TEMPLATE/bug_report.yml`
  - Requires: what happened, repro steps, expected behavior, version/commit, environment
- Added `.github/ISSUE_TEMPLATE/feature_request.yml`
  - Requires: problem statement and proposed solution
- Added `.github/ISSUE_TEMPLATE/config.yml`
  - Disables blank issues
  - Routes security reports to private GitHub advisories
- Added `.github/pull_request_template.md`
  - Includes summary, related issue, testing, and a short checklist

## Why
This reduces back-and-forth during triage/review and gives contributors a clear, minimal structure without unnecessary friction.

## Testing
Template/docs-only change; no runtime or code-path changes.