### PR TITLE
fix initrd reload validation

### DIFF
--- a/src/smolvm/types.py
+++ b/src/smolvm/types.py
@@ -344,10 +344,16 @@ class VMConfig(BaseModel):
 
     @field_validator("initrd_path")
     @classmethod
-    def validate_optional_path_exists(cls, v: Path | None) -> Path | None:
+    def validate_optional_path_exists(
+        cls,
+        v: Path | None,
+        info: ValidationInfo,
+    ) -> Path | None:
         """Ensure optional paths exist on the filesystem."""
         if v is None:
             return None
+        if not cls._should_validate_paths(info):
+            return v
         return cls._validate_file_path(v)
 
     @field_validator("extra_drives")

--- a/tests/test_storage.py
+++ b/tests/test_storage.py
@@ -107,6 +107,33 @@ class TestStateManagerVMOperations:
         assert vm_info.vm_id == "vm001"
         assert vm_info.config.kernel_path == sample_config.kernel_path
 
+    def test_get_vm_allows_missing_persisted_initrd(
+        self,
+        state_manager: StateManager,
+        tmp_path: Path,
+    ) -> None:
+        """Persisted VM metadata should tolerate a cleaned-up initrd cache."""
+        kernel = tmp_path / "vmlinux"
+        rootfs = tmp_path / "rootfs.ext4"
+        initrd = tmp_path / "initrd"
+        kernel.touch()
+        rootfs.touch()
+        initrd.touch()
+
+        config = VMConfig(
+            vm_id="vm001",
+            kernel_path=kernel,
+            initrd_path=initrd,
+            rootfs_path=rootfs,
+        )
+        state_manager.create_vm(config)
+        initrd.unlink()
+
+        vm_info = state_manager.get_vm("vm001")
+
+        assert vm_info.vm_id == "vm001"
+        assert vm_info.config.initrd_path == initrd
+
     def test_get_nonexistent_vm_raises(self, state_manager: StateManager) -> None:
         """Test that getting a nonexistent VM raises an error."""
         with pytest.raises(VMNotFoundError) as exc_info:

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -319,6 +319,27 @@ class TestVMConfig:
                 extra_drives=[tmp_path / "missing.ext4"],
             )
 
+    def test_initrd_path_respects_validate_paths_context(self, tmp_path: Path) -> None:
+        """Persisted configs may skip initrd existence checks during reload."""
+        kernel = tmp_path / "vmlinux"
+        rootfs = tmp_path / "rootfs.ext4"
+        initrd = tmp_path / "initrd"
+        kernel.touch()
+        rootfs.touch()
+        initrd.touch()
+
+        raw = VMConfig(
+            vm_id="vm001",
+            kernel_path=kernel,
+            initrd_path=initrd,
+            rootfs_path=rootfs,
+        ).model_dump_json()
+        initrd.unlink()
+
+        config = VMConfig.model_validate_json(raw, context={"validate_paths": False})
+
+        assert config.initrd_path == initrd
+
     def test_invalid_disk_mode_rejected(self, tmp_path: Path) -> None:
         """Test unsupported disk_mode values are rejected."""
         kernel = tmp_path / "vmlinux"


### PR DESCRIPTION
## Summary

Briefly describe what changed and why.

## Related Issues

- Closes #

## Testing

List what you ran locally (or write "not run" with reason).

- `uv run pytest`
- `uv run ruff check .`
- `uv run mypy src`

## Checklist

- [ ] Scope is focused and limited to this change
- [ ] Tests added/updated for behavior changes
- [ ] Docs updated for user-visible changes
- [ ] No secrets or sensitive data included


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * VM configurations can now be loaded even when initrd files are missing, with optional control over filesystem path validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->