### PR TITLE
feat: add --workspace flag for host directory mounting

### DIFF
--- a/src/smolvm/__init__.py
+++ b/src/smolvm/__init__.py
@@ -18,6 +18,8 @@ A Python SDK for running AI agents and executing untrusted code in a secure,
 sandboxed environment.
 """
 
+from importlib.metadata import version as _pkg_version
+
 from smolvm.browser import BrowserSession
 from smolvm.build import SSH_BOOT_ARGS, ImageBuilder
 from smolvm.exceptions import (
@@ -54,10 +56,9 @@ from smolvm.types import (
     VMConfig,
     VMInfo,
     VMState,
+    WorkspaceMount,
 )
 from smolvm.vm import SmolVMManager
-
-from importlib.metadata import version as _pkg_version
 
 __version__ = _pkg_version("smolvm")
 
@@ -88,6 +89,7 @@ __all__ = [
     "SnapshotInfo",
     "CommandResult",
     "BrowserViewport",
+    "WorkspaceMount",
     "BrowserSessionConfig",
     "BrowserSessionInfo",
     "BrowserSessionState",

--- a/src/smolvm/cli.py
+++ b/src/smolvm/cli.py
@@ -24,6 +24,7 @@ import platform
 import re
 import subprocess
 from collections.abc import Sequence
+from pathlib import Path
 from typing import TYPE_CHECKING, TypedDict
 
 from rich.panel import Panel
@@ -482,6 +483,17 @@ def build_parser() -> argparse.ArgumentParser:
         "--json",
         action="store_true",
         help="Emit machine-readable JSON output.",
+    )
+    create_parser.add_argument(
+        "--workspace",
+        type=Path,
+        default=None,
+        metavar="PATH",
+        help=(
+            "Host directory to mount at /workspace inside the sandbox. "
+            "The host directory stays read-only; writes inside the sandbox "
+            "go to an overlay and do not affect the host."
+        ),
     )
     _add_boot_timeout_arg(create_parser)
 
@@ -1001,6 +1013,7 @@ def _build_and_boot_with_progress(
     console: object,
     build_fn: object,
     boot_timeout: int,
+    workspace: Path | None = None,
 ) -> object:
     """Build a VM config and boot it, showing a Rich progress bar.
 
@@ -1042,7 +1055,7 @@ def _build_and_boot_with_progress(
         boot_task = progress.add_task(
             "Booting computer and waiting for SSH...", total=None
         )
-        vm = SmolVM(config, ssh_key_path=ssh_key_path)
+        vm = SmolVM(config, ssh_key_path=ssh_key_path, workspace=workspace)
         vm.start(boot_timeout=boot_timeout)
         vm.wait_for_ssh(timeout=boot_timeout)
         progress.remove_task(boot_task)
@@ -1087,6 +1100,7 @@ def _run_create(args: argparse.Namespace) -> int:
                         on_download=on_download,
                     ),
                     boot_timeout=args.boot_timeout,
+                    workspace=args.workspace,
                 )
             else:
                 config, ssh_key_path = _build_s3_image_config(
@@ -1096,7 +1110,7 @@ def _run_create(args: argparse.Namespace) -> int:
                     mem_size_mib=args.memory_mib,
                     ssh_key_path=None,
                 )
-                vm = SmolVM(config, ssh_key_path=ssh_key_path)
+                vm = SmolVM(config, ssh_key_path=ssh_key_path, workspace=args.workspace)
                 vm.start(boot_timeout=args.boot_timeout)
                 vm.wait_for_ssh(timeout=args.boot_timeout)
         else:
@@ -1115,6 +1129,7 @@ def _run_create(args: argparse.Namespace) -> int:
                         on_download=on_download,
                     ),
                     boot_timeout=args.boot_timeout,
+                    workspace=args.workspace,
                 )
             else:
                 config, ssh_key_path = _build_auto_config(
@@ -1125,7 +1140,7 @@ def _run_create(args: argparse.Namespace) -> int:
                     disk_size_mib=args.disk_size_mib,
                     ssh_key_path=None,
                 )
-                vm = SmolVM(config, ssh_key_path=ssh_key_path)
+                vm = SmolVM(config, ssh_key_path=ssh_key_path, workspace=args.workspace)
                 vm.start(boot_timeout=args.boot_timeout)
                 vm.wait_for_ssh(timeout=args.boot_timeout)
 

--- a/src/smolvm/cli.py
+++ b/src/smolvm/cli.py
@@ -485,14 +485,17 @@ def build_parser() -> argparse.ArgumentParser:
         help="Emit machine-readable JSON output.",
     )
     create_parser.add_argument(
-        "--workspace",
-        type=Path,
+        "--mount",
+        action="append",
         default=None,
-        metavar="PATH",
+        dest="mounts",
+        metavar="HOST_PATH[:GUEST_PATH]",
         help=(
-            "Host directory to mount at /workspace inside the sandbox. "
-            "The host directory stays read-only; writes inside the sandbox "
-            "go to an overlay and do not affect the host."
+            "Host directory to mount inside the sandbox. "
+            "Defaults to /workspace if no guest path is given. "
+            "The host directory stays read-only; writes go to an "
+            "overlay and do not affect the host. "
+            "Can be repeated for multiple mounts."
         ),
     )
     _add_boot_timeout_arg(create_parser)
@@ -1013,7 +1016,7 @@ def _build_and_boot_with_progress(
     console: object,
     build_fn: object,
     boot_timeout: int,
-    workspace: Path | None = None,
+    mounts: list[str] | None = None,
 ) -> object:
     """Build a VM config and boot it, showing a Rich progress bar.
 
@@ -1055,7 +1058,7 @@ def _build_and_boot_with_progress(
         boot_task = progress.add_task(
             "Booting computer and waiting for SSH...", total=None
         )
-        vm = SmolVM(config, ssh_key_path=ssh_key_path, workspace=workspace)
+        vm = SmolVM(config, ssh_key_path=ssh_key_path, mounts=mounts)
         vm.start(boot_timeout=boot_timeout)
         vm.wait_for_ssh(timeout=boot_timeout)
         progress.remove_task(boot_task)
@@ -1100,7 +1103,7 @@ def _run_create(args: argparse.Namespace) -> int:
                         on_download=on_download,
                     ),
                     boot_timeout=args.boot_timeout,
-                    workspace=args.workspace,
+                    mounts=args.mounts,
                 )
             else:
                 config, ssh_key_path = _build_s3_image_config(
@@ -1110,7 +1113,7 @@ def _run_create(args: argparse.Namespace) -> int:
                     mem_size_mib=args.memory_mib,
                     ssh_key_path=None,
                 )
-                vm = SmolVM(config, ssh_key_path=ssh_key_path, workspace=args.workspace)
+                vm = SmolVM(config, ssh_key_path=ssh_key_path, mounts=args.mounts)
                 vm.start(boot_timeout=args.boot_timeout)
                 vm.wait_for_ssh(timeout=args.boot_timeout)
         else:
@@ -1129,7 +1132,7 @@ def _run_create(args: argparse.Namespace) -> int:
                         on_download=on_download,
                     ),
                     boot_timeout=args.boot_timeout,
-                    workspace=args.workspace,
+                    mounts=args.mounts,
                 )
             else:
                 config, ssh_key_path = _build_auto_config(
@@ -1140,7 +1143,7 @@ def _run_create(args: argparse.Namespace) -> int:
                     disk_size_mib=args.disk_size_mib,
                     ssh_key_path=None,
                 )
-                vm = SmolVM(config, ssh_key_path=ssh_key_path, workspace=args.workspace)
+                vm = SmolVM(config, ssh_key_path=ssh_key_path, mounts=args.mounts)
                 vm.start(boot_timeout=args.boot_timeout)
                 vm.wait_for_ssh(timeout=args.boot_timeout)
 

--- a/src/smolvm/facade.py
+++ b/src/smolvm/facade.py
@@ -30,6 +30,7 @@ from __future__ import annotations
 
 import logging
 import platform
+import shlex
 import socket
 import subprocess
 import time
@@ -59,6 +60,7 @@ from smolvm.types import (
     VMConfig,
     VMInfo,
     VMState,
+    WorkspaceMount,
 )
 from smolvm.vm import SmolVMManager
 
@@ -468,6 +470,7 @@ class SmolVM:
         ssh_user: str = "root",
         ssh_key_path: str | None = None,
         internet_settings: InternetSettings | dict[str, Any] | None = None,
+        workspace: Path | str | None = None,
     ) -> None:
         if config is not None and vm_id is not None:
             raise ValueError("Provide either config or vm_id, not both.")
@@ -526,6 +529,22 @@ class SmolVM:
                 )
             if config is not None:
                 config = config.model_copy(update={"internet_settings": internet_settings})
+
+        # Normalize and merge workspace into the config
+        if workspace is not None:
+            if vm_id is not None:
+                raise ValueError(
+                    "workspace cannot be set when reconnecting to an existing VM."
+                )
+            ws_path = Path(workspace) if isinstance(workspace, str) else workspace
+            mount = WorkspaceMount(host_path=ws_path)
+            if config is not None:
+                if config.workspace_mounts:
+                    raise ValueError(
+                        "workspace_mounts is already set on the provided VMConfig; "
+                        "pass it in one place only."
+                    )
+                config = config.model_copy(update={"workspace_mounts": [mount]})
 
         self._ssh_user = ssh_user
         self._ssh_key_path = ssh_key_path
@@ -718,6 +737,24 @@ class SmolVM:
                 len(injected),
                 ", ".join(injected),
             )
+
+        # Mount workspace directories after boot if configured.
+        if self._info.config.workspace_mounts:
+            if not self.can_run_commands():
+                raise SmolVMError(
+                    "Cannot mount workspaces: VM image does not support SSH.",
+                    {"vm_id": self._vm_id},
+                )
+            if not self._ssh_ready:
+                self.wait_for_ssh(timeout=boot_timeout)
+            if self._ssh is None:
+                self._ssh = SSHClient(
+                    host=self._info.network.guest_ip,
+                    user=self._ssh_user,
+                    key_path=self._ssh_key_path,
+                )
+                self._ssh_ready = True
+            self._mount_workspaces()
 
         return self
 
@@ -1267,6 +1304,24 @@ class SmolVM:
                 self._ssh_ready = True
             await asyncio.to_thread(inject_env_vars, self._ssh, env_vars)
 
+        # Mount workspace directories after boot if configured.
+        if self._info.config.workspace_mounts:
+            if not self.can_run_commands():
+                raise SmolVMError(
+                    "Cannot mount workspaces: VM image does not support SSH.",
+                    {"vm_id": self._vm_id},
+                )
+            if not self._ssh_ready:
+                await self.async_wait_for_ssh(timeout=boot_timeout)
+            if self._ssh is None:
+                self._ssh = SSHClient(
+                    host=self._info.network.guest_ip,
+                    user=self._ssh_user,
+                    key_path=self._ssh_key_path,
+                )
+                self._ssh_ready = True
+            await asyncio.to_thread(self._mount_workspaces)
+
         return self
 
     async def async_stop(self, timeout: float = 3.0) -> SmolVM:
@@ -1484,6 +1539,59 @@ class SmolVM:
     # ------------------------------------------------------------------
     # Internals
     # ------------------------------------------------------------------
+
+    def _mount_workspaces(self) -> None:
+        """Mount 9p workspace shares with overlayfs inside the guest."""
+        assert self._ssh is not None  # noqa: S101 — caller guarantees SSH ready
+
+        workspace_mounts = self._info.config.workspace_mounts
+        if not workspace_mounts:
+            return
+
+        for index, ws in enumerate(workspace_mounts):
+            tag = ws.mount_tag or f"workspace{index}"
+            guest_path = shlex.quote(ws.guest_path)
+            lower = shlex.quote(f"/mnt/.smolvm-ws-{tag}")
+            upper = shlex.quote(f"/tmp/.smolvm-ws-{tag}-upper")
+            work = shlex.quote(f"/tmp/.smolvm-ws-{tag}-work")
+            qtag = shlex.quote(tag)
+
+            mount_script = (
+                f"modprobe 9p 2>/dev/null; "
+                f"modprobe 9pnet_virtio 2>/dev/null; "
+                f"modprobe overlay 2>/dev/null; "
+                f"mkdir -p {lower} {upper} {work} {guest_path} && "
+                f"mount -t 9p -o trans=virtio,version=9p2000.L,ro "
+                f"{qtag} {lower} && "
+                f"mount -t overlay overlay "
+                f"-o lowerdir={lower},upperdir={upper},workdir={work} "
+                f"{guest_path}"
+            )
+            result = self._ssh.run(mount_script, timeout=15)
+            if result.exit_code != 0:
+                stderr = result.stderr.strip()
+                if "unknown filesystem type" in stderr or "No such device" in stderr:
+                    raise SmolVMError(
+                        "Guest kernel does not support 9p or overlay filesystem. "
+                        "The guest image needs CONFIG_NET_9P, CONFIG_NET_9P_VIRTIO, "
+                        "CONFIG_9P_FS, and CONFIG_OVERLAY_FS kernel options.",
+                        {"vm_id": self._vm_id, "mount_tag": tag, "stderr": stderr},
+                    )
+                raise SmolVMError(
+                    f"Failed to mount workspace '{tag}' at {ws.guest_path}",
+                    {
+                        "vm_id": self._vm_id,
+                        "exit_code": result.exit_code,
+                        "stdout": result.stdout.strip(),
+                        "stderr": stderr,
+                    },
+                )
+            logger.info(
+                "VM %s: mounted workspace '%s' at %s (overlay)",
+                self._vm_id,
+                tag,
+                ws.guest_path,
+            )
 
     def _reset_runtime_state(self, *, close_ssh: bool = True) -> None:
         """Clear cached runtime connection state after lifecycle changes."""

--- a/src/smolvm/facade.py
+++ b/src/smolvm/facade.py
@@ -1548,8 +1548,15 @@ class SmolVM:
         if not workspace_mounts:
             return
 
+        if self._ssh_user != "root":
+            raise SmolVMError(
+                "Workspace mounts require ssh_user='root' because the guest "
+                "must run modprobe and mount.",
+                {"vm_id": self._vm_id, "ssh_user": self._ssh_user},
+            )
+
         for index, ws in enumerate(workspace_mounts):
-            tag = ws.mount_tag or f"workspace{index}"
+            tag = ws.resolved_tag(index)
             guest_path = shlex.quote(ws.guest_path)
             lower = shlex.quote(f"/mnt/.smolvm-ws-{tag}")
             upper = shlex.quote(f"/tmp/.smolvm-ws-{tag}-upper")

--- a/src/smolvm/facade.py
+++ b/src/smolvm/facade.py
@@ -166,6 +166,24 @@ def _resolve_auto_config_public_key(ssh_key_path: str | None) -> tuple[str, Path
     return ssh_key_path, public_key
 
 
+def _parse_mount_specs(specs: list[str]) -> list[WorkspaceMount]:
+    """Parse ``HOST_PATH[:GUEST_PATH]`` strings into WorkspaceMount objects.
+
+    If no guest path is given, the mount defaults to ``/workspace``
+    (for a single mount) or ``/workspace-N`` (for multiples).
+    """
+    mounts: list[WorkspaceMount] = []
+    for index, spec in enumerate(specs):
+        # Split on the *last* colon to allow Windows-style paths in the future
+        if ":" in spec:
+            host_str, guest_path = spec.rsplit(":", 1)
+        else:
+            host_str = spec
+            guest_path = "/workspace" if len(specs) == 1 else f"/workspace-{index}"
+        mounts.append(WorkspaceMount(host_path=Path(host_str), guest_path=guest_path))
+    return mounts
+
+
 def _build_auto_config_image_name(
     guest_os: GuestOS,
     *,
@@ -470,7 +488,7 @@ class SmolVM:
         ssh_user: str = "root",
         ssh_key_path: str | None = None,
         internet_settings: InternetSettings | dict[str, Any] | None = None,
-        workspace: Path | str | None = None,
+        mounts: list[str] | None = None,
     ) -> None:
         if config is not None and vm_id is not None:
             raise ValueError("Provide either config or vm_id, not both.")
@@ -530,21 +548,20 @@ class SmolVM:
             if config is not None:
                 config = config.model_copy(update={"internet_settings": internet_settings})
 
-        # Normalize and merge workspace into the config
-        if workspace is not None:
+        # Normalize and merge mounts into the config
+        if mounts is not None:
             if vm_id is not None:
                 raise ValueError(
-                    "workspace cannot be set when reconnecting to an existing VM."
+                    "mounts cannot be set when reconnecting to an existing VM."
                 )
-            ws_path = Path(workspace) if isinstance(workspace, str) else workspace
-            mount = WorkspaceMount(host_path=ws_path)
+            workspace_mounts = _parse_mount_specs(mounts)
             if config is not None:
                 if config.workspace_mounts:
                     raise ValueError(
                         "workspace_mounts is already set on the provided VMConfig; "
                         "pass it in one place only."
                     )
-                config = config.model_copy(update={"workspace_mounts": [mount]})
+                config = config.model_copy(update={"workspace_mounts": workspace_mounts})
 
         self._ssh_user = ssh_user
         self._ssh_key_path = ssh_key_path

--- a/src/smolvm/types.py
+++ b/src/smolvm/types.py
@@ -110,6 +110,47 @@ class VsockConfig(BaseModel):
     model_config = {"frozen": True}
 
 
+class WorkspaceMount(BaseModel):
+    """Host directory to mount inside the guest via virtio-9p + overlayfs.
+
+    The host directory is exposed read-only through QEMU's virtio-9p
+    passthrough.  An overlayfs layer on top lets the guest read and write
+    freely — but changes stay inside the VM and never touch the host.
+
+    Attributes:
+        host_path: Absolute path to a directory on the host.
+        guest_path: Mount point inside the guest (default ``/workspace``).
+        mount_tag: 9p mount tag passed to QEMU.  Auto-generated when omitted.
+    """
+
+    host_path: Path
+    guest_path: str = "/workspace"
+    mount_tag: str | None = None
+
+    @field_validator("host_path")
+    @classmethod
+    def validate_host_path(cls, v: Path) -> Path:
+        """Ensure the host path exists and is a directory."""
+        v = v.resolve()
+        if not v.exists():
+            raise ValueError(f"Workspace path does not exist: {v}")
+        if not v.is_dir():
+            raise ValueError(f"Workspace path is not a directory: {v}")
+        return v
+
+    @field_validator("guest_path")
+    @classmethod
+    def validate_guest_path(cls, v: str) -> str:
+        """Ensure the guest mount point is an absolute path."""
+        if not v.startswith("/"):
+            raise ValueError(
+                f"guest_path must be an absolute path, got: {v!r}"
+            )
+        return v
+
+    model_config = {"frozen": True}
+
+
 class InternetSettings(BaseModel):
     """Network access controls for a VM.
 
@@ -243,6 +284,7 @@ class VMConfig(BaseModel):
     port_forwards: list[PortForwardConfig] = []
     vsock: VsockConfig | None = None
     internet_settings: InternetSettings | None = None
+    workspace_mounts: list[WorkspaceMount] = []
 
     @field_validator("vm_id", mode="before")
     @classmethod
@@ -315,6 +357,28 @@ class VMConfig(BaseModel):
                 raise ValueError(f"Duplicate guest port in port_forwards: {forward.guest_port}")
             seen_host_ports.add(forward.host_port)
             seen_guest_ports.add(forward.guest_port)
+        return v
+
+    @field_validator("workspace_mounts")
+    @classmethod
+    def validate_workspace_mounts(
+        cls, v: list[WorkspaceMount],
+    ) -> list[WorkspaceMount]:
+        """Ensure workspace mount tags and guest paths are unique."""
+        seen_tags: set[str] = set()
+        seen_guest_paths: set[str] = set()
+        for index, mount in enumerate(v):
+            tag = mount.mount_tag or f"workspace{index}"
+            if tag in seen_tags:
+                raise ValueError(
+                    f"Duplicate workspace mount tag: {tag}"
+                )
+            if mount.guest_path in seen_guest_paths:
+                raise ValueError(
+                    f"Duplicate workspace guest_path: {mount.guest_path}"
+                )
+            seen_tags.add(tag)
+            seen_guest_paths.add(mount.guest_path)
         return v
 
     model_config = {"frozen": True}

--- a/src/smolvm/types.py
+++ b/src/smolvm/types.py
@@ -148,6 +148,10 @@ class WorkspaceMount(BaseModel):
             )
         return v
 
+    def resolved_tag(self, index: int) -> str:
+        """Return the mount tag, falling back to ``workspace{index}``."""
+        return self.mount_tag or f"workspace{index}"
+
     model_config = {"frozen": True}
 
 
@@ -368,7 +372,7 @@ class VMConfig(BaseModel):
         seen_tags: set[str] = set()
         seen_guest_paths: set[str] = set()
         for index, mount in enumerate(v):
-            tag = mount.mount_tag or f"workspace{index}"
+            tag = mount.resolved_tag(index)
             if tag in seen_tags:
                 raise ValueError(
                     f"Duplicate workspace mount tag: {tag}"

--- a/src/smolvm/vm.py
+++ b/src/smolvm/vm.py
@@ -502,6 +502,8 @@ class SmolVMManager:
             raise SmolVMError("Snapshotting currently supports only isolated-disk VMs")
         if vm_info.config.extra_drives:
             raise SmolVMError("Snapshotting currently supports only VMs without extra drives")
+        if vm_info.config.workspace_mounts:
+            raise SmolVMError("Snapshotting is not supported for VMs with workspace mounts")
         if vm_info.network is None:
             raise SmolVMError("VM has no network configuration", {"vm_id": vm_info.vm_id})
 
@@ -744,6 +746,13 @@ class SmolVMManager:
         effective_config = config
         if effective_config.backend != backend:
             effective_config = effective_config.model_copy(update={"backend": backend})
+
+        if effective_config.workspace_mounts and backend == BACKEND_FIRECRACKER:
+            raise SmolVMError(
+                "Workspace mounts (virtio-9p) are not supported with the "
+                "Firecracker backend. Use --backend qemu instead.",
+                {"vm_id": effective_config.vm_id, "backend": backend},
+            )
 
         effective_config = self._materialize_rootfs(effective_config)
 
@@ -1518,6 +1527,19 @@ class SmolVMManager:
                 ]
             )
             cmd.extend(["-drive", extra_drive_arg])
+
+        # ── virtio-9p workspace mounts ──────────────────────────────
+        workspace_fsdev_ids: list[tuple[str, str]] = []
+        for index, ws in enumerate(vm_info.config.workspace_mounts):
+            tag = ws.mount_tag or f"workspace{index}"
+            fsdev_id = f"fsdev-{tag}"
+            workspace_fsdev_ids.append((fsdev_id, tag))
+            cmd.extend([
+                "-fsdev",
+                f"local,id={fsdev_id},path={ws.host_path},"
+                f"security_model=mapped-xattr,readonly=on",
+            ])
+
         if control_socket_path is not None:
             cmd.extend(
                 [
@@ -1545,6 +1567,8 @@ class SmolVMManager:
             )
             for drive_id in extra_drive_ids:
                 cmd.extend(["-device", f"virtio-blk-device,drive={drive_id}"])
+            for fsdev_id, tag in workspace_fsdev_ids:
+                cmd.extend(["-device", f"virtio-9p-device,fsdev={fsdev_id},mount_tag={tag}"])
         else:
             machine = "q35,accel=hvf" if system == "Darwin" else "q35"
             cpu = "host" if system == "Darwin" else "max"
@@ -1562,6 +1586,8 @@ class SmolVMManager:
             )
             for drive_id in extra_drive_ids:
                 cmd.extend(["-device", f"virtio-blk-pci,drive={drive_id}"])
+            for fsdev_id, tag in workspace_fsdev_ids:
+                cmd.extend(["-device", f"virtio-9p-pci,fsdev={fsdev_id},mount_tag={tag}"])
 
         logger.debug("Starting QEMU: %s", " ".join(cmd))
 
@@ -2345,6 +2371,18 @@ class SmolVMManager:
             )
             cmd.extend(["-drive", extra_drive_arg])
 
+        # ── virtio-9p workspace mounts ──────────────────────────────
+        workspace_fsdev_ids: list[tuple[str, str]] = []
+        for index, ws in enumerate(vm_info.config.workspace_mounts):
+            tag = ws.mount_tag or f"workspace{index}"
+            fsdev_id = f"fsdev-{tag}"
+            workspace_fsdev_ids.append((fsdev_id, tag))
+            cmd.extend([
+                "-fsdev",
+                f"local,id={fsdev_id},path={ws.host_path},"
+                f"security_model=mapped-xattr,readonly=on",
+            ])
+
         if control_socket_path is not None:
             cmd.extend(["-qmp", f"unix:{control_socket_path},server=on,wait=off"])
         if start_paused:
@@ -2358,6 +2396,8 @@ class SmolVMManager:
                         "-device", f"virtio-net-device,netdev=net0,mac={guest_mac}"])
             for drive_id in extra_drive_ids:
                 cmd.extend(["-device", f"virtio-blk-device,drive={drive_id}"])
+            for fsdev_id, tag in workspace_fsdev_ids:
+                cmd.extend(["-device", f"virtio-9p-device,fsdev={fsdev_id},mount_tag={tag}"])
         else:
             machine = "q35,accel=hvf" if system == "Darwin" else "q35"
             cpu = "host" if system == "Darwin" else "max"
@@ -2366,6 +2406,8 @@ class SmolVMManager:
                         "-device", f"virtio-net-pci,netdev=net0,mac={guest_mac}"])
             for drive_id in extra_drive_ids:
                 cmd.extend(["-device", f"virtio-blk-pci,drive={drive_id}"])
+            for fsdev_id, tag in workspace_fsdev_ids:
+                cmd.extend(["-device", f"virtio-9p-pci,fsdev={fsdev_id},mount_tag={tag}"])
 
         log_file = open(log_path, "w")  # noqa: SIM115
         key = f"qemu:{vm_info.vm_id}"

--- a/src/smolvm/vm.py
+++ b/src/smolvm/vm.py
@@ -747,10 +747,10 @@ class SmolVMManager:
         if effective_config.backend != backend:
             effective_config = effective_config.model_copy(update={"backend": backend})
 
-        if effective_config.workspace_mounts and backend == BACKEND_FIRECRACKER:
+        if effective_config.workspace_mounts and backend != BACKEND_QEMU:
             raise SmolVMError(
-                "Workspace mounts (virtio-9p) are not supported with the "
-                "Firecracker backend. Use --backend qemu instead.",
+                "Workspace mounts (virtio-9p) are only supported with the "
+                "QEMU backend. Use --backend qemu.",
                 {"vm_id": effective_config.vm_id, "backend": backend},
             )
 
@@ -1531,7 +1531,7 @@ class SmolVMManager:
         # ── virtio-9p workspace mounts ──────────────────────────────
         workspace_fsdev_ids: list[tuple[str, str]] = []
         for index, ws in enumerate(vm_info.config.workspace_mounts):
-            tag = ws.mount_tag or f"workspace{index}"
+            tag = ws.resolved_tag(index)
             fsdev_id = f"fsdev-{tag}"
             workspace_fsdev_ids.append((fsdev_id, tag))
             cmd.extend([
@@ -2374,7 +2374,7 @@ class SmolVMManager:
         # ── virtio-9p workspace mounts ──────────────────────────────
         workspace_fsdev_ids: list[tuple[str, str]] = []
         for index, ws in enumerate(vm_info.config.workspace_mounts):
-            tag = ws.mount_tag or f"workspace{index}"
+            tag = ws.resolved_tag(index)
             fsdev_id = f"fsdev-{tag}"
             workspace_fsdev_ids.append((fsdev_id, tag))
             cmd.extend([

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -365,7 +365,7 @@ class TestCliCreate:
             ssh_key_path=None,
             on_download=ANY,
         )
-        mock_vm_cls.assert_called_once_with(config, ssh_key_path="/tmp/id_ed25519")
+        mock_vm_cls.assert_called_once_with(config, ssh_key_path="/tmp/id_ed25519", workspace=None)
         vm.start.assert_called_once_with(boot_timeout=30.0)
         vm.wait_for_ssh.assert_called_once_with(timeout=30.0)
         vm.close.assert_called_once()
@@ -425,7 +425,7 @@ class TestCliCreate:
             ssh_key_path=None,
             on_download=ANY,
         )
-        mock_vm_cls.assert_called_once_with(config, ssh_key_path="/tmp/id_ed25519")
+        mock_vm_cls.assert_called_once_with(config, ssh_key_path="/tmp/id_ed25519", workspace=None)
         vm.start.assert_called_once_with(boot_timeout=45.0)
         vm.wait_for_ssh.assert_called_once_with(timeout=45.0)
         vm.stop.assert_not_called()
@@ -472,7 +472,7 @@ class TestCliCreate:
             ssh_key_path=None,
             on_download=ANY,
         )
-        mock_vm_cls.assert_called_once_with(config, ssh_key_path="/tmp/id_ed25519")
+        mock_vm_cls.assert_called_once_with(config, ssh_key_path="/tmp/id_ed25519", workspace=None)
         vm.start.assert_called_once_with(boot_timeout=30.0)
         vm.wait_for_ssh.assert_called_once_with(timeout=30.0)
         vm.close.assert_called_once()

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -365,7 +365,7 @@ class TestCliCreate:
             ssh_key_path=None,
             on_download=ANY,
         )
-        mock_vm_cls.assert_called_once_with(config, ssh_key_path="/tmp/id_ed25519", workspace=None)
+        mock_vm_cls.assert_called_once_with(config, ssh_key_path="/tmp/id_ed25519", mounts=None)
         vm.start.assert_called_once_with(boot_timeout=30.0)
         vm.wait_for_ssh.assert_called_once_with(timeout=30.0)
         vm.close.assert_called_once()
@@ -425,7 +425,7 @@ class TestCliCreate:
             ssh_key_path=None,
             on_download=ANY,
         )
-        mock_vm_cls.assert_called_once_with(config, ssh_key_path="/tmp/id_ed25519", workspace=None)
+        mock_vm_cls.assert_called_once_with(config, ssh_key_path="/tmp/id_ed25519", mounts=None)
         vm.start.assert_called_once_with(boot_timeout=45.0)
         vm.wait_for_ssh.assert_called_once_with(timeout=45.0)
         vm.stop.assert_not_called()
@@ -472,7 +472,7 @@ class TestCliCreate:
             ssh_key_path=None,
             on_download=ANY,
         )
-        mock_vm_cls.assert_called_once_with(config, ssh_key_path="/tmp/id_ed25519", workspace=None)
+        mock_vm_cls.assert_called_once_with(config, ssh_key_path="/tmp/id_ed25519", mounts=None)
         vm.start.assert_called_once_with(boot_timeout=30.0)
         vm.wait_for_ssh.assert_called_once_with(timeout=30.0)
         vm.close.assert_called_once()

--- a/tests/test_facade.py
+++ b/tests/test_facade.py
@@ -634,9 +634,11 @@ class TestVMLifecycle:
         mock_sdk = MagicMock()
         mock_info = MagicMock(vm_id="vm001", status=VMState.CREATED)
         mock_info.config.env_vars = {}
+        mock_info.config.workspace_mounts = []
 
         running_info = MagicMock(vm_id="vm001", status=VMState.RUNNING)
         running_info.config.env_vars = {}
+        running_info.config.workspace_mounts = []
 
         mock_sdk.create.return_value = mock_info
         mock_sdk.start.return_value = running_info
@@ -658,6 +660,8 @@ class TestVMLifecycle:
         mock_sdk = MagicMock()
         running_info = MagicMock(vm_id="vm001", status=VMState.RUNNING)
         running_info.config.env_vars = {}
+        running_info.config.workspace_mounts = []
+
         mock_sdk.create.return_value = running_info
         mock_sdk_cls.return_value = mock_sdk
 
@@ -677,8 +681,12 @@ class TestVMLifecycle:
         mock_sdk = MagicMock()
         paused_info = MagicMock(vm_id="vm001", status=VMState.PAUSED)
         paused_info.config.env_vars = {}
+        paused_info.config.workspace_mounts = []
+
         running_info = MagicMock(vm_id="vm001", status=VMState.RUNNING)
         running_info.config.env_vars = {}
+        running_info.config.workspace_mounts = []
+
         mock_sdk.create.return_value = paused_info
         mock_sdk.resume.return_value = running_info
         mock_sdk_cls.return_value = mock_sdk
@@ -1465,8 +1473,12 @@ class TestVMContextManager:
         mock_sdk = MagicMock()
         created_info = MagicMock(vm_id="vm001", status=VMState.CREATED)
         created_info.config.env_vars = {}
+        created_info.config.workspace_mounts = []
+
         running_info = MagicMock(vm_id="vm001", status=VMState.RUNNING)
         running_info.config.env_vars = {}
+        running_info.config.workspace_mounts = []
+
         stopped_info = MagicMock(vm_id="vm001", status=VMState.STOPPED)
 
         mock_sdk.create.return_value = created_info

--- a/tests/test_workspace.py
+++ b/tests/test_workspace.py
@@ -1,0 +1,275 @@
+# Copyright 2026 Celesto AI
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for the ``--workspace`` (virtio-9p + overlayfs) feature."""
+
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+from pydantic import ValidationError
+
+from smolvm.types import VMConfig, WorkspaceMount
+from smolvm.vm import SmolVMManager
+
+# ── WorkspaceMount validation ───────────────────────────────────────
+
+
+class TestWorkspaceMountValidation:
+    """Tests for WorkspaceMount Pydantic model."""
+
+    def test_valid_directory(self, tmp_path: Path) -> None:
+        ws = WorkspaceMount(host_path=tmp_path)
+        assert ws.host_path == tmp_path.resolve()
+        assert ws.guest_path == "/workspace"
+        assert ws.mount_tag is None
+
+    def test_nonexistent_path_rejected(self, tmp_path: Path) -> None:
+        with pytest.raises(ValidationError, match="does not exist"):
+            WorkspaceMount(host_path=tmp_path / "no-such-dir")
+
+    def test_file_not_directory_rejected(self, tmp_path: Path) -> None:
+        f = tmp_path / "afile.txt"
+        f.touch()
+        with pytest.raises(ValidationError, match="not a directory"):
+            WorkspaceMount(host_path=f)
+
+    def test_relative_guest_path_rejected(self, tmp_path: Path) -> None:
+        with pytest.raises(ValidationError, match="absolute path"):
+            WorkspaceMount(host_path=tmp_path, guest_path="relative/path")
+
+    def test_custom_guest_path(self, tmp_path: Path) -> None:
+        ws = WorkspaceMount(host_path=tmp_path, guest_path="/mnt/data")
+        assert ws.guest_path == "/mnt/data"
+
+    def test_custom_mount_tag(self, tmp_path: Path) -> None:
+        ws = WorkspaceMount(host_path=tmp_path, mount_tag="myshare")
+        assert ws.mount_tag == "myshare"
+
+
+# ── VMConfig workspace_mounts validation ────────────────────────────
+
+
+class TestVMConfigWorkspaceMounts:
+    """Tests for workspace_mounts field on VMConfig."""
+
+    def _make_config(self, tmp_path: Path, **kwargs: object) -> VMConfig:
+        kernel = tmp_path / "vmlinux"
+        rootfs = tmp_path / "rootfs.ext4"
+        kernel.touch()
+        rootfs.touch()
+        return VMConfig(
+            vm_id="ws-test",
+            kernel_path=kernel,
+            rootfs_path=rootfs,
+            backend="qemu",
+            **kwargs,
+        )
+
+    def test_default_is_empty(self, tmp_path: Path) -> None:
+        config = self._make_config(tmp_path)
+        assert config.workspace_mounts == []
+
+    def test_single_mount(self, tmp_path: Path) -> None:
+        ws_dir = tmp_path / "project"
+        ws_dir.mkdir()
+        config = self._make_config(
+            tmp_path,
+            workspace_mounts=[WorkspaceMount(host_path=ws_dir)],
+        )
+        assert len(config.workspace_mounts) == 1
+
+    def test_duplicate_guest_path_rejected(self, tmp_path: Path) -> None:
+        d1 = tmp_path / "a"
+        d2 = tmp_path / "b"
+        d1.mkdir()
+        d2.mkdir()
+        with pytest.raises(ValidationError, match="Duplicate workspace guest_path"):
+            self._make_config(
+                tmp_path,
+                workspace_mounts=[
+                    WorkspaceMount(host_path=d1, guest_path="/workspace"),
+                    WorkspaceMount(host_path=d2, guest_path="/workspace"),
+                ],
+            )
+
+    def test_duplicate_mount_tag_rejected(self, tmp_path: Path) -> None:
+        d1 = tmp_path / "a"
+        d2 = tmp_path / "b"
+        d1.mkdir()
+        d2.mkdir()
+        with pytest.raises(ValidationError, match="Duplicate workspace mount tag"):
+            self._make_config(
+                tmp_path,
+                workspace_mounts=[
+                    WorkspaceMount(
+                        host_path=d1, guest_path="/ws1", mount_tag="share",
+                    ),
+                    WorkspaceMount(
+                        host_path=d2, guest_path="/ws2", mount_tag="share",
+                    ),
+                ],
+            )
+
+
+# ── QEMU command builder ────────────────────────────────────────────
+
+
+@patch("smolvm.vm.subprocess.Popen")
+@patch.object(
+    SmolVMManager,
+    "_find_qemu_binary",
+    return_value=Path("/opt/homebrew/bin/qemu-system-aarch64"),
+)
+def test_start_qemu_includes_9p_workspace_args(
+    _mock_find_qemu_binary: MagicMock,
+    mock_popen: MagicMock,
+    tmp_path: Path,
+) -> None:
+    """QEMU launch should include -fsdev and -device virtio-9p-device for workspaces."""
+    kernel = tmp_path / "vmlinux"
+    rootfs = tmp_path / "rootfs.ext4"
+    kernel.touch()
+    rootfs.touch()
+
+    ws_dir = tmp_path / "project"
+    ws_dir.mkdir()
+
+    config = VMConfig(
+        vm_id="vm-ws-test",
+        kernel_path=kernel,
+        rootfs_path=rootfs,
+        backend="qemu",
+        boot_args="console=ttyAMA0 reboot=k panic=1 init=/init",
+        workspace_mounts=[WorkspaceMount(host_path=ws_dir)],
+    )
+
+    sdk = SmolVMManager(
+        data_dir=tmp_path / "data",
+        socket_dir=tmp_path / "sockets",
+        backend="qemu",
+    )
+    with patch.object(SmolVMManager, "_create_qemu_overlay_disk") as mock_convert:
+        mock_convert.side_effect = lambda source, target: target.touch()
+        vm_info = sdk.create(config)
+
+    proc = MagicMock()
+    proc.pid = 12345
+    mock_popen.return_value = proc
+
+    with patch("smolvm.vm.platform.system", return_value="Darwin"):
+        sdk._start_qemu(vm_info, tmp_path / "vm-ws-test.log")
+
+    cmd = mock_popen.call_args.args[0]
+
+    # Find the -fsdev argument
+    fsdev_idx = cmd.index("-fsdev")
+    fsdev_arg = cmd[fsdev_idx + 1]
+    assert f"path={ws_dir.resolve()}" in fsdev_arg
+    assert "security_model=mapped-xattr" in fsdev_arg
+    assert "readonly=on" in fsdev_arg
+    assert "id=fsdev-workspace0" in fsdev_arg
+
+    # Find the virtio-9p device (aarch64 → virtio-9p-device)
+    assert "virtio-9p-device,fsdev=fsdev-workspace0,mount_tag=workspace0" in cmd
+
+
+# ── Firecracker rejection ───────────────────────────────────────────
+
+
+def test_workspace_rejected_on_firecracker(tmp_path: Path) -> None:
+    """Workspace mounts should be rejected for the Firecracker backend."""
+    from smolvm.exceptions import SmolVMError
+
+    kernel = tmp_path / "vmlinux"
+    rootfs = tmp_path / "rootfs.ext4"
+    kernel.touch()
+    rootfs.touch()
+
+    ws_dir = tmp_path / "project"
+    ws_dir.mkdir()
+
+    config = VMConfig(
+        vm_id="vm-fc-ws",
+        kernel_path=kernel,
+        rootfs_path=rootfs,
+        backend="firecracker",
+        workspace_mounts=[WorkspaceMount(host_path=ws_dir)],
+    )
+
+    sdk = SmolVMManager(
+        data_dir=tmp_path / "data",
+        socket_dir=tmp_path / "sockets",
+        backend="firecracker",
+    )
+
+    with pytest.raises(SmolVMError, match="not supported with the Firecracker"):
+        sdk.create(config)
+
+
+# ── Snapshot guard ──────────────────────────────────────────────────
+
+
+def test_snapshot_rejected_with_workspace_mounts(tmp_path: Path) -> None:
+    """Snapshotting should be blocked for VMs with workspace mounts."""
+    from smolvm.exceptions import SmolVMError
+
+    kernel = tmp_path / "vmlinux"
+    rootfs = tmp_path / "rootfs.ext4"
+    kernel.touch()
+    rootfs.touch()
+
+    ws_dir = tmp_path / "project"
+    ws_dir.mkdir()
+
+    config = VMConfig(
+        vm_id="vm-snap-ws",
+        kernel_path=kernel,
+        rootfs_path=rootfs,
+        backend="qemu",
+        workspace_mounts=[WorkspaceMount(host_path=ws_dir)],
+    )
+
+    sdk = SmolVMManager(
+        data_dir=tmp_path / "data",
+        socket_dir=tmp_path / "sockets",
+        backend="qemu",
+    )
+    with patch.object(SmolVMManager, "_create_qemu_overlay_disk") as mock_convert:
+        mock_convert.side_effect = lambda source, target: target.touch()
+        vm_info = sdk.create(config)
+
+    with pytest.raises(SmolVMError, match="workspace mounts"):
+        sdk._ensure_snapshot_supported(vm_info)
+
+
+# ── CLI ─────────────────────────────────────────────────────────────
+
+
+class TestCliWorkspaceFlag:
+    """Tests for the --workspace CLI flag on create."""
+
+    def test_workspace_flag_is_parsed(self) -> None:
+        from smolvm.cli import build_parser
+
+        parser = build_parser()
+        args = parser.parse_args(["create", "--workspace", "/tmp"])
+        assert args.workspace == Path("/tmp")
+
+    def test_workspace_flag_defaults_to_none(self) -> None:
+        from smolvm.cli import build_parser
+
+        parser = build_parser()
+        args = parser.parse_args(["create"])
+        assert args.workspace is None

--- a/tests/test_workspace.py
+++ b/tests/test_workspace.py
@@ -57,6 +57,16 @@ class TestWorkspaceMountValidation:
         ws = WorkspaceMount(host_path=tmp_path, mount_tag="myshare")
         assert ws.mount_tag == "myshare"
 
+    def test_resolved_tag_with_explicit_tag(self, tmp_path: Path) -> None:
+        ws = WorkspaceMount(host_path=tmp_path, mount_tag="myshare")
+        assert ws.resolved_tag(0) == "myshare"
+        assert ws.resolved_tag(5) == "myshare"
+
+    def test_resolved_tag_fallback(self, tmp_path: Path) -> None:
+        ws = WorkspaceMount(host_path=tmp_path)
+        assert ws.resolved_tag(0) == "workspace0"
+        assert ws.resolved_tag(3) == "workspace3"
+
 
 # ── VMConfig workspace_mounts validation ────────────────────────────
 
@@ -188,8 +198,11 @@ def test_start_qemu_includes_9p_workspace_args(
 # ── Firecracker rejection ───────────────────────────────────────────
 
 
-def test_workspace_rejected_on_firecracker(tmp_path: Path) -> None:
-    """Workspace mounts should be rejected for the Firecracker backend."""
+@pytest.mark.parametrize("backend", ["firecracker", "libkrun"])
+def test_workspace_rejected_on_non_qemu_backend(
+    tmp_path: Path, backend: str,
+) -> None:
+    """Workspace mounts should be rejected for non-QEMU backends."""
     from smolvm.exceptions import SmolVMError
 
     kernel = tmp_path / "vmlinux"
@@ -201,20 +214,20 @@ def test_workspace_rejected_on_firecracker(tmp_path: Path) -> None:
     ws_dir.mkdir()
 
     config = VMConfig(
-        vm_id="vm-fc-ws",
+        vm_id=f"vm-{backend}-ws",
         kernel_path=kernel,
         rootfs_path=rootfs,
-        backend="firecracker",
+        backend=backend,
         workspace_mounts=[WorkspaceMount(host_path=ws_dir)],
     )
 
     sdk = SmolVMManager(
         data_dir=tmp_path / "data",
         socket_dir=tmp_path / "sockets",
-        backend="firecracker",
+        backend=backend,
     )
 
-    with pytest.raises(SmolVMError, match="not supported with the Firecracker"):
+    with pytest.raises(SmolVMError, match="only supported with the QEMU"):
         sdk.create(config)
 
 
@@ -273,3 +286,56 @@ class TestCliWorkspaceFlag:
         parser = build_parser()
         args = parser.parse_args(["create"])
         assert args.workspace is None
+
+
+# ── Facade guards ───────────────────────────────────────────────────
+
+
+class TestFacadeWorkspaceGuards:
+    """Tests for facade-level workspace mount guards."""
+
+    def test_mount_workspaces_rejects_non_root_ssh(self, tmp_path: Path) -> None:
+        """Workspace mounts should fail fast if ssh_user is not root."""
+        from unittest.mock import MagicMock
+
+        from smolvm.exceptions import SmolVMError
+        from smolvm.facade import SmolVM
+
+        kernel = tmp_path / "vmlinux"
+        rootfs = tmp_path / "rootfs.ext4"
+        kernel.touch()
+        rootfs.touch()
+
+        ws_dir = tmp_path / "project"
+        ws_dir.mkdir()
+
+        config = VMConfig(
+            vm_id="vm-nonroot",
+            kernel_path=kernel,
+            rootfs_path=rootfs,
+            backend="qemu",
+            ssh_capable=True,
+            workspace_mounts=[WorkspaceMount(host_path=ws_dir)],
+        )
+
+        with patch("smolvm.facade.SmolVMManager") as mock_sdk_cls:
+            mock_sdk = MagicMock()
+            mock_info = MagicMock(vm_id="vm-nonroot")
+            mock_info.status = MagicMock()
+            mock_info.status.value = "created"
+            mock_info.config = config
+            mock_sdk.create.return_value = mock_info
+
+            running_info = MagicMock(vm_id="vm-nonroot")
+            running_info.config = config
+            running_info.network.guest_ip = "127.0.0.1"
+            running_info.network.ssh_host_port = 2200
+            mock_sdk.start.return_value = running_info
+            mock_sdk_cls.return_value = mock_sdk
+
+            vm = SmolVM(config, ssh_user="agent")
+            with pytest.raises(SmolVMError, match="require ssh_user='root'"):
+                with patch.object(vm, "can_run_commands", return_value=True), \
+                     patch.object(vm, "wait_for_ssh"), \
+                     patch("smolvm.facade.SSHClient"):
+                    vm.start()

--- a/tests/test_workspace.py
+++ b/tests/test_workspace.py
@@ -270,22 +270,84 @@ def test_snapshot_rejected_with_workspace_mounts(tmp_path: Path) -> None:
 # ── CLI ─────────────────────────────────────────────────────────────
 
 
-class TestCliWorkspaceFlag:
-    """Tests for the --workspace CLI flag on create."""
+class TestCliMountFlag:
+    """Tests for the --mount CLI flag on create."""
 
-    def test_workspace_flag_is_parsed(self) -> None:
+    def test_single_mount_host_only(self) -> None:
         from smolvm.cli import build_parser
 
         parser = build_parser()
-        args = parser.parse_args(["create", "--workspace", "/tmp"])
-        assert args.workspace == Path("/tmp")
+        args = parser.parse_args(["create", "--mount", "/tmp/project"])
+        assert args.mounts == ["/tmp/project"]
 
-    def test_workspace_flag_defaults_to_none(self) -> None:
+    def test_single_mount_with_guest_path(self) -> None:
+        from smolvm.cli import build_parser
+
+        parser = build_parser()
+        args = parser.parse_args(["create", "--mount", "/tmp/project:/code"])
+        assert args.mounts == ["/tmp/project:/code"]
+
+    def test_multiple_mounts(self) -> None:
+        from smolvm.cli import build_parser
+
+        parser = build_parser()
+        args = parser.parse_args([
+            "create",
+            "--mount", "/tmp/a",
+            "--mount", "/tmp/b:/data",
+        ])
+        assert args.mounts == ["/tmp/a", "/tmp/b:/data"]
+
+    def test_mount_defaults_to_none(self) -> None:
         from smolvm.cli import build_parser
 
         parser = build_parser()
         args = parser.parse_args(["create"])
-        assert args.workspace is None
+        assert args.mounts is None
+
+
+# ── Mount spec parsing ──────────────────────────────────────────────
+
+
+class TestParseMountSpecs:
+    """Tests for _parse_mount_specs helper."""
+
+    def test_single_host_only_defaults_to_workspace(self, tmp_path: Path) -> None:
+        from smolvm.facade import _parse_mount_specs
+
+        mounts = _parse_mount_specs([str(tmp_path)])
+        assert len(mounts) == 1
+        assert mounts[0].host_path == tmp_path.resolve()
+        assert mounts[0].guest_path == "/workspace"
+
+    def test_host_with_guest_path(self, tmp_path: Path) -> None:
+        from smolvm.facade import _parse_mount_specs
+
+        mounts = _parse_mount_specs([f"{tmp_path}:/code"])
+        assert len(mounts) == 1
+        assert mounts[0].guest_path == "/code"
+
+    def test_multiple_mounts_get_indexed_defaults(self, tmp_path: Path) -> None:
+        from smolvm.facade import _parse_mount_specs
+
+        d1 = tmp_path / "a"
+        d2 = tmp_path / "b"
+        d1.mkdir()
+        d2.mkdir()
+        mounts = _parse_mount_specs([str(d1), str(d2)])
+        assert mounts[0].guest_path == "/workspace-0"
+        assert mounts[1].guest_path == "/workspace-1"
+
+    def test_mixed_explicit_and_default(self, tmp_path: Path) -> None:
+        from smolvm.facade import _parse_mount_specs
+
+        d1 = tmp_path / "a"
+        d2 = tmp_path / "b"
+        d1.mkdir()
+        d2.mkdir()
+        mounts = _parse_mount_specs([str(d1), f"{d2}:/data"])
+        assert mounts[0].guest_path == "/workspace-0"
+        assert mounts[1].guest_path == "/data"
 
 
 # ── Facade guards ───────────────────────────────────────────────────
@@ -334,8 +396,8 @@ class TestFacadeWorkspaceGuards:
             mock_sdk_cls.return_value = mock_sdk
 
             vm = SmolVM(config, ssh_user="agent")
-            with pytest.raises(SmolVMError, match="require ssh_user='root'"):
-                with patch.object(vm, "can_run_commands", return_value=True), \
-                     patch.object(vm, "wait_for_ssh"), \
-                     patch("smolvm.facade.SSHClient"):
-                    vm.start()
+            with pytest.raises(SmolVMError, match="require ssh_user='root'"), \
+                 patch.object(vm, "can_run_commands", return_value=True), \
+                 patch.object(vm, "wait_for_ssh"), \
+                 patch("smolvm.facade.SSHClient"):
+                vm.start()


### PR DESCRIPTION
## Summary

- Adds `--mount HOST_PATH[:GUEST_PATH]` flag to `smolvm create` that mounts a host directory inside the guest
- Host directory is **read-only** (virtio-9p passthrough) with an **overlayfs** layer on top — the agent can read and write freely, but host files are never modified
- QEMU-only (macOS first); non-QEMU backends reject workspace mounts with a clear error message
- SDK users get a `mounts=` kwarg on `SmolVM()` and a `WorkspaceMount` type for advanced use

### How it works

```
Host: ~/my-project ──(virtio-9p, read-only)──→ Guest: /mnt/.smolvm-ws-lower
                                                         +
                                               Guest: /tmp/.smolvm-ws-upper (overlay)
                                                         =
                                               Guest: /workspace (merged, read-write)
```

### Usage

```bash
# Mount a project directory (defaults to /workspace inside the sandbox)
smolvm create --mount ~/Projects/my-app

# Mount at a custom guest path
smolvm create --mount ~/Projects/my-app:/code

# Multiple mounts
smolvm create --mount ~/Projects/my-app --mount ~/data:/mnt/data

# SSH in and work
smolvm ssh <sandbox-id>
cat /workspace/README.md     # reads from host
echo "new" > /workspace/x.py # writes to overlay (host untouched)
```

#### Python SDK

```python
from smolvm import SmolVM

# Simple — single mount
with SmolVM(mounts=["~/Projects/my-app"]) as vm:
    result = vm.run("ls /workspace")
    print(result.stdout)

# Custom guest path
with SmolVM(mounts=["~/Projects/my-app:/code"]) as vm:
    result = vm.run("cat /code/README.md")

# Multiple mounts
with SmolVM(mounts=["~/src:/code", "~/data:/mnt/data"]) as vm:
    result = vm.run("ls /code /mnt/data")

# Advanced — using WorkspaceMount directly
from smolvm import SmolVM, VMConfig, WorkspaceMount

config = VMConfig(
    ...,
    workspace_mounts=[
        WorkspaceMount(host_path="~/Projects/my-app", guest_path="/code"),
        WorkspaceMount(host_path="~/data", guest_path="/mnt/data"),
    ],
)
with SmolVM(config) as vm:
    result = vm.run("ls /code")
```

Closes #157

## Test plan

- [x] 25 tests in `tests/test_workspace.py` covering:
  - `WorkspaceMount` validation (valid dir, nonexistent path, file-not-dir, relative guest_path, custom tag/path, resolved_tag)
  - `VMConfig.workspace_mounts` (default empty, duplicate guest_path rejected, duplicate tag rejected)
  - QEMU command builder (asserts `-fsdev` and `virtio-9p-device` args with `readonly=on`, `security_model=mapped-xattr`)
  - Non-QEMU backend rejection (Firecracker + libkrun)
  - Snapshot guard (blocks VMs with workspace mounts)
  - CLI flag parsing (`--mount` single, with guest path, multiples, default None)
  - `_parse_mount_specs` (host-only, host:guest, indexed defaults, mixed)
  - Facade guard (non-root SSH user rejected)
- [x] Full test suite passes (575 passed, 9 pre-existing async skips)
- [x] Linter clean (no new issues)
- [x] Manual: `smolvm create --mount /tmp/test-dir && smolvm ssh <id>` → verify `/workspace` is mounted and writable

🤖 Generated with [Claude Code](https://claude.com/claude-code)