### PR TITLE
Recover gracefully from stale workspace mounts

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -42,18 +42,23 @@ Error and warning messages are UX, not stack traces. The reader may
 be a first-time user with no idea how SmolVM works internally — they
 must still be able to act on the message. Every user-facing message
 (CLI output, panels, JSON `error` payloads, JSON `warnings` entries)
-must answer three questions:
+should:
 
-- **What happened?** In plain English. Avoid internal vocabulary
+- **State the fact in plain English.** Avoid internal vocabulary
   ("mount", "host", "tap device", "validator") even when those words
   appear in flag names — the user did not necessarily set the flag.
-- **Why does it matter?** What can the user no longer do? Make sure
-  the consequence is **true in every state the message can fire in**.
-  A warning that says "the sandbox cannot start" is wrong when shown
-  on a running sandbox the user just SSH'd into. Branch the wording
-  on state if the consequence differs.
-- **How do they recover?** Include the exact recovery command, with
-  the actual sandbox name interpolated, not a placeholder.
+- **Name the recovery.** Include the exact recovery command, with the
+  actual sandbox name interpolated, not a placeholder.
+- **Stay short.** One sentence is the goal; two if you must. If you
+  reach for a third sentence, you are probably explaining a
+  consequence that is either false in some state or not actionable —
+  cut it.
+- **Skip consequences you cannot guarantee.** A warning that says
+  "the sandbox cannot start" is wrong if the sandbox is currently
+  running. Saying "won't be able to restart once stopped" is true but
+  irrelevant when the user may not plan to restart anyway. Prefer
+  phrasing that is true regardless of state and let the user judge
+  the impact.
 
 The same rule applies to JSON consumers — agents benefit from the
 same self-contained context. Don't split the message across the human
@@ -65,8 +70,9 @@ output and a separate hint that JSON callers will not see.
 workspace mount missing on host: /Users/aniket/conductor/workspaces/SmolVM/lome
 ```
 
-**Bad** — plain language, but the consequence is false for a running
-sandbox the user can already SSH into:
+**Bad** — plain language, but too long and makes a state-dependent
+claim ("cannot start") that is false for a sandbox the user can SSH
+into right now:
 
 ```
 This sandbox was set up to share the folder '...' with you, but that
@@ -75,14 +81,10 @@ until you put the folder back, or delete the sandbox with
 'smolvm delete sbx-einstein'.
 ```
 
-**Good** — plain English, factual for the sandbox's actual state,
-names the recovery:
+**Good** — one sentence, true in every state, names the recovery:
 
 ```
-This sandbox shares the folder
-'/Users/aniket/conductor/workspaces/SmolVM/lome' from your machine,
-but that folder no longer exists. The sandbox is still running and
-can be used, but it will not be able to start again once stopped.
-Restore the folder, or delete the sandbox with
-'smolvm delete sbx-einstein' when you're done with it.
+Shared folder is missing on your machine:
+'/Users/aniket/conductor/workspaces/SmolVM/lome'. Restore it, or run
+'smolvm delete sbx-einstein' to remove the sandbox.
 ```

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -47,8 +47,11 @@ must answer three questions:
 - **What happened?** In plain English. Avoid internal vocabulary
   ("mount", "host", "tap device", "validator") even when those words
   appear in flag names — the user did not necessarily set the flag.
-- **Why does it matter?** What can the user no longer do? ("This
-  sandbox cannot start.")
+- **Why does it matter?** What can the user no longer do? Make sure
+  the consequence is **true in every state the message can fire in**.
+  A warning that says "the sandbox cannot start" is wrong when shown
+  on a running sandbox the user just SSH'd into. Branch the wording
+  on state if the consequence differs.
 - **How do they recover?** Include the exact recovery command, with
   the actual sandbox name interpolated, not a placeholder.
 
@@ -62,12 +65,24 @@ output and a separate hint that JSON callers will not see.
 workspace mount missing on host: /Users/aniket/conductor/workspaces/SmolVM/lome
 ```
 
-**Good** — plain English, names what to do:
+**Bad** — plain language, but the consequence is false for a running
+sandbox the user can already SSH into:
 
 ```
-This sandbox was set up to share the folder
-'/Users/aniket/conductor/workspaces/SmolVM/lome' with you, but that
+This sandbox was set up to share the folder '...' with you, but that
 folder no longer exists on your machine. The sandbox cannot start
 until you put the folder back, or delete the sandbox with
 'smolvm delete sbx-einstein'.
+```
+
+**Good** — plain English, factual for the sandbox's actual state,
+names the recovery:
+
+```
+This sandbox shares the folder
+'/Users/aniket/conductor/workspaces/SmolVM/lome' from your machine,
+but that folder no longer exists. The sandbox is still running and
+can be used, but it will not be able to start again once stopped.
+Restore the folder, or delete the sandbox with
+'smolvm delete sbx-einstein' when you're done with it.
 ```

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -35,3 +35,39 @@ SmolVM is specifically designed to provide a secure "sandbox" for AI agents to e
 - Do not introduce a new concept unless the page truly needs it.
 - If you must use a technical term, explain it immediately in simple language.
 - Prefer short, concrete sentences over dense explanations.
+
+### User-facing errors and warnings
+
+Error and warning messages are UX, not stack traces. The reader may
+be a first-time user with no idea how SmolVM works internally — they
+must still be able to act on the message. Every user-facing message
+(CLI output, panels, JSON `error` payloads, JSON `warnings` entries)
+must answer three questions:
+
+- **What happened?** In plain English. Avoid internal vocabulary
+  ("mount", "host", "tap device", "validator") even when those words
+  appear in flag names — the user did not necessarily set the flag.
+- **Why does it matter?** What can the user no longer do? ("This
+  sandbox cannot start.")
+- **How do they recover?** Include the exact recovery command, with
+  the actual sandbox name interpolated, not a placeholder.
+
+The same rule applies to JSON consumers — agents benefit from the
+same self-contained context. Don't split the message across the human
+output and a separate hint that JSON callers will not see.
+
+**Bad** — internal vocabulary, no recovery path:
+
+```
+workspace mount missing on host: /Users/aniket/conductor/workspaces/SmolVM/lome
+```
+
+**Good** — plain English, names what to do:
+
+```
+This sandbox was set up to share the folder
+'/Users/aniket/conductor/workspaces/SmolVM/lome' with you, but that
+folder no longer exists on your machine. The sandbox cannot start
+until you put the folder back, or delete the sandbox with
+'smolvm delete sbx-einstein'.
+```

--- a/src/smolvm/cli/main.py
+++ b/src/smolvm/cli/main.py
@@ -68,6 +68,7 @@ class VmRow(TypedDict):
     pid: int | None
     ip_address: str | None
     ssh_port: int | None
+    warnings: list[str]
 
 
 class ListFiltersPayload(TypedDict):
@@ -1097,6 +1098,20 @@ def _emit_cli_error(
     return exit_code
 
 
+def _vm_warnings(vm: VMInfo) -> list[str]:
+    """Collect human-facing warnings about a VM's persisted config.
+
+    Today this only covers stale workspace-mount host paths — the host
+    folder a VM was created against has been moved or deleted, so the VM
+    cannot start until the user repairs the mount or restores the path.
+    """
+    warnings: list[str] = []
+    for mount in vm.config.workspace_mounts:
+        if not mount.host_path.exists():
+            warnings.append(f"workspace mount missing on host: {mount.host_path}")
+    return warnings
+
+
 def _vm_rows(vms: Sequence[VMInfo]) -> list[VmRow]:
     """Normalize VM info objects into CLI list rows."""
     rows: list[VmRow] = []
@@ -1109,6 +1124,7 @@ def _vm_rows(vms: Sequence[VMInfo]) -> list[VmRow]:
                 "pid": vm.pid,
                 "ip_address": network.guest_ip if network else None,
                 "ssh_port": network.ssh_host_port if network else None,
+                "warnings": _vm_warnings(vm),
             }
         )
     return rows
@@ -1121,8 +1137,11 @@ def _render_list(rows: list[VmRow]) -> None:
     table.add_column("Status")
     table.add_column("PID", justify="right")
     for row in rows:
+        name = str(row["name"])
+        if row["warnings"]:
+            name = f"⚠ {name}"
         table.add_row(
-            str(row["name"]),
+            name,
             Text(str(row["status"]), style=status_style(str(row["status"]))),
             str(row["pid"] or "-"),
         )
@@ -1130,6 +1149,15 @@ def _render_list(rows: list[VmRow]) -> None:
     console = console_stdout()
     console.print(table)
     console.print(f"Total: {len(rows)} VM(s).")
+
+    flagged = [row for row in rows if row["warnings"]]
+    if flagged:
+        console.print()
+        console.print(Text("Warnings:", style="bold yellow"))
+        for row in flagged:
+            console.print(f"  {row['name']}:")
+            for warning in row["warnings"]:
+                console.print(f"    • {warning}")
 
 
 def _run_setup(parser: argparse.ArgumentParser, args: argparse.Namespace) -> int:

--- a/src/smolvm/cli/main.py
+++ b/src/smolvm/cli/main.py
@@ -1101,21 +1101,33 @@ def _emit_cli_error(
 def _vm_warnings(vm: VMInfo) -> list[str]:
     """Collect human-facing warnings about a VM's persisted config.
 
-    Today this only covers stale workspace-mount host paths — the folder
-    a VM was created to share has been moved or deleted, so the VM
-    cannot start until the user restores the folder or deletes the VM.
-    Messages are full sentences so JSON consumers (agents) get the same
-    self-contained context the CLI shows.
+    Today this only covers stale workspace-mount host paths. The wording
+    is state-aware: a sandbox that was already running when the host
+    folder vanished keeps running (you can still ssh in), but it will
+    not survive a stop+start cycle — so we say so, instead of falsely
+    claiming the sandbox cannot start. Messages are full sentences so
+    JSON consumers (agents) get the same self-contained context.
     """
     warnings: list[str] = []
+    is_live = vm.status in (VMState.RUNNING, VMState.PAUSED)
     for mount in vm.config.workspace_mounts:
-        if not mount.host_path.exists():
+        if mount.host_path.exists():
+            continue
+        if is_live:
             warnings.append(
-                f"This sandbox was set up to share the folder "
-                f"'{mount.host_path}' with you, but that folder no longer "
-                f"exists on your machine. The sandbox cannot start until "
-                f"you put the folder back, or delete the sandbox with "
-                f"'smolvm delete {vm.vm_id}'."
+                f"This sandbox shares the folder '{mount.host_path}' from "
+                "your machine, but that folder no longer exists. The "
+                "sandbox is still running and can be used, but it will "
+                "not be able to start again once stopped. Restore the "
+                f"folder, or delete the sandbox with 'smolvm delete "
+                f"{vm.vm_id}' when you're done with it."
+            )
+        else:
+            warnings.append(
+                f"This sandbox shares the folder '{mount.host_path}' from "
+                "your machine, but that folder no longer exists. The "
+                "sandbox cannot start until you put the folder back, or "
+                f"delete the sandbox with 'smolvm delete {vm.vm_id}'."
             )
     return warnings
 

--- a/src/smolvm/cli/main.py
+++ b/src/smolvm/cli/main.py
@@ -1101,14 +1101,22 @@ def _emit_cli_error(
 def _vm_warnings(vm: VMInfo) -> list[str]:
     """Collect human-facing warnings about a VM's persisted config.
 
-    Today this only covers stale workspace-mount host paths — the host
-    folder a VM was created against has been moved or deleted, so the VM
-    cannot start until the user repairs the mount or restores the path.
+    Today this only covers stale workspace-mount host paths — the folder
+    a VM was created to share has been moved or deleted, so the VM
+    cannot start until the user restores the folder or deletes the VM.
+    Messages are full sentences so JSON consumers (agents) get the same
+    self-contained context the CLI shows.
     """
     warnings: list[str] = []
     for mount in vm.config.workspace_mounts:
         if not mount.host_path.exists():
-            warnings.append(f"workspace mount missing on host: {mount.host_path}")
+            warnings.append(
+                f"This sandbox was set up to share the folder "
+                f"'{mount.host_path}' with you, but that folder no longer "
+                f"exists on your machine. The sandbox cannot start until "
+                f"you put the folder back, or delete the sandbox with "
+                f"'smolvm delete {vm.vm_id}'."
+            )
     return warnings
 
 
@@ -1155,9 +1163,8 @@ def _render_list(rows: list[VmRow]) -> None:
         console.print()
         console.print(Text("Warnings:", style="bold yellow"))
         for row in flagged:
-            console.print(f"  {row['name']}:")
             for warning in row["warnings"]:
-                console.print(f"    • {warning}")
+                console.print(f"  • {warning}")
 
 
 def _run_setup(parser: argparse.ArgumentParser, args: argparse.Namespace) -> int:

--- a/src/smolvm/cli/main.py
+++ b/src/smolvm/cli/main.py
@@ -1101,33 +1101,19 @@ def _emit_cli_error(
 def _vm_warnings(vm: VMInfo) -> list[str]:
     """Collect human-facing warnings about a VM's persisted config.
 
-    Today this only covers stale workspace-mount host paths. The wording
-    is state-aware: a sandbox that was already running when the host
-    folder vanished keeps running (you can still ssh in), but it will
-    not survive a stop+start cycle — so we say so, instead of falsely
-    claiming the sandbox cannot start. Messages are full sentences so
-    JSON consumers (agents) get the same self-contained context.
+    Today this only covers stale workspace-mount host paths. The
+    message is one short sentence that names the missing folder and
+    the recovery commands; it deliberately makes no claim about
+    consequences (e.g. "cannot restart") because those are either
+    false (running sandbox) or irrelevant to the user's intent.
     """
     warnings: list[str] = []
-    is_live = vm.status in (VMState.RUNNING, VMState.PAUSED)
     for mount in vm.config.workspace_mounts:
-        if mount.host_path.exists():
-            continue
-        if is_live:
+        if not mount.host_path.exists():
             warnings.append(
-                f"This sandbox shares the folder '{mount.host_path}' from "
-                "your machine, but that folder no longer exists. The "
-                "sandbox is still running and can be used, but it will "
-                "not be able to start again once stopped. Restore the "
-                f"folder, or delete the sandbox with 'smolvm delete "
-                f"{vm.vm_id}' when you're done with it."
-            )
-        else:
-            warnings.append(
-                f"This sandbox shares the folder '{mount.host_path}' from "
-                "your machine, but that folder no longer exists. The "
-                "sandbox cannot start until you put the folder back, or "
-                f"delete the sandbox with 'smolvm delete {vm.vm_id}'."
+                f"Shared folder is missing on your machine: "
+                f"'{mount.host_path}'. Restore it, or run "
+                f"'smolvm delete {vm.vm_id}' to remove the sandbox."
             )
     return warnings
 

--- a/src/smolvm/types.py
+++ b/src/smolvm/types.py
@@ -72,6 +72,17 @@ def _generate_snapshot_id() -> str:
 _IDENTIFIER_PATTERN = r"^[a-z0-9][a-z0-9_-]{0,62}[a-z0-9]$|^[a-z0-9]$"
 
 
+def _should_validate_paths(info: ValidationInfo) -> bool:
+    """Return whether path-existence checks should run for this validation.
+
+    Storage reads (``vm_config_from_json``) pass ``validate_paths=False`` in
+    the validation context so a stale or missing host path on disk does not
+    blow up read-only commands like ``smolvm list``. Defaults to ``True`` so
+    direct construction (creates, tests) keeps its safety net.
+    """
+    return bool((info.context or {}).get("validate_paths", True))
+
+
 class BrowserViewport(BaseModel):
     """Viewport settings for browser sessions."""
 
@@ -131,9 +142,17 @@ class WorkspaceMount(BaseModel):
 
     @field_validator("host_path")
     @classmethod
-    def validate_host_path(cls, v: Path) -> Path:
-        """Ensure the host path exists and is a directory."""
+    def validate_host_path(cls, v: Path, info: ValidationInfo) -> Path:
+        """Ensure the host path exists and is a directory.
+
+        Existence and directory checks are skipped when the validation
+        context has ``validate_paths=False`` so persisted configs with
+        stale mount paths still load (read-only commands surface them as
+        warnings instead of crashing).
+        """
         v = v.resolve()
+        if not _should_validate_paths(info):
+            return v
         if not v.exists():
             raise ValueError(f"Workspace path does not exist: {v}")
         if not v.is_dir():
@@ -319,7 +338,7 @@ class VMConfig(BaseModel):
         """Ensure paths exist on the filesystem."""
         if v is None:
             return None
-        if not cls._should_validate_paths(info):
+        if not _should_validate_paths(info):
             return v
         return cls._validate_file_path(v)
 
@@ -354,7 +373,7 @@ class VMConfig(BaseModel):
         """Ensure optional paths exist on the filesystem."""
         if v is None:
             return None
-        if not cls._should_validate_paths(info):
+        if not _should_validate_paths(info):
             return v
         return cls._validate_file_path(v)
 
@@ -362,7 +381,7 @@ class VMConfig(BaseModel):
     @classmethod
     def validate_extra_drives(cls, v: list[Path], info: ValidationInfo) -> list[Path]:
         """Ensure all extra drive paths exist and are files."""
-        if not cls._should_validate_paths(info):
+        if not _should_validate_paths(info):
             return v
         for path in v:
             cls._validate_file_path(path)
@@ -376,11 +395,6 @@ class VMConfig(BaseModel):
         if not v.is_file():
             raise ValueError(f"Path is not a file: {v}")
         return v
-
-    @staticmethod
-    def _should_validate_paths(info: ValidationInfo) -> bool:
-        """Allow storage reads to skip filesystem existence checks."""
-        return bool((info.context or {}).get("validate_paths", True))
 
     @field_validator("env_vars")
     @classmethod

--- a/src/smolvm/vm.py
+++ b/src/smolvm/vm.py
@@ -944,9 +944,10 @@ class SmolVMManager:
         if missing_mounts:
             paths = ", ".join(str(m.host_path) for m in missing_mounts)
             raise SmolVMError(
-                f"Cannot start VM '{vm_id}': workspace mount path missing on host: {paths}. "
-                "Restore the folder, or delete this VM with "
-                f"'smolvm delete {vm_id}' and recreate it.",
+                f"Cannot start sandbox '{vm_id}': it was set up to share a "
+                f"folder from your machine that no longer exists ({paths}). "
+                "Put the folder back, or delete the sandbox with "
+                f"'smolvm delete {vm_id}' and create a new one.",
                 {
                     "vm_id": vm_id,
                     "missing_mounts": [str(m.host_path) for m in missing_mounts],

--- a/src/smolvm/vm.py
+++ b/src/smolvm/vm.py
@@ -938,6 +938,21 @@ class SmolVMManager:
                 {"vm_id": vm_id},
             )
 
+        missing_mounts = [
+            mount for mount in vm_info.config.workspace_mounts if not mount.host_path.exists()
+        ]
+        if missing_mounts:
+            paths = ", ".join(str(m.host_path) for m in missing_mounts)
+            raise SmolVMError(
+                f"Cannot start VM '{vm_id}': workspace mount path missing on host: {paths}. "
+                "Restore the folder, or delete this VM with "
+                f"'smolvm delete {vm_id}' and recreate it.",
+                {
+                    "vm_id": vm_id,
+                    "missing_mounts": [str(m.host_path) for m in missing_mounts],
+                },
+            )
+
         backend = self._backend_for_vm(vm_info)
         log_path = self.data_dir / f"{vm_id}.log"
         adapter = self._runtime_adapter_for_backend(backend)

--- a/src/smolvm/vm.py
+++ b/src/smolvm/vm.py
@@ -944,10 +944,8 @@ class SmolVMManager:
         if missing_mounts:
             paths = ", ".join(str(m.host_path) for m in missing_mounts)
             raise SmolVMError(
-                f"Cannot start sandbox '{vm_id}': it was set up to share a "
-                f"folder from your machine that no longer exists ({paths}). "
-                "Put the folder back, or delete the sandbox with "
-                f"'smolvm delete {vm_id}' and create a new one.",
+                f"Cannot start sandbox '{vm_id}': shared folder is missing: "
+                f"{paths}. Restore it, or run 'smolvm delete {vm_id}'.",
                 {
                     "vm_id": vm_id,
                     "missing_mounts": [str(m.host_path) for m in missing_mounts],

--- a/src/smolvm/vm.py
+++ b/src/smolvm/vm.py
@@ -531,6 +531,34 @@ class SmolVMManager:
             return None
         return expected
 
+    def _check_workspace_mounts(self, vm_info: VMInfo) -> None:
+        """Verify each workspace mount's host folder is still usable.
+
+        The Pydantic validator on ``WorkspaceMount.host_path`` runs at
+        create time, but storage reads pass ``validate_paths=False`` so a
+        config can reach start time after its host folder was deleted or
+        replaced. Catch both cases here (missing path, or path that's no
+        longer a directory) and raise a single friendly error, instead of
+        letting QEMU fail later with a host-side message a first-time user
+        cannot interpret.
+        """
+        bad_paths = [
+            mount.host_path
+            for mount in vm_info.config.workspace_mounts
+            if not (mount.host_path.exists() and mount.host_path.is_dir())
+        ]
+        if not bad_paths:
+            return
+        paths = ", ".join(str(p) for p in bad_paths)
+        raise SmolVMError(
+            f"Cannot start sandbox '{vm_info.vm_id}': shared folder is missing: "
+            f"{paths}. Restore it, or run 'smolvm delete {vm_info.vm_id}'.",
+            {
+                "vm_id": vm_info.vm_id,
+                "missing_mounts": [str(p) for p in bad_paths],
+            },
+        )
+
     def _ensure_snapshot_supported(self, vm_info: VMInfo) -> None:
         """Validate whether snapshot operations are supported for a VM."""
         if vm_info.config.disk_mode != "isolated":
@@ -938,19 +966,7 @@ class SmolVMManager:
                 {"vm_id": vm_id},
             )
 
-        missing_mounts = [
-            mount for mount in vm_info.config.workspace_mounts if not mount.host_path.exists()
-        ]
-        if missing_mounts:
-            paths = ", ".join(str(m.host_path) for m in missing_mounts)
-            raise SmolVMError(
-                f"Cannot start sandbox '{vm_id}': shared folder is missing: "
-                f"{paths}. Restore it, or run 'smolvm delete {vm_id}'.",
-                {
-                    "vm_id": vm_id,
-                    "missing_mounts": [str(m.host_path) for m in missing_mounts],
-                },
-            )
+        self._check_workspace_mounts(vm_info)
 
         backend = self._backend_for_vm(vm_info)
         log_path = self.data_dir / f"{vm_id}.log"
@@ -2138,6 +2154,8 @@ class SmolVMManager:
 
         if vm_info.network is None:
             raise SmolVMError("VM has no network configuration", {"vm_id": vm_id})
+
+        self._check_workspace_mounts(vm_info)
 
         backend = self._backend_for_vm(vm_info)
         log_path = self.data_dir / f"{vm_id}.log"

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1876,6 +1876,8 @@ class TestCliList:
         assert "vm-abc123" in out
         assert "Warnings:" in out
         assert str(missing) in out
+        # The warning explains what to do, not just what's wrong.
+        assert "smolvm delete vm-abc123" in out
 
     def test_list_json_includes_warnings(
         self,
@@ -1902,9 +1904,13 @@ class TestCliList:
 
         assert ret == 0
         payload = json.loads(capsys.readouterr().out)
-        assert payload["data"]["vms"][0]["warnings"] == [
-            f"workspace mount missing on host: {missing}"
-        ]
+        warnings = payload["data"]["vms"][0]["warnings"]
+        assert len(warnings) == 1
+        # JSON consumers (agents) get the same self-contained message:
+        # what's wrong, the missing path, and how to recover.
+        assert str(missing) in warnings[0]
+        assert "no longer exists" in warnings[0]
+        assert "smolvm delete vm-abc123" in warnings[0]
 
 
 class TestCliInfo:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1879,6 +1879,51 @@ class TestCliList:
         # The warning explains what to do, not just what's wrong.
         assert "smolvm delete vm-abc123" in out
 
+    def test_list_warning_is_state_aware(
+        self,
+        mock_sdk_cls: MagicMock,
+        capsys: pytest.CaptureFixture,
+        tmp_path: Path,
+    ) -> None:
+        """A running sandbox keeps working when its host folder vanishes;
+        the warning must say so instead of falsely claiming it can't start.
+        A stopped sandbox does block on the missing folder, so the wording
+        differs."""
+        missing = tmp_path / "deleted-worktree"
+        mount = MagicMock()
+        mount.host_path = missing
+        mock_sdk_cls.return_value.list_vms.return_value = [
+            _make_vm_info(
+                "sbx-running",
+                VMState.RUNNING,
+                "172.16.0.2",
+                2200,
+                12345,
+                workspace_mounts=[mount],
+            ),
+            _make_vm_info(
+                "sbx-stopped",
+                VMState.STOPPED,
+                "172.16.0.3",
+                None,
+                None,
+                workspace_mounts=[mount],
+            ),
+        ]
+
+        ret = main(["list", "--all", "--json"])
+
+        assert ret == 0
+        payload = json.loads(capsys.readouterr().out)
+        running_warning = payload["data"]["vms"][0]["warnings"][0]
+        stopped_warning = payload["data"]["vms"][1]["warnings"][0]
+
+        assert "still running" in running_warning
+        assert "once stopped" in running_warning
+        assert "cannot start" not in running_warning  # the bug we fixed
+
+        assert "cannot start" in stopped_warning
+
     def test_list_json_includes_warnings(
         self,
         mock_sdk_cls: MagicMock,

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -28,7 +28,7 @@ from smolvm.cli.main import (
     build_parser,
     main,
 )
-from smolvm.types import BrowserSessionState, NetworkConfig, VMState
+from smolvm.types import BrowserSessionState, NetworkConfig, VMState, WorkspaceMount
 
 
 def _make_vm_info(
@@ -37,7 +37,7 @@ def _make_vm_info(
     guest_ip: str = "172.16.0.2",
     ssh_host_port: int | None = 2200,
     pid: int | None = 12345,
-    workspace_mounts: list[object] | None = None,
+    workspace_mounts: list[WorkspaceMount] | None = None,
 ) -> MagicMock:
     """Build a lightweight VMInfo-like mock for list tests."""
     vm = MagicMock()
@@ -52,6 +52,28 @@ def _make_vm_info(
     else:
         vm.network = None
     return vm
+
+
+def _make_vm_with_stale_mount(
+    tmp_path: Path,
+    *,
+    vm_id: str = "vm-abc123",
+    status: VMState = VMState.RUNNING,
+) -> tuple[MagicMock, Path]:
+    """Build a VMInfo mock whose workspace mount points at a now-deleted folder.
+
+    The mount is a real ``WorkspaceMount`` (not a loose ``MagicMock()``) so
+    if ``WorkspaceMount`` ever renames its public attributes, these tests
+    fail loudly instead of silently spoofing the API.
+
+    Returns ``(vm_info_mock, missing_host_path)``.
+    """
+    ws_dir = tmp_path / f"{vm_id}-deleted-worktree"
+    ws_dir.mkdir()
+    mount = WorkspaceMount(host_path=ws_dir)
+    ws_dir.rmdir()
+    vm = _make_vm_info(vm_id, status, workspace_mounts=[mount])
+    return vm, mount.host_path
 
 
 def _make_snapshot_info(
@@ -1853,20 +1875,8 @@ class TestCliList:
     ) -> None:
         """`smolvm list` should keep listing VMs whose host mount is gone,
         and print a warning naming the missing path."""
-        missing = tmp_path / "deleted-worktree"
-        mount = MagicMock()
-        mount.host_path = missing
-        vms = [
-            _make_vm_info(
-                "vm-abc123",
-                VMState.RUNNING,
-                "172.16.0.2",
-                2200,
-                12345,
-                workspace_mounts=[mount],
-            ),
-        ]
-        mock_sdk_cls.return_value.list_vms.return_value = vms
+        vm, missing = _make_vm_with_stale_mount(tmp_path)
+        mock_sdk_cls.return_value.list_vms.return_value = [vm]
 
         ret = main(["list"])
 
@@ -1892,19 +1902,8 @@ class TestCliList:
         they're seeing. The chosen wording sidesteps the consequence
         entirely and just states the fact + the recovery.
         """
-        missing = tmp_path / "deleted-worktree"
-        mount = MagicMock()
-        mount.host_path = missing
-        mock_sdk_cls.return_value.list_vms.return_value = [
-            _make_vm_info(
-                "sbx-running",
-                VMState.RUNNING,
-                "172.16.0.2",
-                2200,
-                12345,
-                workspace_mounts=[mount],
-            ),
-        ]
+        vm, _ = _make_vm_with_stale_mount(tmp_path, vm_id="sbx-running")
+        mock_sdk_cls.return_value.list_vms.return_value = [vm]
 
         ret = main(["list", "--json"])
 
@@ -1920,19 +1919,8 @@ class TestCliList:
         tmp_path: Path,
     ) -> None:
         """`smolvm list --json` should expose stale mounts via `warnings`."""
-        missing = tmp_path / "deleted-worktree"
-        mount = MagicMock()
-        mount.host_path = missing
-        mock_sdk_cls.return_value.list_vms.return_value = [
-            _make_vm_info(
-                "vm-abc123",
-                VMState.RUNNING,
-                "172.16.0.2",
-                2200,
-                12345,
-                workspace_mounts=[mount],
-            ),
-        ]
+        vm, missing = _make_vm_with_stale_mount(tmp_path)
+        mock_sdk_cls.return_value.list_vms.return_value = [vm]
 
         ret = main(["list", "--json"])
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1879,16 +1879,19 @@ class TestCliList:
         # The warning explains what to do, not just what's wrong.
         assert "smolvm delete vm-abc123" in out
 
-    def test_list_warning_is_state_aware(
+    def test_list_warning_does_not_claim_running_sandbox_cannot_start(
         self,
         mock_sdk_cls: MagicMock,
         capsys: pytest.CaptureFixture,
         tmp_path: Path,
     ) -> None:
-        """A running sandbox keeps working when its host folder vanishes;
-        the warning must say so instead of falsely claiming it can't start.
-        A stopped sandbox does block on the missing folder, so the wording
-        differs."""
+        """The warning must not falsely claim a running sandbox can't start.
+
+        The user can SSH into a sandbox that was already running when its
+        host folder got deleted — saying 'cannot start' contradicts what
+        they're seeing. The chosen wording sidesteps the consequence
+        entirely and just states the fact + the recovery.
+        """
         missing = tmp_path / "deleted-worktree"
         mount = MagicMock()
         mount.host_path = missing
@@ -1901,28 +1904,14 @@ class TestCliList:
                 12345,
                 workspace_mounts=[mount],
             ),
-            _make_vm_info(
-                "sbx-stopped",
-                VMState.STOPPED,
-                "172.16.0.3",
-                None,
-                None,
-                workspace_mounts=[mount],
-            ),
         ]
 
-        ret = main(["list", "--all", "--json"])
+        ret = main(["list", "--json"])
 
         assert ret == 0
         payload = json.loads(capsys.readouterr().out)
-        running_warning = payload["data"]["vms"][0]["warnings"][0]
-        stopped_warning = payload["data"]["vms"][1]["warnings"][0]
-
-        assert "still running" in running_warning
-        assert "once stopped" in running_warning
-        assert "cannot start" not in running_warning  # the bug we fixed
-
-        assert "cannot start" in stopped_warning
+        warning = payload["data"]["vms"][0]["warnings"][0]
+        assert "cannot start" not in warning.lower()
 
     def test_list_json_includes_warnings(
         self,
@@ -1954,7 +1943,7 @@ class TestCliList:
         # JSON consumers (agents) get the same self-contained message:
         # what's wrong, the missing path, and how to recover.
         assert str(missing) in warnings[0]
-        assert "no longer exists" in warnings[0]
+        assert "missing" in warnings[0]
         assert "smolvm delete vm-abc123" in warnings[0]
 
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -37,12 +37,14 @@ def _make_vm_info(
     guest_ip: str = "172.16.0.2",
     ssh_host_port: int | None = 2200,
     pid: int | None = 12345,
+    workspace_mounts: list[object] | None = None,
 ) -> MagicMock:
     """Build a lightweight VMInfo-like mock for list tests."""
     vm = MagicMock()
     vm.vm_id = vm_id
     vm.status = status
     vm.pid = pid
+    vm.config.workspace_mounts = workspace_mounts or []
     if guest_ip:
         vm.network = MagicMock(spec=NetworkConfig)
         vm.network.guest_ip = guest_ip
@@ -1774,6 +1776,7 @@ class TestCliList:
                 "ip_address": "172.16.0.2",
                 "ssh_port": 2200,
                 "pid": 12345,
+                "warnings": [],
             }
         ]
         mock_sdk_cls.return_value.list_vms.assert_called_once_with(status=VMState.RUNNING)
@@ -1841,6 +1844,67 @@ class TestCliList:
         assert ret == 1
         assert "Error: db unavailable" in capsys.readouterr().err
         mock_sdk_cls.return_value.close.assert_called_once()
+
+    def test_list_flags_stale_workspace_mount(
+        self,
+        mock_sdk_cls: MagicMock,
+        capsys: pytest.CaptureFixture,
+        tmp_path: Path,
+    ) -> None:
+        """`smolvm list` should keep listing VMs whose host mount is gone,
+        and print a warning naming the missing path."""
+        missing = tmp_path / "deleted-worktree"
+        mount = MagicMock()
+        mount.host_path = missing
+        vms = [
+            _make_vm_info(
+                "vm-abc123",
+                VMState.RUNNING,
+                "172.16.0.2",
+                2200,
+                12345,
+                workspace_mounts=[mount],
+            ),
+        ]
+        mock_sdk_cls.return_value.list_vms.return_value = vms
+
+        ret = main(["list"])
+
+        # Rich may wrap long tmp paths across lines; flatten before asserting.
+        out = capsys.readouterr().out.replace("\n", "")
+        assert ret == 0
+        assert "vm-abc123" in out
+        assert "Warnings:" in out
+        assert str(missing) in out
+
+    def test_list_json_includes_warnings(
+        self,
+        mock_sdk_cls: MagicMock,
+        capsys: pytest.CaptureFixture,
+        tmp_path: Path,
+    ) -> None:
+        """`smolvm list --json` should expose stale mounts via `warnings`."""
+        missing = tmp_path / "deleted-worktree"
+        mount = MagicMock()
+        mount.host_path = missing
+        mock_sdk_cls.return_value.list_vms.return_value = [
+            _make_vm_info(
+                "vm-abc123",
+                VMState.RUNNING,
+                "172.16.0.2",
+                2200,
+                12345,
+                workspace_mounts=[mount],
+            ),
+        ]
+
+        ret = main(["list", "--json"])
+
+        assert ret == 0
+        payload = json.loads(capsys.readouterr().out)
+        assert payload["data"]["vms"][0]["warnings"] == [
+            f"workspace mount missing on host: {missing}"
+        ]
 
 
 class TestCliInfo:

--- a/tests/test_workspace.py
+++ b/tests/test_workspace.py
@@ -287,6 +287,110 @@ def test_start_friendly_error_when_workspace_host_path_missing(
     mock_popen.assert_not_called()
 
 
+@patch("smolvm.vm.subprocess.Popen")
+@patch.object(
+    SmolVMManager,
+    "_find_qemu_binary",
+    return_value=Path("/opt/homebrew/bin/qemu-system-aarch64"),
+)
+def test_start_friendly_error_when_workspace_host_path_is_a_file(
+    _mock_find_qemu_binary: MagicMock,
+    mock_popen: MagicMock,
+    tmp_path: Path,
+) -> None:
+    """The preflight should also fire when the path now points to a file
+    instead of a directory — covers the gap where the path technically
+    exists but the original Pydantic ``is_dir()`` check would have
+    rejected it. Without this we'd fall through to a backend error."""
+    from smolvm.exceptions import SmolVMError
+
+    kernel = tmp_path / "vmlinux"
+    rootfs = tmp_path / "rootfs.ext4"
+    kernel.touch()
+    rootfs.touch()
+
+    ws_dir = tmp_path / "project"
+    ws_dir.mkdir()
+
+    config = VMConfig(
+        vm_id="vm-mount-is-file",
+        kernel_path=kernel,
+        rootfs_path=rootfs,
+        backend="qemu",
+        boot_args="console=ttyAMA0 reboot=k panic=1 init=/init",
+        workspace_mounts=[WorkspaceMount(host_path=ws_dir)],
+    )
+
+    sdk = SmolVMManager(
+        data_dir=tmp_path / "data",
+        socket_dir=tmp_path / "sockets",
+        backend="qemu",
+    )
+    with patch.object(SmolVMManager, "_create_qemu_overlay_disk") as mock_convert:
+        mock_convert.side_effect = lambda source, target: target.touch()
+        sdk.create(config)
+
+    # Replace the directory with a file at the same path.
+    ws_dir.rmdir()
+    ws_dir.touch()
+
+    with pytest.raises(SmolVMError, match="shared folder is missing"):
+        sdk.start("vm-mount-is-file")
+    mock_popen.assert_not_called()
+
+
+@patch("smolvm.vm.subprocess.Popen")
+@patch.object(
+    SmolVMManager,
+    "_find_qemu_binary",
+    return_value=Path("/opt/homebrew/bin/qemu-system-aarch64"),
+)
+def test_async_start_runs_the_same_workspace_preflight(
+    _mock_find_qemu_binary: MagicMock,
+    mock_popen: MagicMock,
+    tmp_path: Path,
+) -> None:
+    """``async_start`` is a parallel code path; if it skips the preflight
+    the friendly error becomes a backend failure for async callers. The
+    helper is shared so both surfaces give the same plain-English error.
+    """
+    import asyncio
+
+    from smolvm.exceptions import SmolVMError
+
+    kernel = tmp_path / "vmlinux"
+    rootfs = tmp_path / "rootfs.ext4"
+    kernel.touch()
+    rootfs.touch()
+
+    ws_dir = tmp_path / "project"
+    ws_dir.mkdir()
+
+    config = VMConfig(
+        vm_id="vm-async-stale",
+        kernel_path=kernel,
+        rootfs_path=rootfs,
+        backend="qemu",
+        boot_args="console=ttyAMA0 reboot=k panic=1 init=/init",
+        workspace_mounts=[WorkspaceMount(host_path=ws_dir)],
+    )
+
+    sdk = SmolVMManager(
+        data_dir=tmp_path / "data",
+        socket_dir=tmp_path / "sockets",
+        backend="qemu",
+    )
+    with patch.object(SmolVMManager, "_create_qemu_overlay_disk") as mock_convert:
+        mock_convert.side_effect = lambda source, target: target.touch()
+        sdk.create(config)
+
+    ws_dir.rmdir()
+
+    with pytest.raises(SmolVMError, match="shared folder is missing"):
+        asyncio.run(sdk.async_start("vm-async-stale"))
+    mock_popen.assert_not_called()
+
+
 # ── Firecracker rejection ───────────────────────────────────────────
 
 

--- a/tests/test_workspace.py
+++ b/tests/test_workspace.py
@@ -277,7 +277,7 @@ def test_start_friendly_error_when_workspace_host_path_missing(
 
     ws_dir.rmdir()  # simulate Conductor worktree cleanup
 
-    with pytest.raises(SmolVMError, match="no longer exists") as exc_info:
+    with pytest.raises(SmolVMError, match="shared folder is missing") as exc_info:
         sdk.start("vm-stale-mount")
     # The error names the sandbox and the recovery command, so a first-time
     # user can act on it without reading the source.

--- a/tests/test_workspace.py
+++ b/tests/test_workspace.py
@@ -277,8 +277,13 @@ def test_start_friendly_error_when_workspace_host_path_missing(
 
     ws_dir.rmdir()  # simulate Conductor worktree cleanup
 
-    with pytest.raises(SmolVMError, match="workspace mount path missing on host"):
+    with pytest.raises(SmolVMError, match="no longer exists") as exc_info:
         sdk.start("vm-stale-mount")
+    # The error names the sandbox and the recovery command, so a first-time
+    # user can act on it without reading the source.
+    message = str(exc_info.value)
+    assert "vm-stale-mount" in message
+    assert "smolvm delete vm-stale-mount" in message
     mock_popen.assert_not_called()
 
 

--- a/tests/test_workspace.py
+++ b/tests/test_workspace.py
@@ -68,6 +68,22 @@ class TestWorkspaceMountValidation:
         assert ws.resolved_tag(0) == "workspace0"
         assert ws.resolved_tag(3) == "workspace3"
 
+    def test_missing_host_path_loads_under_validate_paths_false(self, tmp_path: Path) -> None:
+        """Persisted configs reload even when the host path was deleted.
+
+        Read-only commands like ``smolvm list`` pass
+        ``context={"validate_paths": False}`` so a stale mount path on disk
+        does not crash the whole command. The validator must respect that.
+        """
+        ws_dir = tmp_path / "gone"
+        ws_dir.mkdir()
+        raw = WorkspaceMount(host_path=ws_dir).model_dump_json()
+        ws_dir.rmdir()
+
+        ws = WorkspaceMount.model_validate_json(raw, context={"validate_paths": False})
+
+        assert ws.host_path == ws_dir.resolve()
+
 
 # ── VMConfig workspace_mounts validation ────────────────────────────
 
@@ -133,6 +149,28 @@ class TestVMConfigWorkspaceMounts:
                 ],
             )
 
+    def test_persisted_config_reloads_with_missing_mount_host(self, tmp_path: Path) -> None:
+        """Storage reads must succeed when a workspace host folder is gone.
+
+        Reproduces the ``smolvm list`` crash where a deleted Conductor
+        worktree caused the whole command to fail. The fix is that
+        ``WorkspaceMount`` honors the ``validate_paths=False`` context the
+        storage layer already passes via ``vm_config_from_json``.
+        """
+        ws_dir = tmp_path / "project"
+        ws_dir.mkdir()
+        config = self._make_config(
+            tmp_path,
+            workspace_mounts=[WorkspaceMount(host_path=ws_dir)],
+        )
+        raw = config.model_dump_json()
+        ws_dir.rmdir()
+
+        reloaded = VMConfig.model_validate_json(raw, context={"validate_paths": False})
+
+        assert len(reloaded.workspace_mounts) == 1
+        assert reloaded.workspace_mounts[0].host_path == ws_dir.resolve()
+
 
 # ── QEMU command builder ────────────────────────────────────────────
 
@@ -194,6 +232,54 @@ def test_start_qemu_includes_9p_workspace_args(
 
     # Find the virtio-9p device (aarch64 → virtio-9p-device)
     assert "virtio-9p-device,fsdev=fsdev-workspace0,mount_tag=workspace0" in cmd
+
+
+@patch("smolvm.vm.subprocess.Popen")
+@patch.object(
+    SmolVMManager,
+    "_find_qemu_binary",
+    return_value=Path("/opt/homebrew/bin/qemu-system-aarch64"),
+)
+def test_start_friendly_error_when_workspace_host_path_missing(
+    _mock_find_qemu_binary: MagicMock,
+    mock_popen: MagicMock,
+    tmp_path: Path,
+) -> None:
+    """`start` should refuse with a plain-English error when a mount's host
+    folder has been deleted since the VM was created — no Pydantic stack."""
+    from smolvm.exceptions import SmolVMError
+
+    kernel = tmp_path / "vmlinux"
+    rootfs = tmp_path / "rootfs.ext4"
+    kernel.touch()
+    rootfs.touch()
+
+    ws_dir = tmp_path / "project"
+    ws_dir.mkdir()
+
+    config = VMConfig(
+        vm_id="vm-stale-mount",
+        kernel_path=kernel,
+        rootfs_path=rootfs,
+        backend="qemu",
+        boot_args="console=ttyAMA0 reboot=k panic=1 init=/init",
+        workspace_mounts=[WorkspaceMount(host_path=ws_dir)],
+    )
+
+    sdk = SmolVMManager(
+        data_dir=tmp_path / "data",
+        socket_dir=tmp_path / "sockets",
+        backend="qemu",
+    )
+    with patch.object(SmolVMManager, "_create_qemu_overlay_disk") as mock_convert:
+        mock_convert.side_effect = lambda source, target: target.touch()
+        sdk.create(config)
+
+    ws_dir.rmdir()  # simulate Conductor worktree cleanup
+
+    with pytest.raises(SmolVMError, match="workspace mount path missing on host"):
+        sdk.start("vm-stale-mount")
+    mock_popen.assert_not_called()
 
 
 # ── Firecracker rejection ───────────────────────────────────────────


### PR DESCRIPTION
## Summary

Fixes the `smolvm list` crash when a workspace mount's host folder has been deleted on the host (e.g. a Conductor worktree was cleaned up). Previously the command aborted with a Pydantic validation error, leaving the user no way to see, repair, or delete the affected VMs.

The root cause: `WorkspaceMount.validate_host_path` was a plain `@field_validator` that ran the disk-existence check unconditionally, ignoring the `validate_paths=False` context the storage layer (`vm_config_from_json`) already passes. The path validators on `VMConfig` honored that context — this one was simply missed.

## Changes

- **`src/smolvm/types.py`** — `WorkspaceMount.validate_host_path` now honors the `validate_paths=False` context. `_should_validate_paths` is lifted to a module-level helper so `VMConfig` and `WorkspaceMount` share one source of truth.
- **`src/smolvm/cli/main.py`** — `smolvm list` flags VMs with missing host paths instead of staying silent: a `⚠` next to the name in the table and a `Warnings:` section listing each missing path. JSON payload gains a `warnings: list[str]` field on every row so agents see the same signal.
- **`src/smolvm/vm.py`** — `SmolVMManager.start` raises a plain-English `SmolVMError` when a mount's host path is gone at boot time, with a hint to restore the folder or delete the VM, instead of letting QEMU fail late with a host-side error.

## Before / after

Before — one stale mount aborted the whole command:
```
Error: 1 validation error for VMConfig
workspace_mounts.0.host_path
  Value error, Workspace path does not exist: /Users/.../lome
```

After — VMs are listed and the issue is surfaced:
```
          SmolVM Instances
┏━━━━━━━━━━━━━━━━┳━━━━━━━━━┳━━━━━━━┓
┃ Name           ┃ Status  ┃   PID ┃
┡━━━━━━━━━━━━━━━━╇━━━━━━━━━╇━━━━━━━┩
│ ⚠ sbx-einstein │ running │ 12674 │
│ ⚠ sbx-newton   │ running │ 23766 │
└────────────────┴─────────┴───────┘
Total: 2 VM(s).

Warnings:
  sbx-einstein:
    • workspace mount missing on host: /Users/.../lome
  sbx-newton:
    • workspace mount missing on host: /Users/.../lome
```

## Test plan

- [x] `uv run pytest` — all 711 tests pass (11 pre-existing skips)
- [x] New tests cover: WorkspaceMount loads under `validate_paths=False`, VMConfig propagates the context to nested mounts, `smolvm list` keeps listing flagged VMs, `--json` exposes `warnings`, and `start` raises a friendly error when a mount's host path is missing
- [x] Verified live against the reporter's local DB: stale-mount VMs now show up with `⚠` markers instead of crashing

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * `smolvm list` now displays warnings for VMs with missing workspace mount paths, marked with a ⚠ symbol, and includes a dedicated Warnings section with details.

* **Bug Fixes**
  * VM startup now performs preflight checks on workspace mount paths and fails gracefully with a helpful recovery message if paths are missing, preventing silent failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->