### PR TITLE
ci: relax release preflight to decouple smolvm and smolvm-core

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Set up Python
         run: uv python install 3.13
 
-      - name: Verify release ordering and version pin
+      - name: Verify release ordering and core availability
         run: |
           python3 - <<'PY'
           import os
@@ -42,22 +42,28 @@ jobs:
                   f"Expected {expected_tag!r}."
               )
 
-          match = re.fullmatch(r"(?P<base>\d+\.\d+\.\d+)(?P<suffix>.*)", version)
-          if match is None:
-              raise SystemExit(
-                  f"Unsupported project version format {version!r}. Expected X.Y.Z or X.Y.Z<suffix>."
-              )
-
-          base_version = match.group("base")
-          suffix = match.group("suffix")
-          core_version = base_version if suffix else version
-
-          expected_dep = f"smolvm-core=={core_version}"
+          # Find the smolvm-core dependency line. We no longer require the
+          # core version to match smolvm's own version: smolvm 0.0.10 may
+          # depend on smolvm-core 0.0.9, and that's intentional.
           dependencies = data["project"]["dependencies"]
-          if expected_dep not in dependencies:
+          core_dep = next(
+              (d for d in dependencies if re.match(r"^smolvm-core(\s|[<>=!~]|$)", d)),
+              None,
+          )
+          if core_dep is None:
               raise SystemExit(
-                  f"pyproject.toml must pin {expected_dep!r} before publishing smolvm."
+                  "pyproject.toml must declare a smolvm-core dependency before publishing smolvm."
               )
+
+          # Extract a concrete version to verify against PyPI. Works for
+          # `smolvm-core==X.Y.Z`, `smolvm-core>=X.Y.Z,<0.1.0`, etc. — we
+          # check the first version string we find in the constraint.
+          version_match = re.search(r"(\d+\.\d+\.\d+(?:[a-zA-Z0-9.\-]*)?)", core_dep)
+          if version_match is None:
+              raise SystemExit(
+                  f"Could not extract a smolvm-core version from {core_dep!r}."
+              )
+          core_version = version_match.group(1)
 
           url = f"https://pypi.org/pypi/smolvm-core/{core_version}/json"
           try:
@@ -69,17 +75,15 @@ jobs:
           except urllib.error.HTTPError as exc:
               if exc.code == 404:
                   raise SystemExit(
-                      f"smolvm-core {core_version} is not on PyPI yet. Publish tag core-v{core_version} first."
+                      f"smolvm-core {core_version} is not on PyPI yet. "
+                      f"Publish tag core-v{core_version} first."
                   ) from exc
               raise
 
-          if suffix:
-              print(
-                  f"Release preflight OK: prerelease smolvm {version} is pinned to stable "
-                  f"smolvm-core {core_version}, and that core release is available on PyPI."
-              )
-          else:
-              print(f"Release preflight OK: smolvm-core {core_version} is available on PyPI.")
+          print(
+              f"Release preflight OK: smolvm {version} depends on {core_dep!r}; "
+              f"smolvm-core {core_version} is available on PyPI."
+          )
           PY
 
       - name: Build package

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -96,14 +96,33 @@ jobs:
 
       - name: Smoke test built wheels
         run: |
-          VERSION=$(python3 - <<'PY'
+          # Read smolvm version and the smolvm-core version it depends on.
+          # smolvm and smolvm-core are released independently within the
+          # 0.0.x series, so we pull the expected core version from the
+          # pyproject dependency string rather than assuming lockstep.
+          eval "$(python3 - <<'PY'
+          import re
           import tomllib
           from pathlib import Path
 
           data = tomllib.loads(Path("pyproject.toml").read_text())
-          print(data["project"]["version"])
-          PY
+          version = data["project"]["version"]
+
+          core_dep = next(
+              (
+                  d
+                  for d in data["project"]["dependencies"]
+                  if re.match(r"^smolvm-core(\s|[<>=!~]|$)", d)
+              ),
+              None,
           )
+          assert core_dep is not None, "pyproject must declare a smolvm-core dependency"
+          m = re.search(r"(\d+\.\d+\.\d+(?:[a-zA-Z0-9.\-]*)?)", core_dep)
+          assert m is not None, f"could not parse version from {core_dep!r}"
+          print(f"VERSION={version}")
+          print(f"CORE_VERSION={m.group(1)}")
+          PY
+          )"
 
           uv venv .smoke-venv --python 3.13
           uv pip install \
@@ -114,17 +133,12 @@ jobs:
 
           .smoke-venv/bin/python3 - <<PY
           import platform
-          import re
           from importlib.metadata import version as pkg_version
 
           from smolvm.host._accel import HAS_NETLINK
 
-          version = "${VERSION}"
-          match = re.fullmatch(r"(?P<base>\d+\.\d+\.\d+)(?P<suffix>.*)", version)
-          assert match is not None, version
-          core_version = match.group("base") if match.group("suffix") else version
-          assert pkg_version("smolvm") == version
-          assert pkg_version("smolvm-core") == core_version
+          assert pkg_version("smolvm") == "${VERSION}"
+          assert pkg_version("smolvm-core") == "${CORE_VERSION}"
           if platform.system() == "Linux":
               assert HAS_NETLINK, "smolvm-core native extension did not load from built wheel"
           print("artifact install: OK")


### PR DESCRIPTION
## Summary
- Relax the `publish.yml` preflight check so smolvm and smolvm-core no longer need lockstep version bumps
- Previously the workflow required pyproject to pin `smolvm-core==<smolvm base version>`, blocking releases like smolvm `0.0.10` depending on smolvm-core `0.0.9`
- The check now reads whatever smolvm-core constraint exists in pyproject.toml, extracts its version, and verifies that core version is on PyPI before publishing
- Tag-vs-pyproject version match is still enforced

## Test plan
- [ ] Dry-run the preflight script locally against pyproject pinning `smolvm-core==0.0.9` while smolvm is at `0.0.10a0` — expect OK
- [ ] Confirm it still rejects a missing/malformed smolvm-core dependency
- [ ] Confirm it still rejects when the pinned core version is not on PyPI
- [ ] Confirm it still rejects a tag that doesn't match the pyproject version

🤖 Generated with [Claude Code](https://claude.com/claude-code)