### PR TITLE
[codex] Fix setup asset discovery in wheel installs

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -133,13 +133,33 @@ jobs:
 
           .smoke-venv/bin/python3 - <<PY
           import platform
+          import subprocess
+          from pathlib import Path
           from importlib.metadata import version as pkg_version
 
           from smolvm.host._accel import HAS_NETLINK
+          from smolvm.host.setup import detect_setup_platform, resolve_setup_script
 
           assert pkg_version("smolvm") == "${VERSION}"
           assert pkg_version("smolvm-core") == "${CORE_VERSION}"
           if platform.system() == "Linux":
               assert HAS_NETLINK, "smolvm-core native extension did not load from built wheel"
+          setup_script = resolve_setup_script(detect_setup_platform())
+          assert setup_script.is_file(), f"setup script missing from wheel: {setup_script}"
+
+          assets_dir = Path(
+              subprocess.check_output(
+                  [".smoke-venv/bin/smolvm", "setup", "--assets-dir"],
+                  text=True,
+              ).strip()
+          )
+          assert assets_dir.resolve() == setup_script.parent.resolve()
+          for helper in (
+              "configure-runtime-sudoers.sh",
+              "image-build-loopfs.sh",
+              "install-firecracker.sh",
+          ):
+              helper_path = assets_dir / "internal" / helper
+              assert helper_path.is_file(), f"missing packaged helper: {helper_path}"
           print("artifact install: OK")
           PY

--- a/src/smolvm/host/setup.py
+++ b/src/smolvm/host/setup.py
@@ -19,6 +19,8 @@ from __future__ import annotations
 import platform
 import subprocess
 from dataclasses import dataclass
+from importlib.resources import files
+from os import fspath
 from pathlib import Path
 from typing import Literal
 
@@ -47,22 +49,32 @@ class SetupOptions:
 def packaged_asset_root() -> Path:
     """Return the directory containing setup shell assets.
 
-    Checks the packaged ``_setup_assets/`` directory first (present in installed
-    wheels), then falls back to the repository ``scripts/`` directory so that
-    ``uv run smolvm setup`` works from a source checkout.
+    Checks the installed ``smolvm._setup_assets`` package first, then falls
+    back to the repository ``scripts/`` directory so ``uv run smolvm setup``
+    works from a source checkout.
     """
-    pkg_dir = Path(__file__).resolve().parent / "_setup_assets"
-    # In a wheel the scripts live under _setup_assets/.  In a source checkout
-    # they only exist under the repo-root scripts/ directory.
-    marker = pkg_dir / _LINUX_SCRIPT
-    if marker.is_file():
+    pkg_dir = _package_asset_root()
+    if pkg_dir is not None and (pkg_dir / _LINUX_SCRIPT).is_file():
         return pkg_dir
-    # Fall back to the repository scripts/ directory: three parents up from
+
+    # In a source checkout, the installable resource package exists but does
+    # not contain the shell scripts. Fall back to the repo-root scripts/ dir:
     # src/smolvm/host/setup.py → src/smolvm/host → src/smolvm → src → repo root.
     repo_scripts = Path(__file__).resolve().parents[3] / "scripts"
-    if repo_scripts.is_dir():
+    if (repo_scripts / _LINUX_SCRIPT).is_file():
         return repo_scripts
-    return pkg_dir
+
+    # Preserve the installed package path in error messages when the wheel is
+    # present but incomplete; otherwise return the repo fallback candidate.
+    return pkg_dir or repo_scripts
+
+
+def _package_asset_root() -> Path | None:
+    """Return the installed setup asset directory when it is filesystem-backed."""
+    try:
+        return Path(fspath(files("smolvm._setup_assets")))
+    except (ModuleNotFoundError, TypeError):
+        return None
 
 
 def detect_setup_platform(system_name: str | None = None) -> SetupPlatform:

--- a/tests/test_setup.py
+++ b/tests/test_setup.py
@@ -20,7 +20,14 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
-from smolvm.host.setup import SetupOptions, build_setup_command, run_setup
+import smolvm.host.setup as host_setup_module
+from smolvm.host.setup import (
+    SetupOptions,
+    build_setup_command,
+    packaged_asset_root,
+    resolve_setup_script,
+    run_setup,
+)
 
 
 def _make_asset_root(tmp_path: Path) -> Path:
@@ -29,6 +36,65 @@ def _make_asset_root(tmp_path: Path) -> Path:
     (asset_root / "system-setup.sh").write_text("#!/bin/bash\n")
     (asset_root / "system-setup-macos.sh").write_text("#!/bin/bash\n")
     return asset_root
+
+
+def _make_repo_checkout(tmp_path: Path, *, with_scripts: bool) -> Path:
+    repo_root = tmp_path / "repo"
+    setup_py = repo_root / "src" / "smolvm" / "host" / "setup.py"
+    setup_py.parent.mkdir(parents=True)
+    setup_py.write_text("# test fixture\n")
+    if with_scripts:
+        scripts_root = repo_root / "scripts"
+        scripts_root.mkdir(parents=True)
+        (scripts_root / "internal").mkdir(parents=True)
+        (scripts_root / "system-setup.sh").write_text("#!/bin/bash\n")
+        (scripts_root / "system-setup-macos.sh").write_text("#!/bin/bash\n")
+    return setup_py
+
+
+class TestPackagedAssetRoot:
+    """Tests for installed-package and source-checkout asset resolution."""
+
+    def test_prefers_installed_package_assets(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        package_assets = _make_asset_root(tmp_path / "site-packages")
+        monkeypatch.setattr(host_setup_module, "files", lambda package: package_assets)
+
+        assert packaged_asset_root() == package_assets
+
+    def test_falls_back_to_repo_scripts_when_package_assets_missing(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        package_assets = tmp_path / "site-packages" / "smolvm" / "_setup_assets"
+        package_assets.mkdir(parents=True)
+        fake_setup_py = _make_repo_checkout(tmp_path, with_scripts=True)
+
+        monkeypatch.setattr(host_setup_module, "files", lambda package: package_assets)
+        monkeypatch.setattr(host_setup_module, "__file__", str(fake_setup_py))
+
+        assert packaged_asset_root() == fake_setup_py.parents[3] / "scripts"
+
+    def test_resolve_setup_script_raises_when_package_and_repo_assets_missing(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        package_assets = tmp_path / "site-packages" / "smolvm" / "_setup_assets"
+        package_assets.mkdir(parents=True)
+        fake_setup_py = _make_repo_checkout(tmp_path, with_scripts=False)
+
+        monkeypatch.setattr(host_setup_module, "files", lambda package: package_assets)
+        monkeypatch.setattr(host_setup_module, "__file__", str(fake_setup_py))
+
+        with pytest.raises(FileNotFoundError, match="Missing packaged setup asset") as exc_info:
+            resolve_setup_script("linux")
+
+        assert str(package_assets / "system-setup.sh") in str(exc_info.value)
 
 
 class TestBuildSetupCommand:

--- a/tests/test_setup.py
+++ b/tests/test_setup.py
@@ -111,8 +111,8 @@ class TestBuildSetupCommand:
     def test_linux_check_only_keeps_runtime_config_check(self, tmp_path: Path) -> None:
         asset_root = _make_asset_root(tmp_path)
 
-        command = build_setup_command(
-            SetupOptions(check_only=True),
+        command = host_setup_module.build_setup_command(
+            host_setup_module.SetupOptions(check_only=True),
             system_name="Linux",
             asset_root=asset_root,
         )
@@ -127,8 +127,12 @@ class TestBuildSetupCommand:
     def test_linux_no_configure_runtime_removes_flag(self, tmp_path: Path) -> None:
         asset_root = _make_asset_root(tmp_path)
 
-        command = build_setup_command(
-            SetupOptions(check_only=True, configure_runtime=False, skip_deps=True),
+        command = host_setup_module.build_setup_command(
+            host_setup_module.SetupOptions(
+                check_only=True,
+                configure_runtime=False,
+                skip_deps=True,
+            ),
             system_name="Linux",
             asset_root=asset_root,
         )
@@ -143,8 +147,8 @@ class TestBuildSetupCommand:
     def test_linux_remove_runtime_config_only_forwards_removal_args(self, tmp_path: Path) -> None:
         asset_root = _make_asset_root(tmp_path)
 
-        command = build_setup_command(
-            SetupOptions(
+        command = host_setup_module.build_setup_command(
+            host_setup_module.SetupOptions(
                 check_only=True,
                 with_docker=True,
                 configure_runtime=False,
@@ -167,8 +171,12 @@ class TestBuildSetupCommand:
     def test_macos_uses_macos_script_and_supported_flags_only(self, tmp_path: Path) -> None:
         asset_root = _make_asset_root(tmp_path)
 
-        command = build_setup_command(
-            SetupOptions(check_only=True, with_docker=True, configure_runtime=False),
+        command = host_setup_module.build_setup_command(
+            host_setup_module.SetupOptions(
+                check_only=True,
+                with_docker=True,
+                configure_runtime=False,
+            ),
             system_name="Darwin",
             asset_root=asset_root,
         )
@@ -183,8 +191,8 @@ class TestBuildSetupCommand:
     def test_macos_skip_deps_forwarded_to_script(self, tmp_path: Path) -> None:
         asset_root = _make_asset_root(tmp_path)
 
-        command = build_setup_command(
-            SetupOptions(skip_deps=True),
+        command = host_setup_module.build_setup_command(
+            host_setup_module.SetupOptions(skip_deps=True),
             system_name="Darwin",
             asset_root=asset_root,
         )
@@ -198,8 +206,12 @@ class TestBuildSetupCommand:
     def test_linux_for_bake_appends_single_flag(self, tmp_path: Path) -> None:
         asset_root = _make_asset_root(tmp_path)
 
-        command = build_setup_command(
-            SetupOptions(for_bake=True, skip_kvm_check=True, skip_runtime_check=True),
+        command = host_setup_module.build_setup_command(
+            host_setup_module.SetupOptions(
+                for_bake=True,
+                skip_kvm_check=True,
+                skip_runtime_check=True,
+            ),
             system_name="Linux",
             asset_root=asset_root,
         )
@@ -216,8 +228,11 @@ class TestBuildSetupCommand:
     def test_linux_skip_flags_without_for_bake_pass_through(self, tmp_path: Path) -> None:
         asset_root = _make_asset_root(tmp_path)
 
-        command = build_setup_command(
-            SetupOptions(skip_kvm_check=True, skip_runtime_check=True),
+        command = host_setup_module.build_setup_command(
+            host_setup_module.SetupOptions(
+                skip_kvm_check=True,
+                skip_runtime_check=True,
+            ),
             system_name="Linux",
             asset_root=asset_root,
         )
@@ -233,8 +248,8 @@ class TestBuildSetupCommand:
     def test_linux_firecracker_version_forwarded(self, tmp_path: Path) -> None:
         asset_root = _make_asset_root(tmp_path)
 
-        command = build_setup_command(
-            SetupOptions(firecracker_version="v1.15.0"),
+        command = host_setup_module.build_setup_command(
+            host_setup_module.SetupOptions(firecracker_version="v1.15.0"),
             system_name="Linux",
             asset_root=asset_root,
         )
@@ -250,8 +265,8 @@ class TestBuildSetupCommand:
     def test_macos_ignores_linux_only_bake_flags(self, tmp_path: Path) -> None:
         asset_root = _make_asset_root(tmp_path)
 
-        command = build_setup_command(
-            SetupOptions(
+        command = host_setup_module.build_setup_command(
+            host_setup_module.SetupOptions(
                 for_bake=True,
                 skip_kvm_check=True,
                 skip_runtime_check=True,
@@ -270,14 +285,22 @@ class TestBuildSetupCommand:
         asset_root = _make_asset_root(tmp_path)
 
         with pytest.raises(RuntimeError, match="supported only on Linux and macOS"):
-            build_setup_command(SetupOptions(), system_name="Windows", asset_root=asset_root)
+            host_setup_module.build_setup_command(
+                host_setup_module.SetupOptions(),
+                system_name="Windows",
+                asset_root=asset_root,
+            )
 
     def test_missing_asset_fails(self, tmp_path: Path) -> None:
         asset_root = tmp_path / "assets"
         asset_root.mkdir()
 
         with pytest.raises(FileNotFoundError, match="Missing packaged setup asset"):
-            build_setup_command(SetupOptions(), system_name="Linux", asset_root=asset_root)
+            host_setup_module.build_setup_command(
+                host_setup_module.SetupOptions(),
+                system_name="Linux",
+                asset_root=asset_root,
+            )
 
 
 class TestRunSetup:

--- a/tests/test_setup.py
+++ b/tests/test_setup.py
@@ -21,13 +21,6 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 import smolvm.host.setup as host_setup_module
-from smolvm.host.setup import (
-    SetupOptions,
-    build_setup_command,
-    packaged_asset_root,
-    resolve_setup_script,
-    run_setup,
-)
 
 
 def _make_asset_root(tmp_path: Path) -> Path:
@@ -63,7 +56,7 @@ class TestPackagedAssetRoot:
         package_assets = _make_asset_root(tmp_path / "site-packages")
         monkeypatch.setattr(host_setup_module, "files", lambda package: package_assets)
 
-        assert packaged_asset_root() == package_assets
+        assert host_setup_module.packaged_asset_root() == package_assets
 
     def test_falls_back_to_repo_scripts_when_package_assets_missing(
         self,
@@ -77,7 +70,7 @@ class TestPackagedAssetRoot:
         monkeypatch.setattr(host_setup_module, "files", lambda package: package_assets)
         monkeypatch.setattr(host_setup_module, "__file__", str(fake_setup_py))
 
-        assert packaged_asset_root() == fake_setup_py.parents[3] / "scripts"
+        assert host_setup_module.packaged_asset_root() == fake_setup_py.parents[3] / "scripts"
 
     def test_resolve_setup_script_raises_when_package_and_repo_assets_missing(
         self,
@@ -92,7 +85,7 @@ class TestPackagedAssetRoot:
         monkeypatch.setattr(host_setup_module, "__file__", str(fake_setup_py))
 
         with pytest.raises(FileNotFoundError, match="Missing packaged setup asset") as exc_info:
-            resolve_setup_script("linux")
+            host_setup_module.resolve_setup_script("linux")
 
         assert str(package_assets / "system-setup.sh") in str(exc_info.value)
 
@@ -103,7 +96,11 @@ class TestBuildSetupCommand:
     def test_linux_default_includes_configure_runtime(self, tmp_path: Path) -> None:
         asset_root = _make_asset_root(tmp_path)
 
-        command = build_setup_command(SetupOptions(), system_name="Linux", asset_root=asset_root)
+        command = host_setup_module.build_setup_command(
+            host_setup_module.SetupOptions(),
+            system_name="Linux",
+            asset_root=asset_root,
+        )
 
         assert command == [
             "bash",
@@ -298,7 +295,11 @@ class TestRunSetup:
             returncode=7,
         )
 
-        exit_code = run_setup(SetupOptions(), system_name="Linux", asset_root=asset_root)
+        exit_code = host_setup_module.run_setup(
+            host_setup_module.SetupOptions(),
+            system_name="Linux",
+            asset_root=asset_root,
+        )
 
         assert exit_code == 7
 
@@ -314,7 +315,11 @@ class TestRunSetup:
             returncode=0,
         )
 
-        run_setup(SetupOptions(with_docker=True), system_name="Darwin", asset_root=asset_root)
+        host_setup_module.run_setup(
+            host_setup_module.SetupOptions(with_docker=True),
+            system_name="Darwin",
+            asset_root=asset_root,
+        )
 
         mock_run.assert_called_once_with(
             [


### PR DESCRIPTION
## Summary
- resolve installed setup assets from the `smolvm._setup_assets` package instead of inferring a sibling path from `smolvm.host.setup`
- keep the repo `scripts/` directory as the source-checkout fallback for `uv run smolvm setup`
- extend setup tests and the built-wheel smoke test to verify `resolve_setup_script()` and `smolvm setup --assets-dir` after a fresh install

## Why
Wheel installs currently package the setup scripts under `smolvm/_setup_assets`, but the runtime lookup in `smolvm.host.setup` was deriving `smolvm/host/_setup_assets` from `setup.py`'s location. That made `smolvm setup` fail from installed wheels even though the assets were present.

This change makes asset discovery package-based so the public `smolvm setup --assets-dir` contract works in both source checkouts and wheel installs.

Closes #173.

## Validation
- `uv run ruff check src/smolvm/host/setup.py tests/test_setup.py`
- `uv run pytest tests/test_setup.py tests/test_cli.py`
- built fresh `smolvm-core` and `smolvm` wheels, installed them into a clean Python 3.13 venv, and verified:
  - `resolve_setup_script(detect_setup_platform())` resolves successfully
  - `smolvm setup --assets-dir` points to `site-packages/smolvm/_setup_assets`
  - packaged internal setup helpers are present


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved setup asset resolution to prefer installed packaged assets with fallback to repository scripts when packaged assets are unavailable, making the setup process more robust across deployment scenarios.

* **Tests**
  * Expanded test coverage for asset resolution behavior and fallback mechanisms.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->