### PR TITLE
Add extras for agent tool examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -270,6 +270,8 @@ Notes:
 ## Agent Framework Tool Examples
 
 SmolVM can be wrapped as an agent tool or function in common Python agent frameworks.
+Install every example dependency with `pip install 'smolvm[examples]'`.
+Use `pip install 'smolvm[all]'` if you also want dashboard dependencies.
 
 - [Computer-use browser example](examples/agent_tools/computer_use_browser.py): let a model drive a real browser visually to answer a question on a site, with SmolVM handling isolation and live view.
 - [LangChain `@tool` example](examples/agent_tools/langchain_tool.py): let a LangChain agent run shell commands in a safe sandbox.

--- a/examples/agent_tools/langchain_tool.py
+++ b/examples/agent_tools/langchain_tool.py
@@ -39,7 +39,6 @@ from pprint import pprint
 from typing import Any
 
 from smolvm import SmolVM
-from langchain.tools import tool
 
 DEFAULT_MODEL = "openai:gpt-5.4"
 
@@ -81,6 +80,10 @@ def main() -> None:
     """Run a minimal LangChain agent that can call SmolVM as a tool."""
     create_agent = _require_dependency(
         "langchain.agents:create_agent",
+        "pip install langchain langchain-openai",
+    )
+    tool = _require_dependency(
+        "langchain.tools:tool",
         "pip install langchain langchain-openai",
     )
     agent = create_agent(

--- a/examples/agent_tools/openai_agents_tool.py
+++ b/examples/agent_tools/openai_agents_tool.py
@@ -36,12 +36,23 @@ from __future__ import annotations
 
 import asyncio
 import os
-
-from agents import Agent, Runner, function_tool
+from typing import Any
 
 from smolvm import SmolVM
 
 DEFAULT_MODEL = "gpt-4.1"
+
+
+def _require_dependency(import_path: str, install_hint: str) -> Any:
+    """Import an optional dependency lazily with a useful installation hint."""
+    module_name, _, attr_name = import_path.partition(":")
+    try:
+        module = __import__(module_name, fromlist=[attr_name] if attr_name else [])
+    except ImportError as exc:
+        raise RuntimeError(
+            f"Missing dependency '{module_name}'. Install it with: {install_hint}"
+        ) from exc
+    return getattr(module, attr_name) if attr_name else module
 
 
 def _format_command_result(exit_code: int, stdout: str, stderr: str) -> str:
@@ -53,7 +64,6 @@ def _format_command_result(exit_code: int, stdout: str, stderr: str) -> str:
     )
 
 
-@function_tool
 def run_in_smolvm(command: str, timeout: int = 30) -> str:
     """Run a shell command inside an ephemeral SmolVM sandbox.
 
@@ -68,7 +78,13 @@ def run_in_smolvm(command: str, timeout: int = 30) -> str:
 
 async def main() -> None:
     """Run a minimal OpenAI Agents SDK example with SmolVM as a tool."""
-    agent = Agent(
+    agent_cls = _require_dependency("agents:Agent", "pip install openai-agents")
+    runner_cls = _require_dependency("agents:Runner", "pip install openai-agents")
+    function_tool = _require_dependency(
+        "agents:function_tool",
+        "pip install openai-agents",
+    )
+    agent = agent_cls(
         name="SmolVM Assistant",
         model=os.environ.get("OPENAI_AGENTS_MODEL", DEFAULT_MODEL),
         instructions=(
@@ -76,13 +92,13 @@ async def main() -> None:
             "For shell or Python inspection requests, call run_in_smolvm exactly "
             "once and then summarize the result."
         ),
-        tools=[run_in_smolvm],
+        tools=[function_tool(run_in_smolvm)],
     )
     prompt = (
         "Use run_in_smolvm to run this exact command inside the sandbox: "
         "`uname -a && python3 --version`. Then summarize what you found."
     )
-    result = await Runner.run(agent, prompt)
+    result = await runner_cls.run(agent, prompt)
     print(result.final_output)
 
 

--- a/examples/agent_tools/pydanticai_reusable_tool.py
+++ b/examples/agent_tools/pydanticai_reusable_tool.py
@@ -36,10 +36,12 @@ from __future__ import annotations
 
 import os
 from dataclasses import dataclass
-
-from pydantic_ai import Agent, RunContext
+from typing import TYPE_CHECKING, Any
 
 from smolvm import SmolVM
+
+if TYPE_CHECKING:
+    from pydantic_ai import RunContext
 
 DEFAULT_MODEL = "openai:gpt-4.1"
 
@@ -51,15 +53,16 @@ class SandboxDeps:
     vm_id: str | None = None
 
 
-agent = Agent(
-    os.environ.get("PYDANTICAI_MODEL", DEFAULT_MODEL),
-    deps_type=SandboxDeps,
-    instructions=(
-        "You are a coding assistant with access to a reusable SmolVM sandbox. "
-        "For shell and file-system tasks, call run_in_reusable_smolvm exactly "
-        "once and then summarize the result."
-    ),
-)
+def _require_dependency(import_path: str, install_hint: str) -> Any:
+    """Import an optional dependency lazily with a useful installation hint."""
+    module_name, _, attr_name = import_path.partition(":")
+    try:
+        module = __import__(module_name, fromlist=[attr_name] if attr_name else [])
+    except ImportError as exc:
+        raise RuntimeError(
+            f"Missing dependency '{module_name}'. Install it with: {install_hint}"
+        ) from exc
+    return getattr(module, attr_name) if attr_name else module
 
 
 def _format_command_result(exit_code: int, stdout: str, stderr: str) -> str:
@@ -93,7 +96,6 @@ def _cleanup_vm(vm_id: str | None) -> None:
         vm.close()
 
 
-@agent.tool(docstring_format="google", require_parameter_descriptions=True)
 def run_in_reusable_smolvm(
     ctx: RunContext[SandboxDeps],
     command: str,
@@ -113,8 +115,26 @@ def run_in_reusable_smolvm(
         vm.close()
 
 
+def _build_agent() -> Any:
+    agent_cls = _require_dependency("pydantic_ai:Agent", "pip install pydantic-ai")
+    agent = agent_cls(
+        os.environ.get("PYDANTICAI_MODEL", DEFAULT_MODEL),
+        deps_type=SandboxDeps,
+        instructions=(
+            "You are a coding assistant with access to a reusable SmolVM sandbox. "
+            "For shell and file-system tasks, call run_in_reusable_smolvm exactly "
+            "once and then summarize the result."
+        ),
+    )
+    agent.tool(docstring_format="google", require_parameter_descriptions=True)(
+        run_in_reusable_smolvm
+    )
+    return agent
+
+
 def main() -> None:
     """Run two turns against the same SmolVM-backed sandbox."""
+    agent = _build_agent()
     deps = SandboxDeps()
     try:
         first_prompt = (

--- a/examples/agent_tools/pydanticai_tool.py
+++ b/examples/agent_tools/pydanticai_tool.py
@@ -35,21 +35,23 @@ Example:
 from __future__ import annotations
 
 import os
-
-from pydantic_ai import Agent
+from typing import Any
 
 from smolvm import SmolVM
 
 DEFAULT_MODEL = "openai:gpt-4.1"
 
-agent = Agent(
-    os.environ.get("PYDANTICAI_MODEL", DEFAULT_MODEL),
-    instructions=(
-        "You are a coding assistant with access to a secure SmolVM sandbox. "
-        "For shell or Python inspection requests, call run_in_smolvm exactly "
-        "once and then summarize the result."
-    ),
-)
+
+def _require_dependency(import_path: str, install_hint: str) -> Any:
+    """Import an optional dependency lazily with a useful installation hint."""
+    module_name, _, attr_name = import_path.partition(":")
+    try:
+        module = __import__(module_name, fromlist=[attr_name] if attr_name else [])
+    except ImportError as exc:
+        raise RuntimeError(
+            f"Missing dependency '{module_name}'. Install it with: {install_hint}"
+        ) from exc
+    return getattr(module, attr_name) if attr_name else module
 
 
 def _format_command_result(exit_code: int, stdout: str, stderr: str) -> str:
@@ -61,7 +63,6 @@ def _format_command_result(exit_code: int, stdout: str, stderr: str) -> str:
     )
 
 
-@agent.tool_plain(docstring_format="google", require_parameter_descriptions=True)
 def run_in_smolvm(command: str, timeout: int = 30) -> str:
     """Run a shell command inside an ephemeral SmolVM sandbox.
 
@@ -74,8 +75,25 @@ def run_in_smolvm(command: str, timeout: int = 30) -> str:
         return _format_command_result(result.exit_code, result.stdout, result.stderr)
 
 
+def _build_agent() -> Any:
+    agent_cls = _require_dependency("pydantic_ai:Agent", "pip install pydantic-ai")
+    agent = agent_cls(
+        os.environ.get("PYDANTICAI_MODEL", DEFAULT_MODEL),
+        instructions=(
+            "You are a coding assistant with access to a secure SmolVM sandbox. "
+            "For shell or Python inspection requests, call run_in_smolvm exactly "
+            "once and then summarize the result."
+        ),
+    )
+    agent.tool_plain(docstring_format="google", require_parameter_descriptions=True)(
+        run_in_smolvm
+    )
+    return agent
+
+
 def main() -> None:
     """Run a minimal PydanticAI example with SmolVM as a tool."""
+    agent = _build_agent()
     prompt = (
         "Use run_in_smolvm to run this exact command inside the sandbox: "
         "`uname -a && python3 --version`. Then summarize what you found."

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,6 +47,25 @@ dashboard = [
     "uvicorn[standard]>=0.34.0",
     "websockets>=14.0",
 ]
+examples = [
+    "langchain",
+    "langchain-openai",
+    "openai",
+    "openai-agents",
+    "playwright",
+    "pydantic-ai",
+]
+all = [
+    "fastapi>=0.115.0",
+    "uvicorn[standard]>=0.34.0",
+    "websockets>=14.0",
+    "langchain",
+    "langchain-openai",
+    "openai",
+    "openai-agents",
+    "playwright",
+    "pydantic-ai",
+]
 
 [project.scripts]
 smolvm = "smolvm.cli:main"

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -22,6 +22,8 @@ import sys
 import warnings
 from pathlib import Path
 
+import pytest
+
 REPO_ROOT = Path(__file__).resolve().parents[1]
 EXAMPLES_DIR = REPO_ROOT / "examples" / "agent_tools"
 EXPECTED_EXAMPLES = {
@@ -53,6 +55,12 @@ def _load_module(path: Path):
     sys.modules[spec.name] = module
     spec.loader.exec_module(module)
     return module
+
+
+@pytest.mark.parametrize("example_name", sorted(EXPECTED_EXAMPLES))
+def test_agent_tool_examples_import_without_optional_dependencies(example_name: str) -> None:
+    """Import agent-tool examples without requiring optional dependencies."""
+    _load_module(EXAMPLES_DIR / example_name)
 
 
 def test_langchain_tool_import_without_pydantic_v1_warning() -> None:


### PR DESCRIPTION
## Summary

Adds `examples` and `all` optional dependency groups so users can install every agent-tool example dependency with one extra. Refactors the LangChain, OpenAI Agents, and PydanticAI examples to lazy-load optional packages so example tests still pass when those dependencies are not installed, and documents the new install paths.

## Related Issues

- None

## Testing

- `uv run --extra dev pytest`
- `uv run --extra dev ruff check pyproject.toml README.md examples/agent_tools/langchain_tool.py examples/agent_tools/openai_agents_tool.py examples/agent_tools/pydanticai_tool.py examples/agent_tools/pydanticai_reusable_tool.py tests/test_examples.py`
- `uv run mypy src` not run

## Checklist

- [x] Scope is focused and limited to this change
- [x] Tests added/updated for behavior changes
- [x] Docs updated for user-visible changes
- [x] No secrets or sensitive data included


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added installation instructions for example scripts and optional dashboard dependencies in README.

* **Refactor**
  * Improved optional dependency handling—example scripts now gracefully handle missing dependencies at runtime instead of failing at import time.

* **Chores**
  * Added `examples` and `all` optional dependency groups to project configuration for cleaner installation management.

* **Tests**
  * Enhanced test coverage for example module imports without optional dependencies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->