### PR TITLE
fix: publish workflow builds Rust native extension

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -10,28 +10,71 @@ permissions:
   id-token: write
 
 jobs:
-  publish:
+  # Build Linux wheels with Rust extension
+  build-linux:
     runs-on: ubuntu-latest
-
+    strategy:
+      matrix:
+        target: [x86_64, aarch64]
     steps:
-      - name: Check out repository
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+      - uses: actions/checkout@v4
+
+      - uses: PyO3/maturin-action@v1
         with:
-          persist-credentials: false
+          target: ${{ matrix.target }}
+          args: --release --out dist
+          manylinux: auto
 
-      - name: Install uv # zizmor: ignore[cache-poisoning]
-        uses: astral-sh/setup-uv@caf0cab7a618c569241d31dcd442f54681755d39 # v3.2.4
+      - uses: actions/upload-artifact@v4
+        with:
+          name: wheels-linux-${{ matrix.target }}
+          path: dist
 
-      - name: Set up Python
-        run: uv python install 3.12
+  # Build macOS wheels (native extension stubs — is_available() returns False)
+  build-macos:
+    runs-on: macos-latest
+    strategy:
+      matrix:
+        target: [x86_64, aarch64]
+    steps:
+      - uses: actions/checkout@v4
 
-      - name: Install dependencies
-        run: uv sync
+      - uses: PyO3/maturin-action@v1
+        with:
+          target: ${{ matrix.target }}
+          args: --release --out dist
 
-      - name: Build package
-        run: uv build
+      - uses: actions/upload-artifact@v4
+        with:
+          name: wheels-macos-${{ matrix.target }}
+          path: dist
 
-      - name: Publish to PyPI
-        uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # release/v1
+  # Build source distribution (for pip install from source)
+  build-sdist:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: PyO3/maturin-action@v1
+        with:
+          command: sdist
+          args: --out dist
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: sdist
+          path: dist
+
+  # Publish all wheels + sdist to PyPI
+  publish:
+    needs: [build-linux, build-macos, build-sdist]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          path: dist
+          merge-multiple: true
+
+      - uses: pypa/gh-action-pypi-publish@release/v1
         with:
           skip-existing: true

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -5,10 +5,6 @@ on:
     tags:
       - "v*.*.*"
 
-permissions:
-  contents: read
-  id-token: write
-
 jobs:
   # Build Linux wheels with Rust extension
   build-linux:
@@ -22,8 +18,8 @@ jobs:
       - uses: PyO3/maturin-action@v1
         with:
           target: ${{ matrix.target }}
-          args: --release --out dist
-          manylinux: auto
+          args: --release --out dist --find-interpreter
+          manylinux: manylinux_2_17
 
       - uses: actions/upload-artifact@v4
         with:
@@ -42,7 +38,7 @@ jobs:
       - uses: PyO3/maturin-action@v1
         with:
           target: ${{ matrix.target }}
-          args: --release --out dist
+          args: --release --out dist --find-interpreter
 
       - uses: actions/upload-artifact@v4
         with:
@@ -69,12 +65,14 @@ jobs:
   publish:
     needs: [build-linux, build-macos, build-sdist]
     runs-on: ubuntu-latest
+    permissions:
+      id-token: write
     steps:
       - uses: actions/download-artifact@v4
         with:
           path: dist
           merge-multiple: true
 
-      - uses: pypa/gh-action-pypi-publish@release/v1
+      - uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # release/v1
         with:
           skip-existing: true

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -5,10 +5,15 @@ on:
     tags:
       - "v*.*.*"
 
+permissions:
+  contents: read
+
 jobs:
   # Build Linux wheels with Rust extension
   build-linux:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     strategy:
       matrix:
         target: [x86_64, aarch64]
@@ -29,6 +34,8 @@ jobs:
   # Build macOS wheels (native extension stubs — is_available() returns False)
   build-macos:
     runs-on: macos-latest
+    permissions:
+      contents: read
     strategy:
       matrix:
         target: [x86_64, aarch64]
@@ -48,6 +55,8 @@ jobs:
   # Build source distribution (for pip install from source)
   build-sdist:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@v4
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "smolvm"
-dynamic = ["version"]
+version = "0.0.9"
 description = "Secure runtime for AI agents, and tools -- free and open-source from Celesto AI 🧡"
 readme = "README.md"
 license = "Apache-2.0"

--- a/rust/smolvm-native/Cargo.toml
+++ b/rust/smolvm-native/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "smolvm-native"
-version = "0.1.0"
+version = "0.0.9"
 edition = "2021"
 
 [lib]

--- a/rust/smolvm-native/src/lib.rs
+++ b/rust/smolvm-native/src/lib.rs
@@ -123,7 +123,5 @@ fn _native(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_function(wrap_pyfunction!(get_default_interface, m)?)?;
     m.add_function(wrap_pyfunction!(write_sysctl, m)?)?;
 
-    // Version info
-    m.add("__version__", "0.1.0")?;
     Ok(())
 }

--- a/src/smolvm/__init__.py
+++ b/src/smolvm/__init__.py
@@ -57,7 +57,9 @@ from smolvm.types import (
 )
 from smolvm.vm import SmolVMManager
 
-__version__ = "0.0.9"
+from importlib.metadata import version as _pkg_version
+
+__version__ = _pkg_version("smolvm")
 
 __all__ = [
     # Core classes

--- a/src/smolvm/__init__.py
+++ b/src/smolvm/__init__.py
@@ -57,7 +57,7 @@ from smolvm.types import (
 )
 from smolvm.vm import SmolVMManager
 
-__version__ = "0.0.8"
+__version__ = "0.0.9"
 
 __all__ = [
     # Core classes

--- a/tests/test_version.py
+++ b/tests/test_version.py
@@ -1,0 +1,63 @@
+"""Tests for SmolVM version consistency."""
+
+import re
+
+import pytest
+
+
+class TestVersion:
+    """Verify version is consistent across all surfaces."""
+
+    def test_package_version_is_semver(self) -> None:
+        """Package version should be a valid semver string."""
+        import smolvm
+
+        assert re.match(r"^\d+\.\d+\.\d+", smolvm.__version__), (
+            f"Version {smolvm.__version__!r} is not a valid semver"
+        )
+
+    def test_init_version_matches_metadata(self) -> None:
+        """smolvm.__version__ should match importlib.metadata."""
+        import importlib.metadata
+
+        import smolvm
+
+        metadata_version = importlib.metadata.version("smolvm")
+        assert smolvm.__version__ == metadata_version
+
+    def test_cli_version_flag(self) -> None:
+        """smolvm --version should print the package version."""
+        import smolvm
+        from smolvm.cli import build_parser
+
+        parser = build_parser()
+        with pytest.raises(SystemExit) as exc_info:
+            parser.parse_args(["--version"])
+        assert exc_info.value.code == 0
+
+    def test_cli_short_version_flag(self) -> None:
+        """smolvm -V should also trigger version output."""
+        from smolvm.cli import build_parser
+
+        parser = build_parser()
+        with pytest.raises(SystemExit) as exc_info:
+            parser.parse_args(["-V"])
+        assert exc_info.value.code == 0
+
+    def test_version_not_hardcoded_in_init(self) -> None:
+        """__version__ should come from package metadata, not a hardcoded string."""
+        import inspect
+
+        import smolvm
+
+        source = inspect.getsource(smolvm)
+        assert '__version__ = "' not in source, (
+            "__version__ should be read from importlib.metadata, not hardcoded"
+        )
+
+    def test_version_is_current(self) -> None:
+        """Sanity check that version is at least 0.0.9 (post-Rust extension)."""
+        import smolvm
+        from packaging.version import Version
+
+        assert Version(smolvm.__version__) >= Version("0.0.9")


### PR DESCRIPTION
## Summary

The publish workflow used `uv build` which produced a pure Python wheel without the native `.so` extension. Users installing from PyPI got no netlink acceleration.

## Changes

Replace `uv build` with `maturin-action`:
- **Linux wheels**: x86_64 + aarch64 with manylinux (includes compiled `.so`)
- **macOS wheels**: x86_64 + aarch64 (stubs, `is_available()` returns False)
- **Source distribution**: for `pip install` from source with Rust toolchain

## After merging

Tag a release to trigger: `git tag v0.1.0 && git push --tags`

`pip install smolvm` will then install the wheel with the native extension on Linux.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * CI/CD updated to build platform-specific packages for Linux and macOS (x86_64 and aarch64).
  * Source distribution (sdist) is now produced alongside platform builds.
  * Build artifacts are consolidated and then published to PyPI with duplicate uploads skipped.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->