### PR TITLE
feat(presets): auto-inject host git credentials on preset start

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -25,6 +25,20 @@ SmolVM is specifically designed to provide a secure "sandbox" for AI agents to e
   subcommand and put its actions underneath, instead of overloading a
   global verb.
 
+### Git credentials in presets
+
+Both `codex start` and `claude-code start` also copy `~/.gitconfig`,
+`~/.config/git/config`, `~/.git-credentials`, `~/.ssh/`, and
+`~/.config/gh/` from the host into the guest so `git`, `gh`, and
+`ssh git@github.com` work inside the sandbox without re-auth. Missing
+files are skipped silently. SSH keys land at 0600 — the directory
+goes through tar, which preserves modes. Trust note: anyone with
+shell access to the sandbox can read these keys, same trust model
+as `OPENAI_API_KEY` forwarding. macOS `osxkeychain` helper items for
+HTTPS GitHub auth are not yet copied; on macOS run
+`git config --global credential.helper store` once on the host if
+you rely on that helper.
+
 ### Core writing principles
 - Follow progressive disclosure of complexity.
 - Lead with outcomes, not implementation details.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -32,7 +32,11 @@ Both `codex start` and `claude-code start` also copy `~/.gitconfig`,
 `~/.config/gh/` from the host into the guest so `git`, `gh`, and
 `ssh git@github.com` work inside the sandbox without re-auth. Missing
 files are skipped silently. SSH keys land at 0600 — the directory
-goes through tar, which preserves modes. Trust note: anyone with
+goes through tar, which preserves modes; the staged tar zeros uid/gid
+so the guest's root extraction does not inherit host uids (which
+would otherwise make sshd reject the keys with "Bad owner or
+permissions"). `~/.git-credentials` is chmodded to 0600 after upload
+since it stores plaintext OAuth tokens. Trust note: anyone with
 shell access to the sandbox can read these keys, same trust model
 as `OPENAI_API_KEY` forwarding. macOS `osxkeychain` helper items for
 HTTPS GitHub auth are not yet copied; on macOS run

--- a/src/smolvm/presets/__init__.py
+++ b/src/smolvm/presets/__init__.py
@@ -21,6 +21,7 @@ along with any host config files and API keys the harness expects.
 
 from __future__ import annotations
 
+from smolvm.presets._git import GIT_HOST_CONFIGS
 from smolvm.presets._install import apply_preset, collect_host_env
 from smolvm.presets._types import HostConfigCopy, HostKeychainSecret, Preset
 from smolvm.presets.claude_code import CLAUDE_CODE_PRESET
@@ -72,6 +73,7 @@ def preset_command_names() -> list[str]:
 __all__ = [
     "CLAUDE_CODE_PRESET",
     "CODEX_PRESET",
+    "GIT_HOST_CONFIGS",
     "HostConfigCopy",
     "HostKeychainSecret",
     "Preset",

--- a/src/smolvm/presets/_git.py
+++ b/src/smolvm/presets/_git.py
@@ -1,0 +1,38 @@
+# Copyright 2026 Celesto AI
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Host git credentials copied into every preset's sandbox.
+
+Coding agents need ``git``, ``gh``, and ``ssh git@github.com`` to work
+without re-auth. The applier in ``_install.py`` runs these copies
+through the same pipeline as harness-specific configs (e.g.
+``~/.codex``); missing entries are skipped silently. The whole
+``~/.ssh`` directory rides through ``_copy_dir`` so tar preserves
+0o600 modes — sshd would reject world-readable keys otherwise.
+"""
+
+from __future__ import annotations
+
+from smolvm.presets._types import HostConfigCopy
+
+GIT_HOST_CONFIGS: tuple[HostConfigCopy, ...] = (
+    HostConfigCopy(host_path="~/.gitconfig", guest_path="/root/.gitconfig"),
+    HostConfigCopy(host_path="~/.config/git/config", guest_path="/root/.config/git/config"),
+    HostConfigCopy(host_path="~/.git-credentials", guest_path="/root/.git-credentials"),
+    HostConfigCopy(host_path="~/.ssh", guest_path="/root/.ssh"),
+    HostConfigCopy(host_path="~/.config/gh", guest_path="/root/.config/gh"),
+)
+
+
+__all__ = ["GIT_HOST_CONFIGS"]

--- a/src/smolvm/presets/_git.py
+++ b/src/smolvm/presets/_git.py
@@ -29,7 +29,13 @@ from smolvm.presets._types import HostConfigCopy
 GIT_HOST_CONFIGS: tuple[HostConfigCopy, ...] = (
     HostConfigCopy(host_path="~/.gitconfig", guest_path="/root/.gitconfig"),
     HostConfigCopy(host_path="~/.config/git/config", guest_path="/root/.config/git/config"),
-    HostConfigCopy(host_path="~/.git-credentials", guest_path="/root/.git-credentials"),
+    # ~/.git-credentials holds plaintext "https://user:token@host" lines;
+    # SFTP would otherwise drop it at the server's umask (typically 0644).
+    HostConfigCopy(
+        host_path="~/.git-credentials",
+        guest_path="/root/.git-credentials",
+        file_mode=0o600,
+    ),
     HostConfigCopy(host_path="~/.ssh", guest_path="/root/.ssh"),
     HostConfigCopy(host_path="~/.config/gh", guest_path="/root/.config/gh"),
 )

--- a/src/smolvm/presets/_install.py
+++ b/src/smolvm/presets/_install.py
@@ -91,7 +91,7 @@ def apply_preset(
             logger.debug("Skipping missing host config: %s", local)
             continue
         notify(f"Copying {local} → {cfg.guest_path}")
-        _copy_to_guest(ssh, local, cfg.guest_path)
+        _copy_to_guest(ssh, local, cfg.guest_path, file_mode=cfg.file_mode)
         copied_configs.append(cfg.guest_path)
 
     # Keychain step runs after host_configs so a directory copy that
@@ -144,10 +144,16 @@ def apply_preset(
     }
 
 
-def _copy_to_guest(ssh: SSHClient, local: Path, guest_path: str) -> None:
-    """Copy a host file or directory tree to *guest_path* inside the VM."""
+def _copy_to_guest(
+    ssh: SSHClient, local: Path, guest_path: str, *, file_mode: int | None = None
+) -> None:
+    """Copy a host file or directory tree to *guest_path* inside the VM.
+
+    *file_mode* applies only to single-file copies; directory copies
+    inherit per-file modes from the tar archive.
+    """
     if local.is_file():
-        _copy_file(ssh, local, guest_path)
+        _copy_file(ssh, local, guest_path, file_mode=file_mode)
         return
     if local.is_dir():
         _copy_dir(ssh, local, guest_path)
@@ -158,8 +164,17 @@ def _copy_to_guest(ssh: SSHClient, local: Path, guest_path: str) -> None:
     )
 
 
-def _copy_file(ssh: SSHClient, local: Path, guest_path: str) -> None:
-    """Upload a single host file to *guest_path* via SFTP, mkdir parent first."""
+def _copy_file(
+    ssh: SSHClient, local: Path, guest_path: str, *, file_mode: int | None = None
+) -> None:
+    """Upload a single host file to *guest_path* via SFTP, mkdir parent first.
+
+    SFTP ``put`` does not preserve mode and the SFTP server applies its
+    own umask (typically 0644). When the source is a credential file
+    (e.g. ``~/.git-credentials`` with plaintext OAuth tokens), pass
+    *file_mode* to chmod the guest file after the upload so it does
+    not land world-readable.
+    """
     parent = _posix_dirname(guest_path)
     if parent:
         result = ssh.run(f"mkdir -p -- {shlex.quote(parent)}", timeout=10)
@@ -169,16 +184,32 @@ def _copy_file(ssh: SSHClient, local: Path, guest_path: str) -> None:
                 {"exit_code": result.exit_code, "stderr": result.stderr},
             )
     ssh.put_file(local, guest_path)
+    if file_mode is not None:
+        chmod_cmd = f"chmod {file_mode:o} -- {shlex.quote(guest_path)}"
+        result = ssh.run(chmod_cmd, timeout=5)
+        if not result.ok:
+            raise SmolVMError(
+                f"Failed to chmod {guest_path!r} on guest",
+                {"exit_code": result.exit_code, "stderr": result.stderr},
+            )
 
 
 def _copy_dir(ssh: SSHClient, local: Path, guest_path: str) -> None:
-    """Tar a host directory tree and untar it into *guest_path* on the guest."""
+    """Tar a host directory tree and untar it into *guest_path* on the guest.
+
+    Strips ownership (uid/gid/uname/gname) on every TarInfo so the guest
+    extraction — which runs as root and defaults to ``--same-owner`` —
+    does not preserve host uids (e.g. macOS ``501:20``). With host uids
+    intact, ``/root/.ssh/id_ed25519`` would land owned by uid 501 and
+    sshd would reject the key with "Bad owner or permissions". File
+    modes (the 0o600 we care about for SSH keys) are untouched.
+    """
     tmp_path: Path | None = None
     try:
         with tempfile.NamedTemporaryFile(suffix=".tar", delete=False) as tmp:
             tmp_path = Path(tmp.name)
         with tarfile.open(tmp_path, "w") as tf:
-            tf.add(local, arcname=".")
+            tf.add(local, arcname=".", filter=_strip_tar_owner)
 
         guest_tmp = f"/tmp/.smolvm-preset-{uuid4().hex}.tar"
         ssh.put_file(tmp_path, guest_tmp)
@@ -197,6 +228,15 @@ def _copy_dir(ssh: SSHClient, local: Path, guest_path: str) -> None:
     finally:
         if tmp_path is not None:
             tmp_path.unlink(missing_ok=True)
+
+
+def _strip_tar_owner(ti: tarfile.TarInfo) -> tarfile.TarInfo:
+    """Reset every TarInfo's owner to root before it lands in the archive."""
+    ti.uid = 0
+    ti.gid = 0
+    ti.uname = ""
+    ti.gname = ""
+    return ti
 
 
 def _posix_dirname(path: str) -> str:

--- a/src/smolvm/presets/_install.py
+++ b/src/smolvm/presets/_install.py
@@ -31,6 +31,7 @@ from uuid import uuid4
 
 from smolvm.env import inject_env_vars
 from smolvm.exceptions import SmolVMError
+from smolvm.presets._git import GIT_HOST_CONFIGS
 
 if TYPE_CHECKING:
     from smolvm.presets._types import Preset
@@ -76,7 +77,10 @@ def apply_preset(
     notify = on_progress or (lambda _msg: None)
 
     copied_configs: list[str] = []
-    for cfg in preset.host_configs:
+    # Git configs piggyback on host_configs so dir copies (e.g. ~/.ssh)
+    # preserve 0o600 modes via tar and the run summary surfaces them
+    # under the existing copied_configs key.
+    for cfg in (*preset.host_configs, *GIT_HOST_CONFIGS):
         local = Path(cfg.host_path).expanduser()
         if not local.exists():
             if cfg.required:

--- a/src/smolvm/presets/_types.py
+++ b/src/smolvm/presets/_types.py
@@ -28,11 +28,18 @@ class HostConfigCopy:
         guest_path: Destination path inside the guest (absolute).
         required: If True, raise an error when the host path is missing.
             If False (default), the copy is silently skipped.
+        file_mode: Octal permission bits to apply to the guest file
+            after upload. Single-file copies only — directory copies
+            inherit modes from the tar archive. Use this for credential
+            files (e.g. ``~/.git-credentials``) that the SFTP server's
+            umask would otherwise leave world-readable. ``None``
+            (default) leaves the SFTP-applied mode in place.
     """
 
     host_path: str
     guest_path: str
     required: bool = False
+    file_mode: int | None = None
 
 
 @dataclass(frozen=True)

--- a/tests/test_presets.py
+++ b/tests/test_presets.py
@@ -822,3 +822,96 @@ class TestGitCredentialInjection:
         assert any(
             "tar -xf" in cmd and "/root/.ssh" in cmd for cmd in commands_run
         ), commands_run
+
+    def test_git_ssh_tar_owner_stripped_to_root(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """The tar staged for the guest must zero uid/gid on every entry.
+
+        Guests extract as root with default ``--same-owner``; if host
+        uids (e.g. macOS 501:20) survive, ``/root/.ssh/id_ed25519``
+        ends up owned by uid 501 and sshd refuses the key with "Bad
+        owner or permissions". File modes (the 0o600 we care about)
+        must remain intact.
+        """
+        import tarfile
+
+        monkeypatch.setenv("HOME", str(tmp_path))
+        ssh_dir = tmp_path / ".ssh"
+        ssh_dir.mkdir()
+        key = ssh_dir / "id_ed25519"
+        key.write_text("PRIVATE")
+        key.chmod(0o600)
+
+        ssh = MagicMock()
+        ssh.run.return_value = _ok()
+        staged_tars: list[Path] = []
+
+        def capture_put(local: object, _remote: str) -> None:
+            path = Path(str(local))
+            if path.suffix == ".tar":
+                # Copy aside before _copy_dir's finally clause unlinks it.
+                snapshot = tmp_path / f"snapshot-{len(staged_tars)}.tar"
+                snapshot.write_bytes(path.read_bytes())
+                staged_tars.append(snapshot)
+
+        ssh.put_file.side_effect = capture_put
+
+        apply_preset(ssh, self._stub_codex_preset())
+
+        assert staged_tars, "no tar archive was staged"
+        with tarfile.open(staged_tars[0]) as tf:
+            members = tf.getmembers()
+        assert members, "tar archive is empty"
+        assert all(m.uid == 0 and m.gid == 0 for m in members), [
+            (m.name, m.uid, m.gid) for m in members
+        ]
+        assert all(m.uname == "" and m.gname == "" for m in members), [
+            (m.name, m.uname, m.gname) for m in members
+        ]
+        # Mode bits survive — the SSH private key stays at 0o600.
+        key_member = next(m for m in members if m.name.endswith("id_ed25519"))
+        assert key_member.mode & 0o777 == 0o600
+
+    def test_git_credentials_chmodded_to_0600_after_upload(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """``~/.git-credentials`` is plaintext OAuth tokens. SFTP drops
+        the file at the server's umask (typically 0644). The applier
+        must chmod 0600 after upload so the file does not land
+        world-readable inside the guest."""
+        monkeypatch.setenv("HOME", str(tmp_path))
+        (tmp_path / ".git-credentials").write_text(
+            "https://user:token@github.com\n"
+        )
+
+        ssh = MagicMock()
+        ssh.run.return_value = _ok()
+
+        apply_preset(ssh, self._stub_codex_preset())
+
+        commands_run = [call.args[0] for call in ssh.run.call_args_list]
+        assert any(
+            "chmod 600" in cmd and "/root/.git-credentials" in cmd
+            for cmd in commands_run
+        ), commands_run
+
+    def test_gitconfig_not_chmodded(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """``~/.gitconfig`` is conventionally world-readable; only
+        credential files get the 0600 treatment. Guards against
+        accidentally tightening every file_mode."""
+        monkeypatch.setenv("HOME", str(tmp_path))
+        (tmp_path / ".gitconfig").write_text("[user]\n\temail = u@example.com\n")
+
+        ssh = MagicMock()
+        ssh.run.return_value = _ok()
+
+        apply_preset(ssh, self._stub_codex_preset())
+
+        chmod_targets = [
+            cmd for cmd in (call.args[0] for call in ssh.run.call_args_list)
+            if "chmod" in cmd and "/root/.gitconfig" in cmd
+        ]
+        assert chmod_targets == [], chmod_targets

--- a/tests/test_presets.py
+++ b/tests/test_presets.py
@@ -25,6 +25,7 @@ from smolvm.exceptions import SmolVMError
 from smolvm.presets import (
     CLAUDE_CODE_PRESET,
     CODEX_PRESET,
+    GIT_HOST_CONFIGS,
     HostConfigCopy,
     HostKeychainSecret,
     Preset,
@@ -44,6 +45,23 @@ def _ok(stdout: str = "", stderr: str = "") -> CommandResult:
 
 def _fail(stderr: str = "boom") -> CommandResult:
     return CommandResult(exit_code=1, stdout="", stderr=stderr)
+
+
+@pytest.fixture(autouse=True)
+def _isolate_home(
+    tmp_path_factory: pytest.TempPathFactory, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Pin ``$HOME`` to a clean tmp dir for every test in this module.
+
+    ``apply_preset`` always layers ``GIT_HOST_CONFIGS`` (``~/.gitconfig``,
+    ``~/.ssh``, ``~/.config/gh``, …) onto each preset's own copies. If
+    the test runner's real home has any of those files, the unrelated
+    ``copied_configs`` / ``ssh.put_file`` assertions in this file pick
+    them up as extra entries and flake. Tests that need a populated
+    home call ``monkeypatch.setenv('HOME', ...)`` themselves; the later
+    setenv on the same monkeypatch instance overrides this default."""
+    home = tmp_path_factory.mktemp("isolated_home")
+    monkeypatch.setenv("HOME", str(home))
 
 
 class TestRegistry:
@@ -675,3 +693,132 @@ class TestApplyPresetKeychain:
         assert len(keychain_msgs) == 1
         assert "found" in keychain_msgs[0]
         assert "/root/a" in keychain_msgs[0]
+
+
+class TestGitCredentialInjection:
+    """Every preset start auto-copies the host's git/SSH/gh auth files.
+
+    The applier must layer ``GIT_HOST_CONFIGS`` onto whatever the preset
+    declares so a fresh sandbox has working ``git``, ``gh``, and
+    ``ssh git@github.com`` without the agent re-authenticating. Missing
+    files are skipped silently — a host with no ``~/.gitconfig`` should
+    not break ``smolvm codex start``.
+    """
+
+    def test_git_host_configs_constant_shape(self) -> None:
+        """Pin the contract: which host paths land where, and that all
+        entries are optional. Adding/removing a path here is a behavior
+        change that should be intentional."""
+        pairs = {(c.host_path, c.guest_path) for c in GIT_HOST_CONFIGS}
+        assert pairs == {
+            ("~/.gitconfig", "/root/.gitconfig"),
+            ("~/.config/git/config", "/root/.config/git/config"),
+            ("~/.git-credentials", "/root/.git-credentials"),
+            ("~/.ssh", "/root/.ssh"),
+            ("~/.config/gh", "/root/.config/gh"),
+        }
+        assert all(c.required is False for c in GIT_HOST_CONFIGS)
+
+    def _seed_git_home(self, home: Path) -> None:
+        """Create a host home dir with a representative git auth surface."""
+        (home / ".gitconfig").write_text("[user]\n\temail = u@example.com\n")
+        (home / ".git-credentials").write_text("https://x:y@github.com\n")
+        ssh_dir = home / ".ssh"
+        ssh_dir.mkdir()
+        key = ssh_dir / "id_ed25519"
+        key.write_text("PRIVATE")
+        key.chmod(0o600)
+
+    def _stub_codex_preset(self) -> Preset:
+        """Codex preset with the install step neutered.
+
+        The preset's real install_script runs apt-via-NodeSource which
+        doesn't make sense against a MagicMock; replace with a no-op so
+        the test focuses on the copy stage.
+        """
+        from dataclasses import replace
+
+        return replace(CODEX_PRESET, install_script="")
+
+    def _stub_claude_code_preset(self) -> Preset:
+        from dataclasses import replace
+
+        return replace(CLAUDE_CODE_PRESET, install_script="")
+
+    def test_codex_apply_copies_git_files(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("HOME", str(tmp_path))
+        self._seed_git_home(tmp_path)
+
+        ssh = MagicMock()
+        ssh.run.return_value = _ok()
+
+        summary = apply_preset(ssh, self._stub_codex_preset())
+
+        copied = set(summary["copied_configs"])  # type: ignore[arg-type]
+        assert {
+            "/root/.gitconfig",
+            "/root/.git-credentials",
+            "/root/.ssh",
+        }.issubset(copied)
+
+    def test_claude_code_apply_copies_git_files(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("HOME", str(tmp_path))
+        self._seed_git_home(tmp_path)
+
+        ssh = MagicMock()
+        ssh.run.return_value = _ok()
+
+        summary = apply_preset(ssh, self._stub_claude_code_preset())
+
+        copied = set(summary["copied_configs"])  # type: ignore[arg-type]
+        assert {
+            "/root/.gitconfig",
+            "/root/.git-credentials",
+            "/root/.ssh",
+        }.issubset(copied)
+
+    def test_git_injection_silent_when_files_absent(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A host with no git config and no SSH dir must still
+        provision cleanly — copied_configs simply omits the missing
+        guest paths."""
+        monkeypatch.setenv("HOME", str(tmp_path))
+        # No files seeded.
+
+        ssh = MagicMock()
+        ssh.run.return_value = _ok()
+
+        summary = apply_preset(ssh, self._stub_codex_preset())
+
+        copied = set(summary["copied_configs"])  # type: ignore[arg-type]
+        git_guest_paths = {c.guest_path for c in GIT_HOST_CONFIGS}
+        assert copied.isdisjoint(git_guest_paths)
+
+    def test_git_ssh_uploaded_via_tar_dir_path(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """``~/.ssh`` must travel through the tar-based dir-copy path so
+        the guest's keys end up at 0o600 and sshd accepts them. Verified
+        indirectly: the recorded ssh.run includes the ``tar -xf ... -C
+        /root/.ssh`` template from ``_copy_dir``."""
+        monkeypatch.setenv("HOME", str(tmp_path))
+        ssh_dir = tmp_path / ".ssh"
+        ssh_dir.mkdir()
+        key = ssh_dir / "id_ed25519"
+        key.write_text("PRIVATE")
+        key.chmod(0o600)
+
+        ssh = MagicMock()
+        ssh.run.return_value = _ok()
+
+        apply_preset(ssh, self._stub_codex_preset())
+
+        commands_run = [call.args[0] for call in ssh.run.call_args_list]
+        assert any(
+            "tar -xf" in cmd and "/root/.ssh" in cmd for cmd in commands_run
+        ), commands_run


### PR DESCRIPTION
Both `codex start` and `claude-code start` now also copy ~/.gitconfig,
~/.config/git/config, ~/.git-credentials, ~/.ssh/, and ~/.config/gh/
from the host into the guest so git, gh, and ssh git@github.com work
without re-auth. Missing files are skipped silently. The whole ~/.ssh
goes through the existing tar-based dir copy so 0o600 key modes are
preserved and sshd accepts them.

Reuses the existing HostConfigCopy + apply_preset pipeline; the new
GIT_HOST_CONFIGS list is layered onto every preset's host_configs at
apply time, so future presets pick this up automatically.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Git credentials and configurations (including SSH keys) are now automatically forwarded from your host machine to the sandbox environment, enabling git/gh/SSH authentication without re-authentication when using the `codex start` and `claude-code start` presets.

* **Documentation**
  * Added documentation detailing git credential forwarding behavior and configuration requirements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->