### PR TITLE
fix: default to QEMU backend on macOS

### DIFF
--- a/src/smolvm/backends.py
+++ b/src/smolvm/backends.py
@@ -35,7 +35,7 @@ def resolve_backend(requested: str | None = None) -> str:
     Resolution order:
     1) Explicit ``requested`` argument.
     2) ``SMOLVM_BACKEND`` environment variable.
-    3) Platform-aware default (Darwin -> libkrun when available, then qemu; others -> firecracker).
+    3) Platform-aware default (Darwin -> qemu; others -> firecracker).
 
     Args:
         requested: Optional backend string.
@@ -51,8 +51,6 @@ def resolve_backend(requested: str | None = None) -> str:
     if raw == BACKEND_AUTO:
         system = platform.system().lower()
         if system == "darwin":
-            if which("krunvm") is not None:
-                return BACKEND_LIBKRUN
             return BACKEND_QEMU
         return BACKEND_FIRECRACKER
 

--- a/tests/test_backends.py
+++ b/tests/test_backends.py
@@ -3,16 +3,14 @@ from unittest.mock import patch
 from smolvm.backends import BACKEND_LIBKRUN, BACKEND_QEMU, resolve_backend
 
 
-def test_resolve_backend_auto_prefers_libkrun_on_macos_when_available() -> None:
+def test_resolve_backend_auto_defaults_to_qemu_on_macos() -> None:
+    with patch("smolvm.backends.platform.system", return_value="Darwin"):
+        assert resolve_backend("auto") == BACKEND_QEMU
+
+
+def test_resolve_backend_auto_defaults_to_qemu_on_macos_even_with_krunvm() -> None:
     with patch("smolvm.backends.platform.system", return_value="Darwin"), patch(
         "smolvm.backends.which", return_value="/usr/local/bin/krunvm"
-    ):
-        assert resolve_backend("auto") == BACKEND_LIBKRUN
-
-
-def test_resolve_backend_auto_falls_back_to_qemu_on_macos_without_krunvm() -> None:
-    with patch("smolvm.backends.platform.system", return_value="Darwin"), patch(
-        "smolvm.backends.which", return_value=None
     ):
         assert resolve_backend("auto") == BACKEND_QEMU
 


### PR DESCRIPTION
## Summary
- Changes the auto-detected default backend on macOS from libkrun to QEMU
- libkrun process exits before the VM becomes ready, making it unusable as a default
- libkrun can still be selected explicitly via `--backend libkrun` or `SMOLVM_BACKEND=libkrun`

## Test plan
- [x] Updated unit tests to verify QEMU is the default on macOS
- [x] All 3 backend tests pass
- [ ] Manual: `uv run smolvm create --json` should use QEMU on macOS

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Simplified macOS backend auto-selection to consistently use QEMU instead of attempting conditional fallback logic.

* **Tests**
  * Updated backend selection tests to reflect new macOS default behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->