### PR TITLE
fix: update test assertion to match new --os help text

### DIFF
--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -82,15 +82,14 @@ def test_top_level_help_mentions_json_for_agents() -> None:
 def test_create_help_describes_backend_specific_guest_default(
     capsys: pytest.CaptureFixture,
 ) -> None:
-    """Create help should describe the backend-specific guest OS default."""
+    """Create help should describe the OS option and its auto-detected default."""
     with pytest.raises(SystemExit) as exc_info:
         main(["create", "--help"])
 
     assert exc_info.value.code == 0
     help_text = capsys.readouterr().out
-    assert "default: backend-" in help_text
-    assert "specific; ubuntu for qemu-backed creates" in help_text
-    assert "current default backend" in help_text
+    assert "Operating system image" in help_text
+    assert "auto-detected" in help_text
 
 
 class TestCliEnv:


### PR DESCRIPTION
## Summary

- Updates `test_create_help_describes_backend_specific_guest_default` to assert against the new plain-language `--os` help text introduced in #111
- Old assertions checked for `"default: backend-"`, `"ubuntu for qemu-backed creates"`, and `"current default backend"` — the verbose backend-interpolated string that was intentionally simplified
- New assertions check for `"Operating system image"` and `"auto-detected"` (short enough to survive argparse line-wrapping)

## Test plan

- [ ] `pytest tests/test_cli.py::test_create_help_describes_backend_specific_guest_default` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated test assertions for `smolvm create --help` output validation to verify improved help text clarity regarding operating system image selection and auto-detection behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->