### PR TITLE
Fix QEMU boot disk naming and shutdown cleanup

### DIFF
--- a/src/smolvm/runtime_qemu.py
+++ b/src/smolvm/runtime_qemu.py
@@ -91,6 +91,13 @@ class QemuRuntimeAdapter(RuntimeAdapter):
 
         if vm_info.pid and self._context.is_process_running(vm_info.pid):
             self._context.kill_process(vm_info.pid)
+            self._context.wait_for_process(vm_info.pid, min(timeout, 5.0))
+
+        if vm_info.pid and self._context.is_process_running(vm_info.pid):
+            raise SmolVMError(
+                f"QEMU process did not exit for VM '{vm_info.vm_id}'",
+                {"pid": vm_info.pid},
+            )
 
         if vm_info.control_socket_path and vm_info.control_socket_path.exists():
             self._context.unlink_socket(vm_info.control_socket_path)
@@ -153,7 +160,9 @@ class QemuRuntimeAdapter(RuntimeAdapter):
     def restore_snapshot(self, request: SnapshotRestoreRequest) -> RuntimeLaunch:
         """Restore a QEMU snapshot from a copied managed qcow2 disk."""
         snapshot = request.snapshot
-        effective_config = snapshot.vm_config.model_copy(update={"rootfs_path": request.managed_disk_path})
+        effective_config = snapshot.vm_config.model_copy(
+            update={"rootfs_path": request.managed_disk_path}
+        )
         vm_info = VMInfo(
             vm_id=snapshot.vm_id,
             status=VMState.CREATED,

--- a/src/smolvm/vm.py
+++ b/src/smolvm/vm.py
@@ -33,7 +33,6 @@ from pathlib import Path
 from typing import Any, TextIO
 from uuid import uuid4
 
-from smolvm.api import FirecrackerClient
 from smolvm.backends import BACKEND_FIRECRACKER, BACKEND_QEMU, resolve_backend
 from smolvm.exceptions import (
     SmolVMError,
@@ -295,7 +294,9 @@ class SmolVMManager:
             find_qemu_binary=self._find_qemu_binary,
         )
 
-    def _runtime_adapter_for_backend(self, backend: str) -> FirecrackerRuntimeAdapter | QemuRuntimeAdapter:
+    def _runtime_adapter_for_backend(
+        self, backend: str
+    ) -> FirecrackerRuntimeAdapter | QemuRuntimeAdapter:
         """Construct a runtime adapter for the requested backend."""
         context = self._runtime_context()
         if backend == BACKEND_FIRECRACKER:
@@ -304,7 +305,9 @@ class SmolVMManager:
             return QemuRuntimeAdapter(context)
         raise SmolVMError("Unsupported backend", {"backend": backend})
 
-    def _runtime_adapter_for_vm(self, vm_info: VMInfo) -> FirecrackerRuntimeAdapter | QemuRuntimeAdapter:
+    def _runtime_adapter_for_vm(
+        self, vm_info: VMInfo
+    ) -> FirecrackerRuntimeAdapter | QemuRuntimeAdapter:
         """Resolve the runtime adapter for a persisted VM."""
         return self._runtime_adapter_for_backend(self._backend_for_vm(vm_info))
 
@@ -1030,7 +1033,9 @@ class SmolVMManager:
             restore_disk_path = self._restore_staging_disk_path(managed_disk_path)
         restore_vm_config = persisted_vm_config
         if restore_disk_path != managed_disk_path:
-            restore_vm_config = persisted_vm_config.model_copy(update={"rootfs_path": restore_disk_path})
+            restore_vm_config = persisted_vm_config.model_copy(
+                update={"rootfs_path": restore_disk_path}
+            )
         effective_snapshot = snapshot.model_copy(update={"vm_config": restore_vm_config})
         adapter = self._runtime_adapter_for_snapshot(effective_snapshot)
         created_vm_record = False
@@ -1328,9 +1333,10 @@ class SmolVMManager:
         system = platform.system()
 
         disk_format = "qcow2" if vm_info.config.rootfs_path.suffix == ".qcow2" else "raw"
+        root_drive_id = f"{root_node_name}-drive"
         drive_arg = (
             f"file={vm_info.config.rootfs_path},if=none,format={disk_format},"
-            f"id={root_node_name},node-name={root_node_name}"
+            f"id={root_drive_id},node-name={root_node_name}"
         )
         hostfwd_rules = [f"hostfwd=tcp:127.0.0.1:{ssh_port}-:22"]
         for forward in vm_info.config.port_forwards:
@@ -1376,7 +1382,7 @@ class SmolVMManager:
                     "-cpu",
                     cpu,
                     "-device",
-                    f"virtio-blk-device,drive={root_node_name}",
+                    f"virtio-blk-device,drive={root_drive_id}",
                     "-device",
                     f"virtio-net-device,netdev=net0,mac={guest_mac}",
                 ]
@@ -1391,7 +1397,7 @@ class SmolVMManager:
                     "-cpu",
                     cpu,
                     "-device",
-                    f"virtio-blk-pci,drive={root_node_name}",
+                    f"virtio-blk-pci,drive={root_drive_id}",
                     "-device",
                     f"virtio-net-pci,netdev=net0,mac={guest_mac}",
                 ]

--- a/tests/test_runtime_qemu.py
+++ b/tests/test_runtime_qemu.py
@@ -1,0 +1,100 @@
+"""Unit tests for the QEMU runtime adapter."""
+
+from pathlib import Path
+from unittest.mock import MagicMock, call, patch
+
+import pytest
+
+from smolvm.exceptions import SmolVMError
+from smolvm.runtime import RuntimeContext
+from smolvm.runtime_qemu import QemuRuntimeAdapter
+from smolvm.types import NetworkConfig, VMConfig, VMInfo, VMState
+
+
+def _make_context() -> RuntimeContext:
+    """Build a minimal runtime context with mockable process hooks."""
+    return RuntimeContext(
+        data_dir=Path("/tmp/data"),
+        socket_dir=Path("/tmp"),
+        log_files={},
+        resolve_boot_args=lambda vm_info: vm_info.config.boot_args,
+        start_firecracker=MagicMock(),
+        start_qemu=MagicMock(),
+        unlink_socket=MagicMock(),
+        kill_process=MagicMock(),
+        wait_for_process=MagicMock(),
+        is_process_running=MagicMock(),
+        find_qemu_binary=MagicMock(),
+    )
+
+
+def _make_vm_info(tmp_path: Path, *, pid: int = 12345) -> VMInfo:
+    """Create a minimal QEMU-backed VMInfo for adapter tests."""
+    kernel = tmp_path / "vmlinux"
+    rootfs = tmp_path / "rootfs.ext4"
+    socket_path = tmp_path / "qmp.sock"
+    kernel.touch()
+    rootfs.touch()
+    socket_path.touch()
+
+    return VMInfo(
+        vm_id="vm-qemu-stop",
+        status=VMState.RUNNING,
+        config=VMConfig(
+            vm_id="vm-qemu-stop",
+            kernel_path=kernel,
+            rootfs_path=rootfs,
+            backend="qemu",
+            boot_args="console=ttyAMA0 reboot=k panic=1 init=/init",
+        ),
+        network=NetworkConfig(
+            guest_ip="10.0.2.15",
+            gateway_ip="10.0.2.2",
+            netmask="255.255.255.0",
+            tap_device="usernet",
+            guest_mac="aa:fc:00:00:00:01",
+            ssh_host_port=2200,
+        ),
+        pid=pid,
+        control_socket_path=socket_path,
+    )
+
+
+def test_stop_waits_for_hard_kill_before_releasing_socket(tmp_path: Path) -> None:
+    """Forced QEMU termination should wait for exit before cleanup proceeds."""
+    context = _make_context()
+    context.is_process_running.side_effect = [True, True, False]
+    adapter = QemuRuntimeAdapter(context)
+    vm_info = _make_vm_info(tmp_path)
+
+    with patch("os.kill") as mock_os_kill:
+        adapter.stop(vm_info, timeout=10.0)
+
+    mock_os_kill.assert_called_once()
+    context.kill_process.assert_called_once_with(vm_info.pid)
+    assert context.wait_for_process.call_args_list == [
+        call(vm_info.pid, 10.0),
+        call(vm_info.pid, 5.0),
+    ]
+    context.unlink_socket.assert_called_once_with(vm_info.control_socket_path)
+
+
+def test_stop_raises_when_qemu_survives_hard_kill(tmp_path: Path) -> None:
+    """Cleanup should fail loudly if the QEMU process still has not exited."""
+    context = _make_context()
+    context.is_process_running.side_effect = [True, True, True]
+    adapter = QemuRuntimeAdapter(context)
+    vm_info = _make_vm_info(tmp_path)
+
+    with patch("os.kill") as mock_os_kill, pytest.raises(
+        SmolVMError, match="did not exit"
+    ):
+        adapter.stop(vm_info, timeout=10.0)
+
+    mock_os_kill.assert_called_once()
+    context.kill_process.assert_called_once_with(vm_info.pid)
+    assert context.wait_for_process.call_args_list == [
+        call(vm_info.pid, 10.0),
+        call(vm_info.pid, 5.0),
+    ]
+    context.unlink_socket.assert_not_called()

--- a/tests/test_vm_qemu.py
+++ b/tests/test_vm_qemu.py
@@ -69,6 +69,51 @@ def test_start_qemu_includes_configured_hostfwd_rules(
     assert "hostfwd=tcp:127.0.0.1:39012-:6080" in netdev_arg
 
 
+@patch("smolvm.vm.subprocess.Popen")
+@patch.object(
+    SmolVMManager,
+    "_find_qemu_binary",
+    return_value=Path("/opt/homebrew/bin/qemu-system-aarch64"),
+)
+def test_start_qemu_uses_distinct_block_backend_and_node_names(
+    _mock_find_qemu_binary: MagicMock,
+    mock_popen: MagicMock,
+    tmp_path: Path,
+) -> None:
+    """QEMU launch should not reuse the same name for backend id and block node."""
+    kernel = tmp_path / "vmlinux"
+    rootfs = tmp_path / "rootfs.ext4"
+    kernel.touch()
+    rootfs.touch()
+
+    config = VMConfig(
+        vm_id="vm-qemu-nodes",
+        kernel_path=kernel,
+        rootfs_path=rootfs,
+        backend="qemu",
+        boot_args="console=ttyAMA0 reboot=k panic=1 init=/init",
+    )
+
+    sdk = SmolVMManager(data_dir=tmp_path / "data", socket_dir=tmp_path / "sockets", backend="qemu")
+    with patch.object(SmolVMManager, "_convert_qemu_managed_disk") as mock_convert:
+        mock_convert.side_effect = lambda source, target: target.touch()
+        vm_info = sdk.create(config)
+
+    proc = MagicMock()
+    proc.pid = 12345
+    mock_popen.return_value = proc
+
+    with patch("smolvm.vm.platform.system", return_value="Darwin"):
+        sdk._start_qemu(vm_info, tmp_path / "vm-qemu-nodes.log")
+
+    cmd = mock_popen.call_args.args[0]
+    drive_arg = cmd[cmd.index("-drive") + 1]
+    block_device_arg = cmd[cmd.index("-device") + 1]
+    assert "id=rootdisk0-drive" in drive_arg
+    assert "node-name=rootdisk0" in drive_arg
+    assert block_device_arg == "virtio-blk-device,drive=rootdisk0-drive"
+
+
 def test_create_qemu_uses_managed_qcow2_disk(tmp_path: Path) -> None:
     """QEMU isolated disks should be materialized as managed qcow2 files."""
     kernel = tmp_path / "vmlinux"


### PR DESCRIPTION
## Summary

Fix QEMU boot disk configuration by using distinct backend and node identifiers so the root disk attaches correctly at launch. Harden QEMU shutdown cleanup by waiting for forced termination and raising if the process survives. Add regression coverage for both the launch command wiring and hard-kill stop path.

## Related Issues

- Closes #

## Testing

- `uv run pytest tests/test_vm_qemu.py tests/test_runtime_qemu.py`
- `uv run ruff check src/smolvm/runtime_qemu.py src/smolvm/vm.py tests/test_vm_qemu.py tests/test_runtime_qemu.py`
- `uv run mypy src` not run

## Checklist

- [x] Scope is focused and limited to this change
- [x] Tests added/updated for behavior changes
- [ ] Docs updated for user-visible changes
- [x] No secrets or sensitive data included


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  - Enhanced QEMU process shutdown handling with improved error detection and reporting when processes fail to terminate properly.
  - Fixed block device configuration for QEMU to ensure correct device mapping.

* **Tests**
  - Added unit tests for QEMU shutdown scenarios.
  - Added integration tests for QEMU block device configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->