### PR TITLE
docs: Add macOS-specific developer setup guidance

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -39,11 +39,29 @@ uv sync --extra dev --extra dashboard
 
 ### Runtime Prerequisites (for backend/runtime work)
 
+Runtime prerequisites vary by platform:
+
+**Linux (Firecracker backend):**
+
+Run the setup script to install Firecracker, configure KVM permissions, and validate host prerequisites:
+
 ```bash
 uv run smolvm setup
+uv run smolvm doctor
 ```
 
-The repo-level shell scripts in `scripts/` remain the implementation detail behind `smolvm setup`; use them directly only if you are intentionally working on the setup flow itself.
+**macOS (QEMU backend):**
+
+Just install QEMU via Homebrew; no additional setup is needed:
+
+```bash
+brew install qemu
+uv run smolvm doctor  # Verify QEMU and Hypervisor.framework
+```
+
+In both cases, `smolvm doctor` is your validation step — it confirms that your machine is ready to run sandboxes.
+
+**Note on setup scripts:** The repo-level shell scripts in `scripts/` remain the implementation detail behind `smolvm setup`; use them directly only if you are intentionally working on the setup flow itself.
 
 Health check:
 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -2,6 +2,37 @@
 
 Most people install SmolVM with the one-liner from the [README](../README.md#quickstart) and never need to read further. This page is for the cases where you want more control over how SmolVM gets onto a machine — for example, baking it into a golden image, or pinning the exact Firecracker version your AMI ships with.
 
+## macOS Developer Setup
+
+On macOS, SmolVM automatically uses the **QEMU backend** instead of Firecracker (which requires `/dev/kvm` on Linux). QEMU on macOS leverages Hypervisor.framework for hardware acceleration and works out of the box.
+
+**Prerequisites:**
+
+Install QEMU via Homebrew:
+
+```bash
+brew install qemu
+```
+
+**Verification:**
+
+After installing the SmolVM package, verify your setup:
+
+```bash
+pip install smolvm
+smolvm doctor
+```
+
+`smolvm doctor` confirms that QEMU is available and your system is ready to run sandboxes. You do **not** need to run `smolvm setup` on macOS — the system prerequisites are already met once QEMU is installed.
+
+**Example output:**
+
+```
+Backend: qemu
+Platform: Darwin arm64
+Result: OK
+```
+
 ## Standard install
 
 The simplest path:


### PR DESCRIPTION
## Summary

Added macOS-specific developer setup documentation to clarify platform differences and improve onboarding for macOS contributors.

What changed:

Added "macOS Developer Setup" section to [installation.md](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html) explaining that SmolVM uses QEMU backend (not Firecracker) on macOS, with [brew install qemu](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html) as the only prerequisite
Updated "Runtime Prerequisites" in [CONTRIBUTING.md](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html) to document platform-specific setup paths (Firecracker on Linux, QEMU on macOS)

Why: The existing docs assumed a Linux-only (Firecracker) workflow. macOS developers using QEMU/Hypervisor.framework were left unclear about whether they needed to run [smolvm setup](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html) or what prerequisites were actually required. This change makes the distinction explicit and helps next contributor avoid confusion. 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added platform-specific runtime prerequisites and setup instructions for Linux (Firecracker) and macOS (QEMU)
  * Documented macOS developer setup workflow including QEMU installation via Homebrew
  * Clarified validation process with `smolvm doctor` command for both platforms
  * Added guidance on when direct script usage is appropriate

<!-- end of auto-generated comment: release notes by coderabbit.ai -->