### PR TITLE
docs: document --skip-deps flag in install script

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -19,11 +19,16 @@
 # Usage:
 #   curl -sSL https://celesto.ai/install.sh | bash
 #   curl -sSL https://celesto.ai/install.sh | bash -s -- --with-docker
+#   curl -sSL https://celesto.ai/install.sh | bash -s -- --skip-deps
 #
 # What it does:
 #   1. Installs uv (Python package manager) if not present
 #   2. Installs smolvm into an isolated tool environment via uv
 #   3. Runs `smolvm setup` to configure the host
+#
+# Options (forwarded to `smolvm setup`):
+#   --skip-deps      Skip apt dependency installation (assumes deps are present)
+#   --with-docker    Also install Docker for SSH image support
 #
 # After installation, the `smolvm` command is available globally.
 


### PR DESCRIPTION
## Summary
- Adds `--skip-deps` usage example and documents available options (`--skip-deps`, `--with-docker`) in the install script header
- The flag was already functional (forwarded to `smolvm setup`) but not documented

## Test plan
- [ ] Verify `curl -sSL https://celesto.ai/install.sh | bash -s -- --skip-deps` skips apt installs on a Linux host with deps pre-installed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Installation help documentation has been updated to clarify newly available options. The `--skip-deps` flag allows users to skip dependency installation during setup, while the `--with-docker` option enables Docker-based setup for environments that prefer containerized installation. These documented command-line options now provide additional configuration flexibility for users with different environmental requirements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->