### PR TITLE
[codex] Fix smolvm-core sdist packaging

### DIFF
--- a/smolvm-core/Cargo.toml
+++ b/smolvm-core/Cargo.toml
@@ -3,6 +3,10 @@ name = "smolvm-core"
 version = "0.0.9"
 edition = "2021"
 license = "Apache-2.0"
+description = "Rust-native core package for SmolVM"
+homepage = "https://github.com/CelestoAI/SmolVM"
+repository = "https://github.com/CelestoAI/SmolVM"
+readme = "README.md"
 
 [lib]
 name = "_smolvm_core"

--- a/smolvm-core/README.md
+++ b/smolvm-core/README.md
@@ -1,0 +1,13 @@
+# smolvm-core
+
+`smolvm-core` is the small native helper package for SmolVM. It handles low-level system work such as fast network setup, while the main `smolvm` package keeps the public Python API.
+
+Most users should install `smolvm`, not `smolvm-core` directly:
+
+```bash
+pip install smolvm
+```
+
+That install pulls in the matching `smolvm-core` wheel automatically on supported platforms.
+
+Install `smolvm-core` directly only if you are developing the native extension or testing package releases.

--- a/smolvm-core/pyproject.toml
+++ b/smolvm-core/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "maturin"
 name = "smolvm-core"
 dynamic = ["version"]
 description = "Rust-accelerated network operations for SmolVM"
-readme = "../README.md"
+readme = "README.md"
 license = "Apache-2.0"
 requires-python = ">=3.10"
 authors = [
@@ -25,6 +25,11 @@ classifiers = [
     "Programming Language :: Python :: 3.13",
     "Programming Language :: Rust",
 ]
+
+[project.urls]
+Homepage = "https://github.com/CelestoAI/SmolVM"
+Repository = "https://github.com/CelestoAI/SmolVM"
+Documentation = "https://docs.celesto.ai"
 
 [tool.maturin]
 features = ["pyo3/extension-module"]


### PR DESCRIPTION
## Summary

Fix the `smolvm-core` source distribution packaging so the release workflow can build and publish the sdist successfully.

## What changed

- switched `smolvm-core` to use a package-local `README.md` instead of `../README.md`
- added a short package-specific README for the published `smolvm-core` package
- added standard package metadata to `smolvm-core` Python and Cargo manifests

## Root cause

The `smolvm-core` release workflow failed in `maturin sdist` because the package metadata pointed `readme` at `../README.md`. `maturin` rejects parent-directory paths when constructing the archive, so the sdist build failed before upload.

## Validation

- `uv build --package smolvm-core --sdist --out-dir /tmp/smolvm-core-sdist`
- `uv build --package smolvm-core --wheel --out-dir /tmp/smolvm-core-dist`
- `uv build --package smolvm --wheel --out-dir /tmp/smolvm-dist`
- isolated artifact install smoke test using the built wheels
- core release preflight script from the workflow
