### PR TITLE
chore(smolvm-core): tighten Cargo packaging metadata and build config

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -262,9 +262,9 @@ dependencies = [
 
 [[package]]
 name = "nix"
-version = "0.29.0"
+version = "0.30.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "71e2746dc3a24dd78b3cfcb7be93368c6de9963d30f43a6a73998a9cf4b17b46"
+checksum = "74523f3a35e05aba87a1d978330aef40f67b0304ac79c1c00b294c9830543db6"
 dependencies = [
  "bitflags",
  "cfg-if",
@@ -416,17 +416,17 @@ checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
 
 [[package]]
 name = "smolvm-core"
-version = "0.0.9"
+version = "0.0.10"
 dependencies = [
  "futures-util",
  "libc",
  "log",
  "netlink-packet-route",
- "nix 0.29.0",
+ "nix 0.30.1",
  "pyo3",
  "pyo3-log",
  "rtnetlink",
- "thiserror 1.0.69",
+ "thiserror 2.0.18",
  "tokio",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,3 +6,4 @@ resolver = "2"
 opt-level = 3
 lto = "fat"
 codegen-units = 1
+strip = "symbols"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,16 @@
 members = ["smolvm-core"]
 resolver = "2"
 
+[workspace.package]
+edition = "2024"
+rust-version = "1.85"
+license = "Apache-2.0"
+authors = ["Celesto AI <hello@celesto.ai>"]
+homepage = "https://github.com/CelestoAI/SmolVM"
+repository = "https://github.com/CelestoAI/SmolVM"
+keywords = ["sandbox", "vm", "microvm", "pyo3", "agents"]
+categories = ["virtualization", "api-bindings"]
+
 [profile.release]
 opt-level = 3
 lto = "fat"

--- a/smolvm-core/Cargo.toml
+++ b/smolvm-core/Cargo.toml
@@ -1,26 +1,34 @@
 [package]
 name = "smolvm-core"
 version = "0.0.10"
-edition = "2021"
+edition = "2024"
+rust-version = "1.85"
 license = "Apache-2.0"
 description = "Rust-native core package for SmolVM"
+authors = ["Celesto AI <hello@celesto.ai>"]
 homepage = "https://github.com/CelestoAI/SmolVM"
 repository = "https://github.com/CelestoAI/SmolVM"
+documentation = "https://docs.rs/smolvm-core"
 readme = "README.md"
+keywords = ["sandbox", "vm", "microvm", "pyo3", "agents"]
+categories = ["virtualization", "api-bindings"]
 
 [lib]
 name = "_smolvm_core"
 crate-type = ["cdylib", "rlib"]
 
+[features]
+extension-module = ["pyo3/extension-module"]
+
 [dependencies]
-pyo3 = { version = "0.28", features = ["extension-module"] }
+pyo3 = "0.28"
 libc = "0.2"
-thiserror = "1"
+thiserror = "2"
 pyo3-log = "0.13"
 log = "0.4"
 
 [target.'cfg(target_os = "linux")'.dependencies]
-nix = { version = "0.29", features = ["ioctl", "net", "user"] }
+nix = { version = "0.30", features = ["ioctl", "net", "user"] }
 rtnetlink = "0.14"
 netlink-packet-route = "0.19"
 tokio = { version = "1", features = ["rt", "net", "macros"] }

--- a/smolvm-core/Cargo.toml
+++ b/smolvm-core/Cargo.toml
@@ -1,17 +1,17 @@
 [package]
 name = "smolvm-core"
 version = "0.0.10"
-edition = "2024"
-rust-version = "1.85"
-license = "Apache-2.0"
 description = "Rust-native core package for SmolVM"
-authors = ["Celesto AI <hello@celesto.ai>"]
-homepage = "https://github.com/CelestoAI/SmolVM"
-repository = "https://github.com/CelestoAI/SmolVM"
 documentation = "https://docs.rs/smolvm-core"
 readme = "README.md"
-keywords = ["sandbox", "vm", "microvm", "pyo3", "agents"]
-categories = ["virtualization", "api-bindings"]
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+authors.workspace = true
+homepage.workspace = true
+repository.workspace = true
+keywords.workspace = true
+categories.workspace = true
 
 [lib]
 name = "_smolvm_core"

--- a/smolvm-core/pyproject.toml
+++ b/smolvm-core/pyproject.toml
@@ -32,6 +32,6 @@ Repository = "https://github.com/CelestoAI/SmolVM"
 Documentation = "https://docs.celesto.ai"
 
 [tool.maturin]
-features = ["pyo3/extension-module"]
+features = ["extension-module"]
 python-source = "python"
 module-name = "smolvm_core._smolvm_core"


### PR DESCRIPTION
## Summary
- Move `pyo3/extension-module` behind a local `extension-module` Cargo feature so plain `cargo check` / `cargo test` work without libpython link errors. `pyproject.toml` now enables the local feature name, so maturin behavior is unchanged.
- Add packaging metadata that crates.io and `lib.rs` use for discovery: `authors`, `keywords`, `categories`, `documentation`, plus an explicit `rust-version = "1.85"` MSRV.
- Bump edition to **2024** (latest stable, Rust 1.85.0+) and refresh deps: `thiserror` 1→2, `nix` 0.29→0.30.
- Move release-profile tuning to the workspace root — the per-crate `[profile.release]` block in `smolvm-core/Cargo.toml` was being silently ignored by Cargo. The workspace already had `lto = "fat"` + `codegen-units = 1`; this PR adds `strip = "symbols"`.

## Effect
Local wheel build dropped from **220 KB → 198 KB** (~10%) thanks to symbol stripping. No public API changes.

## Test plan
- [x] `cargo check` — clean (pre-existing dead-code warnings unrelated)
- [x] `uvx maturin build --release` — wheel built, no warnings
- [x] `uvx maturin sdist` — sdist built, no "profiles ignored" warning
- [x] `uvx twine check <wheel> <sdist>` — PASSED on both
- [x] `cargo publish --dry-run --allow-dirty` — packaged cleanly
- [ ] CI passes on Linux (where the `nix` / `rtnetlink` deps actually compile)

🤖 Generated with [Claude Code](https://claude.com/claude-code)