### PR TITLE
Add packaged CLI host setup flow

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -39,17 +39,11 @@ uv sync --extra dev --extra dashboard
 
 ### Runtime Prerequisites (for backend/runtime work)
 
-Linux (Firecracker):
-
 ```bash
-sudo ./scripts/system-setup.sh --configure-runtime
+uv run smolvm setup
 ```
 
-macOS (QEMU):
-
-```bash
-./scripts/system-setup-macos.sh
-```
+The repo-level shell scripts in `scripts/` remain the implementation detail behind `smolvm setup`; use them directly only if you are intentionally working on the setup flow itself.
 
 Health check:
 

--- a/README.md
+++ b/README.md
@@ -32,28 +32,15 @@ SmolVM is a Python SDK and CLI for running code and browser tasks inside disposa
 pip install smolvm
 ```
 
-2. Clone this repository to get the setup scripts.
+2. Run the one-time setup for your machine.
 
 ```bash
-git clone https://github.com/CelestoAI/SmolVM.git
-cd SmolVM
+smolvm setup
 ```
 
-3. Run the one-time setup for your machine.
+Linux may prompt for `sudo` during setup so it can install host dependencies and configure runtime permissions.
 
-Linux:
-
-```bash
-sudo ./scripts/system-setup.sh --configure-runtime
-```
-
-macOS:
-
-```bash
-./scripts/system-setup-macos.sh
-```
-
-4. Check that the runtime is ready.
+3. Check that the runtime is ready.
 
 ```bash
 smolvm doctor

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -74,6 +74,13 @@ smolvm-cleanup = "smolvm.cleanup:main"
 [tool.hatch.build.targets.wheel]
 packages = ["src/smolvm"]
 
+[tool.hatch.build.targets.wheel.force-include]
+"scripts/system-setup.sh" = "src/smolvm/_setup_assets/system-setup.sh"
+"scripts/system-setup-macos.sh" = "src/smolvm/_setup_assets/system-setup-macos.sh"
+"scripts/internal/install-firecracker.sh" = "src/smolvm/_setup_assets/internal/install-firecracker.sh"
+"scripts/internal/configure-runtime-sudoers.sh" = "src/smolvm/_setup_assets/internal/configure-runtime-sudoers.sh"
+"scripts/internal/image-build-loopfs.sh" = "src/smolvm/_setup_assets/internal/image-build-loopfs.sh"
+
 [tool.hatch.build]
 exclude = [
     "/ui",

--- a/src/smolvm/_setup_assets/__init__.py
+++ b/src/smolvm/_setup_assets/__init__.py
@@ -1,0 +1,1 @@
+"""Packaged host-setup shell assets for ``smolvm setup``."""

--- a/src/smolvm/cli.py
+++ b/src/smolvm/cli.py
@@ -20,6 +20,7 @@ import argparse
 import importlib
 import importlib.metadata
 import os
+import platform
 import re
 import subprocess
 from collections.abc import Sequence
@@ -213,6 +214,26 @@ def _positive_float(value: str) -> float:
     return parsed
 
 
+class _LinuxOnlyOption(argparse.Action):
+    """Reject setup flags that are only valid on Linux when used on macOS."""
+
+    def __call__(
+        self,
+        parser: argparse.ArgumentParser,
+        namespace: argparse.Namespace,
+        values: str | Sequence[str] | None,
+        option_string: str | None = None,
+    ) -> None:
+        if platform.system() == "Darwin":
+            parser.error(f"argument {option_string}: only supported on Linux")
+
+        if self.nargs == 0:
+            setattr(namespace, self.dest, self.const if self.const is not None else True)
+            return
+
+        setattr(namespace, self.dest, values)
+
+
 def _add_ssh_auth_args(command_parser: argparse.ArgumentParser) -> None:
     """Add common SSH identity arguments to a command parser."""
     command_parser.add_argument(
@@ -273,6 +294,51 @@ def build_parser() -> argparse.ArgumentParser:
         "--strict",
         action="store_true",
         help="Treat warnings as failures.",
+    )
+
+    setup = subparsers.add_parser(
+        "setup",
+        help="Install or validate one-time host prerequisites",
+    )
+    setup.add_argument(
+        "--check-only",
+        action="store_true",
+        help="Validate prerequisites without installing anything.",
+    )
+    setup.add_argument(
+        "--with-docker",
+        action="store_true",
+        help="Install or validate Docker too.",
+    )
+    setup.add_argument(
+        "--no-configure-runtime",
+        action=_LinuxOnlyOption,
+        nargs=0,
+        const=True,
+        default=False,
+        help="Skip scoped runtime sudoers setup (Linux only).",
+    )
+    setup.add_argument(
+        "--skip-deps",
+        action=_LinuxOnlyOption,
+        nargs=0,
+        const=True,
+        default=False,
+        help="Skip Linux package dependency installation (Linux only).",
+    )
+    setup.add_argument(
+        "--runtime-user",
+        action=_LinuxOnlyOption,
+        default=None,
+        help="Target user for Linux runtime privilege configuration (Linux only).",
+    )
+    setup.add_argument(
+        "--remove-runtime-config",
+        action=_LinuxOnlyOption,
+        nargs=0,
+        const=True,
+        default=False,
+        help="Remove Linux runtime privilege configuration (Linux only).",
     )
 
     def _add_ui_args(command_parser: argparse.ArgumentParser) -> None:
@@ -756,6 +822,41 @@ def _render_list(rows: list[VmRow]) -> None:
     console = console_stdout()
     console.print(table)
     console.print(f"Total: {len(rows)} VM(s).")
+
+
+def _run_setup(parser: argparse.ArgumentParser, args: argparse.Namespace) -> int:
+    """Handle ``smolvm setup``."""
+    from smolvm.setup import SetupOptions, run_setup
+
+    invalid_remove_runtime_flags: list[str] = []
+    if args.check_only:
+        invalid_remove_runtime_flags.append("--check-only")
+    if args.with_docker:
+        invalid_remove_runtime_flags.append("--with-docker")
+    if args.no_configure_runtime:
+        invalid_remove_runtime_flags.append("--no-configure-runtime")
+    if args.skip_deps:
+        invalid_remove_runtime_flags.append("--skip-deps")
+
+    if args.remove_runtime_config and invalid_remove_runtime_flags:
+        parser.error(
+            "argument --remove-runtime-config: not allowed with "
+            + ", ".join(invalid_remove_runtime_flags)
+        )
+
+    options = SetupOptions(
+        check_only=args.check_only,
+        with_docker=args.with_docker,
+        configure_runtime=not args.no_configure_runtime,
+        skip_deps=args.skip_deps,
+        runtime_user=args.runtime_user,
+        remove_runtime_config=args.remove_runtime_config,
+    )
+
+    try:
+        return run_setup(options)
+    except Exception as exc:
+        return _emit_cli_error("setup", 1, exc, json_output=False)
 
 
 def _run_list(*, include_all: bool, status_filter: str | None, json_output: bool) -> int:
@@ -1685,6 +1786,9 @@ def main(argv: Sequence[str] | None = None) -> int:
             dry_run=args.dry_run,
             json_output=args.json,
         )
+
+    if args.command == "setup":
+        return _run_setup(parser, args)
 
     if args.command == "list":
         return _run_list(

--- a/src/smolvm/network.py
+++ b/src/smolvm/network.py
@@ -858,6 +858,6 @@ def check_network_prerequisites() -> list[str]:
             try:
                 run_command(cmd, use_sudo=True)
             except SmolVMError:
-                errors.append(f"{label} missing (run setup script)")
+                errors.append(f"{label} missing (run `smolvm setup`)")
 
     return errors

--- a/src/smolvm/setup.py
+++ b/src/smolvm/setup.py
@@ -1,0 +1,126 @@
+# Copyright 2026 Celesto AI
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Host setup runner for the ``smolvm setup`` CLI command."""
+
+from __future__ import annotations
+
+import platform
+import subprocess
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Literal
+
+SetupPlatform = Literal["linux", "macos"]
+
+_LINUX_SCRIPT = "system-setup.sh"
+_MACOS_SCRIPT = "system-setup-macos.sh"
+
+
+@dataclass(frozen=True)
+class SetupOptions:
+    """Resolved CLI options for ``smolvm setup``."""
+
+    check_only: bool = False
+    with_docker: bool = False
+    configure_runtime: bool = True
+    skip_deps: bool = False
+    runtime_user: str | None = None
+    remove_runtime_config: bool = False
+
+
+def packaged_asset_root() -> Path:
+    """Return the packaged directory containing setup shell assets."""
+    return Path(__file__).resolve().parent / "_setup_assets"
+
+
+def detect_setup_platform(system_name: str | None = None) -> SetupPlatform:
+    """Normalize the current OS into the supported setup platform names."""
+    detected = system_name or platform.system()
+    if detected == "Linux":
+        return "linux"
+    if detected == "Darwin":
+        return "macos"
+    raise RuntimeError(
+        "`smolvm setup` is supported only on Linux and macOS. "
+        f"Detected OS: {detected}."
+    )
+
+
+def resolve_setup_script(
+    target: SetupPlatform,
+    *,
+    asset_root: Path | None = None,
+) -> Path:
+    """Resolve the packaged shell script for the requested platform."""
+    root = asset_root or packaged_asset_root()
+    script_name = _LINUX_SCRIPT if target == "linux" else _MACOS_SCRIPT
+    script_path = root / script_name
+    if script_path.is_file():
+        return script_path
+    raise FileNotFoundError(
+        "Missing packaged setup asset.\n"
+        f"Expected: {script_path}\n"
+        "Reinstall smolvm or rebuild the wheel so setup assets are included."
+    )
+
+
+def build_setup_command(
+    options: SetupOptions,
+    *,
+    system_name: str | None = None,
+    asset_root: Path | None = None,
+) -> list[str]:
+    """Build the child ``bash ...`` invocation for ``smolvm setup``."""
+    target = detect_setup_platform(system_name)
+    script_path = resolve_setup_script(target, asset_root=asset_root)
+
+    argv: list[str] = ["bash", str(script_path)]
+
+    if target == "linux":
+        if options.remove_runtime_config:
+            argv.append("--remove-runtime-config")
+            if options.runtime_user:
+                argv.extend(["--runtime-user", options.runtime_user])
+            return argv
+
+        if options.check_only:
+            argv.append("--check-only")
+        if options.with_docker:
+            argv.append("--with-docker")
+        if options.configure_runtime:
+            argv.append("--configure-runtime")
+        if options.skip_deps:
+            argv.append("--skip-deps")
+        if options.runtime_user:
+            argv.extend(["--runtime-user", options.runtime_user])
+        return argv
+
+    if options.check_only:
+        argv.append("--check-only")
+    if options.with_docker:
+        argv.append("--with-docker")
+    return argv
+
+
+def run_setup(
+    options: SetupOptions,
+    *,
+    system_name: str | None = None,
+    asset_root: Path | None = None,
+) -> int:
+    """Execute the packaged setup script with inherited stdio."""
+    command = build_setup_command(options, system_name=system_name, asset_root=asset_root)
+    completed = subprocess.run(command, check=False)
+    return int(completed.returncode)

--- a/src/smolvm/utils.py
+++ b/src/smolvm/utils.py
@@ -28,7 +28,7 @@ logger = logging.getLogger(__name__)
 
 RUNTIME_PRIVILEGE_SETUP_HINT = (
     "Configure non-interactive runtime privileges once:\n"
-    "  sudo ./scripts/system-setup.sh --configure-runtime"
+    "  smolvm setup"
 )
 
 

--- a/tests/test_build.py
+++ b/tests/test_build.py
@@ -98,7 +98,7 @@ class TestImageBuilderLoopFs:
 
         with (
             patch.object(ImageBuilder, "_loopfs_helper_path", return_value=None),
-            pytest.raises(ImageError, match="--configure-runtime"),
+            pytest.raises(ImageError, match="smolvm setup"),
         ):
             builder._run_loopfs("mount", Path("/tmp/rootfs.ext4"), Path("/tmp/mnt"))
 
@@ -115,7 +115,7 @@ class TestImageBuilderLoopFs:
                 "_loopfs_helper_path",
                 return_value=Path("/usr/local/libexec/smolvm-loopfs-helper"),
             ),
-            pytest.raises(ImageError, match="--configure-runtime"),
+            pytest.raises(ImageError, match="smolvm setup"),
         ):
             builder._run_loopfs("mount", Path("/tmp/rootfs.ext4"), Path("/tmp/mnt"))
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -930,6 +930,53 @@ class TestCliDoctor:
         )
 
 
+class TestCliSetup:
+    """Tests for `smolvm setup` CLI wiring."""
+
+    @patch("smolvm.cli._run_setup")
+    @patch("smolvm.cli.platform.system", return_value="Linux")
+    def test_setup_dispatches_to_runner(
+        self,
+        mock_platform_system: MagicMock,
+        mock_run_setup: MagicMock,
+    ) -> None:
+        """`smolvm setup` should dispatch through the setup handler."""
+        mock_run_setup.return_value = 0
+
+        ret = main(["setup"])
+
+        assert ret == 0
+        mock_run_setup.assert_called_once()
+
+    @patch("smolvm.cli.platform.system", return_value="Darwin")
+    def test_setup_rejects_linux_only_flags_on_macos(
+        self,
+        mock_platform_system: MagicMock,
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        """Linux-only setup flags should fail at argparse time on macOS."""
+        with pytest.raises(SystemExit) as exc_info:
+            main(["setup", "--skip-deps"])
+
+        assert exc_info.value.code == 2
+        assert mock_platform_system.called
+        assert "only supported on Linux" in capsys.readouterr().err
+
+    @patch("smolvm.cli.platform.system", return_value="Linux")
+    def test_setup_remove_runtime_config_conflicts_with_other_modes(
+        self,
+        mock_platform_system: MagicMock,
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        """Removal mode should reject provisioning flags via argparse."""
+        with pytest.raises(SystemExit) as exc_info:
+            main(["setup", "--remove-runtime-config", "--with-docker"])
+
+        assert exc_info.value.code == 2
+        assert mock_platform_system.called
+        assert "not allowed with --with-docker" in capsys.readouterr().err
+
+
 class TestCurrentVersionIsPrerelease:
     """Tests for _current_version_is_prerelease helper."""
 

--- a/tests/test_setup.py
+++ b/tests/test_setup.py
@@ -1,0 +1,174 @@
+# Copyright 2026 Celesto AI
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for the ``smolvm setup`` runner."""
+
+import subprocess
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from smolvm.setup import SetupOptions, build_setup_command, run_setup
+
+
+def _make_asset_root(tmp_path: Path) -> Path:
+    asset_root = tmp_path / "assets"
+    (asset_root / "internal").mkdir(parents=True)
+    (asset_root / "system-setup.sh").write_text("#!/bin/bash\n")
+    (asset_root / "system-setup-macos.sh").write_text("#!/bin/bash\n")
+    return asset_root
+
+
+class TestBuildSetupCommand:
+    """Tests for platform-specific setup command construction."""
+
+    def test_linux_default_includes_configure_runtime(self, tmp_path: Path) -> None:
+        asset_root = _make_asset_root(tmp_path)
+
+        command = build_setup_command(SetupOptions(), system_name="Linux", asset_root=asset_root)
+
+        assert command == [
+            "bash",
+            str(asset_root / "system-setup.sh"),
+            "--configure-runtime",
+        ]
+
+    def test_linux_check_only_keeps_runtime_config_check(self, tmp_path: Path) -> None:
+        asset_root = _make_asset_root(tmp_path)
+
+        command = build_setup_command(
+            SetupOptions(check_only=True),
+            system_name="Linux",
+            asset_root=asset_root,
+        )
+
+        assert command == [
+            "bash",
+            str(asset_root / "system-setup.sh"),
+            "--check-only",
+            "--configure-runtime",
+        ]
+
+    def test_linux_no_configure_runtime_removes_flag(self, tmp_path: Path) -> None:
+        asset_root = _make_asset_root(tmp_path)
+
+        command = build_setup_command(
+            SetupOptions(check_only=True, configure_runtime=False, skip_deps=True),
+            system_name="Linux",
+            asset_root=asset_root,
+        )
+
+        assert command == [
+            "bash",
+            str(asset_root / "system-setup.sh"),
+            "--check-only",
+            "--skip-deps",
+        ]
+
+    def test_linux_remove_runtime_config_only_forwards_removal_args(self, tmp_path: Path) -> None:
+        asset_root = _make_asset_root(tmp_path)
+
+        command = build_setup_command(
+            SetupOptions(
+                check_only=True,
+                with_docker=True,
+                configure_runtime=False,
+                skip_deps=True,
+                runtime_user="aniket",
+                remove_runtime_config=True,
+            ),
+            system_name="Linux",
+            asset_root=asset_root,
+        )
+
+        assert command == [
+            "bash",
+            str(asset_root / "system-setup.sh"),
+            "--remove-runtime-config",
+            "--runtime-user",
+            "aniket",
+        ]
+
+    def test_macos_uses_macos_script_and_supported_flags_only(self, tmp_path: Path) -> None:
+        asset_root = _make_asset_root(tmp_path)
+
+        command = build_setup_command(
+            SetupOptions(check_only=True, with_docker=True, configure_runtime=False),
+            system_name="Darwin",
+            asset_root=asset_root,
+        )
+
+        assert command == [
+            "bash",
+            str(asset_root / "system-setup-macos.sh"),
+            "--check-only",
+            "--with-docker",
+        ]
+
+    def test_unsupported_os_fails(self, tmp_path: Path) -> None:
+        asset_root = _make_asset_root(tmp_path)
+
+        with pytest.raises(RuntimeError, match="supported only on Linux and macOS"):
+            build_setup_command(SetupOptions(), system_name="Windows", asset_root=asset_root)
+
+    def test_missing_asset_fails(self, tmp_path: Path) -> None:
+        asset_root = tmp_path / "assets"
+        asset_root.mkdir()
+
+        with pytest.raises(FileNotFoundError, match="Missing packaged setup asset"):
+            build_setup_command(SetupOptions(), system_name="Linux", asset_root=asset_root)
+
+
+class TestRunSetup:
+    """Tests for subprocess execution behavior."""
+
+    @patch("smolvm.setup.subprocess.run")
+    def test_child_exit_code_is_propagated(
+        self,
+        mock_run: MagicMock,
+        tmp_path: Path,
+    ) -> None:
+        asset_root = _make_asset_root(tmp_path)
+        mock_run.return_value = subprocess.CompletedProcess(
+            args=["bash", "system-setup.sh"],
+            returncode=7,
+        )
+
+        exit_code = run_setup(SetupOptions(), system_name="Linux", asset_root=asset_root)
+
+        assert exit_code == 7
+
+    @patch("smolvm.setup.subprocess.run")
+    def test_run_setup_inherits_stdio_and_does_not_capture_output(
+        self,
+        mock_run: MagicMock,
+        tmp_path: Path,
+    ) -> None:
+        asset_root = _make_asset_root(tmp_path)
+        mock_run.return_value = subprocess.CompletedProcess(
+            args=["bash", "system-setup.sh"],
+            returncode=0,
+        )
+
+        run_setup(SetupOptions(with_docker=True), system_name="Darwin", asset_root=asset_root)
+
+        mock_run.assert_called_once_with(
+            [
+                "bash",
+                str(asset_root / "system-setup-macos.sh"),
+                "--with-docker",
+            ],
+            check=False,
+        )

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -85,7 +85,7 @@ class TestRunCommand:
             stderr="sudo: a password is required",
         )
 
-        with pytest.raises(SmolVMError, match="--configure-runtime"):
+        with pytest.raises(SmolVMError, match="smolvm setup"):
             run_command(["ip", "link", "show"], use_sudo=True)
 
     @patch("smolvm.utils.os.geteuid", return_value=0)


### PR DESCRIPTION
## Summary

Add a first-class `smolvm setup` command that runs the packaged Linux or macOS host setup scripts from an installed wheel, including Linux flag validation and runtime-config handling. Update setup hints and onboarding docs to point users at `smolvm setup` instead of repo-local scripts, and add focused tests for command construction, CLI behavior, and updated remediation text.

## Related Issues

- None

## Testing

- `uv run --extra dev pytest tests/test_setup.py tests/test_cli.py tests/test_utils.py tests/test_build.py tests/test_vm.py`
- `uv run --extra dev ruff check src/smolvm/cli.py src/smolvm/setup.py tests/test_setup.py tests/test_cli.py tests/test_utils.py tests/test_build.py`
- `uv run --extra dev mypy src/smolvm/setup.py`
- `uvx hatch build`

## Checklist

- [x] Scope is focused and limited to this change
- [x] Tests added/updated for behavior changes
- [x] Docs updated for user-visible changes
- [x] No secrets or sensitive data included


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced `smolvm setup` CLI command with configuration options including `--check-only`, `--with-docker`, `--skip-deps`, `--no-configure-runtime`, `--remove-runtime-config`, and `--runtime-user`.

* **Documentation**
  * Simplified setup instructions in README and CONTRIBUTING with a unified `smolvm setup` command replacing OS-specific shell scripts.

* **Improvements**
  * Updated error messages throughout to reference `smolvm setup` for clearer user guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->