### PR TITLE
Accept 'smolvm claude start' as alias for 'claude-code'

### DIFF
--- a/src/smolvm/cli/main.py
+++ b/src/smolvm/cli/main.py
@@ -354,6 +354,7 @@ def _add_preset_parsers(
     for preset in list_presets():
         preset_parser = subparsers.add_parser(
             preset.name,
+            aliases=list(preset.aliases),
             help=preset.summary,
             description=preset.summary,
         )
@@ -446,10 +447,15 @@ def _add_preset_parsers(
 
 
 def _is_preset_command(args: argparse.Namespace) -> bool:
-    """Return True when ``args`` came from ``smolvm <preset> ...``."""
-    from smolvm.presets import preset_names
+    """Return True when ``args`` came from ``smolvm <preset> ...``.
 
-    return args.command in preset_names()
+    Accepts canonical preset names and aliases (e.g. ``claude`` for
+    ``claude-code``); argparse stores whichever spelling the user typed
+    in ``args.command``.
+    """
+    from smolvm.presets import preset_command_names
+
+    return args.command in preset_command_names()
 
 
 def build_parser() -> argparse.ArgumentParser:

--- a/src/smolvm/cli/main.py
+++ b/src/smolvm/cli/main.py
@@ -1869,6 +1869,7 @@ def _maybe_attach_and_launch(
 
 def _exec_launch_command(vm: object, launch_command: str) -> int:
     """SSH into *vm* with a TTY and run *launch_command* under a login shell."""
+    from smolvm.env import ENV_FILE
     from smolvm.facade import SmolVM
 
     _vm: SmolVM = vm  # type: ignore[assignment]
@@ -1876,8 +1877,14 @@ def _exec_launch_command(vm: object, launch_command: str) -> int:
     # Insert -t before user@host so OpenSSH allocates a TTY for the remote
     # command. Source profile.d so injected env vars (API keys) are visible
     # to the harness, then exec to keep signal handling clean.
+    #
+    # The env file is only created when at least one host env var was
+    # injected (env.inject_env_vars short-circuits on an empty mapping),
+    # so it may legitimately not exist — e.g. claude-code with subscription
+    # auth where ANTHROPIC_API_KEY is unset on the host. Guard the source
+    # and chain with ';' so a missing file never prevents the launch.
     cmd.insert(-1, "-t")
-    cmd.append(f"{ENV_RELOAD_HINT} && exec {launch_command}")
+    cmd.append(f"[ -r {ENV_FILE} ] && . {ENV_FILE}; exec {launch_command}")
     completed = subprocess.run(cmd, check=False)
     return completed.returncode
 

--- a/src/smolvm/presets/__init__.py
+++ b/src/smolvm/presets/__init__.py
@@ -56,6 +56,19 @@ def preset_names() -> list[str]:
     return sorted(_REGISTRY)
 
 
+def preset_command_names() -> list[str]:
+    """Return every name (canonical + aliases) that the CLI accepts.
+
+    Use this — not :func:`preset_names` — when checking whether an
+    ``args.command`` came from a preset, since the user may have typed
+    an alias like ``claude`` instead of ``claude-code``.
+    """
+    names: set[str] = set(_REGISTRY)
+    for preset in _REGISTRY.values():
+        names.update(preset.aliases)
+    return sorted(names)
+
+
 __all__ = [
     "CLAUDE_CODE_PRESET",
     "CODEX_PRESET",
@@ -65,5 +78,6 @@ __all__ = [
     "collect_host_env",
     "get_preset",
     "list_presets",
+    "preset_command_names",
     "preset_names",
 ]

--- a/src/smolvm/presets/_types.py
+++ b/src/smolvm/presets/_types.py
@@ -45,6 +45,10 @@ class Preset:
 
     Attributes:
         name: CLI-facing identifier (e.g. ``"codex"``).
+        aliases: Extra names that resolve to this preset on the CLI
+            (e.g. ``("claude",)`` for ``claude-code``). Argparse routes
+            them to the same parser; the canonical ``name`` is what
+            ``args.preset_name`` carries.
         summary: One-line description for ``--help`` output.
         install_script: Bash script run via ``ssh.run`` after boot.
             Should be idempotent and self-contained.
@@ -59,6 +63,7 @@ class Preset:
     name: str
     summary: str
     install_script: str
+    aliases: tuple[str, ...] = field(default_factory=tuple)
     host_env_vars: tuple[str, ...] = field(default_factory=tuple)
     host_configs: tuple[HostConfigCopy, ...] = field(default_factory=tuple)
     default_mem_mib: int = 2048

--- a/src/smolvm/presets/claude_code.py
+++ b/src/smolvm/presets/claude_code.py
@@ -21,6 +21,7 @@ from smolvm.presets._types import HostConfigCopy, Preset
 
 CLAUDE_CODE_PRESET = Preset(
     name="claude-code",
+    aliases=("claude",),
     summary="Start a sandbox with Anthropic's Claude Code CLI preinstalled.",
     install_script=npm_install_global("@anthropic-ai/claude-code"),
     host_env_vars=("ANTHROPIC_API_KEY",),

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -2179,6 +2179,51 @@ class TestCliStart:
         # argparse produces "invalid choice" for unknown subcommand
         assert "invalid choice" in err or "argument command" in err
 
+    def test_launch_snippet_runs_when_env_file_missing(
+        self, tmp_path: Path
+    ) -> None:
+        """The remote command built by `_exec_launch_command` must exec the
+        harness even when /etc/profile.d/smolvm_env.sh does not exist —
+        regression for claude-code with subscription auth where no
+        ANTHROPIC_API_KEY is set on the host, so env injection writes
+        nothing and the file is never created."""
+        import subprocess
+
+        from smolvm.cli.main import _exec_launch_command
+
+        captured: list[list[str]] = []
+
+        class _StubSshVm:
+            def _ssh_attach_command(self) -> list[str]:
+                return ["ssh", "-p", "2200", "root@127.0.0.1"]
+
+        def fake_run(cmd: list[str], check: bool = False) -> MagicMock:
+            captured.append(cmd)
+            result = MagicMock()
+            result.returncode = 0
+            return result
+
+        with patch("smolvm.cli.main.subprocess.run", side_effect=fake_run):
+            _exec_launch_command(_StubSshVm(), "claude")
+
+        remote = captured[0][-1]
+        # Now actually evaluate the remote snippet under bash with a
+        # path that does not exist — the launch (here a `:` no-op
+        # standing in for `exec claude`) must still execute.
+        missing_env_file = tmp_path / "definitely-not-here.sh"
+        # The snippet calls `exec claude`; for the runtime check we
+        # substitute a benign command we can verify ran.
+        snippet = remote.replace("exec claude", "echo LAUNCHED")
+        snippet = snippet.replace(
+            "/etc/profile.d/smolvm_env.sh", str(missing_env_file)
+        )
+        completed = subprocess.run(
+            ["bash", "-c", snippet], capture_output=True, text=True, check=False
+        )
+        assert completed.returncode == 0
+        assert "LAUNCHED" in completed.stdout
+        assert "No such file" not in completed.stderr
+
     def test_claude_alias_resolves_to_claude_code(
         self, capsys: pytest.CaptureFixture
     ) -> None:
@@ -2369,9 +2414,17 @@ class TestCliStart:
         # `-t` must come before user@host so OpenSSH allocates a TTY.
         assert "-t" in cmd
         assert cmd.index("-t") < cmd.index("root@127.0.0.1")
-        # Remote command must source the smolvm env file then exec codex.
-        assert cmd[-1].endswith("&& exec codex")
-        assert "/etc/profile.d/smolvm_env.sh" in cmd[-1]
+        # Remote command must guard the env-file source and still exec the
+        # harness if the file is missing (preset may inject zero env vars).
+        remote = cmd[-1]
+        assert "/etc/profile.d/smolvm_env.sh" in remote
+        assert remote.endswith("; exec codex"), (
+            "exec must chain with ';' not '&&' so a missing env file does "
+            f"not abort the launch — got {remote!r}"
+        )
+        assert "[ -r " in remote, (
+            "env file source must be guarded with a file-existence check"
+        )
 
     @patch("smolvm.cli.main.subprocess.run")
     @patch("smolvm.cli.main._apply_preset_with_progress")

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -2197,8 +2197,10 @@ class TestCliStart:
             def _ssh_attach_command(self) -> list[str]:
                 return ["ssh", "-p", "2200", "root@127.0.0.1"]
 
-        def fake_run(cmd: list[str], check: bool = False) -> MagicMock:
-            captured.append(cmd)
+        def fake_run(*args: object, **_kwargs: object) -> MagicMock:
+            # Tolerate future kwargs (e.g. text=, env=) on the real
+            # subprocess.run call without rewriting the stub.
+            captured.append(args[0])  # type: ignore[arg-type]
             result = MagicMock()
             result.returncode = 0
             return result
@@ -2224,9 +2226,7 @@ class TestCliStart:
         assert "LAUNCHED" in completed.stdout
         assert "No such file" not in completed.stderr
 
-    def test_claude_alias_resolves_to_claude_code(
-        self, capsys: pytest.CaptureFixture
-    ) -> None:
+    def test_claude_alias_resolves_to_claude_code(self) -> None:
         """`smolvm claude start` should be accepted as an alias for
         `smolvm claude-code start` — first-time users keep typing the
         short name and the previous behaviour was an unfriendly
@@ -2244,11 +2244,18 @@ class TestCliStart:
     ) -> None:
         """The alias should appear in the top-level help so the
         shorthand is discoverable, not a hidden trick."""
+        import re
+
         with pytest.raises(SystemExit):
             main(["--help"])
         out = capsys.readouterr().out
-        assert "claude" in out
-        assert "claude-code" in out
+        # Must check 'claude' as a distinct token, not a substring of
+        # 'claude-code'. argparse renders the choices block as
+        # ``{a,b,claude-code,claude,...}`` so split on whitespace and the
+        # punctuation argparse uses there.
+        tokens = set(re.split(r"[\s{},]+", out))
+        assert "claude" in tokens
+        assert "claude-code" in tokens
 
     @patch("smolvm.cli.main._apply_preset_with_progress")
     @patch("smolvm.facade._build_auto_config")

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -2179,6 +2179,32 @@ class TestCliStart:
         # argparse produces "invalid choice" for unknown subcommand
         assert "invalid choice" in err or "argument command" in err
 
+    def test_claude_alias_resolves_to_claude_code(
+        self, capsys: pytest.CaptureFixture
+    ) -> None:
+        """`smolvm claude start` should be accepted as an alias for
+        `smolvm claude-code start` — first-time users keep typing the
+        short name and the previous behaviour was an unfriendly
+        argparse 'invalid choice' error."""
+        parser = build_parser()
+        args = parser.parse_args(["claude", "start"])
+        # argparse stores whichever spelling the user typed in
+        # ``args.command``, but the canonical preset name (set via
+        # ``set_defaults``) is what the dispatch path looks up.
+        assert args.command == "claude"
+        assert args.preset_name == "claude-code"
+
+    def test_top_level_help_lists_claude_alias(
+        self, capsys: pytest.CaptureFixture
+    ) -> None:
+        """The alias should appear in the top-level help so the
+        shorthand is discoverable, not a hidden trick."""
+        with pytest.raises(SystemExit):
+            main(["--help"])
+        out = capsys.readouterr().out
+        assert "claude" in out
+        assert "claude-code" in out
+
     @patch("smolvm.cli.main._apply_preset_with_progress")
     @patch("smolvm.facade._build_auto_config")
     @patch("smolvm.facade.SmolVM")


### PR DESCRIPTION
## Summary

Two fixes that together unblock `smolvm claude start --attach` for first-time users.

### 1. Accept `claude` as alias for `claude-code` (the originally-titled fix)

A first-time user who types `smolvm claude start` (the natural short name) hits an argparse error that just dumps every command and forces them to spot `claude-code` in the list:

```
smolvm: error: argument command: invalid choice: 'claude' (choose from
delete, cleanup, doctor, setup, ui, list, info, create, claude-code,
codex, stop, pause, resume, snapshot, ssh, browser, env)
```

The canonical preset name stays `claude-code` (matches the npm package `@anthropic-ai/claude-code`), but `claude` is now an accepted alias. After this both work:

```
smolvm claude start
smolvm claude-code start
```

### 2. Don't abort launch when `/etc/profile.d/smolvm_env.sh` is missing

After the alias landed, the next failure on the same flow:

```
smolvm claude start
...
Launch claude in 'sbx-gauss' now? [Y/n] y
bash: line 1: /etc/profile.d/smolvm_env.sh: No such file or directory
Connection to 127.0.0.1 closed.
```

`_exec_launch_command` was building `source <env_file> && exec <harness>`. But `env.inject_env_vars` skips the file write when there are no host env vars to inject — common with `claude-code` + subscription auth, where `ANTHROPIC_API_KEY` is unset. The unconditional `source` then failed and the `&&` aborted the launch.

Fix: guard the source with `[ -r ENV_FILE ] && . ENV_FILE` and chain the launch with `;`, so the harness execs whether the env file exists or not.

## Changes

- `Preset` gains an `aliases: tuple[str, ...]` field; `CLAUDE_CODE_PRESET` declares `aliases=("claude",)`.
- CLI passes `aliases=list(preset.aliases)` to `subparsers.add_parser(...)`. `args.preset_name` (set via `set_defaults`) keeps the canonical name so downstream lookups don't change.
- New `preset_command_names()` returns canonical + aliases so `_is_preset_command` recognises both spellings.
- `_exec_launch_command` builds a guarded shell snippet that survives a missing env file.

## Test plan

- [x] `uv run pytest` — 717 passing, 11 pre-existing skips
- [x] New tests: `test_claude_alias_resolves_to_claude_code`, `test_top_level_help_lists_claude_alias`, `test_launch_snippet_runs_when_env_file_missing` (actually evals the remote shell snippet under bash with a path that doesn't exist)
- [x] Updated existing assertion in `test_start_attach_runs_codex_via_ssh` for the new `;` + guard pattern
- [x] Manual: `smolvm claude --help` and `smolvm claude start --help` both work

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Preset command aliases now available—use shorter alternative names (e.g., `claude`) alongside canonical names.
  * Preset aliases displayed in help output for discoverability.

* **Bug Fixes**
  * SSH preset execution now safely handles missing environment files, preventing failures.

* **Tests**
  * Added test coverage for preset aliases and SSH robustness.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->