### PR TITLE
fix(ssh): silence paramiko transport logger noise during wait_for_ssh retries

### DIFF
--- a/src/smolvm/ssh.py
+++ b/src/smolvm/ssh.py
@@ -35,6 +35,31 @@ from smolvm.types import CommandResult
 
 logger = logging.getLogger(__name__)
 
+# Silence paramiko's Transport thread logger.
+#
+# During ``SSHClient.wait_for_ssh`` we poll a freshly-booted guest until
+# sshd responds. The first connect attempts often race against cloud-init
+# (which restarts sshd part-way through boot), so paramiko reads EOF on the
+# banner, logs ``Exception (client): Error reading SSH protocol banner`` to
+# its own logger at ERROR level from the Transport thread, *and then* raises
+# SSHException to the caller. SmolVM catches that exception, retries, and
+# the next attempt succeeds — but the stderr noise from the failed attempt
+# is misleading because the operation as a whole succeeded.
+#
+# Every paramiko exception that smolvm cares about is already wrapped into
+# a SmolVMError with the original message preserved (see :meth:`_connect`),
+# and the original exception is chained via ``raise ... from e`` so the full
+# traceback stays available. Suppressing paramiko's own transport logger to
+# CRITICAL therefore loses no information that callers can't already get
+# from the wrapped error — it only silences the per-retry noise.
+#
+# To re-enable paramiko's own logging for debugging, set the level back
+# explicitly in your application code::
+#
+#     import logging
+#     logging.getLogger("paramiko.transport").setLevel(logging.WARNING)
+logging.getLogger("paramiko.transport").setLevel(logging.CRITICAL)
+
 ShellMode = Literal["login", "raw"]
 
 

--- a/tests/test_ssh.py
+++ b/tests/test_ssh.py
@@ -14,6 +14,7 @@
 
 """Tests for SmolVM SSH module."""
 
+import logging
 import socket
 from unittest.mock import MagicMock, patch
 
@@ -22,6 +23,43 @@ import pytest
 from smolvm.exceptions import OperationTimeoutError, SmolVMError
 from smolvm.ssh import SSHClient
 from smolvm.types import CommandResult
+
+
+class TestParamikoLoggerSilenced:
+    """Importing smolvm.ssh must silence paramiko's transport logger.
+
+    Rationale: during ``wait_for_ssh`` retries, paramiko's Transport thread
+    logs ``Exception (client): Error reading SSH protocol banner`` at ERROR
+    level when sshd is briefly unavailable. SmolVM catches the SSHException
+    and retries successfully, so the stderr noise from the failed attempt is
+    misleading. The fix sets the ``paramiko.transport`` logger to CRITICAL
+    so per-retry races stay quiet; smolvm still surfaces real errors via
+    SmolVMError with the original exception chained.
+    """
+
+    def test_paramiko_transport_logger_is_silenced_on_import(self) -> None:
+        # Importing smolvm.ssh should have already configured the logger.
+        # Re-import here defensively in case test isolation has been
+        # tampered with by an earlier test.
+        import smolvm.ssh  # noqa: F401  (import for side effect)
+
+        level = logging.getLogger("paramiko.transport").getEffectiveLevel()
+        assert level >= logging.CRITICAL, (
+            f"paramiko.transport logger level is {level}, expected >= CRITICAL "
+            f"({logging.CRITICAL}) so retry-loop EOF noise stays silent"
+        )
+
+    def test_smolvm_ssh_logger_is_not_silenced(self) -> None:
+        """Silencing paramiko.transport must not affect smolvm's own logger."""
+        # smolvm.ssh.logger should remain at its default (NOTSET / inherited),
+        # so smolvm's own info/debug messages are still surfaced.
+        smolvm_level = logging.getLogger("smolvm.ssh").getEffectiveLevel()
+        # Anything strictly below CRITICAL means we didn't accidentally
+        # blanket-silence the smolvm namespace.
+        assert smolvm_level < logging.CRITICAL, (
+            f"smolvm.ssh logger level is {smolvm_level}; the paramiko "
+            "silencer must not affect smolvm's own loggers"
+        )
 
 
 class TestSSHClientInit:

--- a/tests/test_ssh.py
+++ b/tests/test_ssh.py
@@ -38,11 +38,9 @@ class TestParamikoLoggerSilenced:
     """
 
     def test_paramiko_transport_logger_is_silenced_on_import(self) -> None:
-        # Importing smolvm.ssh should have already configured the logger.
-        # Re-import here defensively in case test isolation has been
-        # tampered with by an earlier test.
-        import smolvm.ssh  # noqa: F401  (import for side effect)
-
+        # The top-level ``from smolvm.ssh import SSHClient`` above has
+        # already triggered the module-level ``setLevel`` call as a side
+        # effect of import. We just verify the resulting state here.
         level = logging.getLogger("paramiko.transport").getEffectiveLevel()
         assert level >= logging.CRITICAL, (
             f"paramiko.transport logger level is {level}, expected >= CRITICAL "


### PR DESCRIPTION
## Summary

Followup to #167. The Debian URL fix unblocks fresh installs, but the create flow still occasionally spews a misleading paramiko traceback to stderr **on a successful run**:

\`\`\`
$ smolvm create --os debian --disk-size-mib 4096 --memory-mib 2048 --json
Exception (client): Error reading SSH protocol banner
Traceback (most recent call last):
  File "/.../paramiko/transport.py", line 2363, in _check_banner
    ...
paramiko.ssh_exception.SSHException: Error reading SSH protocol banner

{"ok": true, "command": "create", "exit_code": 0, ...}   ← the operation succeeded
\`\`\`

The traceback comes from inside paramiko's own Transport thread, not from SmolVM. It's a race during \`SSHClient.wait_for_ssh\`: the first \`_connect()\` attempts often hit sshd while cloud-init is mid-restart of the daemon, paramiko reads EOF on the banner, logs the exception via its own logger at ERROR level, then raises \`SSHException\` to the main thread. SmolVM catches that \`SSHException\` in the retry loop at [ssh.py:343](src/smolvm/ssh.py), waits 200 ms, retries — and the next attempt succeeds, which is why the create reports \`ok: true\`. Only the leaked stderr noise from the failed attempt makes it look broken.

## Fix

One-line silencer at \`smolvm.ssh\` import time:

\`\`\`python
logging.getLogger(\"paramiko.transport\").setLevel(logging.CRITICAL)
\`\`\`

Plus a long comment block explaining why and how to re-enable it for debugging.

## Why this is safe

SmolVM's \`SSHClient._connect\` already wraps **every** paramiko exception:

\`\`\`python
except Exception as e:
    client.close()
    raise SmolVMError(f\"SSH connection failed: {e}\") from e
\`\`\`

So:
1. The original exception's message is preserved verbatim in the \`SmolVMError\`.
2. The full original traceback is chained via \`from e\` and shows up in any error report.
3. SmolVM's own logger (\`smolvm.ssh\`) is untouched — INFO/DEBUG output from \`wait_for_ssh\` (\"Waiting for SSH on ...\", \"SSH is ready on ...\") still surfaces.

Users who want raw paramiko logs for deeper debugging can opt in:

\`\`\`python
import logging
logging.getLogger(\"paramiko.transport\").setLevel(logging.WARNING)
\`\`\`

## Why a logger silencer instead of catching the exception inside paramiko

paramiko logs the exception **before** raising it. It's logged from the Transport thread's \`run()\` method — there's no exception-handling hook the caller can install to suppress that one specific log call. The only way to quiet it from outside paramiko is via Python's logging system. (The alternative would be monkeypatching \`Transport._log\`, which is far worse.)

## Why scoped to \`paramiko.transport\` and not \`paramiko\`

\`paramiko.transport\` is where the per-retry race noise lives. Other paramiko subloggers (auth, sftp, hostkeys) might still surface useful WARNING/ERROR messages for genuine misconfiguration, so I'm not blanket-silencing the whole package. If a future failure mode shows up in another sublogger we can scope-narrow it the same way.

## Test plan

- [x] \`uv run pytest tests/test_ssh.py\` — **19 passed** (+2 new in \`TestParamikoLoggerSilenced\`)
- [x] \`uv run pytest\` (full suite) — **615 passed, 11 skipped** (+1 vs main; the new tests, no other changes)
- [x] New tests assert:
  - importing \`smolvm.ssh\` sets \`paramiko.transport\` logger level \`>= CRITICAL\`
  - the silencer does NOT blanket-affect \`smolvm.ssh\`'s own logger (safety net so future changes can't accidentally silence everything)
- [ ] **Manual verify on the original repro**: run \`smolvm create --os debian --disk-size-mib 4096 --memory-mib 2048 --json\` against this branch on a host that hits the cloud-init/sshd race; confirm no paramiko traceback appears on stderr while \`ok: true\` is still emitted

## Checklist

- [x] Scope is focused and limited to this change
- [x] Tests added/updated for behavior changes
- [x] Docs updated for user-visible changes (inline comment + commit body explain the override path for debugging)
- [x] No secrets or sensitive data included

🤖 Generated with [Claude Code](https://claude.com/claude-code)