### PR TITLE
Add stop command to CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,7 @@ Use the default auto-configured, SSH-ready profile:
 ```bash
 smolvm create --name "project-spacex"
 smolvm ssh "project-spacex"
+smolvm stop "project-spacex"
 
 # Human-friendly Rich output by default
 smolvm list

--- a/src/smolvm/cli.py
+++ b/src/smolvm/cli.py
@@ -93,6 +93,19 @@ class CreatePayload(TypedDict):
     next: CreateNextPayload
 
 
+class StopVmPayload(TypedDict):
+    """Machine-readable VM details for ``smolvm stop``."""
+
+    name: str
+    status: str
+
+
+class StopPayload(TypedDict):
+    """JSON payload for ``smolvm stop``."""
+
+    vm: StopVmPayload
+
+
 class BrowserRow(TypedDict):
     """Machine-readable data for a listed browser session."""
 
@@ -293,6 +306,23 @@ def build_parser() -> argparse.ArgumentParser:
         help="Emit machine-readable JSON output.",
     )
     _add_boot_timeout_arg(create_parser)
+
+    stop_parser = subparsers.add_parser(
+        "stop",
+        help="Stop an existing VM",
+    )
+    stop_parser.add_argument("vm_id", help="VM identifier")
+    stop_parser.add_argument(
+        "--timeout",
+        type=_positive_float,
+        default=3.0,
+        help="Seconds to wait for graceful shutdown (default: 3).",
+    )
+    stop_parser.add_argument(
+        "--json",
+        action="store_true",
+        help="Emit machine-readable JSON output.",
+    )
 
     ssh_parser = subparsers.add_parser(
         "ssh",
@@ -698,6 +728,58 @@ def _run_create(args: argparse.Namespace) -> int:
         return 0
     except Exception as exc:
         return _emit_cli_error("create", 1, exc, json_output=args.json)
+    finally:
+        if vm is not None:
+            vm.close()
+
+
+def _render_stop_result(data: StopPayload) -> None:
+    """Render the human-facing stop result."""
+    console = console_stdout()
+    vm_data = data["vm"]
+
+    console.print(
+        Panel.fit(
+            f"Stopped VM '{vm_data['name']}'.",
+            title="VM Stopped",
+            border_style="yellow",
+        )
+    )
+
+    details = Table(title="VM Details", show_header=False)
+    details.add_column("Field")
+    details.add_column("Value")
+    details.add_row("Name", str(vm_data["name"]))
+    details.add_row(
+        "Status",
+        Text(str(vm_data["status"]), style=status_style(str(vm_data["status"]))),
+    )
+    console.print(details)
+
+
+def _run_stop(args: argparse.Namespace) -> int:
+    """Handle ``smolvm stop``."""
+    from smolvm.facade import SmolVM
+
+    vm: SmolVM | None = None
+    try:
+        vm = SmolVM.from_id(args.vm_id)
+        vm.stop(timeout=args.timeout)
+
+        data: StopPayload = {
+            "vm": {
+                "name": vm.vm_id,
+                "status": VMState.STOPPED.value,
+            }
+        }
+
+        if args.json:
+            emit_json("stop", 0, data=data)
+        else:
+            _render_stop_result(data)
+        return 0
+    except Exception as exc:
+        return _emit_cli_error("stop", 1, exc, json_output=args.json)
     finally:
         if vm is not None:
             vm.close()
@@ -1215,6 +1297,9 @@ def main(argv: Sequence[str] | None = None) -> int:
 
     if args.command == "create":
         return _run_create(args)
+
+    if args.command == "stop":
+        return _run_stop(args)
 
     if args.command == "ssh":
         return _run_ssh(args)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -425,6 +425,65 @@ class TestCliCreate:
         assert "Docker is required" in capsys.readouterr().err
 
 
+class TestCliStop:
+    """Tests for `smolvm stop`."""
+
+    @patch("smolvm.facade.SmolVM")
+    def test_stop_success(
+        self,
+        mock_vm_cls: MagicMock,
+        capsys: pytest.CaptureFixture,
+    ) -> None:
+        """`smolvm stop` should stop an existing VM and report the result."""
+        vm = MagicMock()
+        vm.vm_id = "vm001"
+        mock_vm_cls.from_id.return_value = vm
+
+        ret = main(["stop", "vm001", "--timeout", "7"])
+
+        assert ret == 0
+        mock_vm_cls.from_id.assert_called_once_with("vm001")
+        vm.stop.assert_called_once_with(timeout=7.0)
+        vm.close.assert_called_once()
+        out = capsys.readouterr().out
+        assert "Stopped VM 'vm001'." in out
+        assert "stopped" in out
+
+    @patch("smolvm.facade.SmolVM")
+    def test_stop_json(
+        self,
+        mock_vm_cls: MagicMock,
+        capsys: pytest.CaptureFixture,
+    ) -> None:
+        """`smolvm stop --json` should emit the shared envelope."""
+        vm = MagicMock()
+        vm.vm_id = "vm001"
+        mock_vm_cls.from_id.return_value = vm
+
+        ret = main(["stop", "vm001", "--json"])
+
+        assert ret == 0
+        payload = json.loads(capsys.readouterr().out)
+        assert payload["command"] == "stop"
+        assert payload["ok"] is True
+        assert payload["data"]["vm"]["name"] == "vm001"
+        assert payload["data"]["vm"]["status"] == "stopped"
+
+    @patch("smolvm.facade.SmolVM")
+    def test_stop_missing_vm_prints_error(
+        self,
+        mock_vm_cls: MagicMock,
+        capsys: pytest.CaptureFixture,
+    ) -> None:
+        """Missing VMs should surface a clean error."""
+        mock_vm_cls.from_id.side_effect = Exception("VM 'missing' not found")
+
+        ret = main(["stop", "missing"])
+
+        assert ret == 1
+        assert "VM 'missing' not found" in capsys.readouterr().err
+
+
 class TestCliSSH:
     """Tests for `smolvm ssh`."""
 


### PR DESCRIPTION
## Summary
- add a top-level `smolvm stop <vm_id>` command
- support human-readable and `--json` output for stop operations
- add CLI coverage and document the new usage in the README

## Verification
- `uv run smolvm stop --help`
- `uv run python -m compileall src/smolvm/cli.py`
- mocked smoke checks for JSON and human stop flows via `uv run python`

## Notes
- `pytest` was not available in the local `uv` environment, so full test execution was not possible in this workspace

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added `smolvm stop` command to stop and teardown VMs with configurable timeout
  * Supports both human-readable and JSON output formats

* **Documentation**
  * Updated quickstart guide to include VM shutdown step in the workflow

* **Tests**
  * Added comprehensive test coverage for the stop command functionality

<!-- end of auto-generated comment: release notes by coderabbit.ai -->