### PR TITLE
Follow-up: improve Docker daemon image-build errors

### DIFF
--- a/src/smolvm/build.py
+++ b/src/smolvm/build.py
@@ -99,15 +99,20 @@ class ImageBuilder:
 
     def check_docker(self) -> bool:
         """Check if Docker is available and the daemon is reachable."""
+        docker_bin = shutil.which("docker")
+        if docker_bin is None:
+            return False
+
         try:
             subprocess.run(
-                ["docker", "info"],
+                [docker_bin, "info"],
                 check=True,
                 stdout=subprocess.DEVNULL,
                 stderr=subprocess.DEVNULL,
+                timeout=10,
             )
             return True
-        except (subprocess.CalledProcessError, FileNotFoundError):
+        except (subprocess.CalledProcessError, FileNotFoundError, subprocess.TimeoutExpired):
             return False
 
     def docker_requirement_error(self) -> ImageError:
@@ -122,21 +127,31 @@ class ImageBuilder:
             "Make sure Docker Desktop is running or grant access to /var/run/docker.sock."
         )
 
-        if shutil.which("docker") is None:
+        docker_bin = shutil.which("docker")
+        if docker_bin is None:
             return ImageError(f"Docker is required to build images. {install_hint}")
 
         try:
             subprocess.run(
-                ["docker", "info"],
+                [docker_bin, "info"],
                 check=True,
                 capture_output=True,
                 text=True,
+                timeout=10,
             )
         except FileNotFoundError:
             return ImageError(f"Docker is required to build images. {install_hint}")
+        except subprocess.TimeoutExpired:
+            return ImageError(
+                f"{start_hint} Original Docker error: timed out while contacting Docker."
+            )
         except subprocess.CalledProcessError as exc:
             details = "\n".join(part.strip() for part in (exc.stderr, exc.stdout) if part).strip()
             details_lower = details.lower()
+            if "permission denied" in details_lower and "docker.sock" in details_lower:
+                return ImageError(
+                    f"{permission_hint} Original Docker error: {details or 'unknown error.'}"
+                )
             if (
                 "cannot connect to the docker daemon" in details_lower
                 or "is the docker daemon running" in details_lower
@@ -144,10 +159,6 @@ class ImageBuilder:
             ):
                 return ImageError(
                     f"{start_hint} Original Docker error: {details or 'unknown error.'}"
-                )
-            if "permission denied" in details_lower and "docker.sock" in details_lower:
-                return ImageError(
-                    f"{permission_hint} Original Docker error: {details or 'unknown error.'}"
                 )
             return ImageError(
                 "Docker is required to build images, but Docker could not be used successfully. "

--- a/tests/test_build.py
+++ b/tests/test_build.py
@@ -68,6 +68,25 @@ class TestDockerDiagnostics:
         assert "Start Docker Desktop or the Docker service" in str(error)
         assert "Cannot connect to the Docker daemon" in str(error)
 
+    @patch("smolvm.build.subprocess.run")
+    def test_docker_requirement_error_when_socket_permission_denied(
+        self, mock_subprocess_run: MagicMock, tmp_path: Path
+    ) -> None:
+        builder = ImageBuilder(cache_dir=tmp_path / "images")
+        mock_subprocess_run.side_effect = subprocess.CalledProcessError(
+            1,
+            ["docker", "info"],
+            stderr=(
+                "error during connect: permission denied while trying to connect "
+                "to the Docker daemon socket at unix:///var/run/docker.sock"
+            ),
+        )
+
+        with patch("smolvm.build.shutil.which", return_value="/usr/bin/docker"):
+            error = builder.docker_requirement_error()
+
+        assert "cannot access the Docker daemon socket" in str(error)
+        assert "docker.sock" in str(error)
 
 
 class TestImageBuilderLoopFs:


### PR DESCRIPTION
fixes #63

### Motivation
- Users hit a generic `Docker is required to build images` error even when Docker is installed but the daemon is not reachable, which provides poor guidance for common failures.
- Make image-build failures actionable by surfacing whether Docker is missing, the daemon is unreachable, or the caller lacks socket permissions.

### Description
- Update `ImageBuilder.check_docker` to use `docker info` so the check verifies the daemon is reachable as well as the client binary being present (`src/smolvm/build.py`).
- Add `ImageBuilder.docker_requirement_error()` to produce richer, actionable `ImageError` messages for three cases: Docker not installed, Docker daemon unreachable (include original Docker error text), and permission/socket-access issues (`src/smolvm/build.py`).
- Replace direct `ImageError` raises in the image build entry points to call the new diagnostic helper so all image-build paths (`build_alpine_ssh`, `build_alpine_ssh_key`, `build_debian_ssh_key`, and similar) surface the improved message (`src/smolvm/build.py`).
- Add unit tests covering the new diagnostics: missing Docker and daemon-unreachable error paths (`tests/test_build.py`).

### Testing
- Ran `ruff check src/smolvm/build.py tests/test_build.py` and it passed.
- Ran `PYTHONPATH=src pytest tests/test_build.py` and all tests passed (`7 passed`).
- Running `pytest tests/test_build.py` without `PYTHONPATH=src` fails in this environment due to the package not being installed into the interpreter path (import error), which is unrelated to the code changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69badda489b48328ad1f5caa708eca7a)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Docker unavailability messages: detect missing Docker binary, daemon timeouts, connection failures, and socket/permission issues; provide clearer, context-aware guidance (install hints, start Docker hints, permission troubleshooting) and include original connection error text when available.

* **Tests**
  * Added tests covering Docker diagnostic scenarios to ensure the improved error messages appear for missing Docker, daemon unreachable/timeouts, and socket permission failures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->