### PR TITLE
fix: skip SSH probing in CLI for already-running VMs

### DIFF
--- a/src/smolvm/cli.py
+++ b/src/smolvm/cli.py
@@ -1652,8 +1652,9 @@ def _run_ssh(args: argparse.Namespace) -> int:
                 "before attaching."
             )
         else:
-            with console.status("Waiting for SSH...", spinner="dots"):
-                vm.wait_for_ssh(timeout=args.boot_timeout)
+            # VM is already running — connect directly without probing.
+            completed = subprocess.run(vm._ssh_direct_command(), check=False)
+            return completed.returncode
         completed = subprocess.run(vm._ssh_attach_command(), check=False)
         return completed.returncode
     except FileNotFoundError:

--- a/src/smolvm/facade.py
+++ b/src/smolvm/facade.py
@@ -947,6 +947,53 @@ class SmolVM:
         command.append(f"{self._ssh.user}@{self._ssh.host}")
         return command
 
+    def _ssh_direct_command(self) -> list[str]:
+        """Build an SSH command from VM metadata without probing.
+
+        Uses the VM's known network info and key path to construct the
+        command directly, skipping the ``wait_for_ssh`` polling machinery.
+        Suitable for interactive CLI use where OpenSSH handles retries.
+        """
+        self._refresh_info()
+
+        if self._info.network is None:
+            raise SmolVMError(
+                "Cannot build SSH command: VM has no network configuration",
+                {"vm_id": self._vm_id},
+            )
+
+        # Prefer the host-forwarded port (127.0.0.1:<port>), fall back to guest IP.
+        ssh_host_port = self._info.network.ssh_host_port
+        if isinstance(ssh_host_port, int):
+            host, port = "127.0.0.1", ssh_host_port
+        else:
+            host, port = self._info.network.guest_ip, 22
+
+        # Resolve key: explicit > default SmolVM key.
+        key_path = self._ssh_key_path
+        if key_path is None:
+            from smolvm.utils import ensure_ssh_key
+
+            try:
+                default_key, _ = ensure_ssh_key()
+                key_path = str(default_key)
+            except Exception:
+                pass
+
+        command = [
+            "ssh",
+            "-o",
+            "StrictHostKeyChecking=no",
+            "-o",
+            "UserKnownHostsFile=/dev/null",
+            "-p",
+            str(port),
+        ]
+        if key_path:
+            command.extend(["-i", key_path, "-o", "IdentitiesOnly=yes"])
+        command.append(f"{self._ssh_user}@{host}")
+        return command
+
     def expose_local(self, guest_port: int, host_port: int | None = None) -> int:
         """Expose a guest TCP port on localhost only.
 

--- a/src/smolvm/facade.py
+++ b/src/smolvm/facade.py
@@ -962,15 +962,13 @@ class SmolVM:
                 {"vm_id": self._vm_id},
             )
 
-        # Prefer the host-forwarded port (127.0.0.1:<port>), fall back to guest IP.
-        ssh_host_port = self._info.network.ssh_host_port
-        if isinstance(ssh_host_port, int):
-            host, port = "127.0.0.1", ssh_host_port
-        else:
-            host, port = self._info.network.guest_ip, 22
+        # Reuse shared endpoint selection (prefers localhost forward, falls
+        # back to guest IP).
+        host, port = self._ssh_endpoints()[0]
 
         # Resolve key: explicit > default SmolVM key.
         key_path = self._ssh_key_path
+        explicit_key = key_path is not None
         if key_path is None:
             from smolvm.utils import ensure_ssh_key
 
@@ -978,7 +976,11 @@ class SmolVM:
                 default_key, _ = ensure_ssh_key()
                 key_path = str(default_key)
             except Exception:
-                pass
+                logger.debug(
+                    "VM %s: could not resolve default SSH key, "
+                    "falling back to agent/default auth",
+                    self._vm_id,
+                )
 
         command = [
             "ssh",
@@ -990,7 +992,12 @@ class SmolVM:
             str(port),
         ]
         if key_path:
-            command.extend(["-i", key_path, "-o", "IdentitiesOnly=yes"])
+            command.extend(["-i", key_path])
+            # Only lock to this key when the user explicitly provided it;
+            # for the auto-resolved SmolVM key, allow agent/default auth
+            # as a fallback.
+            if explicit_key:
+                command.extend(["-o", "IdentitiesOnly=yes"])
         command.append(f"{self._ssh_user}@{host}")
         return command
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -881,7 +881,7 @@ class TestCliSSH:
         """`smolvm ssh` should attach to a running VM without restarting it."""
         vm = MagicMock()
         vm.status = VMState.RUNNING
-        vm._ssh_attach_command.return_value = [
+        vm._ssh_direct_command.return_value = [
             "ssh",
             "-o",
             "StrictHostKeyChecking=no",
@@ -891,8 +891,6 @@ class TestCliSSH:
             "2200",
             "-i",
             "/custom/key",
-            "-o",
-            "IdentitiesOnly=yes",
             "custom-user@127.0.0.1",
         ]
         mock_vm_cls.from_id.return_value = vm
@@ -918,9 +916,9 @@ class TestCliSSH:
             ssh_key_path="/custom/key",
         )
         vm.start.assert_not_called()
-        vm.wait_for_ssh.assert_called_once_with(timeout=15.0)
-        vm._ssh_attach_command.assert_called_once_with()
-        mock_run.assert_called_once_with(vm._ssh_attach_command.return_value, check=False)
+        vm.wait_for_ssh.assert_not_called()
+        vm._ssh_direct_command.assert_called_once_with()
+        mock_run.assert_called_once_with(vm._ssh_direct_command.return_value, check=False)
         vm.close.assert_called_once()
 
     @pytest.mark.parametrize("status", [VMState.CREATED, VMState.STOPPED])


### PR DESCRIPTION
## Summary
- `smolvm ssh <vm-id>` on an already-running VM now connects instantly instead of running a full `wait_for_ssh` polling sequence
- Added `_ssh_direct_command()` to build the SSH command directly from VM metadata (network info + key path), bypassing multi-endpoint TCP probes and paramiko handshakes
- Start/resume paths still use full probing since SSH genuinely needs time to come up after boot

## Context
The CLI's `wait_for_ssh` builds multiple endpoint/key combinations and tries each sequentially, splitting the timeout budget. For a running VM this is unnecessary — the SSH daemon is already up. Direct `ssh` via `vm.ssh_commands()` was instant, but `smolvm ssh` was noticeably slow due to this probing overhead.

## Test plan
- [ ] `smolvm ssh <running-vm-id>` connects instantly (no "Waiting for SSH..." spinner)
- [ ] `smolvm ssh <stopped-vm-id>` still starts the VM and waits for SSH before connecting
- [ ] `smolvm ssh <paused-vm-id>` still resumes and waits for SSH before connecting

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Streamlined SSH workflow when a VM is already running so connections start immediately.

* **Improvements**
  * Hardened SSH invocation with stricter host-key handling, explicit port/key handling, and smarter SSH key selection/fallback.
  * Reduced wait/polling for SSH readiness in the direct-connection path.

* **Tests**
  * Updated tests to reflect the new direct SSH connection behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->