### PR TITLE
feat(naming): configurable prefix for sandbox names

### DIFF
--- a/src/smolvm/_naming.py
+++ b/src/smolvm/_naming.py
@@ -127,6 +127,7 @@ CITIES: tuple[str, ...] = (
 def generate_sandbox_name(
     existing: set[str] | frozenset[str] | None = None,
     *,
+    prefix: str = SANDBOX_PREFIX,
     rng: random.Random | None = None,
 ) -> str:
     """Return a friendly sandbox name like ``sbx-einstein`` or ``sbx-tesla-london``.
@@ -137,11 +138,14 @@ def generate_sandbox_name(
             performed (callers without state-manager access can still get a
             scientist-style name and rely on the storage layer to reject
             duplicates).
+        prefix: Namespace prefix for the generated name. Defaults to ``"sbx"``.
+            Presets pass their own name (e.g. ``"codex"``) so sandboxes are
+            visually grouped by harness type.
         rng: Optional ``random.Random`` for deterministic tests.
 
     Strategy:
-        1. Try a bare ``sbx-{scientist}`` for a few random picks.
-        2. On collision, append a random city: ``sbx-{scientist}-{city}``.
+        1. Try a bare ``{prefix}-{scientist}`` for a few random picks.
+        2. On collision, append a random city: ``{prefix}-{scientist}-{city}``.
         3. If everything collides (vanishingly unlikely), fall back to a hex
            suffix that guarantees uniqueness.
     """
@@ -150,13 +154,13 @@ def generate_sandbox_name(
 
     for _ in range(len(SCIENTISTS)):
         scientist = picker.choice(SCIENTISTS)
-        bare = f"{SANDBOX_PREFIX}-{scientist}"
+        bare = f"{prefix}-{scientist}"
         if bare not in taken:
             return bare
         for _ in range(len(CITIES)):
             city = picker.choice(CITIES)
-            qualified = f"{SANDBOX_PREFIX}-{scientist}-{city}"
+            qualified = f"{prefix}-{scientist}-{city}"
             if qualified not in taken:
                 return qualified
 
-    return f"{SANDBOX_PREFIX}-{picker.choice(SCIENTISTS)}-{uuid4().hex[:6]}"
+    return f"{prefix}-{picker.choice(SCIENTISTS)}-{uuid4().hex[:6]}"

--- a/src/smolvm/cli/main.py
+++ b/src/smolvm/cli/main.py
@@ -1744,6 +1744,7 @@ def _run_start(args: argparse.Namespace) -> int:
                 console=console,
                 build_fn=lambda on_download: _build_auto_config(
                     vm_name=args.name,
+                    name_prefix=preset.name,
                     os=GuestOS.UBUNTU,
                     backend=backend,
                     memory=memory_mib,
@@ -1763,6 +1764,7 @@ def _run_start(args: argparse.Namespace) -> int:
         else:
             config, ssh_key_path = _build_auto_config(
                 vm_name=args.name,
+                name_prefix=preset.name,
                 os=GuestOS.UBUNTU,
                 backend=backend,
                 memory=memory_mib,

--- a/src/smolvm/facade.py
+++ b/src/smolvm/facade.py
@@ -295,11 +295,11 @@ def _existing_vm_ids() -> set[str]:
         return set()
 
 
-def _resolve_vm_name(vm_name: str | None) -> str:
-    """Return the user-supplied name or pick a fresh ``sbx-{scientist}`` one."""
+def _resolve_vm_name(vm_name: str | None, *, prefix: str = "sbx") -> str:
+    """Return the user-supplied name or auto-generate one with *prefix*."""
     if vm_name is not None:
         return vm_name
-    return generate_sandbox_name(_existing_vm_ids())
+    return generate_sandbox_name(_existing_vm_ids(), prefix=prefix)
 
 
 def _resolve_auto_config_public_key(ssh_key_path: str | None) -> tuple[str, Path]:
@@ -357,6 +357,7 @@ def _build_s3_image_config(
     *,
     image: str,
     vm_name: str | None = None,
+    name_prefix: str = "sbx",
     backend: str | None = None,
     memory: int | None = None,
     ssh_key_path: str | None = None,
@@ -420,7 +421,7 @@ def _build_s3_image_config(
                 )
             extra_drives.append(seed_path)
 
-    resolved_vm_name = _resolve_vm_name(vm_name)
+    resolved_vm_name = _resolve_vm_name(vm_name, prefix=name_prefix)
     config = VMConfig(
         vm_id=resolved_vm_name,
         vcpu_count=1,
@@ -445,6 +446,7 @@ def _build_s3_image_config(
 def _build_auto_config(
     *,
     vm_name: str | None = None,
+    name_prefix: str = "sbx",
     os: GuestOS | str | None = None,
     backend: str | None = None,
     memory: int | None = None,
@@ -522,7 +524,7 @@ def _build_auto_config(
                 ),
             )
 
-        resolved_vm_name = _resolve_vm_name(vm_name)
+        resolved_vm_name = _resolve_vm_name(vm_name, prefix=name_prefix)
         config = VMConfig(
             vm_id=resolved_vm_name,
             vcpu_count=1,
@@ -598,7 +600,7 @@ def _build_auto_config(
                 ),
             )
 
-        resolved_vm_name = _resolve_vm_name(vm_name)
+        resolved_vm_name = _resolve_vm_name(vm_name, prefix=name_prefix)
         config = VMConfig(
             vm_id=resolved_vm_name,
             vcpu_count=1,
@@ -645,7 +647,7 @@ def _build_auto_config(
             kernel_profile=kernel_profile,
         )
 
-    resolved_vm_name = _resolve_vm_name(vm_name)
+    resolved_vm_name = _resolve_vm_name(vm_name, prefix=name_prefix)
     config = VMConfig(
         vm_id=resolved_vm_name,
         vcpu_count=1,

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -2207,6 +2207,7 @@ class TestCliStart:
         assert ret == 0
         mock_build_auto_config.assert_called_once_with(
             vm_name="sbx-codex",
+            name_prefix="codex",
             os=GuestOS.UBUNTU,
             backend="qemu",
             memory=2048,

--- a/tests/test_naming.py
+++ b/tests/test_naming.py
@@ -51,6 +51,25 @@ def test_returned_name_passes_vm_id_validation() -> None:
         assert re.fullmatch(_IDENTIFIER_PATTERN, name), name
 
 
+def test_custom_prefix() -> None:
+    """A caller-supplied prefix replaces the default ``sbx`` in generated names."""
+    name = generate_sandbox_name(set(), prefix="codex")
+    assert name.startswith("codex-")
+    scientist = name.removeprefix("codex-")
+    assert scientist in SCIENTISTS
+
+
+def test_custom_prefix_with_collision() -> None:
+    taken = {f"codex-{s}" for s in SCIENTISTS}
+    name = generate_sandbox_name(taken, prefix="codex", rng=random.Random(0))
+
+    assert name.startswith("codex-")
+    parts = name.removeprefix("codex-").split("-")
+    assert len(parts) == 2
+    assert parts[0] in SCIENTISTS
+    assert parts[1] in CITIES
+
+
 def test_falls_back_to_hex_when_space_exhausted() -> None:
     """Final fallback guarantees uniqueness even if scientists+cities collide."""
     taken = {f"sbx-{s}" for s in SCIENTISTS}


### PR DESCRIPTION
## Summary

Add a `prefix` parameter to the sandbox name generator so each harness type gets its own namespace. Presets (e.g. codex) now produce names like `codex-einstein` instead of `sbx-einstein`, while `smolvm create` keeps the default `sbx-` prefix. This threads through `generate_sandbox_name` → `_resolve_vm_name` → `_build_auto_config` / `_build_s3_image_config` → `_run_start`.

## Related Issues

- N/A

## Testing

- `uv run pytest tests/test_naming.py` — 6/6 passed (2 new tests for custom prefix)
- `uv run pytest tests/test_facade.py` — 64 passed, 8 skipped
- `uv run ruff check` — no new lint issues

## Checklist

- [x] Scope is focused and limited to this change
- [x] Tests added/updated for behavior changes
- [ ] Docs updated for user-visible changes
- [x] No secrets or sensitive data included