### PR TITLE
fix: harden GitHub Actions workflows (zizmor audit)

### DIFF
--- a/.github/workflows/publish-dashboard-ui.yml
+++ b/.github/workflows/publish-dashboard-ui.yml
@@ -14,10 +14,12 @@ jobs:
 
     steps:
       - name: Check out repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        with:
+          persist-credentials: false
 
-      - name: Set up Node.js
-        uses: actions/setup-node@v4
+      - name: Set up Node.js # zizmor: ignore[cache-poisoning]
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: "20"
           cache: npm
@@ -30,10 +32,13 @@ jobs:
         run: npm run build --prefix ui
 
       - name: Package dashboard dist
+        env:
+          REF_NAME: ${{ github.ref_name }}
         run: |
-          tar -C ui -czf smolvm-dashboard-ui-${{ github.ref_name }}.tar.gz dist
+          tar -C ui -czf "smolvm-dashboard-ui-${REF_NAME}.tar.gz" dist
 
       - name: Upload release asset
-        uses: softprops/action-gh-release@v2
-        with:
-          files: smolvm-dashboard-ui-${{ github.ref_name }}.tar.gz
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REF_NAME: ${{ github.ref_name }}
+        run: gh release upload "${REF_NAME}" "smolvm-dashboard-ui-${REF_NAME}.tar.gz"

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -15,10 +15,12 @@ jobs:
 
     steps:
       - name: Check out repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        with:
+          persist-credentials: false
 
-      - name: Install uv
-        uses: astral-sh/setup-uv@v3
+      - name: Install uv # zizmor: ignore[cache-poisoning]
+        uses: astral-sh/setup-uv@caf0cab7a618c569241d31dcd442f54681755d39 # v3.2.4
 
       - name: Set up Python
         run: uv python install 3.12
@@ -30,6 +32,6 @@ jobs:
         run: uv build
 
       - name: Publish to PyPI
-        uses: pypa/gh-action-pypi-publish@release/v1
+        uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # release/v1
         with:
           skip-existing: true

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -6,21 +6,26 @@ on:
       - main
   pull_request:
 
+permissions:
+  contents: read
+
 jobs:
   pytest:
     runs-on: ubuntu-latest
 
     steps:
       - name: Check out repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        with:
+          persist-credentials: false
 
       - name: Set up Python 3.14
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
         with:
           python-version: "3.14"
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v3
+        uses: astral-sh/setup-uv@caf0cab7a618c569241d31dcd442f54681755d39 # v3.2.4
 
       - name: Install dependencies
         run: uv sync --extra dev --extra all


### PR DESCRIPTION
## Summary
- **Pin all actions to commit SHAs** instead of mutable tag refs (`@v4` → full SHA with version comment)
- **Add `persist-credentials: false`** to all `actions/checkout` steps to prevent credential leakage via artifacts
- **Set `permissions: contents: read`** on `pytest.yml` (was using overly broad defaults)
- **Fix template injection** in `publish-dashboard-ui.yml` — moved `${{ github.ref_name }}` from inline `run:` to env vars
- **Pin `pypa/gh-action-pypi-publish`** to commit hash (was unpinned `release/v1` branch ref)
- **Replace `softprops/action-gh-release`** with built-in `gh release upload` CLI (fewer third-party dependencies)

All findings from `zizmor` resolved. Two remaining low-confidence cache-poisoning warnings are suppressed inline (tag-only triggers limit exposure).

## Test plan
- [ ] Verify `pytest` workflow runs on PR
- [ ] Verify publish workflows still work on next tag push

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI/CD workflows with enhanced security and reproducibility configurations across build, test, and publishing pipelines.

**Note:** This release contains no user-facing changes; updates are internal infrastructure improvements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->