### PR TITLE
Slim `smolvm create` output, add `smolvm info`, rename memory field

### DIFF
--- a/examples/openclaw.py
+++ b/examples/openclaw.py
@@ -205,7 +205,7 @@ def main() -> int:
     config = VMConfig(
         vcpu_count=1,
         # OpenClaw npm install is memory-heavy; 512 MiB can drop SSH mid-command.
-        mem_size_mib=VM_MEMORY_MIB,
+        memory=VM_MEMORY_MIB,
         kernel_path=kernel,
         rootfs_path=rootfs,
         boot_args=SSH_BOOT_ARGS,

--- a/src/smolvm/browser.py
+++ b/src/smolvm/browser.py
@@ -144,7 +144,7 @@ def _build_browser_vm_config(
     config = VMConfig(
         vm_id=_browser_vm_id(session_id, browser_config),
         vcpu_count=1,
-        mem_size_mib=browser_config.mem_size_mib,
+        memory=browser_config.mem_size_mib,
         kernel_path=kernel,
         rootfs_path=rootfs,
         boot_args=_browser_boot_args_for_backend(resolved_backend),

--- a/src/smolvm/cli/main.py
+++ b/src/smolvm/cli/main.py
@@ -24,6 +24,7 @@ import platform
 import re
 import subprocess
 from collections.abc import Sequence
+from datetime import datetime, timezone
 from pathlib import Path
 from typing import TYPE_CHECKING, TypedDict
 
@@ -87,15 +88,36 @@ class CreateVmPayload(TypedDict):
     name: str
     status: str
     os: str
-    backend: str
-    ip_address: str | None
-    ssh_port: int | None
+    started_at: str
 
 
 class CreateNextPayload(TypedDict):
-    """Suggested follow-up action for ``smolvm create``."""
+    """Suggested follow-up actions for ``smolvm create``."""
 
     ssh_command: str
+    info_command: str
+
+
+class InfoVmPayload(TypedDict):
+    """Machine-readable VM details for ``smolvm info``."""
+
+    name: str
+    status: str
+    os: str | None
+    backend: str
+    ip_address: str | None
+    ssh_port: int | None
+    pid: int | None
+    vcpus: int
+    memory_mib: int
+    memory_used_mib: int | None
+    disk_size_mib: int | None
+
+
+class InfoPayload(TypedDict):
+    """JSON payload for ``smolvm info``."""
+
+    vm: InfoVmPayload
 
 
 class CreatePayload(TypedDict):
@@ -474,6 +496,19 @@ def build_parser() -> argparse.ArgumentParser:
         help="Only show sandboxes with this status.",
     )
     list_parser.add_argument(
+        "--json",
+        action="store_true",
+        help="Emit machine-readable JSON output.",
+    )
+
+    info_parser = subparsers.add_parser(
+        "info",
+        help="Show full details for a sandbox.",
+    )
+    info_parser.add_argument(
+        "vm_id", metavar="sandbox", help="Name or ID of the sandbox."
+    )
+    info_parser.add_argument(
         "--json",
         action="store_true",
         help="Emit machine-readable JSON output.",
@@ -1046,6 +1081,175 @@ def _run_list(*, include_all: bool, status_filter: str | None, json_output: bool
             return _emit_cli_error("list", 1, exc, json_output=json_output)
 
 
+_OS_HINT_KEYWORDS = ("ubuntu", "debian", "alpine")
+
+
+def _guess_os_from_paths(vm: VMInfo) -> str | None:
+    """Best-effort guess of the guest OS from cached image paths.
+
+    The per-VM rootfs clone lives under ``data_dir/disks/`` so it carries no
+    OS hint, but ``kernel_path`` (kernel-boot images) and the original rootfs
+    cache directory still embed the OS name. Returns ``None`` when no known
+    OS keyword is found.
+    """
+    candidates: list[str] = []
+    config = vm.config
+    if config.kernel_path is not None:
+        candidates.append(str(config.kernel_path))
+    if config.initrd_path is not None:
+        candidates.append(str(config.initrd_path))
+    candidates.append(str(config.rootfs_path))
+    for path in candidates:
+        lowered = path.lower()
+        for keyword in _OS_HINT_KEYWORDS:
+            if keyword in lowered:
+                return keyword
+    return None
+
+
+def _query_live_vm_info(vm_id: str) -> dict[str, object]:
+    """Query a running VM via SSH for OS pretty-name and used memory.
+
+    Returns an empty dict on any failure so the caller can render fall-through
+    placeholders without surfacing transient SSH errors to the user.
+    """
+    from smolvm.facade import SmolVM
+
+    try:
+        vm = SmolVM.from_id(vm_id)
+    except Exception:
+        return {}
+    try:
+        cmd = (
+            "(. /etc/os-release 2>/dev/null && printf '%s' \"${PRETTY_NAME:-}\"); "
+            "printf '\\n---\\n'; "
+            "free -m 2>/dev/null | awk 'NR==2 {print $3}'"
+        )
+        result = vm.run(cmd, timeout=5, shell="raw")
+    except Exception:
+        return {}
+    finally:
+        try:
+            vm.close()
+        except Exception:
+            pass
+
+    if result.exit_code != 0:
+        return {}
+    parts = result.stdout.split("---")
+    out: dict[str, object] = {}
+    if parts and parts[0].strip():
+        out["os"] = parts[0].strip()
+    if len(parts) > 1:
+        try:
+            out["memory_used_mib"] = int(parts[1].strip())
+        except ValueError:
+            pass
+    return out
+
+
+def _info_payload(vm: VMInfo, *, live_data: dict[str, object] | None = None) -> InfoPayload:
+    """Build the info command payload from a VMInfo plus optional live data."""
+    network = vm.network
+    config = vm.config
+    live = live_data or {}
+
+    disk_size_mib: int | None = None
+    rootfs = config.rootfs_path
+    if rootfs is not None:
+        try:
+            disk_size_mib = rootfs.stat().st_size // (1024 * 1024)
+        except OSError:
+            disk_size_mib = None
+
+    os_value = live.get("os") or _guess_os_from_paths(vm)
+    memory_used = live.get("memory_used_mib")
+
+    return {
+        "vm": {
+            "name": vm.vm_id,
+            "status": vm.status.value,
+            "os": str(os_value) if os_value else None,
+            "backend": config.backend or "auto",
+            "ip_address": network.guest_ip if network else None,
+            "ssh_port": network.ssh_host_port if network else None,
+            "pid": vm.pid,
+            "vcpus": config.vcpu_count,
+            "memory_mib": config.memory,
+            "memory_used_mib": memory_used if isinstance(memory_used, int) else None,
+            "disk_size_mib": disk_size_mib,
+        }
+    }
+
+
+def _render_info_result(data: InfoPayload) -> None:
+    """Render the human-facing info result."""
+    console = console_stdout()
+    vm_data = data["vm"]
+
+    if vm_data["memory_used_mib"] is not None:
+        memory_str = f"{vm_data['memory_used_mib']} / {vm_data['memory_mib']} MiB used"
+    else:
+        memory_str = f"{vm_data['memory_mib']} MiB"
+
+    disk_str = (
+        f"{vm_data['disk_size_mib']} MiB"
+        if vm_data["disk_size_mib"] is not None
+        else "-"
+    )
+
+    details = Table(title="VM Details", show_header=False)
+    details.add_column("Field")
+    details.add_column("Value")
+    details.add_row("Name", str(vm_data["name"]))
+    details.add_row(
+        "Status",
+        Text(str(vm_data["status"]), style=status_style(str(vm_data["status"]))),
+    )
+    details.add_row("OS", str(vm_data["os"] or "-"))
+    details.add_row("Backend", str(vm_data["backend"]))
+    details.add_row("IP Address", str(vm_data["ip_address"] or "-"))
+    details.add_row(
+        "SSH Port",
+        str(vm_data["ssh_port"]) if vm_data["ssh_port"] is not None else "-",
+    )
+    details.add_row("CPUs", str(vm_data["vcpus"]))
+    details.add_row("Memory", memory_str)
+    details.add_row("Disk Size", disk_str)
+    details.add_row(
+        "PID",
+        str(vm_data["pid"]) if vm_data["pid"] is not None else "-",
+    )
+    console.print(details)
+
+
+def _run_info(*, vm_id: str, json_output: bool) -> int:
+    """Handle ``smolvm info``."""
+    from smolvm.vm import SmolVMManager
+
+    with SmolVMManager() as sdk:
+        try:
+            vm = sdk.state.get_vm(vm_id)
+            live_data: dict[str, object] | None = None
+            if vm.status == VMState.RUNNING:
+                live_data = _query_live_vm_info(vm_id)
+            data = _info_payload(vm, live_data=live_data)
+            if json_output:
+                emit_json("info", 0, data=data)
+            else:
+                _render_info_result(data)
+            return 0
+        except Exception as exc:
+            return _emit_cli_error("info", 1, exc, json_output=json_output)
+
+
+def _format_started_at(iso_ts: str) -> str:
+    """Render an ISO timestamp as ``YYYY-MM-DD HH:MM:SS UTC``."""
+    dt = datetime.fromisoformat(iso_ts)
+    if dt.tzinfo is None:
+        dt = dt.replace(tzinfo=timezone.utc)
+    return dt.astimezone(timezone.utc).strftime("%Y-%m-%d %H:%M:%S UTC")
+
 
 def _render_create_result(data: CreatePayload) -> None:
     """Render the human-facing create result."""
@@ -1070,14 +1274,10 @@ def _render_create_result(data: CreatePayload) -> None:
         Text(str(vm_data["status"]), style=status_style(str(vm_data["status"]))),
     )
     details.add_row("OS", str(vm_data["os"]))
-    details.add_row("Backend", str(vm_data["backend"]))
-    details.add_row("IP Address", str(vm_data["ip_address"] or "-"))
-    details.add_row(
-        "SSH Port",
-        str(vm_data["ssh_port"]) if vm_data["ssh_port"] is not None else "-",
-    )
+    details.add_row("Started", _format_started_at(vm_data["started_at"]))
     console.print(details)
     console.print(f"Next: [bold]{next_step['ssh_command']}[/bold]")
+    console.print(f"      [bold]{next_step['info_command']}[/bold]")
 
 
 def _build_and_boot_with_progress(
@@ -1185,7 +1385,7 @@ def _run_create(args: argparse.Namespace) -> int:
                         image=image_uri,
                         vm_name=args.name,
                         backend=args.backend,
-                        mem_size_mib=args.memory_mib,
+                        memory=args.memory_mib,
                         ssh_key_path=None,
                         on_download=on_download,
                     ),
@@ -1197,7 +1397,7 @@ def _run_create(args: argparse.Namespace) -> int:
                     image=image_uri,
                     vm_name=args.name,
                     backend=args.backend,
-                    mem_size_mib=args.memory_mib,
+                    memory=args.memory_mib,
                     ssh_key_path=None,
                 )
                 vm = SmolVM(config, ssh_key_path=ssh_key_path, mounts=args.mounts)
@@ -1213,7 +1413,7 @@ def _run_create(args: argparse.Namespace) -> int:
                         vm_name=args.name,
                         os=args.os,
                         backend=args.backend,
-                        mem_size_mib=args.memory_mib,
+                        memory=args.memory_mib,
                         disk_size_mib=args.disk_size_mib,
                         ssh_key_path=None,
                         on_download=on_download,
@@ -1226,7 +1426,7 @@ def _run_create(args: argparse.Namespace) -> int:
                     vm_name=args.name,
                     os=args.os,
                     backend=args.backend,
-                    mem_size_mib=args.memory_mib,
+                    memory=args.memory_mib,
                     disk_size_mib=args.disk_size_mib,
                     ssh_key_path=None,
                 )
@@ -1235,7 +1435,6 @@ def _run_create(args: argparse.Namespace) -> int:
                 vm.wait_for_ssh(timeout=args.boot_timeout)
 
         os_label = "s3-image" if use_s3_image else resolved_guest_os.value
-        network = vm.info.network
         data: CreatePayload = {
             "vm": {
                 "name": vm.vm_id,
@@ -1245,12 +1444,11 @@ def _run_create(args: argparse.Namespace) -> int:
                     else VMState.RUNNING.value
                 ),
                 "os": os_label,
-                "backend": vm.info.config.backend or "auto",
-                "ip_address": network.guest_ip if network else None,
-                "ssh_port": network.ssh_host_port if network else None,
+                "started_at": datetime.now(timezone.utc).isoformat(),
             },
             "next": {
                 "ssh_command": f"smolvm ssh {vm.vm_id}",
+                "info_command": f"smolvm info {vm.vm_id}",
             },
         }
 
@@ -1939,7 +2137,7 @@ def _run_browser(args: argparse.Namespace) -> int:
                 viewport={"width": args.viewport_width, "height": args.viewport_height},
                 record_video=args.record_video,
                 allow_downloads=not args.no_downloads,
-                mem_size_mib=args.memory_mib,
+                memory=args.memory_mib,
                 disk_size_mib=args.disk_size_mib,
             )
             session = BrowserSession(config)
@@ -2116,6 +2314,9 @@ def main(argv: Sequence[str] | None = None) -> int:
             status_filter=args.status,
             json_output=args.json,
         )
+
+    if args.command == "info":
+        return _run_info(vm_id=args.vm_id, json_output=args.json)
 
     if args.command == "create":
         return _run_create(args)

--- a/src/smolvm/cli/main.py
+++ b/src/smolvm/cli/main.py
@@ -25,6 +25,7 @@ import re
 import subprocess
 import sys
 from collections.abc import Sequence
+from contextlib import suppress
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import TYPE_CHECKING, TypedDict
@@ -1226,32 +1227,48 @@ def _guess_os_from_paths(vm: VMInfo) -> str | None:
     return None
 
 
-def _query_live_vm_info(vm_id: str) -> dict[str, object]:
+def _query_live_vm_info(vm: VMInfo) -> dict[str, object]:
     """Query a running VM via SSH for OS pretty-name and used memory.
+
+    Connects directly with a short ``connect_timeout`` so half-dead VMs
+    (status=running in state but SSH unreachable) fail fast instead of
+    blocking on the SmolVM facade's 30-second SSH-ready wait.
 
     Returns an empty dict on any failure so the caller can render fall-through
     placeholders without surfacing transient SSH errors to the user.
     """
-    from smolvm.facade import SmolVM
+    from smolvm.ssh import SSHClient
 
-    try:
-        vm = SmolVM.from_id(vm_id)
-    except Exception:
+    network = vm.network
+    if network is None:
         return {}
+
+    if network.ssh_host_port is not None:
+        host, port = "127.0.0.1", network.ssh_host_port
+    else:
+        host, port = network.guest_ip, 22
+
+    key_path = Path.home() / ".smolvm" / "keys" / "id_ed25519"
+    client = SSHClient(
+        host=host,
+        port=port,
+        key_path=str(key_path) if key_path.exists() else None,
+        connect_timeout=3,
+    )
+
+    cmd = (
+        "(. /etc/os-release 2>/dev/null && printf '%s' \"${PRETTY_NAME:-}\"); "
+        "printf '\\n---\\n'; "
+        "free -m 2>/dev/null | awk 'NR==2 {print $3}'"
+    )
     try:
-        cmd = (
-            "(. /etc/os-release 2>/dev/null && printf '%s' \"${PRETTY_NAME:-}\"); "
-            "printf '\\n---\\n'; "
-            "free -m 2>/dev/null | awk 'NR==2 {print $3}'"
-        )
-        result = vm.run(cmd, timeout=5, shell="raw")
-    except Exception:
+        result = client.run(cmd, timeout=5, shell="raw")
+    except Exception:  # noqa: BLE001 - any SSH failure means "skip live data"
         return {}
     finally:
-        try:
-            vm.close()
-        except Exception:
-            pass
+        # Best-effort cleanup; a failed close on a dead transport is harmless.
+        with suppress(Exception):
+            client.close()
 
     if result.exit_code != 0:
         return {}
@@ -1263,8 +1280,33 @@ def _query_live_vm_info(vm_id: str) -> dict[str, object]:
         try:
             out["memory_used"] = int(parts[1].strip())
         except ValueError:
+            # `free -m` output unparseable on this guest (busybox variant,
+            # locale, etc.) — omit the field rather than fail the whole probe.
             pass
     return out
+
+
+def _disk_size_mib(rootfs_path: Path | None) -> int | None:
+    """Return the rootfs disk size visible to the guest, in MiB.
+
+    For qcow2 images, the host file footprint can be far smaller than the
+    guest-visible disk because of qcow2's sparse/copy-on-write semantics, so
+    we shell out to ``qemu-img`` for the virtual size. Other image formats
+    (raw, ext4) match the host file size, where ``stat`` is sufficient.
+    """
+    if rootfs_path is None:
+        return None
+    if rootfs_path.suffix.lower() == ".qcow2":
+        from smolvm.facade import _qcow2_virtual_size_mib
+
+        try:
+            return _qcow2_virtual_size_mib(rootfs_path)
+        except Exception:  # noqa: BLE001 - qemu-img missing or image unreadable
+            pass
+    try:
+        return rootfs_path.stat().st_size // (1024 * 1024)
+    except OSError:
+        return None
 
 
 def _info_payload(vm: VMInfo, *, live_data: dict[str, object] | None = None) -> InfoPayload:
@@ -1273,14 +1315,7 @@ def _info_payload(vm: VMInfo, *, live_data: dict[str, object] | None = None) -> 
     config = vm.config
     live = live_data or {}
 
-    disk_size: int | None = None
-    rootfs = config.rootfs_path
-    if rootfs is not None:
-        try:
-            disk_size = rootfs.stat().st_size // (1024 * 1024)
-        except OSError:
-            disk_size = None
-
+    disk_size = _disk_size_mib(config.rootfs_path)
     os_value = live.get("os") or _guess_os_from_paths(vm)
     memory_used = live.get("memory_used")
 
@@ -1351,7 +1386,7 @@ def _run_info(*, vm_id: str, json_output: bool) -> int:
             vm = sdk.state.get_vm(vm_id)
             live_data: dict[str, object] | None = None
             if vm.status == VMState.RUNNING:
-                live_data = _query_live_vm_info(vm_id)
+                live_data = _query_live_vm_info(vm)
             data = _info_payload(vm, live_data=live_data)
             if json_output:
                 emit_json("info", 0, data=data)

--- a/src/smolvm/cli/main.py
+++ b/src/smolvm/cli/main.py
@@ -100,7 +100,11 @@ class CreateNextPayload(TypedDict):
 
 
 class InfoVmPayload(TypedDict):
-    """Machine-readable VM details for ``smolvm info``."""
+    """Machine-readable VM details for ``smolvm info``.
+
+    Memory and disk fields are in MiB (SmolVM's house unit, matching
+    :attr:`VMConfig.memory`).
+    """
 
     name: str
     status: str
@@ -110,9 +114,9 @@ class InfoVmPayload(TypedDict):
     ssh_port: int | None
     pid: int | None
     vcpus: int
-    memory_mib: int
-    memory_used_mib: int | None
-    disk_size_mib: int | None
+    memory: int
+    memory_used: int | None
+    disk_size: int | None
 
 
 class InfoPayload(TypedDict):
@@ -1257,7 +1261,7 @@ def _query_live_vm_info(vm_id: str) -> dict[str, object]:
         out["os"] = parts[0].strip()
     if len(parts) > 1:
         try:
-            out["memory_used_mib"] = int(parts[1].strip())
+            out["memory_used"] = int(parts[1].strip())
         except ValueError:
             pass
     return out
@@ -1269,16 +1273,16 @@ def _info_payload(vm: VMInfo, *, live_data: dict[str, object] | None = None) -> 
     config = vm.config
     live = live_data or {}
 
-    disk_size_mib: int | None = None
+    disk_size: int | None = None
     rootfs = config.rootfs_path
     if rootfs is not None:
         try:
-            disk_size_mib = rootfs.stat().st_size // (1024 * 1024)
+            disk_size = rootfs.stat().st_size // (1024 * 1024)
         except OSError:
-            disk_size_mib = None
+            disk_size = None
 
     os_value = live.get("os") or _guess_os_from_paths(vm)
-    memory_used = live.get("memory_used_mib")
+    memory_used = live.get("memory_used")
 
     return {
         "vm": {
@@ -1290,9 +1294,9 @@ def _info_payload(vm: VMInfo, *, live_data: dict[str, object] | None = None) -> 
             "ssh_port": network.ssh_host_port if network else None,
             "pid": vm.pid,
             "vcpus": config.vcpu_count,
-            "memory_mib": config.memory,
-            "memory_used_mib": memory_used if isinstance(memory_used, int) else None,
-            "disk_size_mib": disk_size_mib,
+            "memory": config.memory,
+            "memory_used": memory_used if isinstance(memory_used, int) else None,
+            "disk_size": disk_size,
         }
     }
 
@@ -1302,14 +1306,14 @@ def _render_info_result(data: InfoPayload) -> None:
     console = console_stdout()
     vm_data = data["vm"]
 
-    if vm_data["memory_used_mib"] is not None:
-        memory_str = f"{vm_data['memory_used_mib']} / {vm_data['memory_mib']} MiB used"
+    if vm_data["memory_used"] is not None:
+        memory_str = f"{vm_data['memory_used']} / {vm_data['memory']} MiB used"
     else:
-        memory_str = f"{vm_data['memory_mib']} MiB"
+        memory_str = f"{vm_data['memory']} MiB"
 
     disk_str = (
-        f"{vm_data['disk_size_mib']} MiB"
-        if vm_data["disk_size_mib"] is not None
+        f"{vm_data['disk_size']} MiB"
+        if vm_data["disk_size"] is not None
         else "-"
     )
 

--- a/src/smolvm/dashboard/server.py
+++ b/src/smolvm/dashboard/server.py
@@ -430,7 +430,7 @@ def _vm_info_to_dict(vm: VMInfo) -> dict[str, Any]:
         "status": vm.status.value,
         "config": {
             "vcpu_count": vm.config.vcpu_count,
-            "mem_size_mib": vm.config.mem_size_mib,
+            "memory": vm.config.memory,
         },
         "network": (
             {

--- a/src/smolvm/facade.py
+++ b/src/smolvm/facade.py
@@ -358,7 +358,7 @@ def _build_s3_image_config(
     image: str,
     vm_name: str | None = None,
     backend: str | None = None,
-    mem_size_mib: int | None = None,
+    memory: int | None = None,
     ssh_key_path: str | None = None,
     on_download: Callable[[str, int, int | None], None] | None = None,
 ) -> tuple[VMConfig, str | None]:
@@ -424,7 +424,7 @@ def _build_s3_image_config(
     config = VMConfig(
         vm_id=resolved_vm_name,
         vcpu_count=1,
-        mem_size_mib=mem_size_mib or 512,
+        memory=memory or 512,
         kernel_path=local_image.kernel_path,
         initrd_path=local_image.initrd_path,
         rootfs_path=local_image.rootfs_path,
@@ -447,7 +447,7 @@ def _build_auto_config(
     vm_name: str | None = None,
     os: GuestOS | str | None = None,
     backend: str | None = None,
-    mem_size_mib: int | None = None,
+    memory: int | None = None,
     disk_size_mib: int | None = None,
     ssh_key_path: str | None = None,
     on_download: Callable[[str, int, int | None], None] | None = None,
@@ -460,9 +460,9 @@ def _build_auto_config(
     resolved_ssh_key_path, public_key_path = _resolve_auto_config_public_key(ssh_key_path)
     public_key_value = public_key_path.read_text().strip()
 
-    resolved_mem_size_mib = _AUTO_CONFIG_DEFAULT_MEM_SIZE_MIB[resolved_os]
-    if mem_size_mib is not None:
-        resolved_mem_size_mib = mem_size_mib
+    resolved_memory = _AUTO_CONFIG_DEFAULT_MEM_SIZE_MIB[resolved_os]
+    if memory is not None:
+        resolved_memory = memory
     default_disk_size_mib = _AUTO_CONFIG_DEFAULT_DISK_SIZE_MIB[resolved_os]
     resolved_disk_size_mib = default_disk_size_mib if disk_size_mib is None else disk_size_mib
     if resolved_disk_size_mib < 64:
@@ -526,7 +526,7 @@ def _build_auto_config(
         config = VMConfig(
             vm_id=resolved_vm_name,
             vcpu_count=1,
-            mem_size_mib=resolved_mem_size_mib,
+            memory=resolved_memory,
             kernel_path=image.kernel_path,
             initrd_path=image.initrd_path,
             rootfs_path=rootfs_path,
@@ -602,7 +602,7 @@ def _build_auto_config(
         config = VMConfig(
             vm_id=resolved_vm_name,
             vcpu_count=1,
-            mem_size_mib=resolved_mem_size_mib,
+            memory=resolved_memory,
             boot_mode="firmware",
             kernel_path=None,
             rootfs_path=rootfs_path,
@@ -649,7 +649,7 @@ def _build_auto_config(
     config = VMConfig(
         vm_id=resolved_vm_name,
         vcpu_count=1,
-        mem_size_mib=resolved_mem_size_mib,
+        memory=resolved_memory,
         kernel_path=kernel,
         rootfs_path=rootfs,
         boot_args=boot_args,
@@ -762,7 +762,7 @@ class SmolVM:
             config, ssh_key_path = _build_s3_image_config(
                 image=image,
                 backend=backend,
-                mem_size_mib=memory,
+                memory=memory,
                 ssh_key_path=ssh_key_path,
             )
         elif config is None and vm_id is None:
@@ -771,7 +771,7 @@ class SmolVM:
             config, ssh_key_path = _build_auto_config(
                 os=os,
                 backend=backend,
-                mem_size_mib=memory,
+                memory=memory,
                 disk_size_mib=disk_size,
                 ssh_key_path=ssh_key_path,
             )

--- a/src/smolvm/runtime/firecracker.py
+++ b/src/smolvm/runtime/firecracker.py
@@ -60,7 +60,7 @@ class FirecrackerRuntimeAdapter(RuntimeAdapter):
             client = FirecrackerClient(control_socket_path)
             client.wait_for_socket(timeout=boot_timeout)
             client.set_boot_source(vm_info.config.kernel_path, self._context.resolve_boot_args(vm_info))
-            client.set_machine_config(vm_info.config.vcpu_count, vm_info.config.mem_size_mib)
+            client.set_machine_config(vm_info.config.vcpu_count, vm_info.config.memory)
             client.add_drive(
                 "rootfs",
                 vm_info.config.rootfs_path,

--- a/src/smolvm/types.py
+++ b/src/smolvm/types.py
@@ -246,7 +246,7 @@ class VMConfig(BaseModel):
         vm_id: Optional unique identifier (lowercase alphanumeric with hyphens).
             If omitted, SmolVM auto-generates one.
         vcpu_count: Number of virtual CPUs (1-32).
-        mem_size_mib: Memory size in MiB (128-16384).
+        memory: Memory size in MiB (128-16384).
         boot_mode: How the guest boots:
 
             - ``"direct_kernel"`` (default): the hypervisor loads
@@ -287,7 +287,7 @@ class VMConfig(BaseModel):
         ),
     ]
     vcpu_count: Annotated[int, Field(ge=1, le=32)] = 2
-    mem_size_mib: Annotated[int, Field(ge=128, le=16384)] = 512
+    memory: Annotated[int, Field(ge=128, le=16384)] = 512
     boot_mode: Literal["direct_kernel", "firmware"] = "direct_kernel"
     kernel_path: Path | None = None
     initrd_path: Path | None = None

--- a/src/smolvm/vm.py
+++ b/src/smolvm/vm.py
@@ -537,7 +537,7 @@ class SmolVMManager:
     def _warn_low_disk_space_for_snapshot(self, vm_info: VMInfo) -> None:
         """Warn when snapshot creation looks likely to exhaust local disk space."""
         rootfs_size = vm_info.config.rootfs_path.stat().st_size
-        mem_size = vm_info.config.mem_size_mib * 1024 * 1024
+        mem_size = vm_info.config.memory * 1024 * 1024
         required_bytes = rootfs_size + (2 * mem_size)
         free_bytes = shutil.disk_usage(self.snapshot_dir).free
         if free_bytes < required_bytes:
@@ -1522,7 +1522,7 @@ class SmolVMManager:
             "-smp",
             str(vm_info.config.vcpu_count),
             "-m",
-            str(vm_info.config.mem_size_mib),
+            str(vm_info.config.memory),
         ]
         # Boot mode: direct-kernel passes -kernel/-append (optionally -initrd);
         # firmware mode lets QEMU boot the rootfs disk via default firmware
@@ -1735,7 +1735,7 @@ class SmolVMManager:
             "--cpus",
             str(vm_info.config.vcpu_count),
             "--memory",
-            str(vm_info.config.mem_size_mib),
+            str(vm_info.config.memory),
             "--kernel",
             str(vm_info.config.kernel_path),
             "--rootfs",
@@ -2271,7 +2271,7 @@ class SmolVMManager:
             "--cpus",
             str(vm_info.config.vcpu_count),
             "--memory",
-            str(vm_info.config.mem_size_mib),
+            str(vm_info.config.memory),
             "--kernel",
             str(vm_info.config.kernel_path),
             "--rootfs",

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1930,7 +1930,7 @@ class TestCliInfo:
         with patch("smolvm.cli.main._query_live_vm_info") as mock_query:
             mock_query.return_value = {
                 "os": "Ubuntu 24.04.1 LTS",
-                "memory_used_mib": 312,
+                "memory_used": 312,
             }
 
             ret = main(["info", "sbx-pauling"])
@@ -2007,9 +2007,9 @@ class TestCliInfo:
             "ssh_port": 2200,
             "pid": 4242,
             "vcpus": 2,
-            "memory_mib": 1024,
-            "memory_used_mib": None,
-            "disk_size_mib": 3,
+            "memory": 1024,
+            "memory_used": None,
+            "disk_size": 3,
         }
 
     def test_info_not_found(

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1924,9 +1924,8 @@ class TestCliInfo:
         capsys: pytest.CaptureFixture,
     ) -> None:
         """For running VMs, info should overlay OS and used memory from SSH."""
-        mock_sdk_cls.return_value.state.get_vm.return_value = self._make_info_vm(
-            status=VMState.RUNNING
-        )
+        vm_info = self._make_info_vm(status=VMState.RUNNING)
+        mock_sdk_cls.return_value.state.get_vm.return_value = vm_info
         with patch("smolvm.cli.main._query_live_vm_info") as mock_query:
             mock_query.return_value = {
                 "os": "Ubuntu 24.04.1 LTS",
@@ -1939,7 +1938,7 @@ class TestCliInfo:
         out = capsys.readouterr().out
         assert "Ubuntu 24.04.1 LTS" in out
         assert "312 / 1024 MiB used" in out
-        mock_query.assert_called_once_with("sbx-pauling")
+        mock_query.assert_called_once_with(vm_info)
 
     def test_info_running_vm_with_unreachable_ssh(
         self,
@@ -2025,6 +2024,27 @@ class TestCliInfo:
         assert ret == 1
         assert "VM 'ghost' not found" in capsys.readouterr().err
         mock_sdk_cls.return_value.close.assert_called_once()
+
+    def test_info_qcow2_uses_virtual_size(
+        self,
+        mock_sdk_cls: MagicMock,
+        tmp_path: Path,
+        capsys: pytest.CaptureFixture,
+    ) -> None:
+        """For qcow2 rootfs, disk size should report the guest-visible virtual size, not the host file footprint."""
+        rootfs = tmp_path / "ubuntu" / "rootfs.qcow2"
+        rootfs.parent.mkdir(parents=True)
+        rootfs.write_bytes(b"\0" * (1 * 1024 * 1024))  # 1 MiB on disk
+        mock_sdk_cls.return_value.state.get_vm.return_value = self._make_info_vm(
+            status=VMState.STOPPED, rootfs_path=rootfs
+        )
+        with patch("smolvm.facade._qcow2_virtual_size_mib", return_value=8192) as mock_qsize:
+            ret = main(["info", "sbx-pauling", "--json"])
+
+        assert ret == 0
+        mock_qsize.assert_called_once_with(rootfs)
+        payload = json.loads(capsys.readouterr().out)
+        assert payload["data"]["vm"]["disk_size"] == 8192
 
 
 class TestCliStart:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -365,7 +365,7 @@ class TestCliCreate:
             vm_name=None,
             os=None,
             backend=None,
-            mem_size_mib=None,
+            memory=None,
             disk_size_mib=4096,
             ssh_key_path=None,
             on_download=ANY,
@@ -378,7 +378,12 @@ class TestCliCreate:
         assert "Created VM 'vm-a1b2c3d4'." in out
         assert "OS" in out
         assert "ubuntu" in out
+        assert "Started" in out
         assert "smolvm ssh vm-a1b2c3d4" in out
+        assert "smolvm info vm-a1b2c3d4" in out
+        assert "Backend" not in out
+        assert "IP Address" not in out
+        assert "SSH Port" not in out
 
     @patch("smolvm.facade._build_auto_config")
     @patch("smolvm.facade.SmolVM")
@@ -425,7 +430,7 @@ class TestCliCreate:
             vm_name="project-spacex",
             os=None,
             backend="qemu",
-            mem_size_mib=1024,
+            memory=1024,
             disk_size_mib=2048,
             ssh_key_path=None,
             on_download=ANY,
@@ -440,11 +445,12 @@ class TestCliCreate:
         assert "Created VM 'project-spacex'." in out
         assert "OS" in out
         assert "ubuntu" in out
-        assert "Backend" in out
-        assert "qemu" in out
-        assert "172.16.0.2" in out
-        assert "2200" in out
+        assert "Started" in out
         assert "smolvm ssh project-spacex" in out
+        assert "smolvm info project-spacex" in out
+        assert "Backend" not in out
+        assert "172.16.0.2" not in out
+        assert "2200" not in out
 
     @patch("smolvm.facade._build_auto_config")
     @patch("smolvm.facade.SmolVM")
@@ -476,7 +482,7 @@ class TestCliCreate:
             vm_name="computer",
             os=None,
             backend=None,
-            mem_size_mib=None,
+            memory=None,
             disk_size_mib=4096,
             ssh_key_path=None,
             on_download=ANY,
@@ -519,8 +525,9 @@ class TestCliCreate:
         assert payload["command"] == "create"
         assert payload["data"]["vm"]["name"] == "project-spacex"
         assert payload["data"]["vm"]["os"] == "ubuntu"
-        assert payload["data"]["vm"]["backend"] == "qemu"
+        assert payload["data"]["vm"]["started_at"]
         assert payload["data"]["next"]["ssh_command"] == "smolvm ssh project-spacex"
+        assert payload["data"]["next"]["info_command"] == "smolvm info project-spacex"
 
     @patch("smolvm.facade._build_auto_config")
     @patch("smolvm.facade.SmolVM")
@@ -549,7 +556,7 @@ class TestCliCreate:
             vm_name="project-spacex",
             os="debian",
             backend=None,
-            mem_size_mib=None,
+            memory=None,
             disk_size_mib=4096,
             ssh_key_path=None,
         )
@@ -582,7 +589,7 @@ class TestCliCreate:
             vm_name=None,
             os="alpine",
             backend=None,
-            mem_size_mib=None,
+            memory=None,
             disk_size_mib=None,
             ssh_key_path=None,
         )
@@ -1833,4 +1840,188 @@ class TestCliList:
 
         assert ret == 1
         assert "Error: db unavailable" in capsys.readouterr().err
+        mock_sdk_cls.return_value.close.assert_called_once()
+
+
+class TestCliInfo:
+    """Tests for `smolvm info`."""
+
+    @pytest.fixture
+    def mock_sdk_cls(self) -> MagicMock:
+        with patch("smolvm.vm.SmolVMManager") as m:
+            m.return_value.__enter__.return_value = m.return_value
+            m.return_value.__exit__.side_effect = lambda *args: m.return_value.close()
+            yield m
+
+    @staticmethod
+    def _make_info_vm(
+        vm_id: str = "sbx-pauling",
+        status: VMState = VMState.RUNNING,
+        backend: str = "qemu",
+        guest_ip: str | None = "10.0.2.15",
+        ssh_host_port: int | None = 2200,
+        pid: int | None = 4242,
+        vcpus: int = 2,
+        memory_mib: int = 1024,
+        rootfs_path: Path | None = None,
+        kernel_path: Path | None = None,
+        initrd_path: Path | None = None,
+    ) -> MagicMock:
+        vm = MagicMock()
+        vm.vm_id = vm_id
+        vm.status = status
+        vm.config.backend = backend
+        vm.config.vcpu_count = vcpus
+        vm.config.memory = memory_mib
+        vm.config.rootfs_path = rootfs_path
+        vm.config.kernel_path = kernel_path
+        vm.config.initrd_path = initrd_path
+        vm.pid = pid
+        if guest_ip is not None:
+            vm.network = MagicMock(spec=NetworkConfig)
+            vm.network.guest_ip = guest_ip
+            vm.network.ssh_host_port = ssh_host_port
+        else:
+            vm.network = None
+        return vm
+
+    def test_info_renders_full_table(
+        self,
+        mock_sdk_cls: MagicMock,
+        tmp_path: Path,
+        capsys: pytest.CaptureFixture,
+    ) -> None:
+        """`smolvm info <name>` should show the full details table."""
+        rootfs = tmp_path / "ubuntu-noble-minimal-qemu-x86_64" / "rootfs.qcow2"
+        rootfs.parent.mkdir(parents=True)
+        rootfs.write_bytes(b"\0" * (5 * 1024 * 1024))  # 5 MiB
+        mock_sdk_cls.return_value.state.get_vm.return_value = self._make_info_vm(
+            status=VMState.STOPPED, rootfs_path=rootfs
+        )
+
+        ret = main(["info", "sbx-pauling"])
+
+        assert ret == 0
+        out = capsys.readouterr().out
+        assert "sbx-pauling" in out
+        assert "stopped" in out
+        assert "qemu" in out
+        assert "10.0.2.15" in out
+        assert "2200" in out
+        assert "4242" in out
+        assert "CPUs" in out
+        assert "Memory" in out
+        assert "1024 MiB" in out
+        assert "Disk Size" in out
+        assert "5 MiB" in out
+        assert "ubuntu" in out
+        mock_sdk_cls.return_value.state.get_vm.assert_called_once_with("sbx-pauling")
+        mock_sdk_cls.return_value.close.assert_called_once()
+
+    def test_info_running_vm_queries_live_data(
+        self,
+        mock_sdk_cls: MagicMock,
+        capsys: pytest.CaptureFixture,
+    ) -> None:
+        """For running VMs, info should overlay OS and used memory from SSH."""
+        mock_sdk_cls.return_value.state.get_vm.return_value = self._make_info_vm(
+            status=VMState.RUNNING
+        )
+        with patch("smolvm.cli.main._query_live_vm_info") as mock_query:
+            mock_query.return_value = {
+                "os": "Ubuntu 24.04.1 LTS",
+                "memory_used_mib": 312,
+            }
+
+            ret = main(["info", "sbx-pauling"])
+
+        assert ret == 0
+        out = capsys.readouterr().out
+        assert "Ubuntu 24.04.1 LTS" in out
+        assert "312 / 1024 MiB used" in out
+        mock_query.assert_called_once_with("sbx-pauling")
+
+    def test_info_running_vm_with_unreachable_ssh(
+        self,
+        mock_sdk_cls: MagicMock,
+        capsys: pytest.CaptureFixture,
+    ) -> None:
+        """If SSH probe fails, info should still render with placeholders."""
+        mock_sdk_cls.return_value.state.get_vm.return_value = self._make_info_vm(
+            status=VMState.RUNNING
+        )
+        with patch("smolvm.cli.main._query_live_vm_info") as mock_query:
+            mock_query.return_value = {}
+
+            ret = main(["info", "sbx-pauling"])
+
+        assert ret == 0
+        out = capsys.readouterr().out
+        assert "1024 MiB" in out
+        # No "used" suffix when memory_used is unavailable.
+        assert "used" not in out
+
+    def test_info_handles_missing_network(
+        self,
+        mock_sdk_cls: MagicMock,
+        capsys: pytest.CaptureFixture,
+    ) -> None:
+        """`smolvm info` should render '-' when the VM has no network."""
+        mock_sdk_cls.return_value.state.get_vm.return_value = self._make_info_vm(
+            status=VMState.STOPPED, guest_ip=None, ssh_host_port=None, pid=None
+        )
+
+        ret = main(["info", "sbx-pauling"])
+
+        assert ret == 0
+        out = capsys.readouterr().out
+        assert "stopped" in out
+        assert "-" in out
+
+    def test_info_json(
+        self,
+        mock_sdk_cls: MagicMock,
+        tmp_path: Path,
+        capsys: pytest.CaptureFixture,
+    ) -> None:
+        """`smolvm info --json` should emit a structured envelope."""
+        rootfs = tmp_path / "alpine-virt" / "rootfs.ext4"
+        rootfs.parent.mkdir(parents=True)
+        rootfs.write_bytes(b"\0" * (3 * 1024 * 1024))  # 3 MiB
+        mock_sdk_cls.return_value.state.get_vm.return_value = self._make_info_vm(
+            status=VMState.STOPPED, rootfs_path=rootfs
+        )
+
+        ret = main(["info", "sbx-pauling", "--json"])
+
+        assert ret == 0
+        payload = json.loads(capsys.readouterr().out)
+        assert payload["command"] == "info"
+        assert payload["ok"] is True
+        assert payload["data"]["vm"] == {
+            "name": "sbx-pauling",
+            "status": "stopped",
+            "os": "alpine",
+            "backend": "qemu",
+            "ip_address": "10.0.2.15",
+            "ssh_port": 2200,
+            "pid": 4242,
+            "vcpus": 2,
+            "memory_mib": 1024,
+            "memory_used_mib": None,
+            "disk_size_mib": 3,
+        }
+
+    def test_info_not_found(
+        self,
+        mock_sdk_cls: MagicMock,
+        capsys: pytest.CaptureFixture,
+    ) -> None:
+        """`smolvm info` returns 1 and an error message when the VM is missing."""
+        mock_sdk_cls.return_value.state.get_vm.side_effect = RuntimeError("VM 'ghost' not found")
+
+        ret = main(["info", "ghost"])
+
+        assert ret == 1
+        assert "VM 'ghost' not found" in capsys.readouterr().err
         mock_sdk_cls.return_value.close.assert_called_once()

--- a/tests/test_facade.py
+++ b/tests/test_facade.py
@@ -40,7 +40,7 @@ def sample_config(tmp_path: Path) -> VMConfig:
     return VMConfig(
         vm_id="vm001",
         vcpu_count=2,
-        mem_size_mib=512,
+        memory=512,
         kernel_path=kernel,
         rootfs_path=rootfs,
     )
@@ -137,7 +137,7 @@ class TestVMInit:
         mock_sdk.create.assert_called_once()
         created_config = mock_sdk.create.call_args[0][0]
         assert "init=/init" in created_config.boot_args
-        assert created_config.mem_size_mib == 512
+        assert created_config.memory == 512
 
     @patch("smolvm.facade.SmolVMManager")
     @patch("smolvm.images.builder.ImageBuilder")
@@ -177,7 +177,7 @@ class TestVMInit:
         assert mock_builder.build_alpine_ssh_key.call_args.kwargs["rootfs_size_mb"] == 4096
         mock_sdk.create.assert_called_once()
         created_config = mock_sdk.create.call_args[0][0]
-        assert created_config.mem_size_mib == 2048
+        assert created_config.memory == 2048
 
     @patch("smolvm.facade.SmolVMManager")
     @patch("smolvm.images.builder.ImageBuilder")
@@ -216,7 +216,7 @@ class TestVMInit:
         assert mock_builder.build_debian_ssh_key.call_args.kwargs["rootfs_size_mb"] == 2048
         mock_builder.build_alpine_ssh_key.assert_not_called()
         created_config = mock_sdk.create.call_args[0][0]
-        assert created_config.mem_size_mib == 512
+        assert created_config.memory == 512
         assert created_config.boot_mode == "direct_kernel"
 
     @patch("smolvm.facade.SmolVMManager")
@@ -774,7 +774,7 @@ class TestVMImageParam:
         mock_build_s3.assert_called_once_with(
             image="s3://bucket/images/alpine/",
             backend=None,
-            mem_size_mib=None,
+            memory=None,
             ssh_key_path=None,
         )
         assert vm.vm_id == "vm-s3test"
@@ -788,7 +788,7 @@ class TestVMImageParam:
         mock_sdk_cls: MagicMock,
         tmp_path: Path,
     ) -> None:
-        """Backend and mem_size_mib should be forwarded to the S3 config builder."""
+        """Backend and memory should be forwarded to the S3 config builder."""
         kernel = tmp_path / "vmlinux"
         rootfs = tmp_path / "rootfs.ext4"
         kernel.touch()
@@ -812,7 +812,7 @@ class TestVMImageParam:
         mock_build_s3.assert_called_once_with(
             image="s3://bucket/img/",
             backend="qemu",
-            mem_size_mib=1024,
+            memory=1024,
             ssh_key_path=None,
         )
 

--- a/tests/test_snapshot.py
+++ b/tests/test_snapshot.py
@@ -51,7 +51,7 @@ def sample_config(tmp_path: Path) -> VMConfig:
     return VMConfig(
         vm_id="vm001",
         vcpu_count=2,
-        mem_size_mib=512,
+        memory=512,
         kernel_path=kernel,
         rootfs_path=rootfs,
     )

--- a/tests/test_snapshot_qemu.py
+++ b/tests/test_snapshot_qemu.py
@@ -48,7 +48,7 @@ def qemu_config(tmp_path: Path) -> VMConfig:
     return VMConfig(
         vm_id="vm001",
         vcpu_count=2,
-        mem_size_mib=512,
+        memory=512,
         kernel_path=kernel,
         rootfs_path=rootfs,
         backend="qemu",

--- a/tests/test_storage.py
+++ b/tests/test_storage.py
@@ -56,7 +56,7 @@ def sample_config(tmp_path: Path) -> VMConfig:
     return VMConfig(
         vm_id="vm001",
         vcpu_count=2,
-        mem_size_mib=512,
+        memory=512,
         kernel_path=kernel,
         rootfs_path=rootfs,
     )

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -50,14 +50,14 @@ class TestVMConfig:
         config = VMConfig(
             vm_id="vm001",
             vcpu_count=2,
-            mem_size_mib=512,
+            memory=512,
             kernel_path=kernel,
             rootfs_path=rootfs,
         )
 
         assert config.vm_id == "vm001"
         assert config.vcpu_count == 2
-        assert config.mem_size_mib == 512
+        assert config.memory == 512
 
     def test_vm_id_auto_generated_when_omitted(self, tmp_path: Path) -> None:
         """Test VM ID is generated when omitted."""
@@ -155,7 +155,7 @@ class TestVMConfig:
         with pytest.raises(ValidationError):
             VMConfig(
                 vm_id="vm001",
-                mem_size_mib=64,
+                memory=64,
                 kernel_path=kernel,
                 rootfs_path=rootfs,
             )
@@ -164,7 +164,7 @@ class TestVMConfig:
         with pytest.raises(ValidationError):
             VMConfig(
                 vm_id="vm001",
-                mem_size_mib=32768,
+                memory=32768,
                 kernel_path=kernel,
                 rootfs_path=rootfs,
             )

--- a/tests/test_vm.py
+++ b/tests/test_vm.py
@@ -51,7 +51,7 @@ def sample_config(tmp_path: Path) -> VMConfig:
     return VMConfig(
         vm_id="vm001",
         vcpu_count=2,
-        mem_size_mib=512,
+        memory=512,
         kernel_path=kernel,
         rootfs_path=rootfs,
     )

--- a/ui/src/hooks/useSwarmData.js
+++ b/ui/src/hooks/useSwarmData.js
@@ -50,7 +50,7 @@ function mapVmToNode(vm) {
         sshHostPort: network.ssh_host_port ?? null,
         pid: vm.pid ?? null,
         vcpu: config.vcpu_count ?? 0,
-        memory: config.mem_size_mib ?? 0,
+        memory: config.memory ?? 0,
     }
 }
 


### PR DESCRIPTION
## Summary

Trims `smolvm create` to show only Name, Status, OS, and Started time, and points users at a new `smolvm info <vm>` command for the full details (Backend, IP, SSH Port, PID, CPUs, configured/used memory, disk size). For running VMs, info opportunistically SSHs in (5s timeout, silent on failure) to overlay live OS pretty-name and used memory; stopped VMs fall back to a filename-based OS hint. Also renames `VMConfig.mem_size_mib` → `VMConfig.memory` to match the public facade naming — no backwards-compat shim, so pre-existing VM records will fail to load.

## Related Issues

- Closes #

## Testing

- `uv run --extra dev pytest` — 642 passed, 13 skipped
- `uv run --extra dev ruff check .` — only pre-existing E501 errors, none introduced by this change
- `uv run --extra dev mypy src` — not run

## Checklist

- [x] Scope is focused and limited to this change
- [x] Tests added/updated for behavior changes
- [ ] Docs updated for user-visible changes
- [x] No secrets or sensitive data included

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a new "smolvm info" command to view VM details (status, OS, CPUs, memory, disk, PID) with optional JSON output and human-friendly table rendering.
  * Live VM info probing via SSH when instances are running.

* **Changes**
  * Memory field renamed to "memory" in APIs, CLI, dashboard and UIs.
  * Create output now includes VM start timestamp and a suggested "info" command.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->