### PR TITLE
refactor(cli): switch harness commands to NOUN-VERB

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,6 +13,18 @@ SmolVM is specifically designed to provide a secure "sandbox" for AI agents to e
 - **Testing:** `pytest` (runs the suite in `tests/`)
 - **Linting & Formatting:** `uv run ruff check .` or `uv run ruff format .`
 
+### CLI design
+
+- New CLI commands follow a **NOUN-VERB** structure: `smolvm <noun> <verb>`,
+  e.g. `smolvm codex start`, not `smolvm start codex`.
+- The noun names the resource (a sandbox, a harness, a browser session); the
+  verb names the action on it (`start`, `stop`, `ssh`).
+- This scales naturally as actions grow: `smolvm codex start`, then later
+  `smolvm codex logs`, `smolvm codex status`, etc.
+- When adding a new harness or resource, register it as a top-level
+  subcommand and put its actions underneath, instead of overloading a
+  global verb.
+
 ### Core writing principles
 - Follow progressive disclosure of complexity.
 - Lead with outcomes, not implementation details.

--- a/src/smolvm/cli/main.py
+++ b/src/smolvm/cli/main.py
@@ -107,7 +107,7 @@ class CreatePayload(TypedDict):
 
 
 class StartPresetPayload(TypedDict):
-    """Preset application summary for ``smolvm start``."""
+    """Preset application summary for ``smolvm <preset> start``."""
 
     name: str
     copied_configs: list[str]
@@ -115,7 +115,7 @@ class StartPresetPayload(TypedDict):
 
 
 class StartPayload(TypedDict):
-    """JSON payload for ``smolvm start``."""
+    """JSON payload for ``smolvm <preset> start``."""
 
     vm: CreateVmPayload
     preset: StartPresetPayload
@@ -311,37 +311,47 @@ def _add_boot_timeout_arg(command_parser: argparse.ArgumentParser) -> None:
     )
 
 
-def _add_start_parser(
+def _add_preset_parsers(
     subparsers: argparse._SubParsersAction[argparse.ArgumentParser],
 ) -> None:
-    """Wire ``smolvm start <preset>`` into the CLI."""
+    """Wire ``smolvm <preset> <action>`` into the CLI.
+
+    Each agent harness is a top-level subcommand (``smolvm codex``,
+    ``smolvm claude-code``) with its own action subcommands. This follows
+    the project's NOUN-VERB CLI convention so future harness actions
+    (``logs``, ``status``, etc.) compose naturally.
+    """
     from smolvm.presets import list_presets
 
-    start_parser = subparsers.add_parser(
-        "start",
-        help="Start a sandbox preconfigured for a specific agent harness.",
-        description=(
-            "Boot a fresh sandbox and preinstall an agent harness. Each "
-            "preset copies relevant host config (e.g. ~/.codex, ~/.claude) "
-            "and forwards API keys from the host environment."
-        ),
-    )
-    preset_sub = start_parser.add_subparsers(
-        dest="preset_name",
-        metavar="harness",
-    )
-
     for preset in list_presets():
-        p = preset_sub.add_parser(
+        preset_parser = subparsers.add_parser(
             preset.name,
             help=preset.summary,
+            description=preset.summary,
         )
-        p.add_argument(
+        action_sub = preset_parser.add_subparsers(
+            dest="preset_action",
+            metavar="ACTION",
+            required=True,
+        )
+
+        start_p = action_sub.add_parser(
+            "start",
+            help=f"Start a sandbox preconfigured for {preset.name}.",
+            description=(
+                f"Boot a fresh sandbox and preinstall {preset.name}. "
+                "Copies relevant host config (e.g. ~/.codex, ~/.claude) "
+                "and forwards API keys from the host environment."
+            ),
+        )
+        start_p.set_defaults(preset_name=preset.name)
+
+        start_p.add_argument(
             "-n",
             "--name",
             help="Name for the sandbox (default: auto-generated).",
         )
-        p.add_argument(
+        start_p.add_argument(
             "--memory",
             dest="memory_mib",
             type=int,
@@ -349,7 +359,7 @@ def _add_start_parser(
             metavar="MIB",
             help=f"Sandbox memory in MiB (default: {preset.default_mem_mib}).",
         )
-        p.add_argument(
+        start_p.add_argument(
             "--disk-size",
             dest="disk_size_mib",
             type=int,
@@ -357,13 +367,13 @@ def _add_start_parser(
             metavar="MIB",
             help=f"Sandbox disk size in MiB (default: {preset.default_disk_mib}).",
         )
-        p.add_argument(
+        start_p.add_argument(
             "--backend",
             choices=["auto", "firecracker", "qemu", "libkrun"],
             default=None,
             help="Virtualization backend (default: qemu, required by ubuntu).",
         )
-        p.add_argument(
+        start_p.add_argument(
             "--mount",
             action="append",
             default=None,
@@ -375,14 +385,14 @@ def _add_start_parser(
                 "Can be repeated."
             ),
         )
-        p.add_argument(
+        start_p.add_argument(
             "--install-timeout",
             type=_positive_float,
             default=600.0,
             help="Seconds to wait for the harness install (default: 600).",
         )
         if preset.launch_command is not None:
-            attach_group = p.add_mutually_exclusive_group()
+            attach_group = start_p.add_mutually_exclusive_group()
             attach_group.add_argument(
                 "--attach",
                 dest="attach",
@@ -399,12 +409,19 @@ def _add_start_parser(
                 action="store_false",
                 help="Skip the post-install attach prompt.",
             )
-        p.add_argument(
+        start_p.add_argument(
             "--json",
             action="store_true",
             help="Emit machine-readable JSON output.",
         )
-        _add_boot_timeout_arg(p)
+        _add_boot_timeout_arg(start_p)
+
+
+def _is_preset_command(args: argparse.Namespace) -> bool:
+    """Return True when ``args`` came from ``smolvm <preset> ...``."""
+    from smolvm.presets import preset_names
+
+    return args.command in preset_names()
 
 
 def build_parser() -> argparse.ArgumentParser:
@@ -664,7 +681,7 @@ def build_parser() -> argparse.ArgumentParser:
     )
     _add_boot_timeout_arg(create_parser)
 
-    _add_start_parser(subparsers)
+    _add_preset_parsers(subparsers)
 
     stop_parser = subparsers.add_parser(
         "stop",
@@ -1382,7 +1399,7 @@ def _run_create(args: argparse.Namespace) -> int:
 
 
 def _render_start_result(data: StartPayload) -> None:
-    """Render the human-facing ``smolvm start`` result."""
+    """Render the human-facing ``smolvm <preset> start`` result."""
     console = console_stdout()
     vm_data = data["vm"]
     preset = data["preset"]
@@ -1425,20 +1442,11 @@ def _render_start_result(data: StartPayload) -> None:
 
 
 def _run_start(args: argparse.Namespace) -> int:
-    """Handle ``smolvm start <preset>``."""
+    """Handle ``smolvm <preset> start``."""
     from smolvm.facade import SmolVM, _build_auto_config
     from smolvm.presets import apply_preset, get_preset
 
-    if not getattr(args, "preset_name", None):
-        # argparse leaves preset_name=None when invoked as bare ``smolvm start``.
-        # Print the start subparser help instead of failing silently.
-        build_parser().parse_args(["start", "--help"])
-        return 2
-
-    try:
-        preset = get_preset(args.preset_name)
-    except KeyError as exc:
-        return _emit_cli_error("start", 2, exc, json_output=args.json)
+    preset = get_preset(args.preset_name)
 
     backend = args.backend or "qemu"
     if backend != "qemu":
@@ -2494,7 +2502,7 @@ def main(argv: Sequence[str] | None = None) -> int:
     if args.command == "create":
         return _run_create(args)
 
-    if args.command == "start":
+    if _is_preset_command(args):
         return _run_start(args)
 
     if args.command == "stop":

--- a/src/smolvm/presets/__init__.py
+++ b/src/smolvm/presets/__init__.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Preconfigured agent-harness blueprints for ``smolvm start``.
+"""Preconfigured agent-harness blueprints for ``smolvm <harness> start``.
 
 A *preset* boots a fresh sandbox and layers on a specific agent
 harness — for example OpenAI's codex CLI or Anthropic's Claude Code —

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1837,7 +1837,7 @@ class TestCliList:
 
 
 class TestCliStart:
-    """Tests for `smolvm start <preset>`."""
+    """Tests for `smolvm <preset> start`."""
 
     def _make_vm_mock(self, vm_id: str = "sbx-codex") -> MagicMock:
         vm = MagicMock()
@@ -1849,25 +1849,32 @@ class TestCliStart:
         vm.info.network.ssh_host_port = 2200
         return vm
 
-    def test_start_help_lists_known_presets(
+    def test_top_level_help_lists_known_presets(
         self, capsys: pytest.CaptureFixture
     ) -> None:
-        """`smolvm start --help` should list every registered preset."""
+        """`smolvm --help` should list every registered preset as a top-level command."""
         with pytest.raises(SystemExit):
-            main(["start", "--help"])
+            main(["--help"])
         out = capsys.readouterr().out
         assert "codex" in out
         assert "claude-code" in out
 
-    def test_start_unknown_preset_errors(
+    def test_preset_help_lists_start_action(
         self, capsys: pytest.CaptureFixture
     ) -> None:
+        """`smolvm codex --help` should list the `start` action."""
+        with pytest.raises(SystemExit):
+            main(["codex", "--help"])
+        out = capsys.readouterr().out
+        assert "start" in out
+
+    def test_unknown_preset_errors(self, capsys: pytest.CaptureFixture) -> None:
         """An unknown preset name should fail at argparse-level."""
         with pytest.raises(SystemExit):
-            main(["start", "hermes"])
+            main(["hermes", "start"])
         err = capsys.readouterr().err
         # argparse produces "invalid choice" for unknown subcommand
-        assert "invalid choice" in err or "argument harness" in err
+        assert "invalid choice" in err or "argument command" in err
 
     @patch("smolvm.cli.main._apply_preset_with_progress")
     @patch("smolvm.facade._build_auto_config")
@@ -1879,7 +1886,7 @@ class TestCliStart:
         mock_apply: MagicMock,
         capsys: pytest.CaptureFixture,
     ) -> None:
-        """`smolvm start codex` boots ubuntu/qemu with preset defaults and applies the preset."""
+        """`smolvm codex start` boots ubuntu/qemu with preset defaults and applies the preset."""
         from smolvm.types import GuestOS
 
         config = MagicMock(vm_id="sbx-codex")
@@ -1892,7 +1899,7 @@ class TestCliStart:
             "injected_env_keys": ["OPENAI_API_KEY"],
         }
 
-        ret = main(["start", "codex", "--name", "sbx-codex"])
+        ret = main(["codex", "start", "--name", "sbx-codex"])
 
         assert ret == 0
         mock_build_auto_config.assert_called_once_with(
@@ -1926,7 +1933,7 @@ class TestCliStart:
         mock_apply_fn: MagicMock,
         capsys: pytest.CaptureFixture,
     ) -> None:
-        """`smolvm start codex --json` should emit the start envelope."""
+        """`smolvm codex start --json` should emit the start envelope."""
         config = MagicMock(vm_id="sbx-1")
         mock_build_auto_config.return_value = (config, "/tmp/id_ed25519")
         vm = self._make_vm_mock("sbx-1")
@@ -1937,7 +1944,7 @@ class TestCliStart:
             "injected_env_keys": ["OPENAI_API_KEY"],
         }
 
-        ret = main(["start", "codex", "--name", "sbx-1", "--json"])
+        ret = main(["codex", "start", "--name", "sbx-1", "--json"])
 
         assert ret == 0
         payload = json.loads(capsys.readouterr().out)
@@ -1969,7 +1976,7 @@ class TestCliStart:
             "injected_env_keys": [],
         }
 
-        ret = main(["start", "claude-code", "--memory", "4096", "--disk-size", "16384"])
+        ret = main(["claude-code", "start", "--memory", "4096", "--disk-size", "16384"])
 
         assert ret == 0
         kwargs = mock_build_auto_config.call_args.kwargs
@@ -1985,7 +1992,7 @@ class TestCliStart:
         capsys: pytest.CaptureFixture,
     ) -> None:
         """Built-in presets target ubuntu, which only boots on qemu."""
-        ret = main(["start", "codex", "--backend", "firecracker"])
+        ret = main(["codex", "start", "--backend", "firecracker"])
 
         assert ret == 2
         err = capsys.readouterr().err
@@ -2025,7 +2032,7 @@ class TestCliStart:
         completed.returncode = 0
         mock_subprocess_run.return_value = completed
 
-        ret = main(["start", "codex", "--attach"])
+        ret = main(["codex", "start", "--attach"])
 
         assert ret == 0
         mock_subprocess_run.assert_called_once()
@@ -2058,7 +2065,7 @@ class TestCliStart:
             "injected_env_keys": [],
         }
 
-        ret = main(["start", "codex", "--no-attach"])
+        ret = main(["codex", "start", "--no-attach"])
 
         assert ret == 0
         mock_subprocess_run.assert_not_called()
@@ -2095,7 +2102,7 @@ class TestCliStart:
         completed.returncode = 0
         mock_subprocess_run.return_value = completed
 
-        ret = main(["start", "codex"])
+        ret = main(["codex", "start"])
 
         assert ret == 0
         mock_input.assert_called_once()
@@ -2128,7 +2135,7 @@ class TestCliStart:
             "injected_env_keys": [],
         }
 
-        ret = main(["start", "codex"])
+        ret = main(["codex", "start"])
 
         assert ret == 0
         mock_input.assert_called_once()
@@ -2155,7 +2162,7 @@ class TestCliStart:
             "injected_env_keys": [],
         }
 
-        ret = main(["start", "codex", "--json"])
+        ret = main(["codex", "start", "--json"])
 
         assert ret == 0
         mock_subprocess_run.assert_not_called()


### PR DESCRIPTION
## Summary
- Promote each agent harness to a top-level subcommand: `smolvm codex start`, `smolvm claude-code start` (was `smolvm start <harness>`).
- Make the preset action subparser required, so bare `smolvm codex` errors via argparse instead of a manual help fallback.
- Document the NOUN-VERB convention in `AGENTS.md` so future CLI work composes new actions (`logs`, `status`, …) per harness instead of overloading a shared verb.

No backward compatibility shim — the old `smolvm start <harness>` form is removed.

## Test plan
- [x] `uv run pytest tests/test_cli.py tests/test_presets.py` — 129 passed
- [x] `uv run smolvm --help` lists `codex` and `claude-code` at the top level
- [x] `uv run smolvm codex --help` shows the `start` action
- [x] `uv run smolvm codex` exits 2 with `the following arguments are required: ACTION`
- [x] `uv run smolvm codex start --help` shows the same flags as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)