### PR TITLE
chore: remove deprecated legacy code and shims

### DIFF
--- a/src/smolvm/storage.py
+++ b/src/smolvm/storage.py
@@ -270,7 +270,6 @@ class StateManager:
         network: NetworkConfig | None = None,
         pid: int | None = None,
         control_socket_path: Path | None = None,
-        socket_path: Path | None = None,
         clear_pid: bool = False,
         clear_socket_path: bool = False,
     ) -> VMInfo:
@@ -282,7 +281,6 @@ class StateManager:
             network: Network configuration (optional).
             pid: Process ID (optional).
             control_socket_path: Runtime control socket path (optional).
-            socket_path: Deprecated alias for ``control_socket_path``.
             clear_pid: If True, set pid to NULL.
             clear_socket_path: If True, set socket_path to NULL.
 
@@ -321,13 +319,9 @@ class StateManager:
             elif clear_pid:
                 updates.append("pid = NULL")
 
-            effective_control_socket_path = control_socket_path
-            if effective_control_socket_path is None and socket_path is not None:
-                effective_control_socket_path = socket_path
-
-            if effective_control_socket_path is not None:
+            if control_socket_path is not None:
                 updates.append("socket_path = ?")
-                params.append(str(effective_control_socket_path))
+                params.append(str(control_socket_path))
             elif clear_socket_path:
                 updates.append("socket_path = NULL")
 

--- a/src/smolvm/types.py
+++ b/src/smolvm/types.py
@@ -347,17 +347,6 @@ class VMInfo(BaseModel):
         control_socket_path: Path to the runtime control socket.
     """
 
-    @model_validator(mode="before")
-    @classmethod
-    def normalize_control_socket_path(cls, raw: Any) -> Any:
-        """Accept the legacy ``socket_path`` field during the transition."""
-        if not isinstance(raw, dict):
-            return raw
-
-        data = dict(raw)
-        if "control_socket_path" not in data and "socket_path" in data:
-            data["control_socket_path"] = data.pop("socket_path")
-        return data
 
     vm_id: str
     status: VMState
@@ -367,11 +356,6 @@ class VMInfo(BaseModel):
     control_socket_path: Path | None = None
 
     model_config = {"frozen": True}
-
-    @property
-    def socket_path(self) -> Path | None:
-        """Deprecated compatibility alias for ``control_socket_path``."""
-        return self.control_socket_path
 
 
 class SnapshotArtifacts(BaseModel):
@@ -386,45 +370,6 @@ class SnapshotArtifacts(BaseModel):
 
 class SnapshotInfo(BaseModel):
     """Persisted metadata for a VM snapshot."""
-
-    @model_validator(mode="before")
-    @classmethod
-    def normalize_legacy_snapshot_fields(cls, raw: Any) -> Any:
-        """Accept the legacy Firecracker-shaped snapshot payload."""
-        if not isinstance(raw, dict):
-            return raw
-
-        data = dict(raw)
-        if "backend" not in data:
-            data["backend"] = "firecracker"
-
-        artifacts = data.get("artifacts")
-        if artifacts is None:
-            disk_path = data.pop("disk_path", None)
-            if disk_path is None:
-                return data
-            data["artifacts"] = {
-                "state_path": data.pop("snapshot_path", None),
-                "memory_path": data.pop("mem_file_path", None),
-                "disk_path": disk_path,
-            }
-            return data
-
-        if isinstance(artifacts, dict):
-            artifacts_data = dict(artifacts)
-        elif isinstance(artifacts, SnapshotArtifacts):
-            artifacts_data = artifacts.model_dump()
-        else:
-            return data
-
-        if artifacts_data.get("state_path") is None:
-            artifacts_data["state_path"] = data.pop("snapshot_path", None)
-        if artifacts_data.get("memory_path") is None:
-            artifacts_data["memory_path"] = data.pop("mem_file_path", None)
-        if artifacts_data.get("disk_path") is None and "disk_path" in data:
-            artifacts_data["disk_path"] = data.pop("disk_path")
-        data["artifacts"] = artifacts_data
-        return data
 
     snapshot_id: Annotated[
         str,
@@ -441,20 +386,7 @@ class SnapshotInfo(BaseModel):
 
     model_config = {"frozen": True}
 
-    @property
-    def snapshot_path(self) -> Path | None:
-        """Deprecated compatibility alias for the state artifact path."""
-        return self.artifacts.state_path
 
-    @property
-    def mem_file_path(self) -> Path | None:
-        """Deprecated compatibility alias for the memory artifact path."""
-        return self.artifacts.memory_path
-
-    @property
-    def disk_path(self) -> Path:
-        """Deprecated compatibility alias for the disk artifact path."""
-        return self.artifacts.disk_path
 
 
 class BrowserSessionInfo(BaseModel):

--- a/src/smolvm/utils.py
+++ b/src/smolvm/utils.py
@@ -158,27 +158,6 @@ def ensure_ssh_key(key_dir: Path | None = None) -> tuple[Path, Path]:
         base_dir = user_home / ".smolvm"
         key_dir = base_dir / "keys"
 
-        legacy_private = base_dir / "id_ed25519"
-        legacy_public = base_dir / "id_ed25519.pub"
-        migrated_private = key_dir / "id_ed25519"
-        migrated_public = key_dir / "id_ed25519.pub"
-
-        # Backward compatibility: reuse legacy key location if present by
-        # copying it into the new ~/.smolvm/keys layout.
-        if (
-            not migrated_private.exists()
-            and not migrated_public.exists()
-            and legacy_private.exists()
-            and legacy_public.exists()
-        ):
-            key_dir.mkdir(parents=True, exist_ok=True)
-            shutil.copy2(legacy_private, migrated_private)
-            shutil.copy2(legacy_public, migrated_public)
-            if sudo_uid is not None and sudo_gid is not None:
-                os.chown(key_dir, sudo_uid, sudo_gid)
-                os.chown(migrated_private, sudo_uid, sudo_gid)
-                os.chown(migrated_public, sudo_uid, sudo_gid)
-
     key_dir = Path(key_dir)
     if not key_dir.exists():
         key_dir.mkdir(parents=True, exist_ok=True)

--- a/src/smolvm/vm.py
+++ b/src/smolvm/vm.py
@@ -104,13 +104,12 @@ def _candidate_data_dirs() -> list[Path]:
             xdg_state_home = user_home / ".local" / "state"
 
     user_state_dir = xdg_state_home / "smolvm"
-    legacy_user_state_dir = user_home / ".smolvm" / "state"
 
     if os.geteuid() == 0 and sudo_user is None:
         # Direct root session: keep system path first.
-        return [DEFAULT_SYSTEM_DATA_DIR, user_state_dir, legacy_user_state_dir]
+        return [DEFAULT_SYSTEM_DATA_DIR, user_state_dir]
 
-    return [user_state_dir, legacy_user_state_dir, DEFAULT_SYSTEM_DATA_DIR]
+    return [user_state_dir, DEFAULT_SYSTEM_DATA_DIR]
 
 
 def resolve_data_dir(data_dir: Path | None = None) -> Path:


### PR DESCRIPTION
Removes backwards compatibility deprecated models, SQLite fallback schemas and legacy ssh-key migration blocks as outlined in the implementation plan.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Breaking Changes**
  * Removed backward-compatibility support for legacy SSH key migration; existing keys must be moved to the new location
  * Legacy configuration field names and aliases are no longer recognized; configurations must use current field names
  * Old state directories are no longer searched or supported; ensure configurations reference current paths

<!-- end of auto-generated comment: release notes by coderabbit.ai -->