### PR TITLE
fix(ci): aarch64 publish + requires-python <3.14

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -20,17 +20,11 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      # maturin builds inside a manylinux Docker container —
-      # use explicit in-container interpreter paths (not host setup-python)
+      # --find-interpreter respects requires-python (<3.14) to skip unsupported versions
       - uses: PyO3/maturin-action@v1
         with:
           target: ${{ matrix.target }}
-          args: >-
-            --release --out dist
-            --interpreter /opt/python/cp310-cp310/bin/python
-            --interpreter /opt/python/cp311-cp311/bin/python
-            --interpreter /opt/python/cp312-cp312/bin/python
-            --interpreter /opt/python/cp313-cp313/bin/python
+          args: --release --out dist --find-interpreter
           manylinux: manylinux_2_17
 
       - uses: actions/upload-artifact@v4

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ version = "0.0.9.dev0"
 description = "Secure runtime for AI agents, and tools -- free and open-source from Celesto AI 🧡"
 readme = "README.md"
 license = "Apache-2.0"
-requires-python = ">=3.10"
+requires-python = ">=3.10,<3.14"
 authors = [
     { name = "Celesto AI", email = "hello@celesto.ai" }
 ]


### PR DESCRIPTION
Hardcoded /opt/python paths don't work for aarch64 (QEMU emulation). Use `--find-interpreter` which respects `requires-python = '>=3.10,<3.14'` to skip 3.14 on all targets.