### PR TITLE
feat: boot --os debian from prebuilt cloud image, no host Docker

### DIFF
--- a/src/smolvm/cli/main.py
+++ b/src/smolvm/cli/main.py
@@ -473,7 +473,8 @@ def build_parser() -> argparse.ArgumentParser:
         default=None,
         help=(
             "Sandbox disk size in MiB. Defaults: 512 for alpine, "
-            "2048 for debian/ubuntu. Minimum 64."
+            "2048 for debian/ubuntu. Minimum: 64 for alpine; 2048 for "
+            "debian/ubuntu on qemu (values below 2048 are rejected)."
         ),
     )
     create_parser.add_argument(

--- a/src/smolvm/cli/main.py
+++ b/src/smolvm/cli/main.py
@@ -471,7 +471,10 @@ def build_parser() -> argparse.ArgumentParser:
         "--disk-size-mib",
         type=int,
         default=None,
-        help="Sandbox disk size in MiB (default: 512).",
+        help=(
+            "Sandbox disk size in MiB. Defaults: 512 for alpine, "
+            "2048 for debian/ubuntu. Minimum 64."
+        ),
     )
     create_parser.add_argument(
         "--backend",

--- a/src/smolvm/facade.py
+++ b/src/smolvm/facade.py
@@ -28,9 +28,11 @@ interface::
 
 from __future__ import annotations
 
+import json
 import logging
 import platform
 import shlex
+import shutil
 import socket
 import subprocess
 import time
@@ -126,6 +128,21 @@ _QEMU_UBUNTU_AUTO_IMAGES: dict[str, ImageSource] = {
     ),
 }
 
+# Debian "genericcloud" is a single bootable qcow2 with the kernel + initrd
+# inside — no separate unpacked assets like Ubuntu publishes. SmolVM uses
+# firmware boot (OVMF/SeaBIOS) for this image, so only the rootfs URL matters.
+# Pinning to /bookworm/latest/ mirrors the existing Ubuntu pattern of not
+# pinning to a dated release.
+_DEBIAN_CURRENT_RELEASE_TAG = "bookworm-latest"
+_DEBIAN_AUTO_IMAGE_URLS: dict[str, str] = {
+    "debian-bookworm-genericcloud-qemu-x86_64": (
+        "https://cloud.debian.org/images/cloud/bookworm/latest/debian-12-genericcloud-amd64.qcow2"
+    ),
+    "debian-bookworm-genericcloud-qemu-aarch64": (
+        "https://cloud.debian.org/images/cloud/bookworm/latest/debian-12-genericcloud-arm64.qcow2"
+    ),
+}
+
 
 def _normalize_guest_os(os: GuestOS | str | None) -> GuestOS:
     """Normalize guest OS input for auto-config flows."""
@@ -147,11 +164,95 @@ def _default_guest_os_for_backend(backend: str) -> GuestOS:
     return GuestOS.ALPINE
 
 
-def _qemu_auto_config_image_name() -> str:
-    """Return the prebuilt QEMU image cache key for the host architecture."""
+def _qemu_auto_config_image_name(guest_os: GuestOS = GuestOS.UBUNTU) -> str:
+    """Return the prebuilt QEMU image cache key for *guest_os* on this host."""
     arch = platform.machine().lower()
     image_arch = "aarch64" if arch in {"arm64", "aarch64"} else "x86_64"
-    return f"ubuntu-noble-minimal-qemu-{image_arch}"
+    if guest_os is GuestOS.UBUNTU:
+        return f"ubuntu-noble-minimal-qemu-{image_arch}"
+    if guest_os is GuestOS.DEBIAN:
+        return f"debian-bookworm-genericcloud-qemu-{image_arch}"
+    raise ValueError(f"No prebuilt QEMU auto-config image for guest OS: {guest_os}")
+
+
+def _qcow2_virtual_size_mib(qcow2_path: Path) -> int:
+    """Return the virtual size of a qcow2 image in MiB."""
+    result = subprocess.run(
+        ["qemu-img", "info", "--output=json", str(qcow2_path)],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    info = json.loads(result.stdout)
+    return int(info["virtual-size"]) // (1024 * 1024)
+
+
+def _prepare_sized_qcow2(
+    *,
+    cache_dir: Path,
+    base_image_name: str,
+    source_qcow2: Path,
+    target_mib: int,
+) -> tuple[Path, int]:
+    """Return a qcow2 rootfs sized to at least *target_mib*.
+
+    The pristine downloaded image is never mutated. When the requested size
+    exceeds the cached image's virtual size, this copies the qcow2 into a
+    size-specific cache directory (``{base_image_name}-{target_mib}m``) and
+    runs ``qemu-img resize`` on the copy. The sized copy is shared across
+    VMs of the same size; per-VM isolation still happens via
+    ``disk_mode="isolated"`` cloning later.
+
+    Returns a tuple of ``(rootfs_path, resolved_target_mib)`` where
+    ``resolved_target_mib`` is the actual virtual size of the returned image
+    (equal to ``target_mib`` for a fresh resize, or the existing cached size
+    for the default-size passthrough).
+    """
+    current_mib = _qcow2_virtual_size_mib(source_qcow2)
+    if target_mib <= current_mib:
+        # Use the pristine cached image. Cloud images ship at their minimum
+        # viable size; we refuse to shrink below that to avoid breaking the
+        # filesystem. Callers should enforce target_mib >= default upstream
+        # and surface a clear error instead of silently falling back here.
+        return source_qcow2, current_mib
+
+    sized_dir = cache_dir / f"{base_image_name}-{target_mib}m"
+    sized_qcow2 = sized_dir / source_qcow2.name
+    if sized_qcow2.is_file():
+        try:
+            existing_mib = _qcow2_virtual_size_mib(sized_qcow2)
+        except subprocess.CalledProcessError:
+            existing_mib = -1
+        if existing_mib == target_mib:
+            return sized_qcow2, existing_mib
+        logger.warning(
+            "Cached resized image %s has unexpected size (%d MiB), rebuilding",
+            sized_qcow2,
+            existing_mib,
+        )
+        sized_qcow2.unlink(missing_ok=True)
+
+    sized_dir.mkdir(parents=True, exist_ok=True)
+    temp_qcow2 = sized_qcow2.with_name(f".{sized_qcow2.name}.{uuid.uuid4().hex}.tmp")
+    try:
+        shutil.copy2(source_qcow2, temp_qcow2)
+        subprocess.run(
+            ["qemu-img", "resize", str(temp_qcow2), f"{target_mib}M"],
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+        temp_qcow2.replace(sized_qcow2)
+    except Exception:
+        temp_qcow2.unlink(missing_ok=True)
+        raise
+    logger.info(
+        "Prepared resized rootfs at %s (%d MiB -> %d MiB)",
+        sized_qcow2,
+        current_mib,
+        target_mib,
+    )
+    return sized_qcow2, target_mib
 
 
 def _resolve_auto_config_public_key(ssh_key_path: str | None) -> tuple[str, Path]:
@@ -164,10 +265,7 @@ def _resolve_auto_config_public_key(ssh_key_path: str | None) -> tuple[str, Path
 
     public_key = Path(f"{ssh_key_path}.pub")
     if not public_key.is_file():
-        raise ValueError(
-            "ssh_key_path must have a matching public key file at "
-            f"{public_key}"
-        )
+        raise ValueError(f"ssh_key_path must have a matching public key file at {public_key}")
     return ssh_key_path, public_key
 
 
@@ -327,12 +425,12 @@ def _build_auto_config(
         raise ValueError("ubuntu auto-config currently requires backend='qemu'")
 
     if resolved_os is GuestOS.UBUNTU:
-        if resolved_disk_size_mib != default_disk_size_mib:
+        if resolved_disk_size_mib < default_disk_size_mib:
             raise ValueError(
-                "ubuntu/qemu auto-config currently supports only the default disk size "
-                f"({default_disk_size_mib} MiB)"
+                f"ubuntu auto-config requires disk_size_mib >= {default_disk_size_mib} "
+                f"(got {resolved_disk_size_mib})"
             )
-        image_name = _qemu_auto_config_image_name()
+        image_name = _qemu_auto_config_image_name(GuestOS.UBUNTU)
         image_manager = ImageManager(registry=_QEMU_UBUNTU_AUTO_IMAGES)
         image = image_manager.ensure_image(image_name, on_download=on_download)
         if image.initrd_path is None:
@@ -340,6 +438,16 @@ def _build_auto_config(
                 "Prebuilt QEMU auto-config image is missing an initrd",
                 {"image_name": image_name},
             )
+
+        if resolved_disk_size_mib > default_disk_size_mib:
+            rootfs_path, _resolved_size = _prepare_sized_qcow2(
+                cache_dir=image_manager.cache_dir,
+                base_image_name=image_name,
+                source_qcow2=image.rootfs_path,
+                target_mib=resolved_disk_size_mib,
+            )
+        else:
+            rootfs_path = image.rootfs_path
 
         boot_profile = KernelBootProfile.QEMU_DESKTOP_INITRAMFS
         boot_args = get_boot_profile_spec(boot_profile).base_boot_args_for_backend(
@@ -374,7 +482,7 @@ def _build_auto_config(
             mem_size_mib=resolved_mem_size_mib,
             kernel_path=image.kernel_path,
             initrd_path=image.initrd_path,
-            rootfs_path=image.rootfs_path,
+            rootfs_path=rootfs_path,
             extra_drives=[seed_path],
             boot_args=boot_args,
             ssh_capable=True,
@@ -382,6 +490,79 @@ def _build_auto_config(
         )
         logger.info(
             "Auto-configured VM: %s (os=%s, backend=%s, source=prebuilt-qemu-image)",
+            resolved_vm_name,
+            resolved_os.value,
+            resolved_backend,
+        )
+        return config, resolved_ssh_key_path
+
+    # Debian on QEMU: fetch the upstream genericcloud qcow2 and boot it via
+    # firmware (OVMF/SeaBIOS). On non-QEMU backends (firecracker, libkrun),
+    # fall through to the docker-build path below.
+    if resolved_os is GuestOS.DEBIAN and resolved_backend == BACKEND_QEMU:
+        if resolved_disk_size_mib < default_disk_size_mib:
+            raise ValueError(
+                f"debian auto-config on qemu requires disk_size_mib >= {default_disk_size_mib} "
+                f"(got {resolved_disk_size_mib})"
+            )
+        image_name = _qemu_auto_config_image_name(GuestOS.DEBIAN)
+        rootfs_url = _DEBIAN_AUTO_IMAGE_URLS.get(image_name)
+        if rootfs_url is None:
+            raise SmolVMError(
+                "No prebuilt Debian image registered for this host architecture",
+                {"image_name": image_name},
+            )
+        image_manager = ImageManager()
+        pristine_rootfs = image_manager.ensure_rootfs_only(
+            image_name,
+            url=rootfs_url,
+            filename="rootfs.qcow2",
+            on_download=on_download,
+        )
+
+        if resolved_disk_size_mib > default_disk_size_mib:
+            rootfs_path, _resolved_size = _prepare_sized_qcow2(
+                cache_dir=image_manager.cache_dir,
+                base_image_name=image_name,
+                source_qcow2=pristine_rootfs,
+                target_mib=resolved_disk_size_mib,
+            )
+        else:
+            rootfs_path = pristine_rootfs
+
+        user_data = default_user_data(public_key_value)
+        seed_key = seed_cache_key(
+            ssh_public_key=public_key_value,
+            instance_id=f"smolvm-debian-{_DEBIAN_CURRENT_RELEASE_TAG}",
+            hostname="smolvm",
+            user_data=user_data,
+        )
+        seed_dir = image_manager.cache_dir / "cloud-init-seeds"
+        seed_path = seed_dir / f"{seed_key}.iso"
+        if not seed_path.exists():
+            build_seed_iso(
+                seed_path,
+                user_data=user_data,
+                meta_data=default_meta_data(
+                    instance_id=f"smolvm-debian-{_DEBIAN_CURRENT_RELEASE_TAG}",
+                    hostname="smolvm",
+                ),
+            )
+
+        resolved_vm_name = vm_name or f"vm-{uuid.uuid4().hex[:8]}"
+        config = VMConfig(
+            vm_id=resolved_vm_name,
+            vcpu_count=1,
+            mem_size_mib=resolved_mem_size_mib,
+            boot_mode="firmware",
+            kernel_path=None,
+            rootfs_path=rootfs_path,
+            extra_drives=[seed_path],
+            ssh_capable=True,
+            backend=resolved_backend,
+        )
+        logger.info(
+            "Auto-configured VM: %s (os=%s, backend=%s, source=prebuilt-debian-firmware)",
             resolved_vm_name,
             resolved_os.value,
             resolved_backend,
@@ -499,9 +680,7 @@ class SmolVM:
             raise ValueError("Provide either config or vm_id, not both.")
 
         if image is not None and (config is not None or vm_id is not None):
-            raise ValueError(
-                "image cannot be combined with config or vm_id."
-            )
+            raise ValueError("image cannot be combined with config or vm_id.")
 
         if image is not None and os is not None:
             raise ValueError(
@@ -556,9 +735,7 @@ class SmolVM:
         # Normalize and merge mounts into the config
         if mounts is not None:
             if vm_id is not None:
-                raise ValueError(
-                    "mounts cannot be set when reconnecting to an existing VM."
-                )
+                raise ValueError("mounts cannot be set when reconnecting to an existing VM.")
             workspace_mounts = _parse_mount_specs(mounts)
             if config is not None:
                 if config.workspace_mounts:
@@ -1036,8 +1213,7 @@ class SmolVM:
                 key_path = str(default_key)
             except Exception:
                 logger.debug(
-                    "VM %s: could not resolve default SSH key, "
-                    "falling back to agent/default auth",
+                    "VM %s: could not resolve default SSH key, falling back to agent/default auth",
                     self._vm_id,
                 )
 
@@ -1811,6 +1987,7 @@ class SmolVM:
         # explicit ssh_key_path should still authenticate correctly.
         if primary_key is None:
             from smolvm.utils import ensure_ssh_key
+
             try:
                 default_key, _ = ensure_ssh_key()
                 default_key_str = str(default_key)

--- a/src/smolvm/facade.py
+++ b/src/smolvm/facade.py
@@ -131,15 +131,24 @@ _QEMU_UBUNTU_AUTO_IMAGES: dict[str, ImageSource] = {
 # Debian "genericcloud" is a single bootable qcow2 with the kernel + initrd
 # inside — no separate unpacked assets like Ubuntu publishes. SmolVM uses
 # firmware boot (OVMF/SeaBIOS) for this image, so only the rootfs URL matters.
-# Pinning to /bookworm/latest/ mirrors the existing Ubuntu pattern of not
-# pinning to a dated release.
-_DEBIAN_CURRENT_RELEASE_TAG = "bookworm-latest"
-_DEBIAN_AUTO_IMAGE_URLS: dict[str, str] = {
+#
+# Pinned to a specific dated release (immutable URL) and verified against the
+# upstream SHA-512 digest from that release's SHA512SUMS file. To bump:
+#   1. Pick a newer build under https://cloud.debian.org/images/cloud/bookworm/
+#   2. Copy the SHA-512 hex digests from its SHA512SUMS file into this registry
+#   3. Verify the partition layout is still a single ext4 partition before
+#      committing — cloud-init growpart assumes this for the disk-resize path
+_DEBIAN_CURRENT_RELEASE_TAG = "20260413-2447"
+_DEBIAN_AUTO_IMAGES: dict[str, tuple[str, str]] = {
     "debian-bookworm-genericcloud-qemu-x86_64": (
-        "https://cloud.debian.org/images/cloud/bookworm/latest/debian-12-genericcloud-amd64.qcow2"
+        f"https://cloud.debian.org/images/cloud/bookworm/{_DEBIAN_CURRENT_RELEASE_TAG}/debian-12-genericcloud-amd64.qcow2",
+        "db11b13c4efcc37828ffadae521d101e85079d349e1418074087bb7d306f11ca"
+        "ccdc2b0b539d6fd50d623d40a898f83c6137268a048d7700397dc35b7dcbc927",
     ),
     "debian-bookworm-genericcloud-qemu-aarch64": (
-        "https://cloud.debian.org/images/cloud/bookworm/latest/debian-12-genericcloud-arm64.qcow2"
+        f"https://cloud.debian.org/images/cloud/bookworm/{_DEBIAN_CURRENT_RELEASE_TAG}/debian-12-genericcloud-arm64.qcow2",
+        "15ad6c52e255c84eb0e91001c5907b27199d8a7164d8ac172cfe9c92850dfaf6"
+        "06a6c3161d6af7f0fd5a5fef2aa8dcd9a23c2eb0fedbfcddb38e2bc306cba98f",
     ),
 }
 
@@ -506,17 +515,19 @@ def _build_auto_config(
                 f"(got {resolved_disk_size_mib})"
             )
         image_name = _qemu_auto_config_image_name(GuestOS.DEBIAN)
-        rootfs_url = _DEBIAN_AUTO_IMAGE_URLS.get(image_name)
-        if rootfs_url is None:
+        debian_entry = _DEBIAN_AUTO_IMAGES.get(image_name)
+        if debian_entry is None:
             raise SmolVMError(
                 "No prebuilt Debian image registered for this host architecture",
                 {"image_name": image_name},
             )
+        rootfs_url, rootfs_sha512 = debian_entry
         image_manager = ImageManager()
         pristine_rootfs = image_manager.ensure_rootfs_only(
             image_name,
             url=rootfs_url,
             filename="rootfs.qcow2",
+            sha512=rootfs_sha512,
             on_download=on_download,
         )
 
@@ -1453,13 +1464,20 @@ class SmolVM:
         """Whether this VM config supports command execution via SSH.
 
         Command execution requires a boot path that is expected to
-        bring up SSH inside the guest.
+        bring up SSH inside the guest. Three shapes qualify:
+
+        1. ``ssh_capable=True`` — the caller has explicitly declared the
+           boot path brings up SSH (used by prebuilt cloud images, S3
+           images, and firmware-boot VMs).
+        2. A microvm direct-kernel boot with ``init=/init`` in the kernel
+           command line (the alpine/debian docker-build path).
+        3. A legacy initrd-backed boot with ``ssh_capable`` implicitly set.
         """
-        initrd_path = self._info.config.initrd_path
-        ssh_capable = getattr(self._info.config, "ssh_capable", False)
-        return "init=/init" in self._info.config.boot_args or (
-            isinstance(initrd_path, Path) and ssh_capable is True
-        )
+        config = self._info.config
+        ssh_capable = getattr(config, "ssh_capable", False)
+        if ssh_capable is True:
+            return True
+        return "init=/init" in config.boot_args
 
     def close(self) -> None:
         """Release underlying SDK resources for this facade instance."""

--- a/src/smolvm/images/manager.py
+++ b/src/smolvm/images/manager.py
@@ -476,6 +476,7 @@ class ImageManager:
         url: str,
         filename: str = "rootfs.qcow2",
         sha256: str | None = None,
+        sha512: str | None = None,
         on_download: Callable[[str, int, int | None], None] | None = None,
     ) -> Path:
         """Ensure a standalone rootfs image is available locally.
@@ -489,8 +490,13 @@ class ImageManager:
             name: Cache directory name (under ``~/.smolvm/images/``).
             url: URL to download the rootfs from.
             filename: Cache filename for the rootfs (default ``rootfs.qcow2``).
-            sha256: Optional expected SHA-256 hex digest. ``None`` skips
-                verification.
+                Sanitized to a basename; path separators or traversal
+                components raise ``ValueError``.
+            sha256: Optional expected SHA-256 hex digest.
+            sha512: Optional expected SHA-512 hex digest. Used when upstream
+                publishes SHA-512 rather than SHA-256 (e.g. Debian cloud).
+                At least one of ``sha256``/``sha512`` is recommended for any
+                image that will be booted as a guest OS.
             on_download: Optional progress callback invoked as
                 ``(label, bytes_in_chunk, total_bytes_or_none)`` with
                 ``label="rootfs"``.
@@ -501,10 +507,16 @@ class ImageManager:
         if not name:
             raise ValueError("image name cannot be empty")
 
+        safe_filename = ImageSource.normalize_cache_filename(filename)
         image_dir = self.cache_dir / name
-        rootfs_path = image_dir / filename
+        rootfs_path = image_dir / safe_filename
 
-        if rootfs_path.is_file() and self._verify_sha256(rootfs_path, sha256):
+        cache_ok = (
+            rootfs_path.is_file()
+            and self._verify_sha256(rootfs_path, sha256)
+            and self._verify_sha512(rootfs_path, sha512)
+        )
+        if cache_ok:
             logger.info("Rootfs '%s' found in cache: %s", name, rootfs_path)
             return rootfs_path
 
@@ -521,6 +533,12 @@ class ImageManager:
             sha256,
             progress_callback=_progress if on_download is not None else None,
         )
+        if sha512 is not None and not self._verify_sha512(rootfs_path, sha512):
+            actual = self._compute_sha512(rootfs_path)
+            rootfs_path.unlink(missing_ok=True)
+            raise ImageError(
+                f"SHA-512 mismatch for {url}\n  expected: {sha512}\n  actual:   {actual}"
+            )
         logger.info("Rootfs '%s' ready at: %s", name, rootfs_path)
         return rootfs_path
 
@@ -659,6 +677,43 @@ class ImageManager:
         if actual != expected:
             logger.debug(
                 "SHA-256 mismatch for %s: expected=%s, actual=%s",
+                path,
+                expected,
+                actual,
+            )
+            return False
+        return True
+
+    @staticmethod
+    def _compute_sha512(path: Path) -> str:
+        """Compute the SHA-512 hex digest of a file."""
+        sha512 = hashlib.sha512()
+        with open(path, "rb") as f:
+            while True:
+                chunk = f.read(_DOWNLOAD_CHUNK_SIZE)
+                if not chunk:
+                    break
+                sha512.update(chunk)
+        return sha512.hexdigest()
+
+    @classmethod
+    def _verify_sha512(cls, path: Path, expected: str | None) -> bool:
+        """Verify the SHA-512 checksum of a file.
+
+        Args:
+            path: Path to the file.
+            expected: Expected SHA-512 hex digest, or None to skip.
+
+        Returns:
+            True if the checksum matches or if no hash was provided.
+        """
+        if expected is None:
+            return True
+
+        actual = cls._compute_sha512(path)
+        if actual != expected.lower():
+            logger.debug(
+                "SHA-512 mismatch for %s: expected=%s, actual=%s",
                 path,
                 expected,
                 actual,

--- a/src/smolvm/images/manager.py
+++ b/src/smolvm/images/manager.py
@@ -249,8 +249,7 @@ def _require_boto3() -> S3Client:
         import boto3  # type: ignore[import-untyped]
     except ImportError:
         raise ImageError(
-            "S3 image support requires boto3. Install it with:\n"
-            "  pip install 'smolvm[s3]'"
+            "S3 image support requires boto3. Install it with:\n  pip install 'smolvm[s3]'"
         ) from None
 
     # Load .env file if present (walks up from cwd to find it).
@@ -439,20 +438,26 @@ class ImageManager:
 
         logger.info("Downloading image '%s' kernel...", name)
         self._download_file(
-            source.kernel_url, kernel_path, source.kernel_sha256,
+            source.kernel_url,
+            kernel_path,
+            source.kernel_sha256,
             progress_callback=_make_cb("kernel"),
         )
 
         if initrd_path is not None and source.initrd_url is not None:
             logger.info("Downloading image '%s' initrd...", name)
             self._download_file(
-                source.initrd_url, initrd_path, source.initrd_sha256,
+                source.initrd_url,
+                initrd_path,
+                source.initrd_sha256,
                 progress_callback=_make_cb("initrd"),
             )
 
         logger.info("Downloading image '%s' rootfs...", name)
         self._download_file(
-            source.rootfs_url, rootfs_path, source.rootfs_sha256,
+            source.rootfs_url,
+            rootfs_path,
+            source.rootfs_sha256,
             progress_callback=_make_cb("rootfs"),
         )
 
@@ -463,6 +468,61 @@ class ImageManager:
             initrd_path=initrd_path,
             rootfs_path=rootfs_path,
         )
+
+    def ensure_rootfs_only(
+        self,
+        name: str,
+        *,
+        url: str,
+        filename: str = "rootfs.qcow2",
+        sha256: str | None = None,
+        on_download: Callable[[str, int, int | None], None] | None = None,
+    ) -> Path:
+        """Ensure a standalone rootfs image is available locally.
+
+        Unlike :meth:`ensure_image`, this downloads only a rootfs with no
+        separate kernel or initrd. It is used for firmware-boot VMs where
+        the guest kernel lives inside the rootfs and QEMU boots directly
+        via OVMF/SeaBIOS firmware.
+
+        Args:
+            name: Cache directory name (under ``~/.smolvm/images/``).
+            url: URL to download the rootfs from.
+            filename: Cache filename for the rootfs (default ``rootfs.qcow2``).
+            sha256: Optional expected SHA-256 hex digest. ``None`` skips
+                verification.
+            on_download: Optional progress callback invoked as
+                ``(label, bytes_in_chunk, total_bytes_or_none)`` with
+                ``label="rootfs"``.
+
+        Returns:
+            Absolute path to the cached rootfs file.
+        """
+        if not name:
+            raise ValueError("image name cannot be empty")
+
+        image_dir = self.cache_dir / name
+        rootfs_path = image_dir / filename
+
+        if rootfs_path.is_file() and self._verify_sha256(rootfs_path, sha256):
+            logger.info("Rootfs '%s' found in cache: %s", name, rootfs_path)
+            return rootfs_path
+
+        image_dir.mkdir(parents=True, exist_ok=True)
+
+        def _progress(chunk: int, total: int | None) -> None:
+            if on_download is not None:
+                on_download("rootfs", chunk, total)
+
+        logger.info("Downloading rootfs '%s'...", name)
+        self._download_file(
+            url,
+            rootfs_path,
+            sha256,
+            progress_callback=_progress if on_download is not None else None,
+        )
+        logger.info("Rootfs '%s' ready at: %s", name, rootfs_path)
+        return rootfs_path
 
     # ------------------------------------------------------------------
     # Private helpers
@@ -651,17 +711,14 @@ class ImageManager:
         initrd_path = image_dir / manifest.initrd if manifest.initrd else None
 
         # Check local cache
-        kernel_ok = (
-            kernel_path.is_file()
-            and self._verify_sha256(kernel_path, manifest.kernel_sha256)
+        kernel_ok = kernel_path.is_file() and self._verify_sha256(
+            kernel_path, manifest.kernel_sha256
         )
-        rootfs_ok = (
-            rootfs_path.is_file()
-            and self._verify_sha256(rootfs_path, manifest.rootfs_sha256)
+        rootfs_ok = rootfs_path.is_file() and self._verify_sha256(
+            rootfs_path, manifest.rootfs_sha256
         )
-        initrd_ok = (
-            initrd_path is None
-            or (initrd_path.is_file() and self._verify_sha256(initrd_path, manifest.initrd_sha256))
+        initrd_ok = initrd_path is None or (
+            initrd_path.is_file() and self._verify_sha256(initrd_path, manifest.initrd_sha256)
         )
 
         def _make_cb(label: str) -> Callable[[int, int | None], None] | None:
@@ -677,7 +734,11 @@ class ImageManager:
                 logger.info("Downloading S3 image '%s' kernel...", manifest.name)
                 s3_key = f"{ref.prefix}/{manifest.kernel}"
                 self._download_s3_file(
-                    s3, ref.bucket, s3_key, kernel_path, manifest.kernel_sha256,
+                    s3,
+                    ref.bucket,
+                    s3_key,
+                    kernel_path,
+                    manifest.kernel_sha256,
                     progress_callback=_make_cb("kernel"),
                 )
 
@@ -685,7 +746,11 @@ class ImageManager:
                 logger.info("Downloading S3 image '%s' rootfs...", manifest.name)
                 s3_key = f"{ref.prefix}/{manifest.rootfs}"
                 self._download_s3_file(
-                    s3, ref.bucket, s3_key, rootfs_path, manifest.rootfs_sha256,
+                    s3,
+                    ref.bucket,
+                    s3_key,
+                    rootfs_path,
+                    manifest.rootfs_sha256,
                     progress_callback=_make_cb("rootfs"),
                 )
 
@@ -693,7 +758,11 @@ class ImageManager:
                 logger.info("Downloading S3 image '%s' initrd...", manifest.name)
                 s3_key = f"{ref.prefix}/{manifest.initrd}"
                 self._download_s3_file(
-                    s3, ref.bucket, s3_key, initrd_path, manifest.initrd_sha256,
+                    s3,
+                    ref.bucket,
+                    s3_key,
+                    initrd_path,
+                    manifest.initrd_sha256,
                     progress_callback=_make_cb("initrd"),
                 )
 
@@ -730,9 +799,7 @@ class ImageManager:
             # download_file/download_fileobj which issue HeadObject
             # first — some S3-compatible stores (e.g. R2) reject
             # HeadObject on certain token types.
-            tmp_fd, tmp_path_str = tempfile.mkstemp(
-                dir=image_dir, suffix=".tmp"
-            )
+            tmp_fd, tmp_path_str = tempfile.mkstemp(dir=image_dir, suffix=".tmp")
             tmp_path = Path(tmp_path_str)
             try:
                 with open(tmp_fd, "wb") as f:
@@ -810,8 +877,6 @@ class ImageManager:
         except ImageError:
             raise
         except Exception as exc:
-            raise ImageError(
-                f"S3 download failed for s3://{bucket}/{key}: {exc}"
-            ) from exc
+            raise ImageError(f"S3 download failed for s3://{bucket}/{key}: {exc}") from exc
         finally:
             tmp_path.unlink(missing_ok=True)

--- a/src/smolvm/types.py
+++ b/src/smolvm/types.py
@@ -143,9 +143,7 @@ class WorkspaceMount(BaseModel):
     def validate_guest_path(cls, v: str) -> str:
         """Ensure the guest mount point is an absolute path."""
         if not v.startswith("/"):
-            raise ValueError(
-                f"guest_path must be an absolute path, got: {v!r}"
-            )
+            raise ValueError(f"guest_path must be an absolute path, got: {v!r}")
         return v
 
     def resolved_tag(self, index: int) -> str:
@@ -247,11 +245,25 @@ class VMConfig(BaseModel):
             If omitted, SmolVM auto-generates one.
         vcpu_count: Number of virtual CPUs (1-32).
         mem_size_mib: Memory size in MiB (128-16384).
-        kernel_path: Path to the kernel image.
+        boot_mode: How the guest boots:
+
+            - ``"direct_kernel"`` (default): the hypervisor loads
+              ``kernel_path`` (and optionally ``initrd_path``) directly and
+              passes ``boot_args`` as the kernel command line. Required for
+              firecracker, libkrun, and microvm-style QEMU boots.
+            - ``"firmware"``: QEMU boots the rootfs disk via its default
+              firmware (OVMF on aarch64, SeaBIOS on x86_64). The guest kernel
+              lives inside ``rootfs_path`` (e.g. a Debian or Ubuntu cloud
+              image). ``kernel_path`` must be ``None`` in this mode, and the
+              backend must be ``"qemu"``.
+
+        kernel_path: Path to the kernel image. Required when
+            ``boot_mode == "direct_kernel"``; must be ``None`` when
+            ``boot_mode == "firmware"``.
         initrd_path: Optional path to the initrd image.
         rootfs_path: Path to the root filesystem image.
         extra_drives: Additional block-device image paths to attach at boot.
-        boot_args: Kernel boot arguments.
+        boot_args: Kernel boot arguments (ignored in firmware mode).
         ssh_capable: Whether this boot path is expected to start guest SSH
             without relying on ``init=/init``.
         backend: Optional runtime backend override ("firecracker", "qemu", or "libkrun").
@@ -274,7 +286,8 @@ class VMConfig(BaseModel):
     ]
     vcpu_count: Annotated[int, Field(ge=1, le=32)] = 2
     mem_size_mib: Annotated[int, Field(ge=128, le=16384)] = 512
-    kernel_path: Path
+    boot_mode: Literal["direct_kernel", "firmware"] = "direct_kernel"
+    kernel_path: Path | None = None
     initrd_path: Path | None = None
     rootfs_path: Path
     extra_drives: list[Path] = []
@@ -300,11 +313,31 @@ class VMConfig(BaseModel):
 
     @field_validator("kernel_path", "rootfs_path")
     @classmethod
-    def validate_path_exists(cls, v: Path, info: ValidationInfo) -> Path:
+    def validate_path_exists(cls, v: Path | None, info: ValidationInfo) -> Path | None:
         """Ensure paths exist on the filesystem."""
+        if v is None:
+            return None
         if not cls._should_validate_paths(info):
             return v
         return cls._validate_file_path(v)
+
+    @model_validator(mode="after")
+    def _check_boot_mode_consistency(self) -> "VMConfig":
+        """Enforce boot_mode <-> kernel_path <-> backend invariants."""
+        if self.boot_mode == "firmware":
+            if self.kernel_path is not None:
+                raise ValueError(
+                    "boot_mode='firmware' requires kernel_path=None "
+                    "(the guest kernel is inside the rootfs disk)"
+                )
+            if self.backend is not None and self.backend != "qemu":
+                raise ValueError(
+                    f"boot_mode='firmware' requires backend='qemu' (got backend={self.backend!r})"
+                )
+        else:  # direct_kernel
+            if self.kernel_path is None:
+                raise ValueError("boot_mode='direct_kernel' requires kernel_path to be set")
+        return self
 
     @field_validator("initrd_path")
     @classmethod
@@ -366,7 +399,8 @@ class VMConfig(BaseModel):
     @field_validator("workspace_mounts")
     @classmethod
     def validate_workspace_mounts(
-        cls, v: list[WorkspaceMount],
+        cls,
+        v: list[WorkspaceMount],
     ) -> list[WorkspaceMount]:
         """Ensure workspace mount tags and guest paths are unique."""
         seen_tags: set[str] = set()
@@ -374,13 +408,9 @@ class VMConfig(BaseModel):
         for index, mount in enumerate(v):
             tag = mount.resolved_tag(index)
             if tag in seen_tags:
-                raise ValueError(
-                    f"Duplicate workspace mount tag: {tag}"
-                )
+                raise ValueError(f"Duplicate workspace mount tag: {tag}")
             if mount.guest_path in seen_guest_paths:
-                raise ValueError(
-                    f"Duplicate workspace guest_path: {mount.guest_path}"
-                )
+                raise ValueError(f"Duplicate workspace guest_path: {mount.guest_path}")
             seen_tags.add(tag)
             seen_guest_paths.add(mount.guest_path)
         return v
@@ -523,7 +553,6 @@ class VMInfo(BaseModel):
         control_socket_path: Path to the runtime control socket.
     """
 
-
     vm_id: str
     status: VMState
     config: VMConfig
@@ -562,8 +591,6 @@ class SnapshotInfo(BaseModel):
     restored_vm_id: str | None = None
 
     model_config = {"frozen": True}
-
-
 
 
 class BrowserSessionInfo(BaseModel):

--- a/src/smolvm/types.py
+++ b/src/smolvm/types.py
@@ -330,9 +330,12 @@ class VMConfig(BaseModel):
                     "boot_mode='firmware' requires kernel_path=None "
                     "(the guest kernel is inside the rootfs disk)"
                 )
-            if self.backend is not None and self.backend != "qemu":
+            if self.backend != "qemu":
                 raise ValueError(
-                    f"boot_mode='firmware' requires backend='qemu' (got backend={self.backend!r})"
+                    f"boot_mode='firmware' requires backend='qemu' "
+                    f"(got backend={self.backend!r}); firmware boot is only "
+                    "supported on the QEMU backend, so the caller must set it "
+                    "explicitly rather than relying on auto-detection"
                 )
         else:  # direct_kernel
             if self.kernel_path is None:

--- a/src/smolvm/vm.py
+++ b/src/smolvm/vm.py
@@ -72,6 +72,28 @@ QEMU_NETMASK = "255.255.255.0"
 QEMU_SLIRP_DNS = "10.0.2.3"
 SNAPSHOT_ID_PATTERN = re.compile(r"^[a-z0-9][a-z0-9_-]{0,62}[a-z0-9]$|^[a-z0-9]$")
 
+# Candidate UEFI firmware locations for aarch64 QEMU firmware-boot.
+# Searched in order; the first existing file wins. macOS Homebrew ships
+# edk2-aarch64-code.fd under the qemu data dir; Debian/Ubuntu split it into
+# a separate qemu-efi-aarch64 package; RHEL uses AAVMF.
+_AARCH64_EDK2_FIRMWARE_CANDIDATES: tuple[str, ...] = (
+    "/opt/homebrew/share/qemu/edk2-aarch64-code.fd",
+    "/usr/local/share/qemu/edk2-aarch64-code.fd",
+    "/usr/share/qemu-efi-aarch64/QEMU_EFI.fd",
+    "/usr/share/AAVMF/AAVMF_CODE.fd",
+    "/usr/share/edk2/aarch64/QEMU_EFI.fd",
+    "/usr/share/edk2-armvirt/aarch64/QEMU_EFI.fd",
+)
+
+
+def _find_aarch64_uefi_firmware() -> Path | None:
+    """Return the first existing aarch64 UEFI firmware file, or ``None``."""
+    for candidate in _AARCH64_EDK2_FIRMWARE_CANDIDATES:
+        path = Path(candidate)
+        if path.is_file():
+            return path
+    return None
+
 
 def _get_sudo_user_info() -> pwd.struct_passwd | None:
     """Return sudo user's passwd entry when running under sudo."""
@@ -532,8 +554,7 @@ class SmolVMManager:
             raise ValueError("snapshot_id cannot be empty")
         if not SNAPSHOT_ID_PATTERN.fullmatch(snapshot_id):
             raise ValueError(
-                "snapshot_id must contain only lowercase letters, numbers, hyphens, "
-                "or underscores"
+                "snapshot_id must contain only lowercase letters, numbers, hyphens, or underscores"
             )
 
         snapshot_root = (self.snapshot_dir / snapshot_id).resolve(strict=False)
@@ -567,9 +588,7 @@ class SmolVMManager:
             and vm_config.internet_settings is not None
             and not vm_config.internet_settings.is_allow_all_domains
         ):
-            allowed_ips = resolve_domains_to_ips(
-                vm_config.internet_settings.allowed_domains
-            )
+            allowed_ips = resolve_domains_to_ips(vm_config.internet_settings.allowed_domains)
             self.network.apply_egress_allowlist(network.tap_device, allowed_ips)
 
         if network.ssh_host_port is not None:
@@ -643,7 +662,7 @@ class SmolVMManager:
             errors.append(
                 "QEMU not found. Install one of: qemu-system-aarch64, qemu-system-x86_64 "
                 "(macOS/Homebrew: brew install qemu)."
-                )
+            )
         elif platform.system() == "Darwin":
             try:
                 result = subprocess.run(
@@ -1141,7 +1160,10 @@ class SmolVMManager:
             self.stop(restore_vm_id)
             existing_vm = self.state.get_vm(restore_vm_id)
 
-        if not snapshot.vm_config.kernel_path.exists():
+        if (
+            snapshot.vm_config.kernel_path is not None
+            and not snapshot.vm_config.kernel_path.exists()
+        ):
             raise SmolVMError(
                 "Snapshot restore requires the original kernel path to exist",
                 {
@@ -1499,18 +1521,31 @@ class SmolVMManager:
             str(vm_info.config.vcpu_count),
             "-m",
             str(vm_info.config.mem_size_mib),
-            "-kernel",
-            str(vm_info.config.kernel_path),
-            "-append",
-            boot_args,
-            "-drive",
-            drive_arg,
-            "-netdev",
-            netdev_arg,
-            "-nographic",
-            "-no-reboot",
         ]
-        if vm_info.config.initrd_path is not None:
+        # Boot mode: direct-kernel passes -kernel/-append (optionally -initrd);
+        # firmware mode lets QEMU boot the rootfs disk via default firmware
+        # (OVMF on aarch64, SeaBIOS on x86_64) — the guest kernel lives inside
+        # the rootfs image.
+        if vm_info.config.boot_mode == "direct_kernel":
+            cmd.extend(
+                [
+                    "-kernel",
+                    str(vm_info.config.kernel_path),
+                    "-append",
+                    boot_args,
+                ]
+            )
+        cmd.extend(
+            [
+                "-drive",
+                drive_arg,
+                "-netdev",
+                netdev_arg,
+                "-nographic",
+                "-no-reboot",
+            ]
+        )
+        if vm_info.config.boot_mode == "direct_kernel" and vm_info.config.initrd_path is not None:
             cmd.extend(["-initrd", str(vm_info.config.initrd_path)])
 
         extra_drive_ids: list[str] = []
@@ -1539,11 +1574,13 @@ class SmolVMManager:
             tag = ws.resolved_tag(index)
             fsdev_id = f"fsdev-{tag}"
             workspace_fsdev_ids.append((fsdev_id, tag))
-            cmd.extend([
-                "-fsdev",
-                f"local,id={fsdev_id},path={ws.host_path},"
-                f"security_model=mapped-xattr,readonly=on",
-            ])
+            cmd.extend(
+                [
+                    "-fsdev",
+                    f"local,id={fsdev_id},path={ws.host_path},"
+                    f"security_model=mapped-xattr,readonly=on",
+                ]
+            )
 
         if control_socket_path is not None:
             cmd.extend(
@@ -1570,6 +1607,17 @@ class SmolVMManager:
                     f"virtio-net-device,netdev=net0,mac={guest_mac}",
                 ]
             )
+            if vm_info.config.boot_mode == "firmware":
+                firmware_path = _find_aarch64_uefi_firmware()
+                if firmware_path is None:
+                    raise SmolVMError(
+                        "aarch64 firmware-boot requires UEFI firmware (edk2/AAVMF) "
+                        "but none was found. Searched: "
+                        f"{', '.join(_AARCH64_EDK2_FIRMWARE_CANDIDATES)}. "
+                        "On macOS run 'brew reinstall qemu'; on Debian/Ubuntu "
+                        "install 'qemu-efi-aarch64'."
+                    )
+                cmd.extend(["-bios", str(firmware_path)])
             for drive_id in extra_drive_ids:
                 cmd.extend(["-device", f"virtio-blk-device,drive={drive_id}"])
             for fsdev_id, tag in workspace_fsdev_ids:
@@ -2090,9 +2138,7 @@ class SmolVMManager:
             return vm_info
 
         backend = self._backend_for_vm(vm_info)
-        await self._runtime_adapter_for_backend(backend).async_stop(
-            vm_info, timeout=timeout
-        )
+        await self._runtime_adapter_for_backend(backend).async_stop(vm_info, timeout=timeout)
         self._close_runtime_log(vm_id, backend, vm_info.control_socket_path)
         vm_info = self.state.update_vm(
             vm_id,
@@ -2142,19 +2188,13 @@ class SmolVMManager:
                 instance_rootfs,
             )
             if backend == BACKEND_QEMU:
-                await self._async_create_qemu_overlay_disk(
-                    config.rootfs_path, instance_rootfs
-                )
+                await self._async_create_qemu_overlay_disk(config.rootfs_path, instance_rootfs)
             else:
-                await self._async_copy_with_reflink(
-                    config.rootfs_path, instance_rootfs
-                )
+                await self._async_copy_with_reflink(config.rootfs_path, instance_rootfs)
 
         return config.model_copy(update={"rootfs_path": instance_rootfs})
 
-    async def _async_create_qemu_overlay_disk(
-        self, base_path: Path, overlay_path: Path
-    ) -> None:
+    async def _async_create_qemu_overlay_disk(self, base_path: Path, overlay_path: Path) -> None:
         """Async version of :meth:`_create_qemu_overlay_disk`."""
         from smolvm.utils import async_run_command
 
@@ -2166,16 +2206,20 @@ class SmolVMManager:
         base_format = "qcow2" if base_path.suffix == ".qcow2" else "raw"
         await async_run_command(
             [
-                str(qemu_img), "create", "-f", "qcow2",
-                "-b", str(base_path.resolve()), "-F", base_format,
+                str(qemu_img),
+                "create",
+                "-f",
+                "qcow2",
+                "-b",
+                str(base_path.resolve()),
+                "-F",
+                base_format,
                 str(overlay_path),
             ],
             use_sudo=False,
         )
 
-    async def _async_copy_with_reflink(
-        self, source_path: Path, target_path: Path
-    ) -> None:
+    async def _async_copy_with_reflink(self, source_path: Path, target_path: Path) -> None:
         """Async version of :meth:`_copy_with_reflink`."""
         import shutil
 
@@ -2205,9 +2249,7 @@ class SmolVMManager:
                 check=False,
             )
             if result.returncode != 0:
-                raise SmolVMError(
-                    f"Failed to remove stale socket: {socket_path}"
-                ) from None
+                raise SmolVMError(f"Failed to remove stale socket: {socket_path}") from None
 
     async def _async_kill_process(self, pid: int) -> None:
         """Async version of :meth:`_kill_process`."""
@@ -2221,9 +2263,7 @@ class SmolVMManager:
             logger.debug("Process %d not found when attempting to kill", pid)
         except PermissionError:
             try:
-                await async_run_command(
-                    ["kill", "-9", str(pid)], check=False
-                )
+                await async_run_command(["kill", "-9", str(pid)], check=False)
             except Exception:
                 logger.warning("Failed to kill process %d", pid)
 
@@ -2351,15 +2391,36 @@ class SmolVMManager:
         netdev_arg = f"user,id=net0,dns={QEMU_SLIRP_DNS},{','.join(hostfwd_rules)}"
 
         cmd: list[str] = [
-            str(qemu_bin), "-smp", str(vm_info.config.vcpu_count),
-            "-m", str(vm_info.config.mem_size_mib),
-            "-kernel", str(vm_info.config.kernel_path),
-            "-append", boot_args,
-            "-drive", drive_arg,
-            "-netdev", netdev_arg,
-            "-nographic", "-no-reboot",
+            str(qemu_bin),
+            "-smp",
+            str(vm_info.config.vcpu_count),
+            "-m",
+            str(vm_info.config.mem_size_mib),
         ]
-        if vm_info.config.initrd_path is not None:
+        # Boot mode: direct-kernel passes -kernel/-append (optionally -initrd);
+        # firmware mode lets QEMU boot the rootfs disk via default firmware
+        # (OVMF on aarch64, SeaBIOS on x86_64) — the guest kernel lives inside
+        # the rootfs image.
+        if vm_info.config.boot_mode == "direct_kernel":
+            cmd.extend(
+                [
+                    "-kernel",
+                    str(vm_info.config.kernel_path),
+                    "-append",
+                    boot_args,
+                ]
+            )
+        cmd.extend(
+            [
+                "-drive",
+                drive_arg,
+                "-netdev",
+                netdev_arg,
+                "-nographic",
+                "-no-reboot",
+            ]
+        )
+        if vm_info.config.boot_mode == "direct_kernel" and vm_info.config.initrd_path is not None:
             cmd.extend(["-initrd", str(vm_info.config.initrd_path)])
 
         extra_drive_ids: list[str] = []
@@ -2371,8 +2432,14 @@ class SmolVMManager:
             drive_format = "qcow2" if drive_suffix == ".qcow2" else "raw"
             readonly = ["readonly=on"] if drive_suffix == ".iso" else []
             extra_drive_arg = ",".join(
-                [f"file={drive_path}", "if=none", f"format={drive_format}",
-                 *readonly, f"id={drive_id}", f"node-name={node_name}"]
+                [
+                    f"file={drive_path}",
+                    "if=none",
+                    f"format={drive_format}",
+                    *readonly,
+                    f"id={drive_id}",
+                    f"node-name={node_name}",
+                ]
             )
             cmd.extend(["-drive", extra_drive_arg])
 
@@ -2382,11 +2449,13 @@ class SmolVMManager:
             tag = ws.resolved_tag(index)
             fsdev_id = f"fsdev-{tag}"
             workspace_fsdev_ids.append((fsdev_id, tag))
-            cmd.extend([
-                "-fsdev",
-                f"local,id={fsdev_id},path={ws.host_path},"
-                f"security_model=mapped-xattr,readonly=on",
-            ])
+            cmd.extend(
+                [
+                    "-fsdev",
+                    f"local,id={fsdev_id},path={ws.host_path},"
+                    f"security_model=mapped-xattr,readonly=on",
+                ]
+            )
 
         if control_socket_path is not None:
             cmd.extend(["-qmp", f"unix:{control_socket_path},server=on,wait=off"])
@@ -2396,9 +2465,29 @@ class SmolVMManager:
         if "aarch64" in qemu_name:
             machine = "virt,accel=hvf" if system == "Darwin" else "virt"
             cpu = "host" if system == "Darwin" else "cortex-a72"
-            cmd.extend(["-machine", machine, "-cpu", cpu,
-                        "-device", f"virtio-blk-device,drive={root_drive_id}",
-                        "-device", f"virtio-net-device,netdev=net0,mac={guest_mac}"])
+            cmd.extend(
+                [
+                    "-machine",
+                    machine,
+                    "-cpu",
+                    cpu,
+                    "-device",
+                    f"virtio-blk-device,drive={root_drive_id}",
+                    "-device",
+                    f"virtio-net-device,netdev=net0,mac={guest_mac}",
+                ]
+            )
+            if vm_info.config.boot_mode == "firmware":
+                firmware_path = _find_aarch64_uefi_firmware()
+                if firmware_path is None:
+                    raise SmolVMError(
+                        "aarch64 firmware-boot requires UEFI firmware (edk2/AAVMF) "
+                        "but none was found. Searched: "
+                        f"{', '.join(_AARCH64_EDK2_FIRMWARE_CANDIDATES)}. "
+                        "On macOS run 'brew reinstall qemu'; on Debian/Ubuntu "
+                        "install 'qemu-efi-aarch64'."
+                    )
+                cmd.extend(["-bios", str(firmware_path)])
             for drive_id in extra_drive_ids:
                 cmd.extend(["-device", f"virtio-blk-device,drive={drive_id}"])
             for fsdev_id, tag in workspace_fsdev_ids:
@@ -2406,9 +2495,18 @@ class SmolVMManager:
         else:
             machine = "q35,accel=hvf" if system == "Darwin" else "q35"
             cpu = "host" if system == "Darwin" else "max"
-            cmd.extend(["-machine", machine, "-cpu", cpu,
-                        "-device", f"virtio-blk-pci,drive={root_drive_id}",
-                        "-device", f"virtio-net-pci,netdev=net0,mac={guest_mac}"])
+            cmd.extend(
+                [
+                    "-machine",
+                    machine,
+                    "-cpu",
+                    cpu,
+                    "-device",
+                    f"virtio-blk-pci,drive={root_drive_id}",
+                    "-device",
+                    f"virtio-net-pci,netdev=net0,mac={guest_mac}",
+                ]
+            )
             for drive_id in extra_drive_ids:
                 cmd.extend(["-device", f"virtio-blk-pci,drive={drive_id}"])
             for fsdev_id, tag in workspace_fsdev_ids:
@@ -2508,7 +2606,9 @@ class SmolVMManager:
             if backend == BACKEND_FIRECRACKER and ssh_host_port is not None and guest_ip:
                 with suppress(Exception):
                     await self.network.async_cleanup_ssh_port_forward(
-                        vm_id=vm_id, guest_ip=guest_ip, host_port=ssh_host_port,
+                        vm_id=vm_id,
+                        guest_ip=guest_ip,
+                        host_port=ssh_host_port,
                     )
 
             with suppress(Exception):

--- a/tests/test_facade.py
+++ b/tests/test_facade.py
@@ -373,7 +373,62 @@ class TestVMInit:
     ) -> None:
         """Ubuntu should reject --disk-size-mib below the default."""
         with pytest.raises(ValueError, match="disk_size_mib >= 2048"):
-            _build_auto_config(os="ubuntu", disk_size_mib=512)
+            _build_auto_config(os="ubuntu", backend="qemu", disk_size_mib=512)
+
+    def test_firmware_boot_vmconfig_rejects_non_qemu_backend(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        """VMConfig should reject firmware boot without explicit backend='qemu'."""
+        rootfs = tmp_path / "rootfs.qcow2"
+        rootfs.touch()
+
+        # backend=None (auto) must be rejected.
+        with pytest.raises(ValueError, match="requires backend='qemu'"):
+            VMConfig(
+                vm_id="vm-fw-none",
+                boot_mode="firmware",
+                kernel_path=None,
+                rootfs_path=rootfs,
+                ssh_capable=True,
+                backend=None,
+            )
+
+        # backend='firecracker' must also be rejected.
+        with pytest.raises(ValueError, match="requires backend='qemu'"):
+            VMConfig(
+                vm_id="vm-fw-fc",
+                boot_mode="firmware",
+                kernel_path=None,
+                rootfs_path=rootfs,
+                ssh_capable=True,
+                backend="firecracker",
+            )
+
+    def test_firmware_boot_vmconfig_can_run_commands(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        """A firmware-boot VM with ssh_capable=True should pass can_run_commands."""
+        rootfs = tmp_path / "rootfs.qcow2"
+        rootfs.touch()
+
+        config = VMConfig(
+            vm_id="vm-fw-ok",
+            boot_mode="firmware",
+            kernel_path=None,
+            rootfs_path=rootfs,
+            ssh_capable=True,
+            backend="qemu",
+        )
+
+        mock_sdk = MagicMock()
+        mock_sdk.create.return_value = MagicMock(
+            vm_id="vm-fw-ok", status=VMState.CREATED, config=config
+        )
+        with patch("smolvm.facade.SmolVMManager", return_value=mock_sdk):
+            vm = SmolVM(config)
+            assert vm.can_run_commands() is True
 
     def test_custom_auto_sizing_with_config_raises(self, sample_config: VMConfig) -> None:
         """Custom auto sizing options are only valid in zero-config mode."""

--- a/tests/test_facade.py
+++ b/tests/test_facade.py
@@ -182,14 +182,14 @@ class TestVMInit:
     @patch("smolvm.facade.SmolVMManager")
     @patch("smolvm.images.builder.ImageBuilder")
     @patch("smolvm.utils.ensure_ssh_key")
-    def test_autoconfigure_with_debian_uses_debian_builder(
+    def test_autoconfigure_with_debian_firecracker_uses_debian_builder(
         self,
         mock_ensure_ssh_key: MagicMock,
         mock_builder_cls: MagicMock,
         mock_sdk_cls: MagicMock,
         tmp_path: Path,
     ) -> None:
-        """Debian auto-config should use the Debian builder and defaults."""
+        """Debian on firecracker should still use the docker-build fallback."""
         kernel = tmp_path / "auto-kernel"
         rootfs = tmp_path / "auto-rootfs.ext4"
         private_key = tmp_path / "id_ed25519"
@@ -208,7 +208,7 @@ class TestVMInit:
         mock_sdk.create.return_value = MagicMock(vm_id="vm001", status=VMState.CREATED)
         mock_sdk_cls.return_value = mock_sdk
 
-        vm = SmolVM(os="debian")
+        vm = SmolVM(os="debian", backend="firecracker")
 
         assert vm.vm_id.startswith("vm-")
         mock_builder.build_debian_ssh_key.assert_called_once()
@@ -217,6 +217,7 @@ class TestVMInit:
         mock_builder.build_alpine_ssh_key.assert_not_called()
         created_config = mock_sdk.create.call_args[0][0]
         assert created_config.mem_size_mib == 512
+        assert created_config.boot_mode == "direct_kernel"
 
     @patch("smolvm.facade.SmolVMManager")
     @patch("smolvm.images.builder.ImageBuilder")
@@ -247,19 +248,19 @@ class TestVMInit:
         mock_sdk.create.return_value = MagicMock(vm_id="vm001", status=VMState.CREATED)
         mock_sdk_cls.return_value = mock_sdk
 
-        SmolVM(os=GuestOS.DEBIAN)
+        SmolVM(os=GuestOS.DEBIAN, backend="firecracker")
 
         mock_builder.build_debian_ssh_key.assert_called_once()
 
     @patch("smolvm.images.builder.ImageBuilder")
     @patch("smolvm.utils.ensure_ssh_key")
-    def test_build_auto_config_debian_disk_override(
+    def test_build_auto_config_debian_firecracker_disk_override(
         self,
         mock_ensure_ssh_key: MagicMock,
         mock_builder_cls: MagicMock,
         tmp_path: Path,
     ) -> None:
-        """Explicit disk sizes should override Debian defaults."""
+        """Explicit disk sizes should override Debian defaults on firecracker."""
         kernel = tmp_path / "auto-kernel"
         rootfs = tmp_path / "auto-rootfs.ext4"
         private_key = tmp_path / "id_ed25519"
@@ -274,9 +275,105 @@ class TestVMInit:
         mock_builder.build_debian_ssh_key.return_value = (kernel, rootfs)
         mock_builder_cls.return_value = mock_builder
 
-        _build_auto_config(os="debian", disk_size_mib=4096)
+        _build_auto_config(os="debian", backend="firecracker", disk_size_mib=4096)
 
         assert mock_builder.build_debian_ssh_key.call_args.kwargs["rootfs_size_mb"] == 4096
+
+    @patch("smolvm.facade._prepare_sized_qcow2")
+    @patch("smolvm.facade.ImageManager")
+    @patch("smolvm.images.builder.ImageBuilder")
+    @patch("smolvm.utils.ensure_ssh_key")
+    def test_autoconfigure_debian_qemu_uses_prebuilt_firmware_boot(
+        self,
+        mock_ensure_ssh_key: MagicMock,
+        mock_builder_cls: MagicMock,
+        mock_image_manager_cls: MagicMock,
+        mock_prepare_sized: MagicMock,
+        tmp_path: Path,
+    ) -> None:
+        """Debian on qemu should fetch the prebuilt qcow2 and use firmware boot."""
+        private_key = tmp_path / "id_ed25519"
+        public_key = tmp_path / "id_ed25519.pub"
+        private_key.touch()
+        public_key.write_text("ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIMockKey user@test\n")
+
+        pristine_rootfs = tmp_path / "debian-rootfs.qcow2"
+        pristine_rootfs.touch()
+
+        mock_ensure_ssh_key.return_value = (private_key, public_key)
+
+        mock_image_manager = MagicMock()
+        mock_image_manager.cache_dir = tmp_path / "cache"
+        mock_image_manager.ensure_rootfs_only.return_value = pristine_rootfs
+        mock_image_manager_cls.return_value = mock_image_manager
+
+        # _prepare_sized_qcow2 returns the same path when target == default.
+        mock_prepare_sized.return_value = (pristine_rootfs, 2048)
+
+        mock_builder_cls.return_value = MagicMock()
+
+        config, _ = _build_auto_config(os="debian", backend="qemu")
+
+        # Prebuilt path, not the docker fallback.
+        mock_image_manager.ensure_rootfs_only.assert_called_once()
+        mock_builder_cls.return_value.build_debian_ssh_key.assert_not_called()
+
+        assert config.boot_mode == "firmware"
+        assert config.kernel_path is None
+        assert config.rootfs_path == pristine_rootfs
+        assert len(config.extra_drives) == 1  # cloud-init seed ISO
+        assert config.extra_drives[0].suffix == ".iso"
+        assert config.backend == "qemu"
+
+    @patch("smolvm.facade._prepare_sized_qcow2")
+    @patch("smolvm.facade.ImageManager")
+    @patch("smolvm.utils.ensure_ssh_key")
+    def test_autoconfigure_debian_qemu_disk_override_triggers_resize(
+        self,
+        mock_ensure_ssh_key: MagicMock,
+        mock_image_manager_cls: MagicMock,
+        mock_prepare_sized: MagicMock,
+        tmp_path: Path,
+    ) -> None:
+        """--disk-size-mib on debian/qemu should be forwarded to resize helper."""
+        private_key = tmp_path / "id_ed25519"
+        public_key = tmp_path / "id_ed25519.pub"
+        private_key.touch()
+        public_key.write_text("ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIMockKey user@test\n")
+
+        pristine = tmp_path / "pristine.qcow2"
+        sized = tmp_path / "sized.qcow2"
+        pristine.touch()
+        sized.touch()
+
+        mock_ensure_ssh_key.return_value = (private_key, public_key)
+        mock_image_manager = MagicMock()
+        mock_image_manager.cache_dir = tmp_path / "cache"
+        mock_image_manager.ensure_rootfs_only.return_value = pristine
+        mock_image_manager_cls.return_value = mock_image_manager
+        mock_prepare_sized.return_value = (sized, 4096)
+
+        config, _ = _build_auto_config(os="debian", backend="qemu", disk_size_mib=4096)
+
+        mock_prepare_sized.assert_called_once()
+        assert mock_prepare_sized.call_args.kwargs["target_mib"] == 4096
+        assert config.rootfs_path == sized
+
+    def test_autoconfigure_debian_qemu_rejects_undersized_disk(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        """Debian/qemu should reject --disk-size-mib below the default."""
+        with pytest.raises(ValueError, match="disk_size_mib >= 2048"):
+            _build_auto_config(os="debian", backend="qemu", disk_size_mib=1024)
+
+    def test_autoconfigure_ubuntu_rejects_undersized_disk(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        """Ubuntu should reject --disk-size-mib below the default."""
+        with pytest.raises(ValueError, match="disk_size_mib >= 2048"):
+            _build_auto_config(os="ubuntu", disk_size_mib=512)
 
     def test_custom_auto_sizing_with_config_raises(self, sample_config: VMConfig) -> None:
         """Custom auto sizing options are only valid in zero-config mode."""
@@ -376,7 +473,8 @@ class TestVMInit:
         assert "root=LABEL=cloudimg-rootfs" in config.boot_args
         assert config.extra_drives[0].suffix == ".iso"
         mock_image_manager.ensure_image.assert_called_once_with(
-            "ubuntu-noble-minimal-qemu-aarch64", on_download=None,
+            "ubuntu-noble-minimal-qemu-aarch64",
+            on_download=None,
         )
 
     @patch("smolvm.facade.platform.machine", return_value="arm64")
@@ -444,37 +542,52 @@ class TestVMInit:
         mock_ensure_ssh_key.assert_not_called()
 
     @patch("smolvm.facade.platform.machine", return_value="arm64")
+    @patch("smolvm.facade.build_seed_iso")
+    @patch("smolvm.facade.ImageManager")
     @patch("smolvm.images.builder.ImageBuilder")
     @patch("smolvm.utils.ensure_ssh_key")
-    def test_named_debian_auto_config_qemu_keeps_backend_specific_settings(
+    def test_named_debian_auto_config_qemu_uses_prebuilt_image(
         self,
         mock_ensure_ssh_key: MagicMock,
         mock_builder_cls: MagicMock,
+        mock_image_manager_cls: MagicMock,
+        mock_build_seed_iso: MagicMock,
         _: MagicMock,
         tmp_path: Path,
     ) -> None:
-        """Debian auto-config should use the same backend-specific cache naming."""
-        kernel = tmp_path / "auto-kernel"
-        rootfs = tmp_path / "auto-rootfs.ext4"
+        """Debian on qemu should fetch the prebuilt qcow2 under an aarch64 cache key."""
+        rootfs = tmp_path / "rootfs.qcow2"
         private_key = tmp_path / "id_ed25519"
         public_key = tmp_path / "id_ed25519.pub"
-        kernel.touch()
         rootfs.touch()
         private_key.touch()
         public_key.write_text("ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIMockKey user@test\n")
 
         mock_ensure_ssh_key.return_value = (private_key, public_key)
-        mock_builder = MagicMock()
-        mock_builder.build_debian_ssh_key.return_value = (kernel, rootfs)
-        mock_builder_cls.return_value = mock_builder
+        mock_build_seed_iso.side_effect = lambda path, **kwargs: (
+            path.parent.mkdir(parents=True, exist_ok=True),
+            path.touch(),
+        )[-1]
+        mock_image_manager = MagicMock()
+        mock_image_manager.cache_dir = tmp_path
+        mock_image_manager.ensure_rootfs_only.return_value = rootfs
+        mock_image_manager_cls.return_value = mock_image_manager
 
         config, _ = _build_auto_config(vm_name="project-spacex", os="debian", backend="qemu")
 
         assert config.backend == "qemu"
-        assert config.boot_args == "console=ttyAMA0 reboot=k panic=1 init=/init"
+        assert config.boot_mode == "firmware"
+        assert config.kernel_path is None
+        assert config.rootfs_path == rootfs
+        assert config.ssh_capable is True
+        # Cloud-init seed ISO is attached.
+        assert config.extra_drives[0].suffix == ".iso"
+        # Prebuilt path, not the docker fallback.
+        mock_builder_cls.return_value.build_debian_ssh_key.assert_not_called()
+        mock_image_manager.ensure_rootfs_only.assert_called_once()
         assert (
-            mock_builder.build_debian_ssh_key.call_args.kwargs["name"]
-            == "debian-ssh-key-aarch64"
+            mock_image_manager.ensure_rootfs_only.call_args.args[0]
+            == "debian-bookworm-genericcloud-qemu-aarch64"
         )
 
     @patch("smolvm.facade.SmolVMManager")
@@ -908,7 +1021,6 @@ class TestVMRun:
         assert 0.5 <= wait_timeout <= 30.0
         assert mock_ssh.run.call_count == 2
 
-
     @patch("smolvm.facade.SSHClient")
     @patch("smolvm.facade.SmolVMManager")
     def test_run_falls_back_to_guest_ip_when_localhost_unreachable(
@@ -1047,7 +1159,10 @@ class TestVMRun:
 
         vm = SmolVM(sample_config)
 
-        with patch("smolvm.utils.ensure_ssh_key", return_value=(default_key_path, default_key_path.parent / "id_ed25519.pub")):
+        with patch(
+            "smolvm.utils.ensure_ssh_key",
+            return_value=(default_key_path, default_key_path.parent / "id_ed25519.pub"),
+        ):
             vm.wait_for_ssh(timeout=30.0)
 
         # Should have tried the default smolvm key after both no-key attempts failed

--- a/tests/test_images.py
+++ b/tests/test_images.py
@@ -375,6 +375,109 @@ class TestVerifySHA256:
         assert result.kernel_path.exists()
 
 
+class TestEnsureRootfsOnly:
+    """Tests for ImageManager.ensure_rootfs_only."""
+
+    def test_strips_path_traversal_from_filename(self, tmp_path: Path) -> None:
+        """A filename with '..' components must be basenamed, never escape cache."""
+        mgr = ImageManager(cache_dir=tmp_path)
+
+        captured_dest: list[Path] = []
+
+        def fake_download(
+            self: ImageManager,
+            url: str,
+            dest: Path,
+            expected_sha256: str | None = None,
+            *,
+            progress_callback: object = None,
+        ) -> None:
+            captured_dest.append(dest)
+            dest.parent.mkdir(parents=True, exist_ok=True)
+            dest.write_bytes(b"ok")
+
+        with patch.object(ImageManager, "_download_file", fake_download):
+            result = mgr.ensure_rootfs_only(
+                "evil-image",
+                url="https://example.com/rootfs.qcow2",
+                filename="../../../etc/passwd",
+            )
+
+        # The destination must stay inside cache_dir/evil-image/, with only
+        # the basename ("passwd") retained from the caller input.
+        assert len(captured_dest) == 1
+        dest = captured_dest[0]
+        assert dest == tmp_path / "evil-image" / "passwd"
+        assert result == dest
+        # Sanity check: the attacker-controlled traversal target does not exist.
+        assert not (tmp_path / "etc" / "passwd").exists()
+
+    def test_rejects_absolute_filename(self, tmp_path: Path) -> None:
+        """An absolute filename must be rejected."""
+        mgr = ImageManager(cache_dir=tmp_path)
+        with pytest.raises(ValueError, match="relative paths"):
+            mgr.ensure_rootfs_only(
+                "evil-image",
+                url="https://example.com/rootfs.qcow2",
+                filename="/tmp/escape.qcow2",
+            )
+
+    def test_sha512_mismatch_deletes_file_and_raises(self, tmp_path: Path) -> None:
+        """A SHA-512 mismatch should delete the downloaded file and raise."""
+        mgr = ImageManager(cache_dir=tmp_path)
+
+        def fake_download(
+            self: ImageManager,
+            url: str,
+            dest: Path,
+            expected_sha256: str | None = None,
+            *,
+            progress_callback: object = None,
+        ) -> None:
+            dest.parent.mkdir(parents=True, exist_ok=True)
+            dest.write_bytes(b"corrupt")
+
+        with patch.object(ImageManager, "_download_file", fake_download):
+            with pytest.raises(ImageError, match="SHA-512 mismatch"):
+                mgr.ensure_rootfs_only(
+                    "bad-image",
+                    url="https://example.com/rootfs.qcow2",
+                    sha512="0" * 128,
+                )
+
+        # The file must be deleted so retries don't return a bad cache.
+        assert not (tmp_path / "bad-image" / "rootfs.qcow2").exists()
+
+    def test_sha512_match_caches_file(self, tmp_path: Path) -> None:
+        """A valid SHA-512 should pass and the file should be cached."""
+        import hashlib
+
+        content = b"hello world"
+        expected_sha512 = hashlib.sha512(content).hexdigest()
+        mgr = ImageManager(cache_dir=tmp_path)
+
+        def fake_download(
+            self: ImageManager,
+            url: str,
+            dest: Path,
+            expected_sha256: str | None = None,
+            *,
+            progress_callback: object = None,
+        ) -> None:
+            dest.parent.mkdir(parents=True, exist_ok=True)
+            dest.write_bytes(content)
+
+        with patch.object(ImageManager, "_download_file", fake_download):
+            result = mgr.ensure_rootfs_only(
+                "good-image",
+                url="https://example.com/rootfs.qcow2",
+                sha512=expected_sha512,
+            )
+
+        assert result.exists()
+        assert result.read_bytes() == content
+
+
 class TestImageManagerInit:
     """Tests for ImageManager initialization."""
 
@@ -491,9 +594,7 @@ class TestS3ImageManifest:
 
     def test_manifest_rejects_colliding_filenames_with_initrd(self) -> None:
         with pytest.raises(ValueError, match="collide"):
-            S3ImageManifest(
-                name="bad", kernel="vmlinux", rootfs="rootfs.ext4", initrd="vmlinux"
-            )
+            S3ImageManifest(name="bad", kernel="vmlinux", rootfs="rootfs.ext4", initrd="vmlinux")
 
 
 def _make_s3_manifest_data(
@@ -551,10 +652,13 @@ class TestEnsureS3Image:
             kernel_sha256=hashlib.sha256(kernel_content).hexdigest(),
             rootfs_sha256=hashlib.sha256(rootfs_content).hexdigest(),
         )
-        mock_s3 = self._mock_s3_client(manifest, {
-            "vmlinux.bin": kernel_content,
-            "rootfs.ext4": rootfs_content,
-        })
+        mock_s3 = self._mock_s3_client(
+            manifest,
+            {
+                "vmlinux.bin": kernel_content,
+                "rootfs.ext4": rootfs_content,
+            },
+        )
 
         mgr = ImageManager(cache_dir=tmp_path / "images")
         with patch("smolvm.images.manager._require_boto3", return_value=mock_s3):
@@ -575,10 +679,13 @@ class TestEnsureS3Image:
             kernel_sha256=hashlib.sha256(kernel_content).hexdigest(),
             rootfs_sha256=hashlib.sha256(rootfs_content).hexdigest(),
         )
-        mock_s3 = self._mock_s3_client(manifest, {
-            "vmlinux.bin": kernel_content,
-            "rootfs.ext4": rootfs_content,
-        })
+        mock_s3 = self._mock_s3_client(
+            manifest,
+            {
+                "vmlinux.bin": kernel_content,
+                "rootfs.ext4": rootfs_content,
+            },
+        )
 
         mgr = ImageManager(cache_dir=tmp_path / "images")
 
@@ -602,10 +709,13 @@ class TestEnsureS3Image:
             kernel_sha256=hashlib.sha256(kernel_content).hexdigest(),
             rootfs_sha256=hashlib.sha256(rootfs_content).hexdigest(),
         )
-        mock_s3 = self._mock_s3_client(manifest, {
-            "vmlinux.bin": kernel_content,
-            "rootfs.ext4": rootfs_content,
-        })
+        mock_s3 = self._mock_s3_client(
+            manifest,
+            {
+                "vmlinux.bin": kernel_content,
+                "rootfs.ext4": rootfs_content,
+            },
+        )
 
         mgr = ImageManager(cache_dir=tmp_path / "images")
 
@@ -628,10 +738,13 @@ class TestEnsureS3Image:
     def test_no_sha_still_caches(self, tmp_path: Path) -> None:
         """Images without SHA-256 hashes should still cache and return."""
         manifest = _make_s3_manifest_data()  # no sha256 fields
-        mock_s3 = self._mock_s3_client(manifest, {
-            "vmlinux.bin": b"kernel",
-            "rootfs.ext4": b"rootfs",
-        })
+        mock_s3 = self._mock_s3_client(
+            manifest,
+            {
+                "vmlinux.bin": b"kernel",
+                "rootfs.ext4": b"rootfs",
+            },
+        )
 
         mgr = ImageManager(cache_dir=tmp_path / "images")
         with patch("smolvm.images.manager._require_boto3", return_value=mock_s3):
@@ -670,7 +783,10 @@ class TestEnsureS3Image:
         """Missing boto3 should produce a clear installation hint."""
         mgr = ImageManager(cache_dir=tmp_path / "images")
         with (
-            patch("smolvm.images.manager._require_boto3", side_effect=ImageError("S3 image support requires boto3")),
+            patch(
+                "smolvm.images.manager._require_boto3",
+                side_effect=ImageError("S3 image support requires boto3"),
+            ),
             pytest.raises(ImageError, match="requires boto3"),
         ):
             mgr.ensure_s3_image("s3://bucket/images/test/")
@@ -689,11 +805,14 @@ class TestEnsureS3Image:
             "rootfs_sha256": hashlib.sha256(rootfs_content).hexdigest(),
             "initrd_sha256": hashlib.sha256(initrd_content).hexdigest(),
         }
-        mock_s3 = self._mock_s3_client(manifest_data, {
-            "vmlinuz": kernel_content,
-            "rootfs.qcow2": rootfs_content,
-            "initrd.img": initrd_content,
-        })
+        mock_s3 = self._mock_s3_client(
+            manifest_data,
+            {
+                "vmlinuz": kernel_content,
+                "rootfs.qcow2": rootfs_content,
+                "initrd.img": initrd_content,
+            },
+        )
 
         mgr = ImageManager(cache_dir=tmp_path / "images")
         with patch("smolvm.images.manager._require_boto3", return_value=mock_s3):
@@ -712,10 +831,13 @@ class TestEnsureS3Image:
             kernel_sha256=hashlib.sha256(kernel_content).hexdigest(),
             rootfs_sha256=hashlib.sha256(rootfs_content).hexdigest(),
         )
-        mock_s3 = self._mock_s3_client(manifest, {
-            "vmlinux.bin": kernel_content,
-            "rootfs.ext4": rootfs_content,
-        })
+        mock_s3 = self._mock_s3_client(
+            manifest,
+            {
+                "vmlinux.bin": kernel_content,
+                "rootfs.ext4": rootfs_content,
+            },
+        )
 
         mgr = ImageManager(cache_dir=tmp_path / "images")
 


### PR DESCRIPTION
## Summary

`smolvm create --os debian` used to run `docker build` on the host to produce the rootfs, so any flaky Debian apt mirror would bubble up as a SmolVM `ImageError` — this was triggered by a real Fastly CDN sync hiccup serving a corrupt `libsasl2-modules-db` package. On the QEMU backend (the Mac default), debian now fetches the upstream `debian-12-genericcloud` qcow2 from `cloud.debian.org` and boots it via OVMF/SeaBIOS firmware. No Docker daemon, no apt, no mirror roulette. The existing docker-build path is retained as a backend-gated fallback for `--backend firecracker`/`libkrun` so Linux users don't lose fast-boot backends for debian.

As a bonus, `--disk-size-mib` now works on both debian and ubuntu prebuilt paths via `qemu-img resize` + cloud-init `growpart` — which also lifts the pre-existing ubuntu disk-size lock.

### What changed

- **`VMConfig.boot_mode`** (`"direct_kernel"` | `"firmware"`) with a model validator enforcing `firmware` ⇔ `kernel_path is None` ⇔ `backend == "qemu"`. `kernel_path` is now `Path | None`.
- **QEMU firmware-boot branch** in both sync and async command builders in `vm.py`: skips `-kernel`/`-append`/`-initrd` and passes `-bios <edk2-aarch64-code.fd>` on aarch64 (searches Homebrew / Debian / RHEL paths). Snapshot-restore kernel-path check is guarded for `None`.
- **`ImageManager.ensure_rootfs_only`** — new method for downloading a standalone rootfs (no separate kernel/initrd), reusing the existing atomic-write + SHA-256 verification path.
- **`_prepare_sized_qcow2`** helper in `facade.py` — copies the pristine cached qcow2 into a size-specific cache dir (`{image}-{size}m`) and runs `qemu-img resize`, so multiple VMs at the same size share a resized copy. `qemu-img` is already a required dependency verified at `host/doctor.py:544`.
- **Debian prebuilt branch** in `_build_auto_config` gated on `BACKEND_QEMU`. Reuses the existing `default_user_data` / `build_seed_iso` cloud-init helpers unchanged — they work for both ubuntu and debian genericcloud.
- **Ubuntu disk-size lock lifted** (`facade.py:329-334`): `--disk-size-mib 8192 --os ubuntu` now works.
- **Tests**: existing debian tests pin `backend="firecracker"` to keep exercising the docker fallback path; new tests cover the prebuilt firmware boot, resize triggering, and undersized-disk rejection for both debian and ubuntu.

### Routing table

| Command | Path |
|---|---|
| `smolvm create --os debian` (Mac, qemu auto) | New prebuilt firmware-boot |
| `smolvm create --os debian --backend qemu` | New prebuilt firmware-boot |
| `smolvm create --os debian --backend firecracker` | Existing `build_debian_ssh_key` docker path |
| `smolvm create --os debian --backend libkrun` | Existing `build_debian_ssh_key` docker path |
| `smolvm create --os ubuntu [--disk-size-mib N]` | Existing prebuilt + new resize |
| `smolvm create --os alpine` | Unchanged |

### Reviewer notes

- The URL pattern follows Canonical's approach for ubuntu (no SHA pin, tracks `bookworm/latest/`). Upstream publishes SHA-512, not SHA-256, so pinning sha256 would require generating our own — left as a future tightening if we want stronger reproducibility.
- Debian genericcloud uses a single ext4 partition (no LVM, no separate `/boot`), so `cc_growpart` + `cc_resizefs` work out of the box. If Debian ever changes that layout, the manual verification step below would catch the regression.
- On aarch64, UEFI firmware (edk2/AAVMF) is required for firmware-boot. The resolver searches `/opt/homebrew/share/qemu/edk2-aarch64-code.fd`, `/usr/share/qemu-efi-aarch64/QEMU_EFI.fd`, and a few others, and emits a clear error pointing at `brew reinstall qemu` or `apt install qemu-efi-aarch64` if none are found.

## Related Issues

- Closes #

## Testing

- `uv run pytest` — **607 passed, 11 skipped** (unchanged from main)
- `uv run ruff check .` — 28 errors, all pre-existing on `main` (verified via stash/pop); 0 introduced by this change
- `uv run ruff format` — applied to touched files
- Programmatic smoke test confirming `smolvm create --os debian --backend qemu --disk-size-mib 4096` now routes through the prebuilt firmware-boot path (no ImageBuilder call, `boot_mode == "firmware"`, resize triggered)
- **Not run (reviewer should try)**: end-to-end boot of a real debian VM and `ssh debian-box -- df -h /` to confirm cloud-init growpart expands the rootfs on first boot. Unit tests cover the construction path; they don't cover actual boot.

## Checklist

- [x] Scope is focused and limited to this change
- [x] Tests added/updated for behavior changes
- [x] Docs updated for user-visible changes (CLI `--disk-size-mib` help text)
- [x] No secrets or sensitive data included

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Debian support for QEMU backend with firmware boot mode
  * Automatic disk resizing for Debian/QEMU when exceeding default size
  * AARCH64 UEFI firmware auto-discovery for firmware boot mode

* **Improvements**
  * Relaxed disk-size validation to accept >= default instead of exact match

* **Documentation**
  * Updated disk-size parameter help text with OS-conditional defaults and minimum requirements

<!-- end of auto-generated comment: release notes by coderabbit.ai -->