### PR TITLE
Fix SmolVM port reservation, browser session durability, and QEMU shutdown behavior

### DIFF
--- a/src/smolvm/browser.py
+++ b/src/smolvm/browser.py
@@ -30,7 +30,7 @@ from smolvm.types import (
     VMConfig,
     VMState,
 )
-from smolvm.vm import resolve_data_dir
+from smolvm.vm import QEMU_HOST_PORT_FORWARD_PURPOSE, resolve_data_dir
 
 logger = logging.getLogger(__name__)
 
@@ -43,6 +43,8 @@ _BROWSER_GUEST_DOWNLOAD_ROOT = f"{_BROWSER_GUEST_ROOT}/downloads"
 _BROWSER_GUEST_ARTIFACT_ROOT = f"{_BROWSER_GUEST_ROOT}/artifacts"
 _BROWSER_GUEST_LOG_ROOT = "/var/log/smolvm-browser"
 _BROWSER_KERNEL_PROFILE = KernelBootProfile.MICROVM_DIRECT
+_BROWSER_DEBUG_PORT_PURPOSE = "browser-cdp"
+_BROWSER_LIVE_PORT_PURPOSE = "browser-live"
 
 
 def _generate_browser_session_id() -> str:
@@ -89,7 +91,7 @@ def _allocate_browser_host_port(exclude: set[int] | None = None) -> int:
 
 
 def _qemu_browser_port_forwards(config: BrowserSessionConfig) -> list[PortForwardConfig]:
-    """Return stable QEMU host forwards for browser endpoints."""
+    """Return placeholder QEMU host forwards for browser endpoints."""
     reserved: set[int] = set()
     debug_port = _allocate_browser_host_port(reserved)
     reserved.add(debug_port)
@@ -115,10 +117,10 @@ def _build_browser_vm_config(
 ) -> tuple[VMConfig, str | None]:
     """Build the underlying VM config for a browser session."""
     from smolvm.build import ImageBuilder
-    from smolvm.utils import ensure_ssh_key
+    from smolvm.utils import resolve_ssh_key_pair
 
     resolved_backend = resolve_backend(browser_config.backend)
-    private_key, public_key = ensure_ssh_key()
+    private_key, public_key = resolve_ssh_key_pair(ssh_key_path)
     resolved_ssh_key_path = ssh_key_path or str(private_key)
 
     builder = ImageBuilder()
@@ -176,6 +178,7 @@ class BrowserSession:
         self._ssh_key_path = ssh_key_path
         self._state = _browser_state_manager(self._data_dir)
         self._owns_session = False
+        self._qemu_browser_forwards_stable = False
         self._vm: SmolVM | None = None
         self._playwright_runtime: Any | None = None
 
@@ -221,16 +224,23 @@ class BrowserSession:
                 ssh_key_path=self._ssh_key_path,
             )
             self._ssh_key_path = resolved_ssh_key_path
+            create_vm_config = self._prepare_browser_vm_create_config(vm_config)
             vm = SmolVM(
-                vm_config,
+                create_vm_config,
                 data_dir=self._data_dir,
                 socket_dir=self._socket_dir,
                 ssh_key_path=self._ssh_key_path,
+            )
+            vm_config = self._configure_browser_vm_port_forwards(
+                vm,
+                session_config,
+                initial_config=vm_config,
             )
             info = BrowserSessionInfo(
                 session_id=session_id,
                 vm_id=vm.vm_id,
                 status=BrowserSessionState.CREATED,
+                debug_port=self._configured_browser_port(vm_config, _BROWSER_DEBUG_PORT),
                 profile_id=session_config.profile_id,
                 expires_at=expires_at,
                 artifacts_dir=artifacts_dir,
@@ -268,6 +278,8 @@ class BrowserSession:
                 exc_info=True,
             )
             self._vm = None
+        else:
+            self._qemu_browser_forwards_stable = self._has_stable_qemu_browser_forwards()
 
     @property
     def session_id(self) -> str:
@@ -292,12 +304,14 @@ class BrowserSession:
     @property
     def cdp_url(self) -> str | None:
         """HTTP CDP endpoint exposed on localhost."""
-        return self._info.cdp_url
+        return self._current_browser_url(_BROWSER_DEBUG_PORT, ensure_exposed=False)
 
     @property
     def live_url(self) -> str | None:
         """Optional live-view URL exposed on localhost."""
-        return self._info.live_url
+        if self._session_config.mode != "live":
+            return None
+        return self._current_browser_url(_BROWSER_LIVE_PORT, ensure_exposed=False)
 
     @property
     def artifacts_dir(self) -> Path | None:
@@ -355,8 +369,11 @@ class BrowserSession:
                 raise SmolVMError(
                     f"Browser session '{self.session_id}' did not expose a CDP port in time."
                 )
-            debug_host_port = self._resolve_browser_host_port(_BROWSER_DEBUG_PORT)
-            cdp_url = f"http://127.0.0.1:{debug_host_port}"
+            debug_host_port = self._resolve_browser_host_port(
+                _BROWSER_DEBUG_PORT,
+                ensure_exposed=True,
+            )
+            cdp_url = self._browser_url(_BROWSER_DEBUG_PORT, debug_host_port)
 
             live_url: str | None = None
             if self._session_config.mode == "live":
@@ -364,8 +381,11 @@ class BrowserSession:
                     raise SmolVMError(
                         f"Browser session '{self.session_id}' did not expose a live view in time."
                     )
-                live_host_port = self._resolve_browser_host_port(_BROWSER_LIVE_PORT)
-                live_url = f"http://127.0.0.1:{live_host_port}/vnc.html?autoconnect=1&resize=scale"
+                live_host_port = self._resolve_browser_host_port(
+                    _BROWSER_LIVE_PORT,
+                    ensure_exposed=True,
+                )
+                live_url = self._browser_url(_BROWSER_LIVE_PORT, live_host_port)
 
             self._info = self._state.update_browser_session(
                 self.session_id,
@@ -415,7 +435,8 @@ class BrowserSession:
 
     def connect_playwright(self) -> Any:
         """Connect Playwright to the browser session over CDP."""
-        if self._info.cdp_url is None:
+        cdp_url = self._current_browser_url(_BROWSER_DEBUG_PORT, ensure_exposed=True)
+        if cdp_url is None:
             raise SmolVMError("Browser session is not ready; start it before connecting.")
 
         try:
@@ -428,7 +449,13 @@ class BrowserSession:
         if self._playwright_runtime is None:
             self._playwright_runtime = sync_playwright().start()
 
-        return self._playwright_runtime.chromium.connect_over_cdp(self._info.cdp_url)
+        if cdp_url != self._info.cdp_url:
+            self._info = self._state.update_browser_session(
+                self.session_id,
+                cdp_url=cdp_url,
+            )
+
+        return self._playwright_runtime.chromium.connect_over_cdp(cdp_url)
 
     def screenshot(
         self,
@@ -451,9 +478,15 @@ class BrowserSession:
 
     def open_live_view(self) -> bool:
         """Open the live-view URL in the local default browser."""
-        if self._info.live_url is None:
+        live_url = self._current_browser_url(_BROWSER_LIVE_PORT, ensure_exposed=True)
+        if live_url is None:
             raise SmolVMError("This browser session does not expose a live_url.")
-        return webbrowser.open(self._info.live_url)
+        if live_url != self._info.live_url:
+            self._info = self._state.update_browser_session(
+                self.session_id,
+                live_url=live_url,
+            )
+        return webbrowser.open(live_url)
 
     def push_file(self, local_path: str | Path, guest_path: str) -> None:
         """Upload a file into the guest using the session SSH channel."""
@@ -575,17 +608,166 @@ class BrowserSession:
                 f"Failed to launch guest browser: {result.stderr.strip() or result.stdout}"
             )
 
-    def _resolve_browser_host_port(self, guest_port: int) -> int:
-        """Return a localhost port that exposes a browser guest port.
+    @staticmethod
+    def _prepare_browser_vm_create_config(vm_config: VMConfig) -> VMConfig:
+        """Strip placeholder QEMU port forwards before VM creation."""
+        if resolve_backend(vm_config.backend) != BACKEND_QEMU or not vm_config.port_forwards:
+            return vm_config
+        return vm_config.model_copy(update={"port_forwards": []})
 
-        Browser services such as Chromium's DevTools endpoint can bind guest
-        loopback only. Route them through ``expose_local()`` so SmolVM can
-        fall back to an SSH tunnel when direct guest networking is not enough.
-        """
+    def _configure_browser_vm_port_forwards(
+        self,
+        vm: SmolVM,
+        session_config: BrowserSessionConfig,
+        *,
+        initial_config: VMConfig,
+    ) -> VMConfig:
+        """Persist stable browser endpoint forwards for QEMU-backed sessions."""
+        if resolve_backend(initial_config.backend) != BACKEND_QEMU:
+            return initial_config
+
+        try:
+            forwards = [
+                PortForwardConfig(
+                    host_port=self._state.reserve_host_port(
+                        vm.vm_id,
+                        _BROWSER_DEBUG_PORT,
+                        purpose=QEMU_HOST_PORT_FORWARD_PURPOSE,
+                    ),
+                    guest_port=_BROWSER_DEBUG_PORT,
+                )
+            ]
+            if session_config.mode == "live":
+                forwards.append(
+                    PortForwardConfig(
+                        host_port=self._state.reserve_host_port(
+                            vm.vm_id,
+                            _BROWSER_LIVE_PORT,
+                            purpose=QEMU_HOST_PORT_FORWARD_PURPOSE,
+                        ),
+                        guest_port=_BROWSER_LIVE_PORT,
+                    )
+                )
+
+            updated_config = initial_config.model_copy(update={"port_forwards": forwards})
+            self._state.update_vm(vm.vm_id, config=updated_config)
+            vm.refresh()
+            self._qemu_browser_forwards_stable = True
+            return updated_config
+        except Exception:
+            self._qemu_browser_forwards_stable = False
+            return initial_config
+
+    def _has_stable_qemu_browser_forwards(self) -> bool:
+        """Return whether this session can rely on persisted QEMU host forwards."""
+        if self._browser_backend() != BACKEND_QEMU or self._vm is None:
+            return False
+
+        try:
+            vm_config = self._vm.refresh().info.config
+        except Exception:
+            return False
+
+        required_ports = {_BROWSER_DEBUG_PORT}
+        if self._session_config.mode == "live":
+            required_ports.add(_BROWSER_LIVE_PORT)
+        forwarded_ports = {forward.guest_port for forward in vm_config.port_forwards}
+        return required_ports.issubset(forwarded_ports)
+
+    @staticmethod
+    def _configured_browser_port(vm_config: VMConfig, guest_port: int) -> int | None:
+        """Return one configured browser host port from persisted VM config."""
+        for forward in vm_config.port_forwards:
+            if forward.guest_port == guest_port:
+                return forward.host_port
+        return None
+
+    def _stable_qemu_browser_host_port(self, guest_port: int) -> int:
+        """Return a persisted QEMU browser host port."""
         if self._vm is None:
             raise SmolVMError("Browser session VM is unavailable.")
 
-        return self._vm.expose_local(guest_port=guest_port)
+        vm_info = self._vm.refresh().info
+        for forward in vm_info.config.port_forwards:
+            if forward.guest_port == guest_port:
+                return forward.host_port
+
+        raise SmolVMError(
+            f"Browser session '{self.session_id}' does not have a QEMU forward for guest port "
+            f"{guest_port}."
+        )
+
+    def _resolve_browser_host_port(self, guest_port: int, *, ensure_exposed: bool) -> int:
+        """Return the stable host port for a browser guest port."""
+        if self._vm is None:
+            raise SmolVMError("Browser session VM is unavailable.")
+
+        if self._browser_backend() == BACKEND_QEMU:
+            if self._qemu_browser_forwards_stable:
+                return self._stable_qemu_browser_host_port(guest_port)
+            if ensure_exposed:
+                return self._vm.expose_local(guest_port=guest_port)
+            raise SmolVMError(
+                f"Browser session '{self.session_id}' does not have a durable QEMU forward for "
+                f"guest port {guest_port}."
+            )
+
+        purpose = self._browser_port_purpose(guest_port)
+        host_port = self._state.get_host_port(self.vm_id, guest_port, purpose=purpose)
+        if host_port is None:
+            host_port = self._state.reserve_host_port(
+                self.vm_id,
+                guest_port,
+                purpose=purpose,
+            )
+        if ensure_exposed:
+            return self._vm.expose_local(guest_port=guest_port, host_port=host_port)
+        return host_port
+
+    def _current_browser_url(self, guest_port: int, *, ensure_exposed: bool) -> str | None:
+        """Return the current browser endpoint URL for a guest port."""
+        if guest_port == _BROWSER_LIVE_PORT and self._session_config.mode != "live":
+            return None
+
+        fallback = self._info.cdp_url if guest_port == _BROWSER_DEBUG_PORT else self._info.live_url
+        if self._info.status != BrowserSessionState.READY:
+            return fallback
+
+        try:
+            host_port = self._resolve_browser_host_port(
+                guest_port,
+                ensure_exposed=ensure_exposed,
+            )
+        except Exception:
+            if ensure_exposed:
+                raise
+            return fallback
+        return self._browser_url(guest_port, host_port)
+
+    def _browser_backend(self) -> str:
+        """Return the resolved runtime backend for this browser session."""
+        if self._vm is not None:
+            with suppress(Exception):
+                return resolve_backend(self._vm.info.config.backend)
+        return resolve_backend(self._session_config.backend)
+
+    @staticmethod
+    def _browser_port_purpose(guest_port: int) -> str:
+        """Return the reservation purpose label for one browser endpoint."""
+        if guest_port == _BROWSER_DEBUG_PORT:
+            return _BROWSER_DEBUG_PORT_PURPOSE
+        if guest_port == _BROWSER_LIVE_PORT:
+            return _BROWSER_LIVE_PORT_PURPOSE
+        raise ValueError(f"Unsupported browser guest port: {guest_port}")
+
+    @staticmethod
+    def _browser_url(guest_port: int, host_port: int) -> str:
+        """Build a host URL for a browser guest port."""
+        if guest_port == _BROWSER_DEBUG_PORT:
+            return f"http://127.0.0.1:{host_port}"
+        if guest_port == _BROWSER_LIVE_PORT:
+            return f"http://127.0.0.1:{host_port}/vnc.html?autoconnect=1&resize=scale"
+        raise ValueError(f"Unsupported browser guest port: {guest_port}")
 
     def _wait_for_guest_port(self, port: int, *, timeout: float) -> bool:
         if self._vm is None:

--- a/src/smolvm/facade.py
+++ b/src/smolvm/facade.py
@@ -58,6 +58,7 @@ _LOCAL_FORWARD_PROBE_TIMEOUT = 2.0
 _LOCAL_FORWARD_PROBE_INTERVAL = 0.2
 _LOCAL_TUNNEL_START_TIMEOUT = 10.0
 _LOCAL_FORWARD_MAX_PORT_ATTEMPTS = 10
+_LOCAL_FORWARD_RESERVATION_PURPOSE = "local-forward"
 
 
 def _build_auto_config(
@@ -70,7 +71,7 @@ def _build_auto_config(
 ) -> tuple[VMConfig, str | None]:
     """Build the default SSH-ready VM config used by zero-config flows."""
     from smolvm.build import ImageBuilder
-    from smolvm.utils import ensure_ssh_key
+    from smolvm.utils import resolve_ssh_key_pair
 
     resolved_backend = resolve_backend(backend)
     kernel_profile = KernelBootProfile.MICROVM_DIRECT
@@ -79,7 +80,7 @@ def _build_auto_config(
         platform.machine(),
     )
 
-    private_key, public_key = ensure_ssh_key()
+    private_key, public_key = resolve_ssh_key_pair(ssh_key_path)
     resolved_ssh_key_path = ssh_key_path or str(private_key)
 
     resolved_mem_size_mib = 512 if mem_size_mib is None else mem_size_mib
@@ -610,26 +611,59 @@ class SmolVM:
             raise ValueError("guest_port must be 1-65535")
 
         requested_port = host_port
-        if host_port is None:
-            host_port = self._allocate_local_port()
-        if host_port < 1 or host_port > 65535:
+        if host_port is not None and (host_port < 1 or host_port > 65535):
             raise ValueError("host_port must be 1-65535")
 
-        initial_key = (host_port, guest_port)
-        existing = self._local_forwards.get(initial_key)
-        if existing is not None:
-            return existing.host_port
-
-        candidate_ports = [host_port]
-        fallback_port = self._allocate_local_port({host_port})
-        if fallback_port != host_port:
-            candidate_ports.append(fallback_port)
+        if requested_port is None:
+            for tracked in self._local_forwards.values():
+                if tracked.guest_port == guest_port:
+                    return tracked.host_port
+        else:
+            existing = self._local_forwards.get((requested_port, guest_port))
+            if existing is not None:
+                return existing.host_port
 
         guest_ip = self._info.network.guest_ip
         attempts: list[str] = []
         should_try_nftables = self._should_try_nftables_local_forward()
 
+        candidate_ports: list[int] = []
+        if requested_port is not None:
+            candidate_ports.append(requested_port)
+            fallback_port = self._allocate_local_port({requested_port})
+            if fallback_port != requested_port:
+                candidate_ports.append(fallback_port)
+        else:
+            existing_reserved = self._sdk.state.get_host_port(
+                self._vm_id,
+                guest_port,
+                purpose=_LOCAL_FORWARD_RESERVATION_PURPOSE,
+            )
+            if isinstance(existing_reserved, int):
+                candidate_ports.append(existing_reserved)
+            else:
+                candidate_ports.append(self._allocate_local_port())
+            fallback_port = self._allocate_local_port(set(candidate_ports))
+            if fallback_port not in candidate_ports:
+                candidate_ports.append(fallback_port)
+
         for candidate in candidate_ports:
+            try:
+                reserved_port = self._sdk.state.reserve_host_port(
+                    self._vm_id,
+                    guest_port,
+                    purpose=_LOCAL_FORWARD_RESERVATION_PURPOSE,
+                    host_port=candidate,
+                )
+                if isinstance(reserved_port, int):
+                    candidate = reserved_port
+            except Exception as e:
+                attempts.append(
+                    "host-port reservation failed for "
+                    f"guest:{guest_port} request={candidate}: {e}"
+                )
+                continue
+
             key = (candidate, guest_port)
             existing = self._local_forwards.get(key)
             if existing is not None:
@@ -637,6 +671,7 @@ class SmolVM:
 
             if any(forward.host_port == candidate for forward in self._local_forwards.values()):
                 attempts.append(f"localhost:{candidate} already exposed by this VM instance")
+                self._release_local_forward_reservation(guest_port, host_port=candidate)
                 continue
 
             nftables_configured = False
@@ -704,6 +739,7 @@ class SmolVM:
                 attempts.append(
                     f"ssh tunnel localhost:{candidate} -> guest:{guest_port} failed: {e}"
                 )
+                self._release_local_forward_reservation(guest_port, host_port=candidate)
                 continue
 
         context = {
@@ -729,7 +765,7 @@ class SmolVM:
         key = (host_port, guest_port)
         tracked = self._local_forwards.pop(key, None)
         if tracked is not None:
-            self._cleanup_local_forward(tracked)
+            self._cleanup_local_forward(tracked, release_reservation=True)
             return self
 
         self._refresh_info()
@@ -745,6 +781,7 @@ class SmolVM:
             host_port=host_port,
             guest_port=guest_port,
         )
+        self._release_local_forward_reservation(guest_port, host_port=host_port)
         return self
 
     # ------------------------------------------------------------------
@@ -804,6 +841,7 @@ class SmolVM:
 
     def close(self) -> None:
         """Release underlying SDK resources for this facade instance."""
+        self._cleanup_local_forwards()
         self._sdk.close()
 
     # ------------------------------------------------------------------
@@ -1100,7 +1138,11 @@ class SmolVM:
 
         for key, tracked in list(self._local_forwards.items()):
             try:
-                self._cleanup_local_forward(tracked, guest_ip=guest_ip)
+                self._cleanup_local_forward(
+                    tracked,
+                    guest_ip=guest_ip,
+                    release_reservation=False,
+                )
             except Exception:
                 logger.warning(
                     "Failed to cleanup local forward localhost:%d -> guest:%d for VM %s",
@@ -1254,34 +1296,54 @@ class SmolVM:
         forward: _LocalForward,
         *,
         guest_ip: str | None = None,
+        release_reservation: bool = False,
     ) -> None:
         """Remove one tracked localhost exposure."""
         if forward.transport == "ssh_tunnel":
             self._stop_local_tunnel(forward.tunnel_proc)
-            return
+        else:
+            if guest_ip is None:
+                with suppress(Exception):
+                    self._refresh_info()
+                    if self._info.network is not None:
+                        guest_ip = self._info.network.guest_ip
 
-        if guest_ip is None:
-            with suppress(Exception):
-                self._refresh_info()
-                if self._info.network is not None:
-                    guest_ip = self._info.network.guest_ip
+            if guest_ip is None:
+                logger.warning(
+                    "Skipping nftables cleanup for localhost:%d -> guest:%d on VM %s "
+                    "because guest network info is unavailable",
+                    forward.host_port,
+                    forward.guest_port,
+                    self._vm_id,
+                )
+            else:
+                self._sdk.network.cleanup_local_port_forward(
+                    vm_id=self._vm_id,
+                    guest_ip=guest_ip,
+                    host_port=forward.host_port,
+                    guest_port=forward.guest_port,
+                )
 
-        if guest_ip is None:
-            logger.warning(
-                "Skipping nftables cleanup for localhost:%d -> guest:%d on VM %s "
-                "because guest network info is unavailable",
-                forward.host_port,
+        if release_reservation:
+            self._release_local_forward_reservation(
                 forward.guest_port,
-                self._vm_id,
+                host_port=forward.host_port,
             )
-            return
 
-        self._sdk.network.cleanup_local_port_forward(
-            vm_id=self._vm_id,
-            guest_ip=guest_ip,
-            host_port=forward.host_port,
-            guest_port=forward.guest_port,
-        )
+    def _release_local_forward_reservation(
+        self,
+        guest_port: int,
+        *,
+        host_port: int | None = None,
+    ) -> None:
+        """Release one reserved localhost exposure mapping."""
+        with suppress(Exception):
+            self._sdk.state.release_host_port(
+                self._vm_id,
+                guest_port,
+                purpose=_LOCAL_FORWARD_RESERVATION_PURPOSE,
+                host_port=host_port,
+            )
 
     def _command_exec_remediation(self) -> str:
         """Return actionable guidance when command execution is unavailable."""

--- a/src/smolvm/storage.py
+++ b/src/smolvm/storage.py
@@ -20,6 +20,7 @@ Uses exclusive transactions to prevent race conditions in IP assignment.
 
 import json
 import logging
+import socket
 import sqlite3
 from collections.abc import Iterator
 from contextlib import contextmanager
@@ -57,6 +58,10 @@ IP_PREFIX = "172.16.0."
 SSH_PORT_START = 2200
 SSH_PORT_END = 2999
 
+# Generic host-port reservation pool for non-SSH forwards.
+HOST_PORT_START = 39000
+HOST_PORT_END = 48999
+
 
 class StateManager:
     """Manages persistent state for VMs and IP allocations.
@@ -82,7 +87,7 @@ class StateManager:
         """Get a database connection with proper isolation.
 
         Args:
-            exclusive: If True, use exclusive transaction for writes.
+            exclusive: If True, acquire a write lock before any reads.
 
         Yields:
             SQLite connection with row factory set.
@@ -90,11 +95,12 @@ class StateManager:
         conn = sqlite3.connect(
             str(self.db_path),
             timeout=30.0,
-            isolation_level="EXCLUSIVE" if exclusive else "DEFERRED",
+            isolation_level=None,
         )
         conn.execute("PRAGMA foreign_keys = ON")
         conn.row_factory = sqlite3.Row
         try:
+            conn.execute("BEGIN IMMEDIATE" if exclusive else "BEGIN")
             yield conn
             conn.commit()
         except Exception:
@@ -141,6 +147,23 @@ class StateManager:
                 CREATE INDEX IF NOT EXISTS idx_ssh_forwards_vm_id ON ssh_forwards(vm_id);
                 CREATE INDEX IF NOT EXISTS idx_ssh_forwards_host_port ON ssh_forwards(host_port);
 
+                CREATE TABLE IF NOT EXISTS host_port_reservations (
+                    id INTEGER PRIMARY KEY AUTOINCREMENT,
+                    vm_id TEXT NOT NULL,
+                    host_address TEXT NOT NULL,
+                    host_port INTEGER NOT NULL UNIQUE,
+                    guest_port INTEGER NOT NULL,
+                    purpose TEXT NOT NULL,
+                    created_at TEXT NOT NULL,
+                    UNIQUE(vm_id, host_address, guest_port, purpose),
+                    FOREIGN KEY (vm_id) REFERENCES vms(id) ON DELETE CASCADE
+                );
+
+                CREATE INDEX IF NOT EXISTS idx_host_port_reservations_vm_id
+                    ON host_port_reservations(vm_id);
+                CREATE INDEX IF NOT EXISTS idx_host_port_reservations_host_port
+                    ON host_port_reservations(host_port);
+
                 CREATE TABLE IF NOT EXISTS browser_sessions (
                     session_id TEXT PRIMARY KEY,
                     vm_id TEXT NOT NULL UNIQUE,
@@ -177,6 +200,29 @@ class StateManager:
                 CREATE INDEX IF NOT EXISTS idx_snapshots_vm_id ON snapshots(vm_id);
             """
             )
+
+    @staticmethod
+    def _is_host_port_available(host_address: str, host_port: int) -> bool:
+        """Return whether a TCP host port is currently bindable."""
+        try:
+            with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
+                sock.bind((host_address, host_port))
+        except OSError:
+            return False
+        return True
+
+    @staticmethod
+    def _allocated_host_ports(conn: sqlite3.Connection) -> set[int]:
+        """Return all host ports reserved across SSH and generic forwards."""
+        allocated = {
+            int(row["host_port"])
+            for row in conn.execute("SELECT host_port FROM ssh_forwards").fetchall()
+        }
+        allocated.update(
+            int(row["host_port"])
+            for row in conn.execute("SELECT host_port FROM host_port_reservations").fetchall()
+        )
+        return allocated
 
     def create_vm(self, config: VMConfig) -> VMInfo:
         """Create a new VM record.
@@ -257,6 +303,7 @@ class StateManager:
         self,
         vm_id: str,
         *,
+        config: VMConfig | None = None,
         status: VMState | None = None,
         network: NetworkConfig | None = None,
         pid: int | None = None,
@@ -268,6 +315,7 @@ class StateManager:
 
         Args:
             vm_id: The VM identifier.
+            config: Replacement VM configuration (optional).
             status: New status (optional).
             network: Network configuration (optional).
             pid: Process ID (optional).
@@ -295,6 +343,10 @@ class StateManager:
             # Build update query dynamically
             updates = ["updated_at = ?"]
             params: list = [now]
+
+            if config is not None:
+                updates.append("config = ?")
+                params.append(config.model_dump_json())
 
             if status is not None:
                 updates.append("status = ?")
@@ -880,8 +932,7 @@ class StateManager:
                     )
                 return existing_host_port
 
-            allocated = conn.execute("SELECT host_port FROM ssh_forwards").fetchall()
-            allocated_set = {int(row["host_port"]) for row in allocated}
+            allocated_set = self._allocated_host_ports(conn)
 
             candidate_ports = [host_port] if host_port is not None else range(
                 SSH_PORT_START, SSH_PORT_END + 1
@@ -889,13 +940,25 @@ class StateManager:
             for candidate_port in candidate_ports:
                 if candidate_port in allocated_set:
                     continue
-                conn.execute(
-                    """
-                    INSERT INTO ssh_forwards (vm_id, host_port, guest_port, created_at)
-                    VALUES (?, ?, ?, ?)
-                    """,
-                    (vm_id, candidate_port, guest_port, now),
-                )
+                if not self._is_host_port_available("127.0.0.1", candidate_port):
+                    if host_port is not None:
+                        raise NetworkError(f"Requested SSH host port {host_port} is not available")
+                    continue
+                try:
+                    conn.execute(
+                        """
+                        INSERT INTO ssh_forwards (vm_id, host_port, guest_port, created_at)
+                        VALUES (?, ?, ?, ?)
+                        """,
+                        (vm_id, candidate_port, guest_port, now),
+                    )
+                except sqlite3.IntegrityError:
+                    if host_port is not None:
+                        raise NetworkError(
+                            f"Requested SSH host port {host_port} is not available"
+                        ) from None
+                    allocated_set.add(candidate_port)
+                    continue
                 logger.info("Reserved SSH host port %d for VM %s", candidate_port, vm_id)
                 return candidate_port
 
@@ -938,6 +1001,233 @@ class StateManager:
             result = conn.execute("DELETE FROM ssh_forwards WHERE vm_id = ?", (vm_id,))
             if result.rowcount > 0:
                 logger.info("Released SSH host port for VM: %s", vm_id)
+
+    def reserve_host_port(
+        self,
+        vm_id: str,
+        guest_port: int,
+        *,
+        purpose: str,
+        host_port: int | None = None,
+        host_address: str = "127.0.0.1",
+        port_start: int = HOST_PORT_START,
+        port_end: int = HOST_PORT_END,
+        exclude_ports: set[int] | None = None,
+    ) -> int:
+        """Reserve a host TCP port for a non-SSH guest service."""
+        if not vm_id:
+            raise ValueError("vm_id cannot be empty")
+        if guest_port < 1 or guest_port > 65535:
+            raise ValueError("guest_port must be 1-65535")
+        if not purpose:
+            raise ValueError("purpose cannot be empty")
+        if not host_address:
+            raise ValueError("host_address cannot be empty")
+        if port_start < 1 or port_start > 65535 or port_end < 1 or port_end > 65535:
+            raise ValueError("port range must be 1-65535")
+        if port_start > port_end:
+            raise ValueError("port_start cannot be greater than port_end")
+        excluded_ports = set(exclude_ports or ())
+
+        now = datetime.now(timezone.utc).isoformat()
+
+        with self._get_connection(exclusive=True) as conn:
+            existing = conn.execute(
+                """
+                SELECT host_port FROM host_port_reservations
+                WHERE vm_id = ? AND host_address = ? AND guest_port = ? AND purpose = ?
+                """,
+                (vm_id, host_address, guest_port, purpose),
+            ).fetchone()
+            if existing:
+                existing_host_port = int(existing["host_port"])
+                if host_port is not None and existing_host_port != host_port:
+                    raise NetworkError(
+                        f"VM {vm_id} already reserves host port {existing_host_port} "
+                        f"for guest port {guest_port} ({purpose}), cannot reserve {host_port}"
+                    )
+                return existing_host_port
+
+            allocated_set = self._allocated_host_ports(conn) | excluded_ports
+            candidate_ports = [host_port] if host_port is not None else range(port_start, port_end + 1)
+            for candidate_port in candidate_ports:
+                if candidate_port in allocated_set:
+                    continue
+                if not self._is_host_port_available(host_address, candidate_port):
+                    if host_port is not None:
+                        raise NetworkError(f"Requested host port {host_port} is not available")
+                    continue
+                try:
+                    conn.execute(
+                        """
+                        INSERT INTO host_port_reservations (
+                            vm_id, host_address, host_port, guest_port, purpose, created_at
+                        )
+                        VALUES (?, ?, ?, ?, ?, ?)
+                        """,
+                        (vm_id, host_address, candidate_port, guest_port, purpose, now),
+                    )
+                except sqlite3.IntegrityError:
+                    if host_port is not None:
+                        raise NetworkError(
+                            f"Requested host port {host_port} is not available"
+                        ) from None
+                    allocated_set.add(candidate_port)
+                    continue
+                logger.info(
+                    "Reserved host port %d for VM %s (guest=%d, purpose=%s)",
+                    candidate_port,
+                    vm_id,
+                    guest_port,
+                    purpose,
+                )
+                return candidate_port
+
+        if host_port is not None:
+            raise NetworkError(f"Requested host port {host_port} is not available")
+        raise NetworkError("No host ports available in pool")
+
+    def get_host_port(
+        self,
+        vm_id: str,
+        guest_port: int,
+        *,
+        purpose: str,
+        host_address: str = "127.0.0.1",
+    ) -> int | None:
+        """Return the reserved host port for a guest port/purpose mapping."""
+        if not vm_id:
+            raise ValueError("vm_id cannot be empty")
+        if guest_port < 1 or guest_port > 65535:
+            raise ValueError("guest_port must be 1-65535")
+        if not purpose:
+            raise ValueError("purpose cannot be empty")
+        if not host_address:
+            raise ValueError("host_address cannot be empty")
+
+        with self._get_connection() as conn:
+            row = conn.execute(
+                """
+                SELECT host_port FROM host_port_reservations
+                WHERE vm_id = ? AND host_address = ? AND guest_port = ? AND purpose = ?
+                """,
+                (vm_id, host_address, guest_port, purpose),
+            ).fetchone()
+
+        if row:
+            return int(row["host_port"])
+        return None
+
+    def list_host_ports(
+        self,
+        vm_id: str,
+        *,
+        purpose: str | None = None,
+    ) -> list[tuple[int, int, str, str]]:
+        """List reserved non-SSH host ports for a VM."""
+        if not vm_id:
+            raise ValueError("vm_id cannot be empty")
+
+        with self._get_connection() as conn:
+            if purpose is None:
+                rows = conn.execute(
+                    """
+                    SELECT host_port, guest_port, purpose, host_address
+                    FROM host_port_reservations
+                    WHERE vm_id = ?
+                    ORDER BY host_port
+                    """,
+                    (vm_id,),
+                ).fetchall()
+            else:
+                rows = conn.execute(
+                    """
+                    SELECT host_port, guest_port, purpose, host_address
+                    FROM host_port_reservations
+                    WHERE vm_id = ? AND purpose = ?
+                    ORDER BY host_port
+                    """,
+                    (vm_id, purpose),
+                ).fetchall()
+
+        return [
+            (int(row["host_port"]), int(row["guest_port"]), str(row["purpose"]), str(row["host_address"]))
+            for row in rows
+        ]
+
+    def release_host_port(
+        self,
+        vm_id: str,
+        guest_port: int,
+        *,
+        purpose: str,
+        host_address: str = "127.0.0.1",
+        host_port: int | None = None,
+    ) -> None:
+        """Release one reserved non-SSH host port mapping."""
+        if not vm_id:
+            raise ValueError("vm_id cannot be empty")
+        if guest_port < 1 or guest_port > 65535:
+            raise ValueError("guest_port must be 1-65535")
+        if not purpose:
+            raise ValueError("purpose cannot be empty")
+        if not host_address:
+            raise ValueError("host_address cannot be empty")
+
+        with self._get_connection(exclusive=True) as conn:
+            if host_port is None:
+                result = conn.execute(
+                    """
+                    DELETE FROM host_port_reservations
+                    WHERE vm_id = ? AND host_address = ? AND guest_port = ? AND purpose = ?
+                    """,
+                    (vm_id, host_address, guest_port, purpose),
+                )
+            else:
+                result = conn.execute(
+                    """
+                    DELETE FROM host_port_reservations
+                    WHERE vm_id = ? AND host_address = ? AND guest_port = ?
+                      AND purpose = ? AND host_port = ?
+                    """,
+                    (vm_id, host_address, guest_port, purpose, host_port),
+                )
+            if result.rowcount > 0:
+                logger.info(
+                    "Released reserved host port mapping for VM %s "
+                    "(guest=%d, purpose=%s, host_port=%s)",
+                    vm_id,
+                    guest_port,
+                    purpose,
+                    "*" if host_port is None else host_port,
+                )
+
+    def release_host_ports(self, vm_id: str, *, purpose: str | None = None) -> None:
+        """Release reserved non-SSH host ports for a VM."""
+        if not vm_id:
+            raise ValueError("vm_id cannot be empty")
+
+        with self._get_connection(exclusive=True) as conn:
+            if purpose is None:
+                result = conn.execute(
+                    "DELETE FROM host_port_reservations WHERE vm_id = ?",
+                    (vm_id,),
+                )
+            else:
+                result = conn.execute(
+                    """
+                    DELETE FROM host_port_reservations
+                    WHERE vm_id = ? AND purpose = ?
+                    """,
+                    (vm_id, purpose),
+                )
+            if result.rowcount > 0:
+                logger.info(
+                    "Released %d reserved host port(s) for VM %s%s",
+                    result.rowcount,
+                    vm_id,
+                    "" if purpose is None else f" (purpose={purpose})",
+                )
 
     def reconcile(self) -> list[str]:
         """Check for stale VMs (marked RUNNING/PAUSED but process is dead).

--- a/src/smolvm/utils.py
+++ b/src/smolvm/utils.py
@@ -223,3 +223,31 @@ def ensure_ssh_key(key_dir: Path | None = None) -> tuple[Path, Path]:
         os.chown(public_key, sudo_uid, sudo_gid)
 
     return private_key, public_key
+
+
+def resolve_ssh_keypair(ssh_key_path: str | Path | None = None) -> tuple[Path, Path]:
+    """Resolve the SSH key pair used for guest authorization and client access."""
+    if ssh_key_path is None:
+        return ensure_ssh_key()
+
+    private_key = Path(ssh_key_path).expanduser()
+    if not private_key.exists():
+        raise SmolVMError(f"SSH private key does not exist: {private_key}")
+    if not private_key.is_file():
+        raise SmolVMError(f"SSH private key is not a file: {private_key}")
+
+    public_key = private_key.with_name(f"{private_key.name}.pub")
+    if not public_key.exists():
+        raise SmolVMError(
+            "Custom ssh_key_path requires a matching public key file.\n"
+            f"Expected: {public_key}"
+        )
+    if not public_key.is_file():
+        raise SmolVMError(f"SSH public key is not a file: {public_key}")
+
+    return private_key, public_key
+
+
+def resolve_ssh_key_pair(ssh_key_path: str | Path | None = None) -> tuple[Path, Path]:
+    """Backward-compatible alias for :func:`resolve_ssh_keypair`."""
+    return resolve_ssh_keypair(ssh_key_path)

--- a/src/smolvm/vm.py
+++ b/src/smolvm/vm.py
@@ -17,6 +17,7 @@
 Orchestrates VM lifecycle, networking, and state management across runtimes.
 """
 
+import json
 import logging
 import os
 import platform
@@ -25,6 +26,7 @@ import re
 import shlex
 import shutil
 import signal
+import socket
 import subprocess
 import time
 from contextlib import suppress
@@ -58,6 +60,8 @@ DEFAULT_SOCKET_DIR = Path("/tmp")
 QEMU_GUEST_IP = "10.0.2.15"
 QEMU_GATEWAY_IP = "10.0.2.2"
 QEMU_NETMASK = "255.255.255.0"
+QEMU_HOST_PORT_FORWARD_PURPOSE = "qemu-port-forward"
+QEMU_QMP_TIMEOUT_SECONDS = 1.0
 SNAPSHOT_ID_PATTERN = re.compile(r"^[a-z0-9][a-z0-9_-]{0,62}[a-z0-9]$|^[a-z0-9]$")
 
 
@@ -278,6 +282,10 @@ class SmolVMManager:
     def _instance_disk_path(self, vm_id: str) -> Path:
         """Return managed isolated disk path for a VM ID."""
         return self.disk_dir / f"{vm_id}.ext4"
+
+    def _qemu_qmp_socket_path(self, vm_id: str) -> Path:
+        """Return the QMP control socket path for a QEMU VM."""
+        return self.socket_dir / f"qmp-{vm_id}.sock"
 
     def _materialize_rootfs(self, config: VMConfig) -> VMConfig:
         """Materialize the effective rootfs path for a VM create request.
@@ -540,6 +548,14 @@ class SmolVMManager:
             ssh_host_port = self.state.reserve_ssh_port(effective_config.vm_id)
 
             if backend == BACKEND_QEMU:
+                for forward in effective_config.port_forwards:
+                    self.state.reserve_host_port(
+                        effective_config.vm_id,
+                        forward.guest_port,
+                        purpose=QEMU_HOST_PORT_FORWARD_PURPOSE,
+                        host_port=forward.host_port,
+                        host_address=forward.host_address,
+                    )
                 mac_seed = (ssh_host_port % 254) + 1
                 guest_mac = self.network.generate_mac(mac_seed)
                 network_config = NetworkConfig(
@@ -803,14 +819,17 @@ class SmolVMManager:
 
         if backend == BACKEND_QEMU:
             if vm_info.pid and self._is_process_running(vm_info.pid):
-                try:
-                    os.kill(vm_info.pid, signal.SIGTERM)
-                    self._wait_for_process(vm_info.pid, timeout)
-                except Exception as e:
-                    logger.warning("Graceful QEMU shutdown failed for %s: %s", vm_id, e)
+                self._shutdown_qemu(vm_id, vm_info.pid, timeout)
 
             if vm_info.pid and self._is_process_running(vm_info.pid):
                 self._kill_process(vm_info.pid)
+
+            qmp_socket_path = self._qemu_qmp_socket_path(vm_id)
+            if qmp_socket_path.exists():
+                try:
+                    self._unlink_socket(qmp_socket_path, socket_label="QEMU QMP")
+                except Exception as exc:
+                    logger.warning("Failed to remove QMP socket for %s: %s", vm_id, exc)
 
             qemu_key = f"qemu:{vm_id}"
             fh = self._log_files.pop(qemu_key, None)
@@ -1176,7 +1195,8 @@ class SmolVMManager:
             vm_info = self.state.get_vm(vm_id)
         except VMNotFoundError:
             # Best-effort cleanup of leaked artifacts, then propagate the lookup error.
-            self._cleanup_resources(vm_id)
+            with suppress(Exception):
+                self._cleanup_resources(vm_id)
             raise
 
         if vm_info.status in (VMState.RUNNING, VMState.PAUSED):
@@ -1323,6 +1343,7 @@ class SmolVMManager:
 
         qemu_name = qemu_bin.name
         system = platform.system()
+        qmp_socket_path = self._qemu_qmp_socket_path(vm_info.vm_id)
 
         drive_arg = f"file={vm_info.config.rootfs_path},if=none,format=raw,id=hd0"
         hostfwd_rules = [f"hostfwd=tcp:127.0.0.1:{ssh_port}-:22"]
@@ -1342,6 +1363,8 @@ class SmolVMManager:
             str(vm_info.config.kernel_path),
             "-append",
             boot_args,
+            "-qmp",
+            f"unix:{qmp_socket_path},server=on,wait=off",
             "-drive",
             drive_arg,
             "-netdev",
@@ -1350,9 +1373,12 @@ class SmolVMManager:
             "-no-reboot",
         ]
 
+        if qmp_socket_path.exists():
+            self._unlink_socket(qmp_socket_path, socket_label="QEMU QMP")
+
         if "aarch64" in qemu_name:
-            machine = "virt,accel=hvf" if system == "Darwin" else "virt"
-            cpu = "host" if system == "Darwin" else "cortex-a72"
+            machine = "virt,accel=hvf" if system == "Darwin" else "virt,accel=kvm"
+            cpu = "host" if system in {"Darwin", "Linux"} else "cortex-a72"
             cmd.extend(
                 [
                     "-machine",
@@ -1366,8 +1392,8 @@ class SmolVMManager:
                 ]
             )
         else:
-            machine = "q35,accel=hvf" if system == "Darwin" else "q35"
-            cpu = "host" if system == "Darwin" else "max"
+            machine = "q35,accel=hvf" if system == "Darwin" else "q35,accel=kvm"
+            cpu = "host" if system in {"Darwin", "Linux"} else "max"
             cmd.extend(
                 [
                     "-machine",
@@ -1452,7 +1478,7 @@ class SmolVMManager:
         logger.debug("Started Firecracker: PID=%d, socket=%s", process.pid, socket_path)
         return process
 
-    def _unlink_socket(self, socket_path: Path) -> None:
+    def _unlink_socket(self, socket_path: Path, *, socket_label: str = "runtime") -> None:
         """Best-effort socket cleanup with sudo fallback for stale root-owned sockets."""
         try:
             socket_path.unlink()
@@ -1471,13 +1497,105 @@ class SmolVMManager:
             if result.returncode != 0:
                 stderr = (result.stderr or "").strip()
                 raise SmolVMError(
-                    "Failed to remove stale Firecracker socket.\n"
+                    f"Failed to remove stale {socket_label} socket.\n"
                     f"Path: {socket_path}\n"
                     "Run one of the following:\n"
                     f"  sudo rm -f {socket_path}\n"
                     f"  {RUNTIME_PRIVILEGE_SETUP_HINT}\n"
                     f"sudo stderr: {stderr}"
                 ) from None
+
+    def _read_qmp_response(self, stream: Any) -> dict[str, Any]:
+        """Read a single JSON response from a QMP stream."""
+        raw = stream.readline()
+        if not raw:
+            raise SmolVMError("QMP socket closed unexpectedly")
+        try:
+            return json.loads(raw.decode("utf-8"))
+        except json.JSONDecodeError as exc:
+            raise SmolVMError("Received invalid JSON from QMP") from exc
+
+    def _wait_for_qmp_result(self, stream: Any, command: str) -> dict[str, Any]:
+        """Read QMP responses until the requested command returns or errors."""
+        while True:
+            message = self._read_qmp_response(stream)
+            if "event" in message:
+                continue
+            if "return" in message:
+                return message
+            if "error" in message:
+                error = message["error"]
+                desc = error.get("desc", "unknown error") if isinstance(error, dict) else str(error)
+                raise SmolVMError(
+                    f"QMP command '{command}' failed: {desc}",
+                    {"command": command, "error": error},
+                )
+
+    def _send_qmp_command(
+        self,
+        vm_id: str,
+        command: str,
+        *,
+        timeout: float = QEMU_QMP_TIMEOUT_SECONDS,
+    ) -> None:
+        """Connect to QMP and execute a single command."""
+        qmp_socket_path = self._qemu_qmp_socket_path(vm_id)
+        if not qmp_socket_path.exists():
+            raise SmolVMError(
+                "QMP socket is not available",
+                {"vm_id": vm_id, "qmp_socket_path": str(qmp_socket_path)},
+            )
+
+        with socket.socket(socket.AF_UNIX, socket.SOCK_STREAM) as client:
+            client.settimeout(timeout)
+            client.connect(str(qmp_socket_path))
+            with client.makefile("rwb") as stream:
+                greeting = self._read_qmp_response(stream)
+                if "QMP" not in greeting:
+                    raise SmolVMError(
+                        "QMP greeting not received",
+                        {"vm_id": vm_id, "qmp_socket_path": str(qmp_socket_path)},
+                    )
+
+                stream.write(json.dumps({"execute": "qmp_capabilities"}).encode("utf-8") + b"\n")
+                stream.flush()
+                self._wait_for_qmp_result(stream, "qmp_capabilities")
+
+                stream.write(json.dumps({"execute": command}).encode("utf-8") + b"\n")
+                stream.flush()
+                self._wait_for_qmp_result(stream, command)
+
+    def _shutdown_qemu(self, vm_id: str, pid: int, timeout: float) -> None:
+        """Stop QEMU with QMP first, then signals as fallback."""
+        if not self._is_process_running(pid):
+            return
+
+        deadline = time.time() + max(timeout, 0.0)
+
+        def remaining() -> float:
+            return max(0.0, deadline - time.time())
+
+        try:
+            self._send_qmp_command(vm_id, "system_powerdown")
+            self._wait_for_process(pid, remaining())
+            if not self._is_process_running(pid):
+                return
+        except Exception as exc:
+            logger.warning("QMP system_powerdown failed for %s: %s", vm_id, exc)
+
+        try:
+            self._send_qmp_command(vm_id, "quit")
+            self._wait_for_process(pid, min(remaining(), 2.0))
+            if not self._is_process_running(pid):
+                return
+        except Exception as exc:
+            logger.warning("QMP quit failed for %s: %s", vm_id, exc)
+
+        try:
+            os.kill(pid, signal.SIGTERM)
+            self._wait_for_process(pid, min(remaining(), 2.0))
+        except Exception as exc:
+            logger.warning("SIGTERM shutdown failed for %s: %s", vm_id, exc)
 
     def _kill_process(self, pid: int) -> None:
         """Kill a process.
@@ -1552,88 +1670,152 @@ class SmolVMManager:
         )
         return f"{args} {ip_arg}".strip()
 
+    def _record_cleanup_failure(
+        self,
+        vm_id: str,
+        step: str,
+        exc: Exception,
+        failures: list[str],
+    ) -> None:
+        """Track a cleanup failure without aborting later steps."""
+        message = f"{step}: {exc}"
+        failures.append(message)
+        logger.warning("Cleanup step failed for %s (%s): %s", vm_id, step, exc)
+
+    def _raise_cleanup_failures(self, vm_id: str, failures: list[str]) -> None:
+        """Raise a single error summarizing all cleanup failures."""
+        if not failures:
+            return
+        raise SmolVMError(
+            f"Failed to fully clean up VM '{vm_id}'",
+            {"vm_id": vm_id, "cleanup_failures": failures},
+        )
+
     def _cleanup_resources(self, vm_id: str) -> None:
         """Clean up resources for a VM.
 
         Args:
             vm_id: The VM identifier.
         """
+        failures: list[str] = []
+        vm_info: VMInfo | None = None
+        backend = self.backend
+        lease: tuple[str, str] | None = None
+        ssh_host_port: int | None = None
+        guest_ip: str | None = None
+
         try:
+            vm_info = self.state.get_vm(vm_id)
+        except VMNotFoundError:
             vm_info = None
-            with suppress(VMNotFoundError):
-                vm_info = self.state.get_vm(vm_id)
+        except Exception as exc:
+            self._record_cleanup_failure(vm_id, "load-vm-state", exc, failures)
 
-            backend = self.backend
-            if vm_info is not None:
-                with suppress(SmolVMError):
-                    backend = self._backend_for_vm(vm_info)
+        if vm_info is not None:
+            try:
+                backend = self._backend_for_vm(vm_info)
+            except Exception as exc:
+                self._record_cleanup_failure(vm_id, "resolve-backend", exc, failures)
 
+        try:
             lease = self.state.get_ip_lease(vm_id)
+        except Exception as exc:
+            self._record_cleanup_failure(vm_id, "load-ip-lease", exc, failures)
 
-            ssh_host_port: int | None = None
-            guest_ip: str | None = lease[0] if lease else None
-            if vm_info and vm_info.network:
-                ssh_host_port = vm_info.network.ssh_host_port
-                guest_ip = vm_info.network.guest_ip
-            else:
+        if lease:
+            guest_ip = lease[0]
+
+        if vm_info and vm_info.network:
+            ssh_host_port = vm_info.network.ssh_host_port
+            guest_ip = vm_info.network.guest_ip
+        else:
+            try:
                 ssh_host_port = self.state.get_ssh_port(vm_id)
+            except Exception as exc:
+                self._record_cleanup_failure(vm_id, "load-ssh-port", exc, failures)
 
-            if backend == BACKEND_FIRECRACKER and ssh_host_port is not None and guest_ip:
-                with suppress(Exception):
-                    self.network.cleanup_ssh_port_forward(
-                        vm_id=vm_id,
-                        guest_ip=guest_ip,
-                        host_port=ssh_host_port,
-                    )
+        if backend == BACKEND_FIRECRACKER and ssh_host_port is not None and guest_ip:
+            try:
+                self.network.cleanup_ssh_port_forward(
+                    vm_id=vm_id,
+                    guest_ip=guest_ip,
+                    host_port=ssh_host_port,
+                )
+            except Exception as exc:
+                self._record_cleanup_failure(vm_id, "cleanup-ssh-port-forward", exc, failures)
 
-            # Reconnect flows may not have in-memory local-forward state.
-            # Always remove any persisted localhost forwarding rules by vm_id.
-            with suppress(Exception):
-                self.network.cleanup_all_local_port_forwards(vm_id)
+        try:
+            self.network.cleanup_all_local_port_forwards(vm_id)
+        except Exception as exc:
+            self._record_cleanup_failure(vm_id, "cleanup-local-port-forwards", exc, failures)
 
-            # Get IP lease info
-            if lease:
-                _, tap_device = lease
+        if lease:
+            _, tap_device = lease
 
-                if backend == BACKEND_FIRECRACKER:
-                    # Cleanup Linux TAP/NAT only for Firecracker backend.
-                    with suppress(Exception):
-                        self.network.remove_egress_rules(tap_device)
+            if backend == BACKEND_FIRECRACKER:
+                try:
+                    self.network.remove_egress_rules(tap_device)
+                except Exception as exc:
+                    self._record_cleanup_failure(vm_id, "remove-egress-rules", exc, failures)
+                try:
                     self.network.cleanup_nat_rules(tap_device)
+                except Exception as exc:
+                    self._record_cleanup_failure(vm_id, "cleanup-nat-rules", exc, failures)
+                try:
                     self.network.cleanup_tap(tap_device)
+                except Exception as exc:
+                    self._record_cleanup_failure(vm_id, "cleanup-tap", exc, failures)
 
-                # Release IP lease regardless of backend.
+            try:
                 self.state.release_ip(vm_id)
+            except Exception as exc:
+                self._record_cleanup_failure(vm_id, "release-ip-lease", exc, failures)
 
-            if ssh_host_port is not None:
+        if ssh_host_port is not None:
+            try:
                 self.state.release_ssh_port(vm_id)
+            except Exception as exc:
+                self._record_cleanup_failure(vm_id, "release-ssh-port", exc, failures)
 
-            # Cleanup Firecracker socket artifacts.
-            socket_path = self.socket_dir / f"fc-{vm_id}.sock"
-            if socket_path.exists():
-                self._unlink_socket(socket_path)
+        try:
+            self.state.release_host_ports(vm_id)
+        except Exception as exc:
+            self._record_cleanup_failure(vm_id, "release-host-ports", exc, failures)
 
-            # Close tracked log file handles.
-            firecracker_key = str(socket_path)
-            qemu_key = f"qemu:{vm_id}"
-            for key in (firecracker_key, qemu_key):
-                fh = self._log_files.pop(key, None)
-                if fh is not None:
-                    with suppress(Exception):
-                        fh.close()
+        firecracker_socket_path = self.socket_dir / f"fc-{vm_id}.sock"
+        if firecracker_socket_path.exists():
+            try:
+                self._unlink_socket(firecracker_socket_path, socket_label="Firecracker")
+            except Exception as exc:
+                self._record_cleanup_failure(vm_id, "cleanup-firecracker-socket", exc, failures)
 
-            managed_disk = self._managed_disk_for_vm(vm_info)
-            if managed_disk and managed_disk.exists():
-                if vm_info.config.retain_disk_on_delete:
-                    logger.info(
-                        "Retaining isolated disk for VM %s at %s",
-                        vm_id,
-                        managed_disk,
-                    )
-                else:
-                    with suppress(Exception):
-                        managed_disk.unlink()
-                        logger.info("Removed isolated disk for VM %s: %s", vm_id, managed_disk)
+        qmp_socket_path = self._qemu_qmp_socket_path(vm_id)
+        if qmp_socket_path.exists():
+            try:
+                self._unlink_socket(qmp_socket_path, socket_label="QEMU QMP")
+            except Exception as exc:
+                self._record_cleanup_failure(vm_id, "cleanup-qmp-socket", exc, failures)
 
-        except Exception as e:
-            logger.warning("Error during cleanup for %s: %s", vm_id, e)
+        firecracker_key = str(firecracker_socket_path)
+        qemu_key = f"qemu:{vm_id}"
+        for key in (firecracker_key, qemu_key):
+            fh = self._log_files.pop(key, None)
+            if fh is None:
+                continue
+            try:
+                fh.close()
+            except Exception as exc:
+                self._record_cleanup_failure(vm_id, f"close-log-handle[{key}]", exc, failures)
+
+        managed_disk = self._managed_disk_for_vm(vm_info)
+        if managed_disk and managed_disk.exists():
+            if vm_info and vm_info.config.retain_disk_on_delete:
+                logger.info("Retaining isolated disk for VM %s at %s", vm_id, managed_disk)
+            else:
+                try:
+                    managed_disk.unlink()
+                    logger.info("Removed isolated disk for VM %s: %s", vm_id, managed_disk)
+                except Exception as exc:
+                    self._record_cleanup_failure(vm_id, "remove-managed-disk", exc, failures)
+
+        self._raise_cleanup_failures(vm_id, failures)


### PR DESCRIPTION
## Summary
- add durable host-port reservations in state storage and use immediate write locking for serialized allocation
- route localhost exposure and browser session endpoints through stable reserved ports instead of process-local ephemeral forwards
- fix browser custom SSH key handling by resolving and authorizing the matching public key
- reserve and release QEMU host forwards as part of VM lifecycle management
- improve QEMU runtime behavior with explicit Linux KVM acceleration, QMP-based shutdown, and stronger cleanup failure handling that preserves VM state on partial teardown

## Testing
- `PYTHONPATH=src python3 -m pytest tests/test_storage.py tests/test_vm.py tests/test_vm_qemu.py tests/test_browser.py tests/test_facade.py tests/test_cli.py -q`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added persistent port forwarding configuration to improve stability across VM sessions.
  * Enhanced host port reservation system for more reliable network mapping.

* **Bug Fixes**
  * Improved VM shutdown behavior and resource cleanup on close.
  * Fixed port forwarding reliability issues with browser connectivity.

* **Improvements**
  * Strengthened SSH key validation and resolution logic.
  * Enhanced resource cleanup to prevent state leaks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->