### PR TITLE
Improve smolvm ssh startup notice

### DIFF
--- a/src/smolvm/cli.py
+++ b/src/smolvm/cli.py
@@ -444,6 +444,10 @@ def _run_ssh(args: argparse.Namespace) -> int:
         )
 
         if vm.status in {VMState.CREATED, VMState.STOPPED}:
+            print(
+                f"Notice: VM '{args.vm_id}' isn't running yet. "
+                "SSH may take a little longer while SmolVM starts it."
+            )
             vm.start(boot_timeout=args.boot_timeout)
         elif vm.status == VMState.ERROR:
             print(

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -373,6 +373,7 @@ class TestCliSSH:
         mock_vm_cls: MagicMock,
         mock_run: MagicMock,
         status: VMState,
+        capsys: pytest.CaptureFixture[str],
     ) -> None:
         """`smolvm ssh` should auto-start attachable non-running VMs."""
         vm = MagicMock()
@@ -384,6 +385,11 @@ class TestCliSSH:
         ret = main(["ssh", "vm001"])
 
         assert ret == 0
+        out = capsys.readouterr().out
+        assert (
+            "Notice: VM 'vm001' isn't running yet. SSH may take a little longer while SmolVM starts it."
+            in out
+        )
         vm.start.assert_called_once_with(boot_timeout=30.0)
         vm.wait_for_ssh.assert_called_once_with(timeout=30.0)
         mock_run.assert_called_once_with(["ssh", "root@127.0.0.1"], check=False)


### PR DESCRIPTION
## Summary

Improve the `smolvm ssh` message shown when a VM is not running yet so it reads more naturally for developers. The command still auto-starts attachable VMs before connecting, and the CLI test now asserts the notice is printed.

## Related Issues

- Closes #

## Testing

- `uv run --extra dev pytest tests/test_cli.py -k "ssh"`
- `uv run --extra dev ruff check src/smolvm/cli.py tests/test_cli.py`
- `python3 -m compileall src/smolvm/cli.py`

## Checklist

- [x] Scope is focused and limited to this change
- [x] Tests added/updated for behavior changes
- [ ] Docs updated for user-visible changes
- [x] No secrets or sensitive data included
