### PR TITLE
cli/sdk: rename memory/disk-size flags and bump debian/ubuntu disk default

### DIFF
--- a/docs/deep-dive/optimization-plan.md
+++ b/docs/deep-dive/optimization-plan.md
@@ -88,7 +88,7 @@ S3 bucket
 **CLI:**
 ```bash
 smolvm create --image s3://bucket/images/alpine-ssh/
-smolvm create --image s3://bucket/images/alpine-ssh/ --name my-vm --memory-mib 1024
+smolvm create --image s3://bucket/images/alpine-ssh/ --name my-vm --memory 1024
 ```
 `--image` and `--os` are mutually exclusive.
 

--- a/src/smolvm/cli/main.py
+++ b/src/smolvm/cli/main.py
@@ -520,7 +520,7 @@ def build_parser() -> argparse.ArgumentParser:
         metavar="MIB",
         help=(
             "Sandbox disk size in MiB. Defaults: 512 for alpine, "
-            "2048 for debian/ubuntu. Minimum: 64 for alpine; 2048 for "
+            "4096 for debian/ubuntu. Minimum: 64 for alpine; 2048 for "
             "debian/ubuntu on qemu (values below 2048 are rejected)."
         ),
     )
@@ -1156,6 +1156,15 @@ def _run_create(args: argparse.Namespace) -> int:
             if args.os is not None
             else _default_guest_os_for_backend(resolved_backend)
         )
+
+        # CLI default: roomier disk for debian/ubuntu so package installs
+        # and apt cache don't fill the rootfs on a basic `smolvm create`.
+        if (
+            not use_s3_image
+            and args.disk_size_mib is None
+            and resolved_guest_os in {GuestOS.DEBIAN, GuestOS.UBUNTU}
+        ):
+            args.disk_size_mib = 4096
 
         if use_s3_image:
             # S3 image path

--- a/src/smolvm/cli/main.py
+++ b/src/smolvm/cli/main.py
@@ -505,15 +505,19 @@ def build_parser() -> argparse.ArgumentParser:
         ),
     )
     create_parser.add_argument(
-        "--memory-mib",
+        "--memory",
+        dest="memory_mib",
         type=int,
         default=None,
+        metavar="MIB",
         help="Sandbox memory in MiB (default: 512).",
     )
     create_parser.add_argument(
-        "--disk-size-mib",
+        "--disk-size",
+        dest="disk_size_mib",
         type=int,
         default=None,
+        metavar="MIB",
         help=(
             "Sandbox disk size in MiB. Defaults: 512 for alpine, "
             "2048 for debian/ubuntu. Minimum: 64 for alpine; 2048 for "
@@ -724,15 +728,19 @@ def build_parser() -> argparse.ArgumentParser:
         help="Browser viewport height (default: 720).",
     )
     browser_start.add_argument(
-        "--memory-mib",
+        "--memory",
+        dest="memory_mib",
         type=int,
         default=2048,
+        metavar="MIB",
         help="Sandbox memory in MiB (default: 2048).",
     )
     browser_start.add_argument(
-        "--disk-size-mib",
+        "--disk-size",
+        dest="disk_size_mib",
         type=int,
         default=4096,
+        metavar="MIB",
         help="Sandbox disk size in MiB (default: 4096).",
     )
     browser_start.add_argument(

--- a/src/smolvm/cli/main.py
+++ b/src/smolvm/cli/main.py
@@ -1157,6 +1157,15 @@ def _run_create(args: argparse.Namespace) -> int:
             else _default_guest_os_for_backend(resolved_backend)
         )
 
+        # --disk-size has no effect for prebuilt S3 images (the rootfs size
+        # is baked into the image). Reject it explicitly so users aren't
+        # silently misled into thinking it took effect.
+        if use_s3_image and args.disk_size_mib is not None:
+            raise ValueError(
+                "--disk-size is incompatible with --image: the disk size of "
+                "an S3 image is fixed by the image itself."
+            )
+
         # CLI default: roomier disk for debian/ubuntu so package installs
         # and apt cache don't fill the rootfs on a basic `smolvm create`.
         if (

--- a/src/smolvm/facade.py
+++ b/src/smolvm/facade.py
@@ -661,8 +661,8 @@ class SmolVM:
         socket_dir: Override the default socket directory.
         backend: Runtime backend override (``firecracker``, ``qemu``, or ``auto``).
         os: Guest OS for auto-config mode (``"alpine"`` or ``"debian"``).
-        mem_size_mib: Guest memory in MiB for auto-config mode (``SmolVM()`` only).
-        disk_size_mib: Root filesystem size in MiB for auto-config mode (``SmolVM()`` only).
+        memory: Guest memory in MiB for auto-config mode (``SmolVM()`` only).
+        disk_size: Root filesystem size in MiB for auto-config mode (``SmolVM()`` only).
         ssh_user: SSH user for :meth:`run` (default ``root``).
         ssh_key_path: Optional SSH private key path. If omitted,
             SmolVM first tries default SSH auth, then falls back to
@@ -687,8 +687,8 @@ class SmolVM:
         socket_dir: Path | None = None,
         backend: str | None = None,
         os: GuestOS | str | None = None,
-        mem_size_mib: int | None = None,
-        disk_size_mib: int | None = None,
+        memory: int | None = None,
+        disk_size: int | None = None,
         ssh_user: str = "root",
         ssh_key_path: str | None = None,
         internet_settings: InternetSettings | dict[str, Any] | None = None,
@@ -707,10 +707,10 @@ class SmolVM:
             )
 
         if (config is not None or vm_id is not None) and (
-            mem_size_mib is not None or disk_size_mib is not None or os is not None
+            memory is not None or disk_size is not None or os is not None
         ):
             raise ValueError(
-                "mem_size_mib, disk_size_mib, and os can only be set when both "
+                "memory, disk_size, and os can only be set when both "
                 "config and vm_id are omitted (auto-config mode)."
             )
 
@@ -733,7 +733,7 @@ class SmolVM:
             config, ssh_key_path = _build_s3_image_config(
                 image=image,
                 backend=backend,
-                mem_size_mib=mem_size_mib,
+                mem_size_mib=memory,
                 ssh_key_path=ssh_key_path,
             )
         elif config is None and vm_id is None:
@@ -742,8 +742,8 @@ class SmolVM:
             config, ssh_key_path = _build_auto_config(
                 os=os,
                 backend=backend,
-                mem_size_mib=mem_size_mib,
-                disk_size_mib=disk_size_mib,
+                mem_size_mib=memory,
+                disk_size_mib=disk_size,
                 ssh_key_path=ssh_key_path,
             )
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -409,9 +409,9 @@ class TestCliCreate:
                 "create",
                 "--name",
                 "project-spacex",
-                "--memory-mib",
+                "--memory",
                 "1024",
-                "--disk-size-mib",
+                "--disk-size",
                 "2048",
                 "--backend",
                 "qemu",
@@ -631,13 +631,13 @@ class TestCliCreateImage:
         assert "not allowed" in capsys.readouterr().err
 
     def test_image_with_name_and_memory(self) -> None:
-        """--image should work alongside --name and --memory-mib."""
+        """--image should work alongside --name and --memory."""
         parser = build_parser()
         args = parser.parse_args([
             "create",
             "--image", "s3://bucket/img/",
             "--name", "my-vm",
-            "--memory-mib", "1024",
+            "--memory", "1024",
         ])
         assert args.image == "s3://bucket/img/"
         assert args.name == "my-vm"

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -366,7 +366,7 @@ class TestCliCreate:
             os=None,
             backend=None,
             mem_size_mib=None,
-            disk_size_mib=None,
+            disk_size_mib=4096,
             ssh_key_path=None,
             on_download=ANY,
         )
@@ -448,12 +448,16 @@ class TestCliCreate:
 
     @patch("smolvm.facade._build_auto_config")
     @patch("smolvm.facade.SmolVM")
+    @patch("smolvm.runtime.backends.platform.system", return_value="Darwin")
     def test_create_success_with_short_name_flag(
         self,
+        _: MagicMock,
         mock_vm_cls: MagicMock,
         mock_build_auto_config: MagicMock,
+        monkeypatch: pytest.MonkeyPatch,
     ) -> None:
         """`smolvm create -n ...` should behave the same as `--name`."""
+        monkeypatch.delenv("SMOLVM_BACKEND", raising=False)
         config = MagicMock(vm_id="computer")
         mock_build_auto_config.return_value = (config, "/tmp/id_ed25519")
 
@@ -473,7 +477,7 @@ class TestCliCreate:
             os=None,
             backend=None,
             mem_size_mib=None,
-            disk_size_mib=None,
+            disk_size_mib=4096,
             ssh_key_path=None,
             on_download=ANY,
         )
@@ -546,11 +550,40 @@ class TestCliCreate:
             os="debian",
             backend=None,
             mem_size_mib=None,
-            disk_size_mib=None,
+            disk_size_mib=4096,
             ssh_key_path=None,
         )
         payload = json.loads(capsys.readouterr().out)
         assert payload["data"]["vm"]["os"] == "debian"
+
+    @patch("smolvm.facade._build_auto_config")
+    @patch("smolvm.facade.SmolVM")
+    def test_create_alpine_does_not_get_disk_size_default(
+        self,
+        mock_vm_cls: MagicMock,
+        mock_build_auto_config: MagicMock,
+    ) -> None:
+        """The 4096 MiB CLI default only applies to debian/ubuntu, not alpine."""
+        mock_build_auto_config.return_value = (MagicMock(vm_id="vm"), "/tmp/id_ed25519")
+        vm = MagicMock()
+        vm.vm_id = "vm"
+        vm.info.config.backend = "firecracker"
+        vm.info.network = MagicMock(spec=NetworkConfig)
+        vm.info.network.guest_ip = "172.16.0.2"
+        vm.info.network.ssh_host_port = 2200
+        mock_vm_cls.return_value = vm
+
+        ret = main(["create", "--os", "alpine", "--json"])
+
+        assert ret == 0
+        mock_build_auto_config.assert_called_once_with(
+            vm_name=None,
+            os="alpine",
+            backend=None,
+            mem_size_mib=None,
+            disk_size_mib=None,
+            ssh_key_path=None,
+        )
 
     @patch("smolvm.facade._build_auto_config")
     @patch("smolvm.facade.SmolVM")

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -562,8 +562,10 @@ class TestCliCreate:
         self,
         mock_vm_cls: MagicMock,
         mock_build_auto_config: MagicMock,
+        monkeypatch: pytest.MonkeyPatch,
     ) -> None:
         """The 4096 MiB CLI default only applies to debian/ubuntu, not alpine."""
+        monkeypatch.delenv("SMOLVM_BACKEND", raising=False)
         mock_build_auto_config.return_value = (MagicMock(vm_id="vm"), "/tmp/id_ed25519")
         vm = MagicMock()
         vm.vm_id = "vm"
@@ -584,6 +586,9 @@ class TestCliCreate:
             disk_size_mib=None,
             ssh_key_path=None,
         )
+        vm.start.assert_called_once_with(boot_timeout=30.0)
+        vm.wait_for_ssh.assert_called_once_with(timeout=30.0)
+        vm.close.assert_called_once()
 
     @patch("smolvm.facade._build_auto_config")
     @patch("smolvm.facade.SmolVM")
@@ -664,17 +669,34 @@ class TestCliCreateImage:
         assert "not allowed" in capsys.readouterr().err
 
     def test_image_with_name_and_memory(self) -> None:
-        """--image should work alongside --name and --memory."""
+        """--image should work alongside --name, --memory, and --disk-size."""
         parser = build_parser()
         args = parser.parse_args([
             "create",
             "--image", "s3://bucket/img/",
             "--name", "my-vm",
             "--memory", "1024",
+            "--disk-size", "2048",
         ])
         assert args.image == "s3://bucket/img/"
         assert args.name == "my-vm"
         assert args.memory_mib == 1024
+        assert args.disk_size_mib == 2048
+
+    def test_image_with_disk_size_is_rejected(
+        self,
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        """--disk-size has no effect on prebuilt S3 images and must be rejected."""
+        ret = main([
+            "create",
+            "--image", "s3://bucket/img/",
+            "--disk-size", "8192",
+        ])
+
+        assert ret == 1
+        err = capsys.readouterr().err
+        assert "--disk-size is incompatible with --image" in err
 
 
 class TestCliStop:

--- a/tests/test_facade.py
+++ b/tests/test_facade.py
@@ -335,7 +335,7 @@ class TestVMInit:
         mock_prepare_sized: MagicMock,
         tmp_path: Path,
     ) -> None:
-        """--disk-size-mib on debian/qemu should be forwarded to resize helper."""
+        """--disk-size on debian/qemu should be forwarded to resize helper."""
         private_key = tmp_path / "id_ed25519"
         public_key = tmp_path / "id_ed25519.pub"
         private_key.touch()
@@ -363,7 +363,7 @@ class TestVMInit:
         self,
         tmp_path: Path,
     ) -> None:
-        """Debian/qemu should reject --disk-size-mib below the default."""
+        """Debian/qemu should reject --disk-size below the default."""
         with pytest.raises(ValueError, match="disk_size_mib >= 2048"):
             _build_auto_config(os="debian", backend="qemu", disk_size_mib=1024)
 
@@ -371,7 +371,7 @@ class TestVMInit:
         self,
         tmp_path: Path,
     ) -> None:
-        """Ubuntu should reject --disk-size-mib below the default."""
+        """Ubuntu should reject --disk-size below the default."""
         with pytest.raises(ValueError, match="disk_size_mib >= 2048"):
             _build_auto_config(os="ubuntu", backend="qemu", disk_size_mib=512)
 

--- a/tests/test_facade.py
+++ b/tests/test_facade.py
@@ -170,7 +170,7 @@ class TestVMInit:
         mock_sdk.create.return_value = MagicMock(vm_id="vm001", status=VMState.CREATED)
         mock_sdk_cls.return_value = mock_sdk
 
-        vm = SmolVM(mem_size_mib=2048, disk_size_mib=4096)
+        vm = SmolVM(memory=2048, disk_size=4096)
 
         assert vm.vm_id.startswith("vm-")
         mock_builder.build_alpine_ssh_key.assert_called_once()
@@ -433,7 +433,7 @@ class TestVMInit:
     def test_custom_auto_sizing_with_config_raises(self, sample_config: VMConfig) -> None:
         """Custom auto sizing options are only valid in zero-config mode."""
         with pytest.raises(ValueError, match="auto-config mode"):
-            SmolVM(sample_config, mem_size_mib=1024)
+            SmolVM(sample_config, memory=1024)
 
     def test_debian_pinned_urls_carry_build_suffix(self) -> None:
         """Each pinned Debian URL must include the build tag in the filename.
@@ -807,7 +807,7 @@ class TestVMImageParam:
         mock_sdk.create.return_value = MagicMock(vm_id="vm-s3mem", status=VMState.CREATED)
         mock_sdk_cls.return_value = mock_sdk
 
-        SmolVM(image="s3://bucket/img/", backend="qemu", mem_size_mib=1024)
+        SmolVM(image="s3://bucket/img/", backend="qemu", memory=1024)
 
         mock_build_s3.assert_called_once_with(
             image="s3://bucket/img/",


### PR DESCRIPTION
## Summary
Three related changes to the memory/disk surface:

1. **CLI flag rename** — `smolvm create` and `smolvm browser start` now accept `--memory` / `--disk-size` (was `--memory-mib` / `--disk-size-mib`). Help metavar shows `MIB` so units stay visible.
2. **SDK kwarg rename** — `SmolVM(memory=2048, disk_size=4096)` (was `mem_size_mib=` / `disk_size_mib=`). Internal data model (`VMConfig.mem_size_mib`, `_build_auto_config`, etc.) keeps the unit-suffixed names — they map directly to the Firecracker wire format.
3. **CLI disk default bump** — `smolvm create` now defaults `--disk-size` to **4096 MiB** for debian/ubuntu (was 2048). Alpine stays at 512. SDK default is intentionally unchanged so existing `SmolVM(disk_size=2048)` callers don't trip the auto-config minimum validator.

## Test plan
- [x] `uv run --with pytest python -m pytest tests/test_cli.py tests/test_facade.py` (153 passed, 8 skipped)
- [x] `smolvm create --help` and `smolvm browser start --help` show `--memory MIB` / `--disk-size MIB`
- [x] New `test_create_alpine_does_not_get_disk_size_default` locks in that the 4096 default is OS-scoped

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **CLI Updates**
  * Resource sizing flags replaced: use `--memory` and `--disk-size` for `smolvm create` and `smolvm browser start`.
  * `--disk-size` is explicitly rejected when creating from a prebuilt S3 image (avoids silent ignore).
  * Debian/Ubuntu instances now default to 4 GB disk.

* **API Changes**
  * SmolVM constructor now accepts `memory` and `disk_size` parameters.

* **Documentation**
  * CLI examples updated to use the new flag names.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->