### PR TITLE
feat(setup): bake-time-friendly install for two-stage deploys

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,37 @@ Linux may prompt for `sudo` during setup so it can install host dependencies and
 
 </details>
 
+<details>
+<summary>Bake-time install (golden AMI / two-stage deploys)</summary>
+
+If you bake an image on a host without `/dev/kvm` (for example, a cheap AWS builder) and boot it later on a KVM-enabled host, run setup in **bake mode**:
+
+```bash
+smolvm setup --for-bake --runtime-user ubuntu
+```
+
+`--for-bake` skips the install-time KVM check and the post-install sudoers self-test, so the install completes on a builder that isn't yet runtime-ready. On the runtime host, finish with:
+
+```bash
+smolvm doctor
+```
+
+To pin the Firecracker version (so a downstream AMI doesn't drift when SmolVM bumps it), pass either a flag or an environment variable:
+
+```bash
+smolvm setup --firecracker-version v1.14.1
+# or
+SMOLVM_FIRECRACKER_VERSION=v1.14.1 smolvm setup
+```
+
+If you need the location of the packaged shell scripts (e.g. to invoke them directly from a Packer provisioner), use the stable CLI instead of importing from the Python package:
+
+```bash
+smolvm setup --assets-dir
+```
+
+</details>
+
 ### Start a sandbox in Python
 
 ```python

--- a/README.md
+++ b/README.md
@@ -65,36 +65,7 @@ Linux may prompt for `sudo` during setup so it can install host dependencies and
 
 </details>
 
-<details>
-<summary>Bake-time install (golden AMI / two-stage deploys)</summary>
-
-If you bake an image on a host without `/dev/kvm` (for example, a cheap AWS builder) and boot it later on a KVM-enabled host, run setup in **bake mode**:
-
-```bash
-smolvm setup --for-bake --runtime-user ubuntu
-```
-
-`--for-bake` skips the install-time KVM check and the post-install sudoers self-test, so the install completes on a builder that isn't yet runtime-ready. On the runtime host, finish with:
-
-```bash
-smolvm doctor
-```
-
-To pin the Firecracker version (so a downstream AMI doesn't drift when SmolVM bumps it), pass either a flag or an environment variable:
-
-```bash
-smolvm setup --firecracker-version v1.14.1
-# or
-SMOLVM_FIRECRACKER_VERSION=v1.14.1 smolvm setup
-```
-
-If you need the location of the packaged shell scripts (e.g. to invoke them directly from a Packer provisioner), use the stable CLI instead of importing from the Python package:
-
-```bash
-smolvm setup --assets-dir
-```
-
-</details>
+For golden-AMI builds, two-stage deploys, pinning the Firecracker version, and other non-default install paths, see [docs/installation.md](docs/installation.md).
 
 ### Start a sandbox in Python
 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -1,0 +1,81 @@
+# Installation
+
+Most people install SmolVM with the one-liner from the [README](../README.md#quickstart) and never need to read further. This page is for the cases where you want more control over how SmolVM gets onto a machine — for example, baking it into a golden image, or pinning the exact Firecracker version your AMI ships with.
+
+## Standard install
+
+The simplest path:
+
+```bash
+pip install smolvm
+smolvm setup
+smolvm doctor
+```
+
+`smolvm setup` installs Firecracker, configures host networking permissions, and confirms the machine is ready to run sandboxes. It assumes the machine already has `/dev/kvm` (i.e. it is the host where sandboxes will run).
+
+## Bake-time install (golden AMI / two-stage deploys)
+
+Some teams want to pre-install everything SmolVM needs into a base image, so that booting a fresh machine becomes "boot the AMI, accept secrets, start serving traffic" rather than "boot, then spend several minutes installing." This is common on AWS where you bake the image on a cheap builder (e.g. `c5.large`) and run it on an expensive metal instance (e.g. `c5.metal`) where KVM is actually available.
+
+The challenge is that the builder doesn't have `/dev/kvm`, so the default `smolvm setup` refuses to run. **Bake mode** is the answer:
+
+```bash
+smolvm setup --for-bake --runtime-user ubuntu
+```
+
+`--for-bake` skips the install-time checks that depend on the live runtime environment:
+
+- The `/dev/kvm` device check (the builder doesn't have one yet).
+- The post-install sudoers self-test (the builder may not have networking tools warmed up).
+
+Once the AMI boots on a real KVM host, finish setup by running:
+
+```bash
+smolvm doctor
+```
+
+`smolvm doctor` verifies that `/dev/kvm` is present, that Firecracker is on the path, and that the sudoers rules actually grant the runtime user the access they need. **You should treat `smolvm doctor` as a required first-boot step** — it is the safety net that catches anything bake mode skipped.
+
+### Pinning the Firecracker version
+
+When you bake an AMI, you usually want to know exactly which Firecracker version it ships with, independent of which SmolVM version you happen to be installing. Pass a flag or set an environment variable:
+
+```bash
+smolvm setup --firecracker-version v1.14.1
+```
+
+```bash
+SMOLVM_FIRECRACKER_VERSION=v1.14.1 smolvm setup
+```
+
+The flag takes precedence over the env var. Both override SmolVM's built-in default. The legacy `FC_VERSION` env var still works for backwards compatibility, but new pipelines should use `SMOLVM_FIRECRACKER_VERSION`.
+
+### Locating the packaged shell scripts
+
+If your bake pipeline needs to invoke SmolVM's setup scripts directly (e.g. from a Packer provisioner), use the stable CLI to find them:
+
+```bash
+SMOLVM_ASSETS="$(smolvm setup --assets-dir)"
+bash "${SMOLVM_ASSETS}/internal/configure-runtime-sudoers.sh" --runtime-user ubuntu
+```
+
+This avoids reaching into the Python package layout — `smolvm setup --assets-dir` is the supported interface and won't change between releases. Don't import `from smolvm.host.setup import packaged_asset_root`; that's an internal helper.
+
+### Granular escape hatches
+
+`--for-bake` is shorthand for the common bake-mode case. If you need finer control, the underlying flags are:
+
+- `--skip-kvm-check` — install Firecracker without requiring `/dev/kvm`.
+- `--skip-runtime-check` — install the sudoers rule without running the post-install self-test.
+
+You can combine them with the other `smolvm setup` flags as you need.
+
+### What can still go wrong at runtime
+
+Bake mode trades install-time strictness for portability. Two failure modes are worth knowing about:
+
+1. **Binary path differences between the builder and the runtime host.** The sudoers file records the exact location of `nft`, `ip`, and friends as they were found on the builder. If the runtime host installs them in different folders, the sudoers rule silently won't match. `smolvm doctor` is the place this surfaces — run it on first boot, before any sandbox starts.
+2. **Missing tools surface later.** Without the install-time self-test, a missing `nftables` package shows up the first time a sandbox tries to set up networking, not during install. Again, `smolvm doctor` catches this earlier.
+
+Both are reasons to treat `smolvm doctor` as a hard gate at first boot — fail closed if it returns a non-zero exit code.

--- a/scripts/internal/configure-runtime-sudoers.sh
+++ b/scripts/internal/configure-runtime-sudoers.sh
@@ -22,12 +22,13 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 RUNTIME_USER="${SUDO_USER:-}"
 CHECK_ONLY=false
 REMOVE=false
+SKIP_RUNTIME_CHECK=false
 LOOPFS_HELPER_SRC="${SCRIPT_DIR}/image-build-loopfs.sh"
 LOOPFS_HELPER_DST="/usr/local/libexec/smolvm-loopfs-helper"
 
 usage() {
     cat <<EOF
-Usage: ${SCRIPT_NAME} [--runtime-user <user>] [--check-only] [--remove]
+Usage: ${SCRIPT_NAME} [--runtime-user <user>] [--check-only] [--remove] [--skip-runtime-check]
 
 Configures scoped sudoers rules so SmolVM runtime commands can run without
 interactive password prompts.
@@ -36,6 +37,9 @@ Options:
   --runtime-user <user>   Target non-root user (default: \$SUDO_USER).
   --check-only            Validate existing runtime sudoers and command access.
   --remove                Remove generated runtime sudoers file.
+  --skip-runtime-check    Install sudoers without running the post-install live
+                          access self-test (use during AMI bake; verify on the
+                          runtime host with --check-only or 'smolvm doctor').
   -h, --help              Show this help.
 EOF
 }
@@ -64,6 +68,9 @@ while [[ $# -gt 0 ]]; do
             ;;
         --remove)
             REMOVE=true
+            ;;
+        --skip-runtime-check)
+            SKIP_RUNTIME_CHECK=true
             ;;
         -h|--help)
             usage
@@ -206,4 +213,9 @@ validate_sudoers_file "${tmp_file}"
 
 echo "✅ Installed runtime sudoers: ${SUDOERS_FILE}"
 echo "✅ Installed runtime helper: ${LOOPFS_HELPER_DST}"
-check_runtime_access
+if [[ "${SKIP_RUNTIME_CHECK}" == "true" ]]; then
+    echo "ℹ️ Skipping post-install runtime access check (--skip-runtime-check)."
+    echo "   Verify on the runtime host with --check-only or 'smolvm doctor'."
+else
+    check_runtime_access
+fi

--- a/scripts/internal/install-firecracker.sh
+++ b/scripts/internal/install-firecracker.sh
@@ -20,15 +20,21 @@ set -euo pipefail
 
 WITH_IMAGES=false
 SKIP_DEPS=false
+REQUIRE_KVM=false
+FC_VERSION_OVERRIDE=""
 
 usage() {
     cat <<EOF_USAGE
-Usage: $(basename "$0") [--with-images] [--skip-deps]
+Usage: $(basename "$0") [--with-images] [--skip-deps] [--require-kvm] [--firecracker-version <ver>]
 
 Options:
-  --with-images  Download kernel/rootfs images after install
-  --skip-deps    Skip apt dependency install (requires wget + tar)
-  -h, --help     Show this help
+  --with-images               Download kernel/rootfs images after install
+  --skip-deps                 Skip apt dependency install (requires wget + tar)
+  --require-kvm               Fail if /dev/kvm is missing (default: skip the check
+                              so installs work on bake hosts; runtime/doctor catch it)
+  --firecracker-version <ver> Pin Firecracker release tag (default: built-in or
+                              \$SMOLVM_FIRECRACKER_VERSION / \$FC_VERSION env)
+  -h, --help                  Show this help
 EOF_USAGE
 }
 
@@ -39,6 +45,18 @@ while [[ $# -gt 0 ]]; do
             ;;
         --skip-deps)
             SKIP_DEPS=true
+            ;;
+        --require-kvm)
+            REQUIRE_KVM=true
+            ;;
+        --firecracker-version)
+            if [[ $# -lt 2 ]]; then
+                echo "❌ --firecracker-version requires a value"
+                usage
+                exit 1
+            fi
+            FC_VERSION_OVERRIDE="$2"
+            shift
             ;;
         -h|--help)
             usage
@@ -73,10 +91,17 @@ run_root() {
 
 echo "=== Installing Firecracker ==="
 
-FC_VERSION="${FC_VERSION:-v1.14.1}"
+# Version precedence: --firecracker-version flag > SMOLVM_FIRECRACKER_VERSION > FC_VERSION (legacy) > default.
+if [[ -n "${FC_VERSION_OVERRIDE}" ]]; then
+    FC_VERSION="${FC_VERSION_OVERRIDE}"
+elif [[ -n "${SMOLVM_FIRECRACKER_VERSION:-}" ]]; then
+    FC_VERSION="${SMOLVM_FIRECRACKER_VERSION}"
+else
+    FC_VERSION="${FC_VERSION:-v1.14.1}"
+fi
 ARCH=$(uname -m)
 
-if [[ ! -e /dev/kvm ]]; then
+if [[ "${REQUIRE_KVM}" == "true" && ! -e /dev/kvm ]]; then
     echo "ERROR: /dev/kvm not found. KVM is required."
     exit 1
 fi

--- a/scripts/internal/install-firecracker.sh
+++ b/scripts/internal/install-firecracker.sh
@@ -55,6 +55,16 @@ while [[ $# -gt 0 ]]; do
                 usage
                 exit 1
             fi
+            if [[ -z "$2" || "$2" == -* ]]; then
+                echo "❌ --firecracker-version got an invalid value: '$2'"
+                echo "   Expected a release tag like 'v1.14.1' (no leading dash, not empty)."
+                exit 1
+            fi
+            if [[ ! "$2" =~ ^[A-Za-z0-9._-]+$ ]]; then
+                echo "❌ --firecracker-version contains invalid characters: '$2'"
+                echo "   Allowed: letters, digits, '.', '_', '-' (e.g. 'v1.14.1')."
+                exit 1
+            fi
             FC_VERSION_OVERRIDE="$2"
             shift
             ;;
@@ -99,6 +109,13 @@ elif [[ -n "${SMOLVM_FIRECRACKER_VERSION:-}" ]]; then
 else
     FC_VERSION="${FC_VERSION:-v1.14.1}"
 fi
+
+if [[ ! "${FC_VERSION}" =~ ^[A-Za-z0-9._-]+$ ]]; then
+    echo "❌ Firecracker version '${FC_VERSION}' is not a valid release tag."
+    echo "   Allowed: letters, digits, '.', '_', '-' (e.g. 'v1.14.1')."
+    exit 1
+fi
+
 ARCH=$(uname -m)
 
 if [[ "${REQUIRE_KVM}" == "true" && ! -e /dev/kvm ]]; then

--- a/scripts/system-setup.sh
+++ b/scripts/system-setup.sh
@@ -41,7 +41,6 @@ REMOVE_RUNTIME_CONFIG=false
 RUNTIME_USER=""
 SKIP_KVM_CHECK=false
 SKIP_RUNTIME_CHECK=false
-FOR_BAKE=false
 FIRECRACKER_VERSION=""
 
 usage() {
@@ -95,7 +94,6 @@ while [[ $# -gt 0 ]]; do
             shift
             ;;
         --for-bake)
-            FOR_BAKE=true
             SKIP_KVM_CHECK=true
             SKIP_RUNTIME_CHECK=true
             ;;

--- a/scripts/system-setup.sh
+++ b/scripts/system-setup.sh
@@ -39,6 +39,10 @@ SKIP_DEPS=false
 CONFIGURE_RUNTIME=false
 REMOVE_RUNTIME_CONFIG=false
 RUNTIME_USER=""
+SKIP_KVM_CHECK=false
+SKIP_RUNTIME_CHECK=false
+FOR_BAKE=false
+FIRECRACKER_VERSION=""
 
 usage() {
     cat <<EOF_USAGE
@@ -47,13 +51,20 @@ Usage: $(basename "$0") [options]
 Installs host dependencies and Firecracker (no Python/venv involvement).
 
 Options:
-  --check-only               Only validate system prerequisites; do not install.
-  --with-docker              Install Docker (required for SSH image demo).
-  --skip-deps                Skip apt dependency install (assumes deps already present).
-  --configure-runtime        Configure scoped NOPASSWD sudoers for SmolVM runtime.
-  --remove-runtime-config    Remove generated runtime sudoers config.
-  --runtime-user <user>      Target user for runtime sudoers/docker group (default: invoking user).
-  -h, --help                 Show this help.
+  --check-only                   Only validate system prerequisites; do not install.
+  --with-docker                  Install Docker (required for SSH image demo).
+  --skip-deps                    Skip apt dependency install (assumes deps already present).
+  --configure-runtime            Configure scoped NOPASSWD sudoers for SmolVM runtime.
+  --remove-runtime-config        Remove generated runtime sudoers config.
+  --runtime-user <user>          Target user for runtime sudoers/docker group (default: invoking user).
+  --for-bake                     Bake-friendly install: implies --skip-kvm-check and
+                                 --skip-runtime-check. Use during AMI builds, then run
+                                 'smolvm doctor' on the runtime host to verify.
+  --skip-kvm-check               Do not require /dev/kvm at install time.
+  --skip-runtime-check           Skip the post-install sudoers self-test on the live host.
+  --firecracker-version <ver>    Pin Firecracker release tag (e.g. v1.14.1). Falls back
+                                 to \$SMOLVM_FIRECRACKER_VERSION or the built-in default.
+  -h, --help                     Show this help.
 EOF_USAGE
 }
 
@@ -81,6 +92,26 @@ while [[ $# -gt 0 ]]; do
                 exit 1
             fi
             RUNTIME_USER="$2"
+            shift
+            ;;
+        --for-bake)
+            FOR_BAKE=true
+            SKIP_KVM_CHECK=true
+            SKIP_RUNTIME_CHECK=true
+            ;;
+        --skip-kvm-check)
+            SKIP_KVM_CHECK=true
+            ;;
+        --skip-runtime-check)
+            SKIP_RUNTIME_CHECK=true
+            ;;
+        --firecracker-version)
+            if [[ $# -lt 2 ]]; then
+                echo "❌ --firecracker-version requires a value"
+                usage
+                exit 1
+            fi
+            FIRECRACKER_VERSION="$2"
             shift
             ;;
         -h|--help)
@@ -180,9 +211,14 @@ run_runtime_config() {
         return 1
     fi
 
+    local configure_args=(--runtime-user "${runtime_user}")
+    if [[ "${SKIP_RUNTIME_CHECK}" == "true" ]]; then
+        configure_args+=(--skip-runtime-check)
+    fi
+
     case "${mode}" in
         configure)
-            bash "${RUNTIME_CONFIG_SCRIPT}" --runtime-user "${runtime_user}"
+            bash "${RUNTIME_CONFIG_SCRIPT}" "${configure_args[@]}"
             ;;
         check)
             bash "${RUNTIME_CONFIG_SCRIPT}" --runtime-user "${runtime_user}" --check-only
@@ -207,6 +243,8 @@ missing_items=()
 check_kvm() {
     if [[ -e /dev/kvm ]]; then
         echo "  ✅ KVM device present (/dev/kvm)"
+    elif [[ "${SKIP_KVM_CHECK}" == "true" ]]; then
+        echo "  ℹ️ KVM device missing (/dev/kvm) — skipped (--skip-kvm-check / --for-bake)"
     else
         echo "  ❌ KVM device missing (/dev/kvm)"
         missing_items+=("KVM (/dev/kvm)")
@@ -279,10 +317,18 @@ echo "=== SmolVM System Setup ==="
 
 echo "Checking KVM..."
 if [[ ! -e /dev/kvm ]]; then
-    echo "❌ /dev/kvm not found. Enable KVM or nested virtualization."
-    exit 1
+    if [[ "${SKIP_KVM_CHECK}" == "true" ]]; then
+        echo "ℹ️ /dev/kvm not present; skipping KVM check (--skip-kvm-check / --for-bake)."
+        echo "   Run 'smolvm doctor' on the runtime host to verify KVM before booting VMs."
+    else
+        echo "❌ /dev/kvm not found. Enable KVM or nested virtualization."
+        echo "   For bake-time installs on hosts without /dev/kvm, pass --for-bake."
+        exit 1
+    fi
 fi
-ensure_kvm_group_membership
+if [[ -e /dev/kvm ]]; then
+    ensure_kvm_group_membership
+fi
 
 if [[ "${SKIP_DEPS}" == "true" ]]; then
     echo "Skipping dependency installation (--skip-deps)"
@@ -329,7 +375,11 @@ else
         exit 1
     fi
     echo "Installing Firecracker..."
-    bash "${INSTALL_SCRIPT}" --skip-deps
+    install_args=(--skip-deps)
+    if [[ -n "${FIRECRACKER_VERSION}" ]]; then
+        install_args+=(--firecracker-version "${FIRECRACKER_VERSION}")
+    fi
+    bash "${INSTALL_SCRIPT}" "${install_args[@]}"
 fi
 
 if ! command -v firecracker >/dev/null 2>&1; then

--- a/src/smolvm/cli/main.py
+++ b/src/smolvm/cli/main.py
@@ -419,11 +419,12 @@ def build_parser() -> argparse.ArgumentParser:
     )
     setup.add_argument(
         "--firecracker-version",
+        action=_LinuxOnlyOption,
         default=None,
         metavar="VER",
-        help=(
+        help=_linux_only_help(
             "Pin Firecracker release tag (e.g. v1.14.1). Falls back to "
-            "$SMOLVM_FIRECRACKER_VERSION or the built-in default."
+            "$SMOLVM_FIRECRACKER_VERSION or the built-in default (Linux only)."
         ),
     )
     setup.add_argument(

--- a/src/smolvm/cli/main.py
+++ b/src/smolvm/cli/main.py
@@ -390,6 +390,47 @@ def build_parser() -> argparse.ArgumentParser:
         default=False,
         help=_linux_only_help("Remove previously configured runtime permissions (Linux only)."),
     )
+    setup.add_argument(
+        "--for-bake",
+        action=_LinuxOnlyOption,
+        nargs=0,
+        const=True,
+        default=False,
+        help=_linux_only_help(
+            "Bake-friendly install: skip KVM and runtime self-tests so this can run "
+            "on a builder without /dev/kvm. Run 'smolvm doctor' on the runtime host."
+        ),
+    )
+    setup.add_argument(
+        "--skip-kvm-check",
+        action=_LinuxOnlyOption,
+        nargs=0,
+        const=True,
+        default=False,
+        help=_linux_only_help("Do not require /dev/kvm at install time (Linux only)."),
+    )
+    setup.add_argument(
+        "--skip-runtime-check",
+        action=_LinuxOnlyOption,
+        nargs=0,
+        const=True,
+        default=False,
+        help=_linux_only_help("Skip the post-install sudoers self-test (Linux only)."),
+    )
+    setup.add_argument(
+        "--firecracker-version",
+        default=None,
+        metavar="VER",
+        help=(
+            "Pin Firecracker release tag (e.g. v1.14.1). Falls back to "
+            "$SMOLVM_FIRECRACKER_VERSION or the built-in default."
+        ),
+    )
+    setup.add_argument(
+        "--assets-dir",
+        action="store_true",
+        help="Print the packaged setup-assets directory and exit.",
+    )
 
     def _add_ui_args(command_parser: argparse.ArgumentParser) -> None:
         command_parser.add_argument(
@@ -912,7 +953,11 @@ def _render_list(rows: list[VmRow]) -> None:
 
 def _run_setup(parser: argparse.ArgumentParser, args: argparse.Namespace) -> int:
     """Handle ``smolvm setup``."""
-    from smolvm.host.setup import SetupOptions, run_setup
+    from smolvm.host.setup import SetupOptions, packaged_asset_root, run_setup
+
+    if args.assets_dir:
+        print(packaged_asset_root())
+        return 0
 
     invalid_remove_runtime_flags: list[str] = []
     if args.check_only:
@@ -937,7 +982,17 @@ def _run_setup(parser: argparse.ArgumentParser, args: argparse.Namespace) -> int
         skip_deps=args.skip_deps,
         runtime_user=args.runtime_user,
         remove_runtime_config=args.remove_runtime_config,
+        for_bake=args.for_bake,
+        skip_kvm_check=args.skip_kvm_check,
+        skip_runtime_check=args.skip_runtime_check,
+        firecracker_version=args.firecracker_version,
     )
+
+    if options.for_bake:
+        console_stdout().print(
+            "[yellow]ℹ️  --for-bake skips KVM and runtime self-tests. "
+            "Run 'smolvm doctor' on the runtime host before booting VMs.[/yellow]"
+        )
 
     try:
         return run_setup(options)

--- a/src/smolvm/cli/main.py
+++ b/src/smolvm/cli/main.py
@@ -2060,9 +2060,13 @@ def main(argv: Sequence[str] | None = None) -> int:
     parser = build_parser()
     args = parser.parse_args(argv)
 
-    # Best-effort PyPI update nag. Skipped in --json mode so we never
-    # pollute machine-readable output.
-    maybe_print_update_notice(json_output=bool(getattr(args, "json", False)))
+    # Best-effort PyPI update nag. Skipped in --json mode and for
+    # `setup --assets-dir` so we never pollute machine-readable output
+    # that scripts (Packer, Make, etc.) consume directly.
+    suppress_update_notice = bool(getattr(args, "json", False)) or (
+        args.command == "setup" and bool(getattr(args, "assets_dir", False))
+    )
+    maybe_print_update_notice(json_output=suppress_update_notice)
 
     if args.command == "delete":
         return run_delete(

--- a/src/smolvm/host/doctor.py
+++ b/src/smolvm/host/doctor.py
@@ -426,6 +426,15 @@ def generate_doctor_report(backend: str | None = None) -> DoctorReport:
                 name="kvm",
                 status="pass" if kvm_ok else "fail",
                 detail="/dev/kvm is available" if kvm_ok else "/dev/kvm unavailable",
+                fix=(
+                    None
+                    if kvm_ok
+                    else (
+                        "Run on a KVM-enabled host. If this image was built with "
+                        "'smolvm setup --for-bake', /dev/kvm is expected only on the "
+                        "runtime host, not the builder."
+                    )
+                ),
             )
         )
 

--- a/src/smolvm/host/setup.py
+++ b/src/smolvm/host/setup.py
@@ -38,6 +38,10 @@ class SetupOptions:
     skip_deps: bool = False
     runtime_user: str | None = None
     remove_runtime_config: bool = False
+    for_bake: bool = False
+    skip_kvm_check: bool = False
+    skip_runtime_check: bool = False
+    firecracker_version: str | None = None
 
 
 def packaged_asset_root() -> Path:
@@ -53,9 +57,9 @@ def packaged_asset_root() -> Path:
     marker = pkg_dir / _LINUX_SCRIPT
     if marker.is_file():
         return pkg_dir
-    # Fall back to the repository scripts/ directory (two levels up from
-    # src/smolvm/ → repo root).
-    repo_scripts = Path(__file__).resolve().parents[2] / "scripts"
+    # Fall back to the repository scripts/ directory: three parents up from
+    # src/smolvm/host/setup.py → src/smolvm/host → src/smolvm → src → repo root.
+    repo_scripts = Path(__file__).resolve().parents[3] / "scripts"
     if repo_scripts.is_dir():
         return repo_scripts
     return pkg_dir
@@ -121,6 +125,14 @@ def build_setup_command(
             argv.append("--skip-deps")
         if options.runtime_user:
             argv.extend(["--runtime-user", options.runtime_user])
+        if options.for_bake:
+            argv.append("--for-bake")
+        if options.skip_kvm_check and not options.for_bake:
+            argv.append("--skip-kvm-check")
+        if options.skip_runtime_check and not options.for_bake:
+            argv.append("--skip-runtime-check")
+        if options.firecracker_version:
+            argv.extend(["--firecracker-version", options.firecracker_version])
         return argv
 
     if options.check_only:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1177,6 +1177,63 @@ class TestCliSetup:
         assert mock_platform_system.called
         assert "not allowed with --with-docker" in capsys.readouterr().err
 
+    @patch("smolvm.cli.main.platform.system", return_value="Linux")
+    @patch("smolvm.host.setup.run_setup")
+    def test_setup_for_bake_forwards_options(
+        self,
+        mock_run_setup: MagicMock,
+        mock_platform_system: MagicMock,
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        """``--for-bake`` should populate the bake-mode SetupOptions fields."""
+        mock_run_setup.return_value = 0
+
+        ret = main(["setup", "--for-bake", "--runtime-user", "ubuntu"])
+
+        assert ret == 0
+        mock_run_setup.assert_called_once()
+        options = mock_run_setup.call_args.args[0]
+        assert options.for_bake is True
+        assert options.runtime_user == "ubuntu"
+        # User-facing notice about doctor follow-up.
+        assert "smolvm doctor" in capsys.readouterr().out
+
+    @patch("smolvm.cli.main.platform.system", return_value="Linux")
+    @patch("smolvm.host.setup.run_setup")
+    def test_setup_firecracker_version_forwarded(
+        self,
+        mock_run_setup: MagicMock,
+        mock_platform_system: MagicMock,
+    ) -> None:
+        """``--firecracker-version`` should populate SetupOptions.firecracker_version."""
+        mock_run_setup.return_value = 0
+
+        ret = main(["setup", "--firecracker-version", "v1.15.0"])
+
+        assert ret == 0
+        options = mock_run_setup.call_args.args[0]
+        assert options.firecracker_version == "v1.15.0"
+
+    @patch("smolvm.cli.main.platform.system", return_value="Linux")
+    @patch("smolvm.host.setup.run_setup")
+    def test_setup_assets_dir_prints_path_without_running_bash(
+        self,
+        mock_run_setup: MagicMock,
+        mock_platform_system: MagicMock,
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        """``--assets-dir`` should print the asset root and exit 0 without invoking bash."""
+        ret = main(["setup", "--assets-dir"])
+
+        assert ret == 0
+        mock_run_setup.assert_not_called()
+        out = capsys.readouterr().out.strip()
+        assert out, "expected --assets-dir to print a path"
+        # The printed path should contain the script we depend on.
+        assert (Path(out) / "system-setup.sh").is_file() or (
+            Path(out) / "system-setup-macos.sh"
+        ).is_file()
+
 
 class TestCurrentVersionIsPrerelease:
     """Tests for _current_version_is_prerelease helper."""

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1234,6 +1234,40 @@ class TestCliSetup:
             Path(out) / "system-setup-macos.sh"
         ).is_file()
 
+    @patch("smolvm.cli.main.maybe_print_update_notice")
+    @patch("smolvm.cli.main.platform.system", return_value="Linux")
+    @patch("smolvm.host.setup.run_setup")
+    def test_setup_assets_dir_suppresses_update_notice(
+        self,
+        mock_run_setup: MagicMock,
+        mock_platform_system: MagicMock,
+        mock_notice: MagicMock,
+    ) -> None:
+        """``--assets-dir`` output is consumed by scripts; nag must be suppressed."""
+        ret = main(["setup", "--assets-dir"])
+
+        assert ret == 0
+        mock_notice.assert_called_once()
+        assert mock_notice.call_args.kwargs.get("json_output") is True
+
+    @patch("smolvm.cli.main.maybe_print_update_notice")
+    @patch("smolvm.cli.main.platform.system", return_value="Linux")
+    @patch("smolvm.host.setup.run_setup")
+    def test_setup_without_assets_dir_does_not_suppress_update_notice(
+        self,
+        mock_run_setup: MagicMock,
+        mock_platform_system: MagicMock,
+        mock_notice: MagicMock,
+    ) -> None:
+        """Plain ``setup`` (no --assets-dir, no --json) leaves the nag enabled."""
+        mock_run_setup.return_value = 0
+
+        ret = main(["setup"])
+
+        assert ret == 0
+        mock_notice.assert_called_once()
+        assert mock_notice.call_args.kwargs.get("json_output") is False
+
 
 class TestCurrentVersionIsPrerelease:
     """Tests for _current_version_is_prerelease helper."""

--- a/tests/test_setup.py
+++ b/tests/test_setup.py
@@ -132,6 +132,77 @@ class TestBuildSetupCommand:
             "--skip-deps",
         ]
 
+    def test_linux_for_bake_appends_single_flag(self, tmp_path: Path) -> None:
+        asset_root = _make_asset_root(tmp_path)
+
+        command = build_setup_command(
+            SetupOptions(for_bake=True, skip_kvm_check=True, skip_runtime_check=True),
+            system_name="Linux",
+            asset_root=asset_root,
+        )
+
+        # --for-bake implies the two skips on the bash side, so we don't
+        # double-emit them when for_bake is set.
+        assert command == [
+            "bash",
+            str(asset_root / "system-setup.sh"),
+            "--configure-runtime",
+            "--for-bake",
+        ]
+
+    def test_linux_skip_flags_without_for_bake_pass_through(self, tmp_path: Path) -> None:
+        asset_root = _make_asset_root(tmp_path)
+
+        command = build_setup_command(
+            SetupOptions(skip_kvm_check=True, skip_runtime_check=True),
+            system_name="Linux",
+            asset_root=asset_root,
+        )
+
+        assert command == [
+            "bash",
+            str(asset_root / "system-setup.sh"),
+            "--configure-runtime",
+            "--skip-kvm-check",
+            "--skip-runtime-check",
+        ]
+
+    def test_linux_firecracker_version_forwarded(self, tmp_path: Path) -> None:
+        asset_root = _make_asset_root(tmp_path)
+
+        command = build_setup_command(
+            SetupOptions(firecracker_version="v1.15.0"),
+            system_name="Linux",
+            asset_root=asset_root,
+        )
+
+        assert command == [
+            "bash",
+            str(asset_root / "system-setup.sh"),
+            "--configure-runtime",
+            "--firecracker-version",
+            "v1.15.0",
+        ]
+
+    def test_macos_ignores_linux_only_bake_flags(self, tmp_path: Path) -> None:
+        asset_root = _make_asset_root(tmp_path)
+
+        command = build_setup_command(
+            SetupOptions(
+                for_bake=True,
+                skip_kvm_check=True,
+                skip_runtime_check=True,
+                firecracker_version="v1.15.0",
+            ),
+            system_name="Darwin",
+            asset_root=asset_root,
+        )
+
+        assert command == [
+            "bash",
+            str(asset_root / "system-setup-macos.sh"),
+        ]
+
     def test_unsupported_os_fails(self, tmp_path: Path) -> None:
         asset_root = _make_asset_root(tmp_path)
 


### PR DESCRIPTION
Closes #171.

## Summary

Decouples install from on-host validation so `smolvm setup` can run during AMI bake on a builder without `/dev/kvm`, then be verified on the runtime host with `smolvm doctor`. Existing `smolvm setup` on KVM-enabled hosts is unchanged.

- Add `--for-bake` (skips KVM and runtime self-tests in one flag), plus granular `--skip-kvm-check` / `--skip-runtime-check` escape hatches.
- Add `--firecracker-version` flag and `SMOLVM_FIRECRACKER_VERSION` env var so downstream AMI pipelines can pin without forking the script. `FC_VERSION` still works as a backwards-compatible alias.
- Add `smolvm setup --assets-dir` so consumers stop importing the internal `packaged_asset_root()` symbol.
- Add a fix-hint to the KVM doctor check pointing at `--for-bake`.
- Fix a latent `parents[2]→parents[3]` bug in `packaged_asset_root()` so the source-checkout fallback actually resolves to the repo `scripts/` directory.

## Out of scope (deferred to follow-ups)

- A nested `smolvm setup step <name>` CLI surface (issue #171 ask #3, larger form).
- Portable sudoers rendering (canonical paths or first-boot refresh) to address bake-vs-runtime path divergence — should ship alongside a doctor check that validates the installed sudoers file against the current host's binary paths.

## Test plan

- [x] `uv run pytest` — 642 passed, 11 skipped
- [x] `uv run --with ruff ruff check` clean on changed files (6 pre-existing errors on `main` unchanged)
- [x] `bash -n` syntax check on all three updated shell scripts
- [x] `smolvm setup --help` shows new flags
- [x] `smolvm setup --assets-dir` prints the asset-root path and exits 0
- [ ] Manual smoke on a non-KVM Ubuntu container: `docker run --rm -it ubuntu:24.04 bash` then run `smolvm setup --for-bake --runtime-user $USER`
- [ ] Manual smoke on a KVM-enabled host: confirm default `smolvm setup` still enforces `/dev/kvm`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `smolvm setup --for-bake` to support image building where `/dev/kvm` is unavailable during baking phase.
  * Added `smolvm setup --firecracker-version <version>` to pin Firecracker release version.
  * Added `smolvm setup --assets-dir` to retrieve packaged script locations.
  * Enhanced `smolvm doctor` messaging for KVM-related diagnostics.

* **Documentation**
  * Added "Bake-time install" guide documenting two-stage deployment workflow for golden AMI builds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->