### PR TITLE
Auto-generate VM names for create

### DIFF
--- a/src/smolvm/cli.py
+++ b/src/smolvm/cli.py
@@ -275,12 +275,11 @@ def build_parser() -> argparse.ArgumentParser:
 
     create_parser = subparsers.add_parser(
         "create",
-        help="Create a named SSH-ready VM and leave it running",
+        help="Create an SSH-ready VM and leave it running",
     )
     create_parser.add_argument(
         "--name",
-        required=True,
-        help="VM identifier to create.",
+        help="VM identifier to create (default: auto-generated).",
     )
     create_parser.add_argument(
         "--memory-mib",

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -294,6 +294,44 @@ class TestCliCreate:
 
     @patch("smolvm.facade._build_auto_config")
     @patch("smolvm.facade.SmolVM")
+    def test_create_auto_generated_name(
+        self,
+        mock_vm_cls: MagicMock,
+        mock_build_auto_config: MagicMock,
+        capsys: pytest.CaptureFixture,
+    ) -> None:
+        """`smolvm create` should auto-generate a VM name when omitted."""
+        config = MagicMock(vm_id="vm-a1b2c3d4")
+        mock_build_auto_config.return_value = (config, "/tmp/id_ed25519")
+
+        vm = MagicMock()
+        vm.vm_id = "vm-a1b2c3d4"
+        vm.info.config.backend = "qemu"
+        vm.info.network = MagicMock(spec=NetworkConfig)
+        vm.info.network.guest_ip = "172.16.0.2"
+        vm.info.network.ssh_host_port = 2200
+        mock_vm_cls.return_value = vm
+
+        ret = main(["create"])
+
+        assert ret == 0
+        mock_build_auto_config.assert_called_once_with(
+            vm_name=None,
+            backend=None,
+            mem_size_mib=None,
+            disk_size_mib=None,
+            ssh_key_path=None,
+        )
+        mock_vm_cls.assert_called_once_with(config, ssh_key_path="/tmp/id_ed25519")
+        vm.start.assert_called_once_with(boot_timeout=30.0)
+        vm.wait_for_ssh.assert_called_once_with(timeout=30.0)
+        vm.close.assert_called_once()
+        out = capsys.readouterr().out
+        assert "Created VM 'vm-a1b2c3d4'." in out
+        assert "smolvm ssh vm-a1b2c3d4" in out
+
+    @patch("smolvm.facade._build_auto_config")
+    @patch("smolvm.facade.SmolVM")
     def test_create_success(
         self,
         mock_vm_cls: MagicMock,


### PR DESCRIPTION
## Summary
- make `smolvm create` accept an omitted `--name`
- rely on the existing auto-generated VM ID path in `_build_auto_config`
- add CLI coverage for creating a VM without an explicit name

## Testing
- `PYTHONPATH=src python3 -m pytest tests/test_cli.py -q`
- `PYTHONPATH=src python3 -m pytest tests/test_facade.py -q`
