### PR TITLE
fix: pass --skip-deps to smolvm setup in install script

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -127,7 +127,7 @@ install_smolvm() {
 
 run_setup() {
     info "Running smolvm setup …"
-    smolvm setup ${SETUP_ARGS[@]+"${SETUP_ARGS[@]}"}
+    smolvm setup --skip-deps ${SETUP_ARGS[@]+"${SETUP_ARGS[@]}"}
 }
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- Always pass `--skip-deps` to `smolvm setup` during the one-command install flow
- The install script already handles dependency installation via `uv`, so `smolvm setup` doesn't need to re-run `apt`

## Test plan
- [ ] Run `curl -sSL https://celesto.ai/install.sh | bash` on a clean Linux host and verify apt is not invoked by `smolvm setup`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Installation script now skips automatic apt dependency installation during setup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->