### PR TITLE
[codex] Repair Ubuntu workspace mounts

### DIFF
--- a/src/smolvm/facade.py
+++ b/src/smolvm/facade.py
@@ -752,9 +752,13 @@ class SmolVM:
         # (on the kwarg or the config) still get the SmolVMManager error if
         # their choice can't host mounts.
         wants_mounts = bool(mounts) or (config is not None and bool(config.workspace_mounts))
-        if backend is None and wants_mounts and vm_id is None:
-            if config is None or config.backend is None:
-                backend = BACKEND_QEMU
+        if (
+            backend is None
+            and wants_mounts
+            and vm_id is None
+            and (config is None or config.backend is None)
+        ):
+            backend = BACKEND_QEMU
 
         if image is not None:
             # S3 image mode
@@ -1102,7 +1106,8 @@ class SmolVM:
 
         if self._info.status != VMState.RUNNING:
             raise SmolVMError(
-                f"VM is not running. Start the VM using vm.start() before running commands (current state: {self._info.status.value})",
+                "VM is not running. Start the VM using vm.start() before "
+                f"running commands (current state: {self._info.status.value})",
                 {"vm_id": self._vm_id},
             )
         if not self.can_run_commands():
@@ -1194,7 +1199,8 @@ class SmolVM:
 
         if self._info.status != VMState.RUNNING:
             raise SmolVMError(
-                f"VM is not running. Start the VM using vm.start() before waiting for SSH (current state: {self._info.status.value})",
+                "VM is not running. Start the VM using vm.start() before "
+                f"waiting for SSH (current state: {self._info.status.value})",
                 {"vm_id": self._vm_id},
             )
         if self._info.network is None:
@@ -1820,6 +1826,8 @@ class SmolVM:
                 {"vm_id": self._vm_id, "ssh_user": self._ssh_user},
             )
 
+        self._ensure_9p_workspace_support()
+
         for index, ws in enumerate(workspace_mounts):
             tag = ws.resolved_tag(index)
             guest_path = shlex.quote(ws.guest_path)
@@ -1864,6 +1872,55 @@ class SmolVM:
                 tag,
                 ws.guest_path,
             )
+
+    def _ensure_9p_workspace_support(self) -> None:
+        """Best-effort repair for Ubuntu cloud images missing 9p modules."""
+        assert self._ssh is not None  # noqa: S101 — caller guarantees SSH ready
+
+        probe_script = (
+            "modprobe 9p 2>/dev/null && "
+            "modprobe 9pnet_virtio 2>/dev/null && "
+            "modprobe overlay 2>/dev/null"
+        )
+        probe = self._ssh.run(probe_script, timeout=15)
+        if probe.exit_code == 0:
+            return
+
+        install_script = r"""
+set -eu
+. /etc/os-release 2>/dev/null || ID=
+if [ "${ID:-}" != "ubuntu" ] || ! command -v apt-get >/dev/null 2>&1; then
+  exit 42
+fi
+export DEBIAN_FRONTEND=noninteractive
+apt-get update -qq
+apt-get install -y -qq "linux-modules-extra-$(uname -r)"
+modprobe 9p
+modprobe 9pnet_virtio
+modprobe overlay
+""".strip()
+        install = self._ssh.run(install_script, timeout=240)
+        if install.exit_code == 0:
+            logger.info(
+                "VM %s: installed Ubuntu linux-modules-extra for workspace mounts",
+                self._vm_id,
+            )
+            return
+
+        raise SmolVMError(
+            "Cannot mount workspaces: guest is missing 9p or overlay kernel support. "
+            "Ubuntu guests can usually be repaired by installing "
+            "linux-modules-extra-$(uname -r); this guest could not be repaired "
+            "automatically.",
+            {
+                "vm_id": self._vm_id,
+                "probe_exit_code": probe.exit_code,
+                "probe_stderr": probe.stderr.strip(),
+                "install_exit_code": install.exit_code,
+                "install_stdout": install.stdout.strip(),
+                "install_stderr": install.stderr.strip(),
+            },
+        )
 
     def _reset_runtime_state(self, *, close_ssh: bool = True) -> None:
         """Clear cached runtime connection state after lifecycle changes."""

--- a/src/smolvm/facade.py
+++ b/src/smolvm/facade.py
@@ -1893,8 +1893,18 @@ if [ "${ID:-}" != "ubuntu" ] || ! command -v apt-get >/dev/null 2>&1; then
   exit 42
 fi
 export DEBIAN_FRONTEND=noninteractive
-apt-get update -qq
-apt-get install -y -qq "linux-modules-extra-$(uname -r)"
+APT_LOCKS="/var/lib/dpkg/lock-frontend /var/lib/dpkg/lock /var/lib/apt/lists/lock"
+deadline=$(( $(date +%s) + 120 ))
+while command -v fuser >/dev/null 2>&1 && fuser $APT_LOCKS >/dev/null 2>&1; do
+  if [ "$(date +%s)" -ge "$deadline" ]; then
+    echo "Timed out waiting for apt/dpkg locks" >&2
+    exit 43
+  fi
+  sleep 2
+done
+APT_OPTS='-o DPkg::Lock::Timeout=120 -o Acquire::Retries=3'
+apt-get $APT_OPTS update -qq
+apt-get $APT_OPTS install -y -qq "linux-modules-extra-$(uname -r)"
 modprobe 9p
 modprobe 9pnet_virtio
 modprobe overlay

--- a/tests/test_workspace.py
+++ b/tests/test_workspace.py
@@ -21,7 +21,7 @@ import pytest
 from pydantic import ValidationError
 
 from smolvm.facade import SmolVM
-from smolvm.types import VMConfig, VMState, WorkspaceMount
+from smolvm.types import CommandResult, VMConfig, VMState, WorkspaceMount
 from smolvm.vm import SmolVMManager
 
 # ── WorkspaceMount validation ───────────────────────────────────────
@@ -475,3 +475,76 @@ class TestFacadeWorkspaceGuards:
                  patch.object(vm, "wait_for_ssh"), \
                  patch("smolvm.facade.SSHClient"):
                 vm.start()
+
+    def test_mount_workspaces_repairs_ubuntu_missing_9p_modules(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        """Ubuntu guests missing 9p modules should install linux-modules-extra."""
+        ws_dir = tmp_path / "project"
+        ws_dir.mkdir()
+        kernel = tmp_path / "vmlinux"
+        rootfs = tmp_path / "rootfs.ext4"
+        kernel.touch()
+        rootfs.touch()
+        config = VMConfig(
+            vm_id="vm-repair",
+            kernel_path=kernel,
+            rootfs_path=rootfs,
+            backend="qemu",
+            workspace_mounts=[WorkspaceMount(host_path=ws_dir)],
+        )
+
+        vm = object.__new__(SmolVM)
+        vm._vm_id = "vm-repair"
+        vm._ssh_user = "root"
+        vm._info = MagicMock(config=config)
+        vm._ssh = MagicMock()
+        vm._ssh.run.side_effect = [
+            CommandResult(exit_code=1, stdout="", stderr="modprobe: FATAL: Module 9p"),
+            CommandResult(exit_code=0, stdout="", stderr=""),
+            CommandResult(exit_code=0, stdout="", stderr=""),
+        ]
+
+        vm._mount_workspaces()
+
+        install_script = vm._ssh.run.call_args_list[1].args[0]
+        mount_script = vm._ssh.run.call_args_list[2].args[0]
+        assert "linux-modules-extra-$(uname -r)" in install_script
+        assert "mount -t 9p" in mount_script
+
+    def test_mount_workspaces_reports_unrepairable_missing_9p(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        """Non-Ubuntu or unrepairable guests should fail before the mount loop."""
+        from smolvm.exceptions import SmolVMError
+
+        ws_dir = tmp_path / "project"
+        ws_dir.mkdir()
+        kernel = tmp_path / "vmlinux"
+        rootfs = tmp_path / "rootfs.ext4"
+        kernel.touch()
+        rootfs.touch()
+        config = VMConfig(
+            vm_id="vm-unrepairable",
+            kernel_path=kernel,
+            rootfs_path=rootfs,
+            backend="qemu",
+            workspace_mounts=[WorkspaceMount(host_path=ws_dir)],
+        )
+
+        vm = object.__new__(SmolVM)
+        vm._vm_id = "vm-unrepairable"
+        vm._ssh_user = "root"
+        vm._info = MagicMock(config=config)
+        vm._ssh = MagicMock()
+        vm._ssh.run.side_effect = [
+            CommandResult(exit_code=1, stdout="", stderr="modprobe: FATAL: Module 9p"),
+            CommandResult(exit_code=42, stdout="", stderr="not ubuntu"),
+        ]
+
+        with pytest.raises(SmolVMError, match="missing 9p or overlay"):
+            vm._mount_workspaces()
+
+        assert vm._ssh.run.call_count == 2

--- a/tests/test_workspace.py
+++ b/tests/test_workspace.py
@@ -510,6 +510,9 @@ class TestFacadeWorkspaceGuards:
 
         install_script = vm._ssh.run.call_args_list[1].args[0]
         mount_script = vm._ssh.run.call_args_list[2].args[0]
+        assert "DPkg::Lock::Timeout=120" in install_script
+        assert "Acquire::Retries=3" in install_script
+        assert "fuser $APT_LOCKS" in install_script
         assert "linux-modules-extra-$(uname -r)" in install_script
         assert "mount -t 9p" in mount_script
 


### PR DESCRIPTION
## Summary

Repair Ubuntu workspace mounts by probing guest 9p/overlay support before mounting and installing the matching `linux-modules-extra-$(uname -r)` package when Ubuntu cloud images are missing 9p modules.

## Related Issues

- None

## Testing

- `uv run --extra dev pytest tests/test_workspace.py`
- `uv run --extra dev ruff check src/smolvm/facade.py tests/test_workspace.py`
- `uv run smolvm create --name debug-real-mount-1947 --os ubuntu --mount ./ --json --boot-timeout 120`

## Checklist

- [x] Scope is focused and limited to this change
- [x] Tests added/updated for behavior changes
- [ ] Docs updated for user-visible changes
- [x] No secrets or sensitive data included


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Workspace mounting now includes kernel module availability checks and automatic repair capabilities on Ubuntu systems.

* **Bug Fixes**
  * Enhanced error messages for workspace mount failures with improved diagnostic details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->