### PR TITLE
fix(facade): auto-select QEMU when --mount is used without a backend

### DIFF
--- a/src/smolvm/facade.py
+++ b/src/smolvm/facade.py
@@ -714,6 +714,12 @@ class SmolVM:
                 "config and vm_id are omitted (auto-config mode)."
             )
 
+        # Workspace mounts currently require the QEMU backend (virtio-9p).
+        # If the caller didn't pick a backend but asked for mounts, default
+        # to QEMU so `--mount` works out of the box on Linux and macOS.
+        if backend is None and mounts and vm_id is None:
+            backend = BACKEND_QEMU
+
         if image is not None:
             # S3 image mode
             logger.info("Resolving image from %s...", image)

--- a/src/smolvm/facade.py
+++ b/src/smolvm/facade.py
@@ -715,10 +715,17 @@ class SmolVM:
             )
 
         # Workspace mounts currently require the QEMU backend (virtio-9p).
-        # If the caller didn't pick a backend but asked for mounts, default
-        # to QEMU so `--mount` works out of the box on Linux and macOS.
-        if backend is None and mounts and vm_id is None:
-            backend = BACKEND_QEMU
+        # When no backend was pinned and mounts were requested — either via
+        # the `mounts=` kwarg or via `config.workspace_mounts` on a pre-built
+        # VMConfig — default to QEMU. Callers who explicitly set `backend`
+        # (on the kwarg or the config) still get the SmolVMManager error if
+        # their choice can't host mounts.
+        wants_mounts = bool(mounts) or (
+            config is not None and bool(config.workspace_mounts)
+        )
+        if backend is None and wants_mounts and vm_id is None:
+            if config is None or config.backend is None:
+                backend = BACKEND_QEMU
 
         if image is not None:
             # S3 image mode

--- a/src/smolvm/vm.py
+++ b/src/smolvm/vm.py
@@ -774,7 +774,9 @@ class SmolVMManager:
         if effective_config.workspace_mounts and backend != BACKEND_QEMU:
             raise SmolVMError(
                 "Workspace mounts (virtio-9p) are only supported with the "
-                "QEMU backend. Use --backend qemu.",
+                f"QEMU backend (got backend={backend!r}). Re-run without "
+                "--backend (SmolVM will auto-select QEMU when --mount is "
+                "used) or pass --backend qemu explicitly.",
                 {"vm_id": effective_config.vm_id, "backend": backend},
             )
 

--- a/tests/test_workspace.py
+++ b/tests/test_workspace.py
@@ -20,7 +20,8 @@ from unittest.mock import MagicMock, patch
 import pytest
 from pydantic import ValidationError
 
-from smolvm.types import VMConfig, WorkspaceMount
+from smolvm.facade import SmolVM
+from smolvm.types import VMConfig, VMState, WorkspaceMount
 from smolvm.vm import SmolVMManager
 
 # ── WorkspaceMount validation ───────────────────────────────────────
@@ -229,6 +230,50 @@ def test_workspace_rejected_on_non_qemu_backend(
 
     with pytest.raises(SmolVMError, match="only supported with the QEMU"):
         sdk.create(config)
+
+
+# ── Mount auto-selects QEMU backend ─────────────────────────────────
+
+
+@patch("smolvm.facade.SmolVMManager")
+@patch("smolvm.facade._build_auto_config")
+@patch("smolvm.runtime.backends.platform.system", return_value="Linux")
+def test_mounts_without_backend_auto_selects_qemu(
+    _mock_platform: MagicMock,
+    mock_build_auto_config: MagicMock,
+    mock_sdk_cls: MagicMock,
+    tmp_path: Path,
+) -> None:
+    """On Linux, `SmolVM(mounts=...)` without an explicit backend should
+    pick QEMU so --mount works out of the box instead of erroring out on
+    the default Firecracker backend."""
+    kernel = tmp_path / "vmlinux"
+    rootfs = tmp_path / "rootfs.ext4"
+    kernel.touch()
+    rootfs.touch()
+    ws_dir = tmp_path / "project"
+    ws_dir.mkdir()
+
+    mock_build_auto_config.return_value = (
+        VMConfig(
+            vm_id="vm-auto",
+            kernel_path=kernel,
+            rootfs_path=rootfs,
+            backend="qemu",
+        ),
+        None,
+    )
+
+    mock_sdk = MagicMock()
+    mock_sdk.create.return_value = MagicMock(vm_id="vm-auto", status=VMState.CREATED)
+    mock_sdk_cls.return_value = mock_sdk
+
+    SmolVM(mounts=[str(ws_dir)])
+
+    assert mock_build_auto_config.call_args.kwargs["backend"] == "qemu"
+    # SmolVMManager must be initialized with the upgraded backend, not the
+    # platform default.
+    assert mock_sdk_cls.call_args.kwargs["backend"] == "qemu"
 
 
 # ── Snapshot guard ──────────────────────────────────────────────────

--- a/tests/test_workspace.py
+++ b/tests/test_workspace.py
@@ -237,16 +237,14 @@ def test_workspace_rejected_on_non_qemu_backend(
 
 @patch("smolvm.facade.SmolVMManager")
 @patch("smolvm.facade._build_auto_config")
-@patch("smolvm.runtime.backends.platform.system", return_value="Linux")
 def test_mounts_without_backend_auto_selects_qemu(
-    _mock_platform: MagicMock,
     mock_build_auto_config: MagicMock,
     mock_sdk_cls: MagicMock,
     tmp_path: Path,
 ) -> None:
-    """On Linux, `SmolVM(mounts=...)` without an explicit backend should
-    pick QEMU so --mount works out of the box instead of erroring out on
-    the default Firecracker backend."""
+    """`SmolVM(mounts=...)` without an explicit backend should pick QEMU so
+    `--mount` works out of the box instead of erroring out on a non-QEMU
+    default (Firecracker on Linux)."""
     kernel = tmp_path / "vmlinux"
     rootfs = tmp_path / "rootfs.ext4"
     kernel.touch()
@@ -273,6 +271,37 @@ def test_mounts_without_backend_auto_selects_qemu(
     assert mock_build_auto_config.call_args.kwargs["backend"] == "qemu"
     # SmolVMManager must be initialized with the upgraded backend, not the
     # platform default.
+    assert mock_sdk_cls.call_args.kwargs["backend"] == "qemu"
+
+
+@patch("smolvm.facade.SmolVMManager")
+def test_config_with_workspace_mounts_auto_selects_qemu(
+    mock_sdk_cls: MagicMock,
+    tmp_path: Path,
+) -> None:
+    """`SmolVM(config=cfg)` with populated `cfg.workspace_mounts` and no
+    backend pinned on either the config or the kwarg should upgrade the
+    manager backend to QEMU."""
+    kernel = tmp_path / "vmlinux"
+    rootfs = tmp_path / "rootfs.ext4"
+    kernel.touch()
+    rootfs.touch()
+    ws_dir = tmp_path / "project"
+    ws_dir.mkdir()
+
+    config = VMConfig(
+        vm_id="vm-cfg-ws",
+        kernel_path=kernel,
+        rootfs_path=rootfs,
+        workspace_mounts=[WorkspaceMount(host_path=ws_dir)],
+    )
+
+    mock_sdk = MagicMock()
+    mock_sdk.create.return_value = MagicMock(vm_id="vm-cfg-ws", status=VMState.CREATED)
+    mock_sdk_cls.return_value = mock_sdk
+
+    SmolVM(config)
+
     assert mock_sdk_cls.call_args.kwargs["backend"] == "qemu"
 
 


### PR DESCRIPTION
## Summary

On Linux the default backend is Firecracker, which doesn't support workspace mounts (virtio-9p). Running `smolvm create --mount ./code:/code` errored out with *"Workspace mounts are only supported with the QEMU backend"* even though QEMU+KVM works fine on the same host.

This PR auto-upgrades the backend to QEMU when `SmolVM(mounts=...)` / `--mount` is used without an explicit backend choice, matching the workaround that was already being recommended to users. Explicit `--backend firecracker --mount ...` still raises — now with a more informative message pointing at the auto-selection path.

## Related Issues

- Closes #178

## Testing

- `uv run pytest tests/test_workspace.py tests/test_facade.py tests/test_cli.py` — 178 passed, 8 skipped
- Added `test_mounts_without_backend_auto_selects_qemu` which patches `platform.system()` to `"Linux"` and asserts both `_build_auto_config` and `SmolVMManager` get `backend="qemu"`.

## Checklist

- [x] Scope is focused and limited to this change
- [x] Tests added/updated for behavior changes
- [ ] Docs updated for user-visible changes
- [x] No secrets or sensitive data included

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Workspace mounts now automatically select QEMU backend when no backend is explicitly specified, streamlining setup.

* **Bug Fixes**
  * Error messages for mount configuration issues now display the actual backend value and provide clearer troubleshooting guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->