### PR TITLE
fix(facade): include build suffix in pinned debian image filenames

### DIFF
--- a/src/smolvm/facade.py
+++ b/src/smolvm/facade.py
@@ -133,20 +133,27 @@ _QEMU_UBUNTU_AUTO_IMAGES: dict[str, ImageSource] = {
 # firmware boot (OVMF/SeaBIOS) for this image, so only the rootfs URL matters.
 #
 # Pinned to a specific dated release (immutable URL) and verified against the
-# upstream SHA-512 digest from that release's SHA512SUMS file. To bump:
+# upstream SHA-512 digest from that release's SHA512SUMS file. Note the
+# filename inside the dated directory carries the build identifier
+# (e.g. ``-20260413-2447``); only the ``latest/`` symlink view exposes the
+# short un-suffixed name. We pin to the dated path for immutability, so the
+# filename here MUST include the build suffix.
+#
+# To bump:
 #   1. Pick a newer build under https://cloud.debian.org/images/cloud/bookworm/
 #   2. Copy the SHA-512 hex digests from its SHA512SUMS file into this registry
-#   3. Verify the partition layout is still a single ext4 partition before
+#   3. Update both the URL build suffix and the _DEBIAN_CURRENT_RELEASE_TAG
+#   4. Verify the partition layout is still a single ext4 partition before
 #      committing — cloud-init growpart assumes this for the disk-resize path
 _DEBIAN_CURRENT_RELEASE_TAG = "20260413-2447"
 _DEBIAN_AUTO_IMAGES: dict[str, tuple[str, str]] = {
     "debian-bookworm-genericcloud-qemu-x86_64": (
-        f"https://cloud.debian.org/images/cloud/bookworm/{_DEBIAN_CURRENT_RELEASE_TAG}/debian-12-genericcloud-amd64.qcow2",
+        f"https://cloud.debian.org/images/cloud/bookworm/{_DEBIAN_CURRENT_RELEASE_TAG}/debian-12-genericcloud-amd64-{_DEBIAN_CURRENT_RELEASE_TAG}.qcow2",
         "db11b13c4efcc37828ffadae521d101e85079d349e1418074087bb7d306f11ca"
         "ccdc2b0b539d6fd50d623d40a898f83c6137268a048d7700397dc35b7dcbc927",
     ),
     "debian-bookworm-genericcloud-qemu-aarch64": (
-        f"https://cloud.debian.org/images/cloud/bookworm/{_DEBIAN_CURRENT_RELEASE_TAG}/debian-12-genericcloud-arm64.qcow2",
+        f"https://cloud.debian.org/images/cloud/bookworm/{_DEBIAN_CURRENT_RELEASE_TAG}/debian-12-genericcloud-arm64-{_DEBIAN_CURRENT_RELEASE_TAG}.qcow2",
         "15ad6c52e255c84eb0e91001c5907b27199d8a7164d8ac172cfe9c92850dfaf6"
         "06a6c3161d6af7f0fd5a5fef2aa8dcd9a23c2eb0fedbfcddb38e2bc306cba98f",
     ),

--- a/tests/test_facade.py
+++ b/tests/test_facade.py
@@ -435,6 +435,34 @@ class TestVMInit:
         with pytest.raises(ValueError, match="auto-config mode"):
             SmolVM(sample_config, mem_size_mib=1024)
 
+    def test_debian_pinned_urls_carry_build_suffix(self) -> None:
+        """Each pinned Debian URL must include the build tag in the filename.
+
+        Debian's dated release directories (e.g. ``bookworm/20260413-2447/``)
+        store files with the build tag *in the filename*, like
+        ``debian-12-genericcloud-arm64-20260413-2447.qcow2``. Only the
+        ``latest/`` symlink view exposes the un-suffixed short names. Pinning
+        to a dated directory with a short filename produces a 404 — this test
+        catches that exact mistake on a future bump.
+        """
+        from smolvm.facade import _DEBIAN_AUTO_IMAGES, _DEBIAN_CURRENT_RELEASE_TAG
+
+        assert _DEBIAN_AUTO_IMAGES, "_DEBIAN_AUTO_IMAGES must not be empty"
+        for image_name, (url, _sha512) in _DEBIAN_AUTO_IMAGES.items():
+            # The dated path must appear in the URL.
+            assert f"/{_DEBIAN_CURRENT_RELEASE_TAG}/" in url, (
+                f"{image_name}: URL missing dated release path "
+                f"{_DEBIAN_CURRENT_RELEASE_TAG!r}: {url}"
+            )
+            # The filename portion must also embed the build tag.
+            filename = url.rsplit("/", 1)[-1]
+            assert _DEBIAN_CURRENT_RELEASE_TAG in filename, (
+                f"{image_name}: filename {filename!r} is missing the build "
+                f"tag {_DEBIAN_CURRENT_RELEASE_TAG!r}. Inside dated release "
+                "directories the filename includes the build identifier; only "
+                "the 'latest/' symlink view uses the short name."
+            )
+
     def test_os_with_config_raises(self, sample_config: VMConfig) -> None:
         """Guest OS selection is only valid in zero-config mode."""
         with pytest.raises(ValueError, match="auto-config mode"):


### PR DESCRIPTION
## Summary

Hotfix for #164. Every fresh install of `smolvm create --os debian --backend qemu` 404s on first download because the pinned URL uses the **short** filename in a **dated release directory** — but Debian only exposes short filenames in the `latest/` symlink view. Inside dated directories, the build identifier is embedded in the filename.

### Concretely

| Where pinned | What's actually there |
|---|---|
| ❌ `https://.../bookworm/20260413-2447/debian-12-genericcloud-arm64.qcow2` | 404 |
| ✅ `https://.../bookworm/20260413-2447/debian-12-genericcloud-arm64-20260413-2447.qcow2` | 200, 326 MiB |
| ✅ `https://.../bookworm/latest/debian-12-genericcloud-arm64.qcow2` | 200, 326 MiB (symlink view) |

We can't switch to `latest/` because the SHA-512 verification needs immutability. So we keep the dated directory and add the build suffix to the filename.

The SHA-512 hashes are unchanged — same file content, different filename.

### Why CI didn't catch this

Unit tests mock `ImageManager`, so they never actually fetched the URL. The test added in this PR (`test_debian_pinned_urls_carry_build_suffix`) is a cheap unit-level guard that asserts every entry in `_DEBIAN_AUTO_IMAGES` has the build tag in its filename, so a future release bump can't drop the suffix again.

### Why caches masked it

`ensure_rootfs_only` checks `rootfs_path.is_file()` before downloading. Anyone who had a successful download under the old (broken) flow before… actually scratch that — there was no working flow before this PR for fresh installs. The masking was for developers who somehow had a previously-cached arm64 qcow2 under the same cache key from earlier experimentation. Once they `rm -rf ~/.smolvm/images/debian-*`, they hit it too.

## Verification

- `curl -ILs` against both URLs → 200 OK with correct content lengths (332M amd64, 326M arm64)
- Programmatic check against `_DEBIAN_AUTO_IMAGES` resolves to a real 200 (`requests.head(url, allow_redirects=True)` → 200)
- `uv run pytest` → **614 passed, 11 skipped** (+1 new regression test, no other changes)
- New test passes on this fix and **fails** on `main` (verified by reverting just the URL change locally before adding the test)

## Test plan

- [x] `uv run pytest tests/test_facade.py`
- [x] `uv run pytest` (full suite)
- [x] Manual `curl -IL` of both pinned URLs
- [ ] End-to-end: a colleague with no `~/.smolvm/images/` cache runs `smolvm create --os debian` from this branch and gets a working VM (the original repro case)

🤖 Generated with [Claude Code](https://claude.com/claude-code)