### PR TITLE
fix(presets): trust workspace mounts as git safe.directory

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -43,6 +43,15 @@ HTTPS GitHub auth are not yet copied; on macOS run
 `git config --global credential.helper store` once on the host if
 you rely on that helper.
 
+After the copies, the applier registers `/workspace*` and
+`/workspace*/**` as `safe.directory` entries in the guest's global
+git config. Workspace mounts are 9p shares that preserve host
+uid/gid, so without this every `git` command in `/workspace` errors
+with "fatal: detected dubious ownership" (CVE-2022-24765). Wildcards
+in `safe.directory` need git ≥ 2.43, which Noble ships. Scoped to
+workspace paths intentionally — using `*` would also work but vouches
+for paths the user never asked us to share.
+
 ### Core writing principles
 - Follow progressive disclosure of complexity.
 - Lead with outcomes, not implementation details.

--- a/src/smolvm/presets/_git.py
+++ b/src/smolvm/presets/_git.py
@@ -24,7 +24,14 @@ through the same pipeline as harness-specific configs (e.g.
 
 from __future__ import annotations
 
+import shlex
+from typing import TYPE_CHECKING
+
+from smolvm.exceptions import SmolVMError
 from smolvm.presets._types import HostConfigCopy
+
+if TYPE_CHECKING:
+    from smolvm.ssh import SSHClient
 
 GIT_HOST_CONFIGS: tuple[HostConfigCopy, ...] = (
     HostConfigCopy(host_path="~/.gitconfig", guest_path="/root/.gitconfig"),
@@ -40,5 +47,36 @@ GIT_HOST_CONFIGS: tuple[HostConfigCopy, ...] = (
     HostConfigCopy(host_path="~/.config/gh", guest_path="/root/.config/gh"),
 )
 
+# Workspace mounts ride a virtio-9p share, which preserves the host's
+# uid/gid (e.g. macOS 501:20). Inside the guest we run as root (uid 0),
+# so git's CVE-2022-24765 ownership check fires on every command with
+# "fatal: detected dubious ownership". Pre-register these paths as safe
+# in the guest's global git config. Two patterns cover both shapes:
+#   /workspace*    — the mount point itself (single mount at /workspace
+#                    or numbered mounts at /workspace-1, /workspace-2…)
+#   /workspace*/** — repos nested below the mount point
+# Wildcards in safe.directory require git ≥ 2.43, which Ubuntu Noble
+# (the only image we boot) ships. Scoped intentionally — the trust
+# scope matches the existing one (anyone with sandbox shell is already
+# trusted), but limiting to /workspace avoids vouching for paths the
+# user never asked us to share.
+WORKSPACE_SAFE_DIRECTORIES: tuple[str, ...] = ("/workspace*", "/workspace*/**")
 
-__all__ = ["GIT_HOST_CONFIGS"]
+
+def register_workspace_safe_directories(ssh: SSHClient) -> None:
+    """Add WORKSPACE_SAFE_DIRECTORIES to the guest's global git config."""
+    args = " ".join(shlex.quote(path) for path in WORKSPACE_SAFE_DIRECTORIES)
+    cmd = f"for p in {args}; do git config --global --add safe.directory \"$p\"; done"
+    result = ssh.run(cmd, timeout=10)
+    if not result.ok:
+        raise SmolVMError(
+            "Failed to register workspace safe.directory entries on guest",
+            {"exit_code": result.exit_code, "stderr": result.stderr},
+        )
+
+
+__all__ = [
+    "GIT_HOST_CONFIGS",
+    "WORKSPACE_SAFE_DIRECTORIES",
+    "register_workspace_safe_directories",
+]

--- a/src/smolvm/presets/_git.py
+++ b/src/smolvm/presets/_git.py
@@ -24,7 +24,6 @@ through the same pipeline as harness-specific configs (e.g.
 
 from __future__ import annotations
 
-import shlex
 from typing import TYPE_CHECKING
 
 from smolvm.exceptions import SmolVMError
@@ -64,9 +63,24 @@ WORKSPACE_SAFE_DIRECTORIES: tuple[str, ...] = ("/workspace*", "/workspace*/**")
 
 
 def register_workspace_safe_directories(ssh: SSHClient) -> None:
-    """Add WORKSPACE_SAFE_DIRECTORIES to the guest's global git config."""
-    args = " ".join(shlex.quote(path) for path in WORKSPACE_SAFE_DIRECTORIES)
-    cmd = f"for p in {args}; do git config --global --add safe.directory \"$p\"; done"
+    """Add WORKSPACE_SAFE_DIRECTORIES to the guest's global git config.
+
+    Idempotent: uses ``--replace-all`` per path with a value-regex that
+    matches only that exact path, so re-runs collapse to one entry per
+    path instead of appending duplicates, and any unrelated
+    ``safe.directory`` entries the user's host gitconfig brought along
+    are preserved.
+    """
+    parts: list[str] = []
+    for path in WORKSPACE_SAFE_DIRECTORIES:
+        # WORKSPACE_SAFE_DIRECTORIES values contain only `/`, letters,
+        # and `*` (the only regex metachar), so escaping by hand is
+        # safe and clearer than pulling in `re.escape`.
+        regex = "^" + path.replace("*", r"\*") + "$"
+        parts.append(
+            f"git config --global --replace-all safe.directory '{path}' '{regex}'"
+        )
+    cmd = " && ".join(parts)
     result = ssh.run(cmd, timeout=10)
     if not result.ok:
         raise SmolVMError(

--- a/src/smolvm/presets/_install.py
+++ b/src/smolvm/presets/_install.py
@@ -31,7 +31,7 @@ from uuid import uuid4
 
 from smolvm.env import inject_env_vars
 from smolvm.exceptions import SmolVMError
-from smolvm.presets._git import GIT_HOST_CONFIGS
+from smolvm.presets._git import GIT_HOST_CONFIGS, register_workspace_safe_directories
 
 if TYPE_CHECKING:
     from smolvm.presets._types import Preset
@@ -93,6 +93,12 @@ def apply_preset(
         notify(f"Copying {local} → {cfg.guest_path}")
         _copy_to_guest(ssh, local, cfg.guest_path, file_mode=cfg.file_mode)
         copied_configs.append(cfg.guest_path)
+
+    # Trust the workspace mounts so git stops refusing to operate on the
+    # 9p-shared repo with "fatal: detected dubious ownership". Runs after
+    # the host gitconfig copy so this entry appends to it rather than
+    # being clobbered.
+    register_workspace_safe_directories(ssh)
 
     # Keychain step runs after host_configs so a directory copy that
     # targets the same parent (e.g. ~/.claude → /root/.claude) cannot

--- a/tests/test_presets.py
+++ b/tests/test_presets.py
@@ -375,6 +375,7 @@ class TestApplyPreset:
         ssh = MagicMock()
         # First .run for inject_env (read_env_vars) succeeds, then install fails.
         ssh.run.side_effect = [
+            _ok(),  # register_workspace_safe_directories
             _ok(),  # read_env_vars in inject_env_vars
             _ok(),  # _atomic_write inside inject_env_vars
             _fail(stderr="line1\nline2\nE: bad apt key\n"),  # install script
@@ -915,3 +916,29 @@ class TestGitCredentialInjection:
             if "chmod" in cmd and "/root/.gitconfig" in cmd
         ]
         assert chmod_targets == [], chmod_targets
+
+    def test_workspace_safe_directory_registered(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Workspace mounts are 9p shares preserving host uid/gid, so
+        git refuses to operate on them with ``fatal: detected dubious
+        ownership`` (CVE-2022-24765). The applier must register the
+        mount paths in the guest's global git config so users do not
+        hit that error on first ``git status``. Two patterns cover
+        both shapes — the mount itself and repos nested below it."""
+        monkeypatch.setenv("HOME", str(tmp_path))
+
+        ssh = MagicMock()
+        ssh.run.return_value = _ok()
+
+        apply_preset(ssh, self._stub_codex_preset())
+
+        commands_run = [call.args[0] for call in ssh.run.call_args_list]
+        config_cmds = [
+            cmd for cmd in commands_run
+            if "git config --global --add safe.directory" in cmd
+        ]
+        assert config_cmds, commands_run
+        joined = " ".join(config_cmds)
+        assert "/workspace*" in joined
+        assert "/workspace*/**" in joined

--- a/tests/test_presets.py
+++ b/tests/test_presets.py
@@ -924,8 +924,17 @@ class TestGitCredentialInjection:
         git refuses to operate on them with ``fatal: detected dubious
         ownership`` (CVE-2022-24765). The applier must register the
         mount paths in the guest's global git config so users do not
-        hit that error on first ``git status``. Two patterns cover
-        both shapes — the mount itself and repos nested below it."""
+        hit that error on first ``git status``.
+
+        Verifies three properties at once:
+          * Both wildcard patterns are registered (mount point itself
+            and any repo nested below it).
+          * ``--replace-all`` is used so re-runs collapse to one entry
+            per path instead of appending duplicates.
+          * The value-pattern is anchored to the exact path so we do
+            not clobber unrelated ``safe.directory`` entries the
+            user's host gitconfig brought into the guest.
+        """
         monkeypatch.setenv("HOME", str(tmp_path))
 
         ssh = MagicMock()
@@ -934,11 +943,11 @@ class TestGitCredentialInjection:
         apply_preset(ssh, self._stub_codex_preset())
 
         commands_run = [call.args[0] for call in ssh.run.call_args_list]
-        config_cmds = [
-            cmd for cmd in commands_run
-            if "git config --global --add safe.directory" in cmd
-        ]
+        config_cmds = [cmd for cmd in commands_run if "safe.directory" in cmd]
         assert config_cmds, commands_run
         joined = " ".join(config_cmds)
-        assert "/workspace*" in joined
-        assert "/workspace*/**" in joined
+        assert "--replace-all safe.directory" in joined
+        assert "'/workspace*'" in joined
+        assert "'/workspace*/**'" in joined
+        assert r"'^/workspace\*$'" in joined
+        assert r"'^/workspace\*/\*\*$'" in joined


### PR DESCRIPTION
## Summary
- Workspace mounts are 9p shares preserving host uid/gid; inside the guest (running as root) git's CVE-2022-24765 check fires on every command with `fatal: detected dubious ownership`.
- `apply_preset` now registers `/workspace*` and `/workspace*/**` as `safe.directory` entries in the guest's global git config, immediately after copying the host gitconfig.
- Two patterns cover both shapes: the mount point itself (`/workspace`, `/workspace-1`, …) and repos nested below it.

## Notes
- Wildcards in `safe.directory` require git ≥ 2.43, which Ubuntu Noble (the only image we boot) ships.
- Scoped to `/workspace*` rather than `*`. Trust scope matches the existing one (anyone with sandbox shell is already trusted), but limiting to /workspace avoids vouching for paths the user never asked us to share.
- Implementation lives next to `GIT_HOST_CONFIGS` in `presets/_git.py` since it's part of the same git-credentials feature surface.

## Test plan
- [x] `uv run pytest tests/test_presets.py` — 50 passed (includes new `test_workspace_safe_directory_registered`)
- [x] `uv run pytest` — 743 passed, 11 skipped
- [x] `uv run ruff check` on changed files — clean
- [ ] Manual: `smolvm codex start` against a host repo, then `git status` inside the guest at `/workspace` — should not emit the dubious-ownership warning.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Git configuration now automatically registers workspace directories as safe, preventing "dubious ownership" failures on shared workspace mounts.

* **Documentation**
  * Updated documentation explaining Git safe directory configuration for workspace mounts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->