### PR TITLE
fix(onboarding): auto-activate kvm group so first-time install just works

### DIFF
--- a/scripts/system-setup.sh
+++ b/scripts/system-setup.sh
@@ -209,7 +209,10 @@ install_kvm_udev_rule() {
 KERNEL=="kvm", GROUP="kvm", MODE="0660", TAG+="uaccess"
 '
 
-    if [[ -f "${rule_path}" ]] && [[ "$(cat "${rule_path}")" == "${rule_body}" ]]; then
+    # `$(cat …)` strips trailing newlines, so re-append one before comparing
+    # against rule_body (which ends with a newline) — otherwise this idempotency
+    # check would never match and we'd re-write + re-trigger udev on every run.
+    if [[ -f "${rule_path}" ]] && [[ "$(cat "${rule_path}")"$'\n' == "${rule_body}" ]]; then
         echo "✅ KVM udev rule already in place at ${rule_path}"
         return 0
     fi
@@ -228,8 +231,12 @@ KERNEL=="kvm", GROUP="kvm", MODE="0660", TAG+="uaccess"
     if udevadm control --reload >/dev/null 2>&1; then
         # Apply immediately so the current session sees the new mode/group
         # without waiting for the next kernel device event.
-        udevadm trigger /dev/kvm >/dev/null 2>&1 || true
-        echo "✅ KVM udev rule installed and applied"
+        if udevadm trigger /dev/kvm >/dev/null 2>&1; then
+            echo "✅ KVM udev rule installed and applied"
+        else
+            echo "⚠️  Wrote ${rule_path} but 'udevadm trigger /dev/kvm' failed."
+            echo "    Run 'sudo udevadm trigger /dev/kvm' or reboot to apply."
+        fi
     else
         echo "⚠️  Wrote ${rule_path} but 'udevadm control --reload' failed."
         echo "    The rule will take effect on next reboot."

--- a/scripts/system-setup.sh
+++ b/scripts/system-setup.sh
@@ -194,6 +194,48 @@ ensure_kvm_group_membership() {
     ensure_group_membership "kvm" "newgrp kvm"
 }
 
+# Install a udev rule that pins /dev/kvm to mode 0660 + group=kvm and
+# tags it for systemd-logind's `uaccess` ACL helper. The mode/group bits
+# normalize behavior across distros (some leave /dev/kvm root-owned by
+# default); the `uaccess` tag means a desktop user logged in at the
+# active seat gets a per-user POSIX ACL on /dev/kvm without joining
+# the kvm group at all. Headless SSH sessions still rely on the kvm
+# group membership above (uaccess only fires for seat sessions), but
+# the rule is harmless there and avoids a footgun if the host later
+# grows a desktop session.
+install_kvm_udev_rule() {
+    local rule_path="/etc/udev/rules.d/65-smolvm-kvm.rules"
+    local rule_body='# Managed by smolvm setup. Do not edit by hand.
+KERNEL=="kvm", GROUP="kvm", MODE="0660", TAG+="uaccess"
+'
+
+    if [[ -f "${rule_path}" ]] && [[ "$(cat "${rule_path}")" == "${rule_body}" ]]; then
+        echo "✅ KVM udev rule already in place at ${rule_path}"
+        return 0
+    fi
+
+    if ! command -v udevadm >/dev/null 2>&1; then
+        echo "ℹ️  udevadm not found; skipping KVM udev rule install."
+        echo "    /dev/kvm permissions will follow whatever the distro ships."
+        return 0
+    fi
+
+    echo "Installing KVM udev rule at ${rule_path}..."
+    install -d -m 0755 /etc/udev/rules.d
+    printf '%s' "${rule_body}" > "${rule_path}"
+    chmod 0644 "${rule_path}"
+
+    if udevadm control --reload >/dev/null 2>&1; then
+        # Apply immediately so the current session sees the new mode/group
+        # without waiting for the next kernel device event.
+        udevadm trigger /dev/kvm >/dev/null 2>&1 || true
+        echo "✅ KVM udev rule installed and applied"
+    else
+        echo "⚠️  Wrote ${rule_path} but 'udevadm control --reload' failed."
+        echo "    The rule will take effect on next reboot."
+    fi
+}
+
 run_runtime_config() {
     local mode="$1"
     local runtime_user
@@ -326,6 +368,7 @@ if [[ ! -e /dev/kvm ]]; then
 fi
 if [[ -e /dev/kvm ]]; then
     ensure_kvm_group_membership
+    install_kvm_udev_rule
 fi
 
 if [[ "${SKIP_DEPS}" == "true" ]]; then

--- a/src/smolvm/cli/_kvm_session.py
+++ b/src/smolvm/cli/_kvm_session.py
@@ -1,0 +1,138 @@
+# Copyright 2026 Celesto AI
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Auto-activate a pending ``kvm`` group membership for the current CLI run.
+
+When a user runs ``sudo usermod -aG kvm $USER``, the new group only takes
+effect for *new* login sessions. Their current shell (and any child
+processes, including ``smolvm``) keeps the old group set, so ``/dev/kvm``
+remains inaccessible until they log out and back in. This module detects
+that exact state and re-execs the CLI under ``sg kvm -c …`` so the kvm
+group is active for the rest of the run, sparing first-time users a
+manual ``newgrp`` or relog.
+
+Linux-only. Returns immediately on macOS and other platforms.
+"""
+
+from __future__ import annotations
+
+import os
+import platform
+import shlex
+import shutil
+import sys
+from collections.abc import Sequence
+from pathlib import Path
+
+# Internal env var used as a loop guard so the re-exec'd child does not
+# re-enter the helper and fork forever.
+_REEXEC_DONE_ENV = "SMOLVM_KVM_REEXEC_DONE"
+
+# User-facing escape hatch: setting this disables the re-exec entirely,
+# useful for advanced users, scripts, or debugging.
+_REEXEC_DISABLE_ENV = "SMOLVM_NO_KVM_REEXEC"
+
+# Subcommands that should *not* trigger a re-exec. ``doctor`` and ``setup``
+# are diagnostic/administrative — silently switching the process's primary
+# gid would hide the very state the user invoked them to inspect or fix.
+# ``--help``/``--version`` short-circuit before any kvm work happens.
+_SKIP_FIRST_ARGS: frozenset[str] = frozenset(
+    {
+        "doctor",
+        "setup",
+        "-h",
+        "--help",
+        "-V",
+        "--version",
+    }
+)
+
+_KVM_DEV = Path("/dev/kvm")
+_KVM_GROUP = "kvm"
+
+
+def maybe_reexec_for_kvm_group(argv: Sequence[str] | None = None) -> None:
+    """Re-exec via ``sg kvm -c`` when a usermod is pending a session refresh.
+
+    ``argv`` defaults to ``sys.argv[1:]`` and is used only to decide whether
+    the requested subcommand is one we deliberately skip (``doctor``,
+    ``setup``, ``--help``, ``--version``). On a successful re-exec this
+    function does not return — execution transfers to the ``sg`` child
+    process. On any failure or skipped path it returns ``None`` and the
+    caller proceeds normally.
+    """
+    if not _should_attempt_reexec(argv):
+        return
+
+    sg_path = shutil.which("sg")
+    if sg_path is None:
+        # Without `sg` we have no way to acquire the group without a relog;
+        # let the regular kvm-permission failure surface with its fix hint.
+        return
+
+    # Mark the env so the child doesn't loop, then exec. After execvp
+    # succeeds, this Python process is replaced and never returns.
+    child_env_marker_set()
+    inner_cmd = shlex.join([sys.executable, *sys.argv])
+    print(
+        "Activating pending kvm group membership for this session "
+        "(via 'sg kvm') so /dev/kvm becomes accessible…",
+        file=sys.stderr,
+        flush=True,
+    )
+    os.execvp(sg_path, [sg_path, _KVM_GROUP, "-c", inner_cmd])
+
+
+def child_env_marker_set() -> None:
+    """Set the loop-guard env var. Extracted for test seams."""
+    os.environ[_REEXEC_DONE_ENV] = "1"
+
+
+def _should_attempt_reexec(argv: Sequence[str] | None) -> bool:
+    """Return True iff the current invocation matches the stale-group state."""
+    if platform.system() != "Linux":
+        return False
+    if os.environ.get(_REEXEC_DONE_ENV) == "1":
+        return False
+    if os.environ.get(_REEXEC_DISABLE_ENV):
+        return False
+
+    args = list(argv) if argv is not None else sys.argv[1:]
+    if args and args[0] in _SKIP_FIRST_ARGS:
+        return False
+
+    if not _KVM_DEV.exists():
+        return False
+    if os.access(_KVM_DEV, os.R_OK | os.W_OK):
+        return False  # already accessible — nothing to do
+
+    # The user must be listed as a member of the kvm group in /etc/group;
+    # otherwise `sg kvm` would prompt for a password. We never want to
+    # surface a password prompt mid-CLI.
+    try:
+        import grp  # POSIX-only; the platform check above guards macOS callers.
+        import pwd
+
+        kvm_members = set(grp.getgrnam(_KVM_GROUP).gr_mem)
+        kvm_gid = grp.getgrnam(_KVM_GROUP).gr_gid
+        current_user = pwd.getpwuid(os.getuid()).pw_name
+    except (KeyError, ImportError):
+        return False
+
+    if current_user not in kvm_members:
+        return False  # genuine "not in group" case — don't paper over it
+    # If kvm is already in our effective set but /dev/kvm is still denied,
+    # something else is wrong (mode bits, ACLs, etc.). Don't re-exec; let
+    # the doctor row surface the real problem.
+    return kvm_gid not in os.getgroups()

--- a/src/smolvm/cli/_kvm_session.py
+++ b/src/smolvm/cli/_kvm_session.py
@@ -43,20 +43,46 @@ _REEXEC_DONE_ENV = "SMOLVM_KVM_REEXEC_DONE"
 # useful for advanced users, scripts, or debugging.
 _REEXEC_DISABLE_ENV = "SMOLVM_NO_KVM_REEXEC"
 
-# Subcommands that should *not* trigger a re-exec. ``doctor`` and ``setup``
-# are diagnostic/administrative — silently switching the process's primary
-# gid would hide the very state the user invoked them to inspect or fix.
-# ``--help``/``--version`` short-circuit before any kvm work happens.
+# Subcommands that should *not* trigger a re-exec. Two groups:
+#
+#   1. Diagnostic/administrative verbs whose job is to *report* state —
+#      silently switching the process's primary gid would hide the very
+#      thing the user invoked them to inspect (``doctor``) or fix
+#      (``setup``).
+#
+#   2. Read-only or VM-process-targeted verbs that don't open ``/dev/kvm``
+#      themselves — listing, inspecting, ssh'ing into an already-running
+#      sandbox, signalling stop/pause, removing state files. Re-execing
+#      under ``sg kvm`` would only add startup latency and a confusing
+#      "activating kvm group" notice for an operation that doesn't need
+#      kvm at all.
+#
+# ``-h``/``--help``/``-V``/``--version`` are checked separately because they
+# can appear at *any* depth (e.g. ``smolvm create --help``), not just as
+# the first argument.
 _SKIP_FIRST_ARGS: frozenset[str] = frozenset(
     {
+        # Diagnostic / administrative
         "doctor",
         "setup",
-        "-h",
-        "--help",
-        "-V",
-        "--version",
+        # Read-only state inspection
+        "list",
+        "info",
+        "env",
+        # VM-process-targeted (talks to an already-running sandbox; no kvm open)
+        "ssh",
+        "stop",
+        "pause",
+        # State-file maintenance
+        "delete",
+        "cleanup",
     }
 )
+
+# Help/version flags can appear anywhere in argv (top-level *or* per-verb,
+# e.g. ``smolvm create --help``). When any of these is present, argparse
+# is going to short-circuit before any kvm work happens, so we should too.
+_HELP_VERSION_FLAGS: frozenset[str] = frozenset({"-h", "--help", "-V", "--version"})
 
 _KVM_DEV = Path("/dev/kvm")
 _KVM_GROUP = "kvm"
@@ -82,7 +108,11 @@ def maybe_reexec_for_kvm_group(argv: Sequence[str] | None = None) -> None:
         return
 
     # Mark the env so the child doesn't loop, then exec. After execvp
-    # succeeds, this Python process is replaced and never returns.
+    # succeeds, this Python process is replaced and never returns; if it
+    # raises (rare — sg disappeared between which() and execvp(), bad
+    # interpreter, etc.) we must drop the marker so the regular kvm
+    # permission failure surfaces normally instead of being silenced by a
+    # loop guard meant for the *next* process.
     child_env_marker_set()
     inner_cmd = shlex.join([sys.executable, *sys.argv])
     print(
@@ -91,12 +121,25 @@ def maybe_reexec_for_kvm_group(argv: Sequence[str] | None = None) -> None:
         file=sys.stderr,
         flush=True,
     )
-    os.execvp(sg_path, [sg_path, _KVM_GROUP, "-c", inner_cmd])
+    try:
+        os.execvp(sg_path, [sg_path, _KVM_GROUP, "-c", inner_cmd])
+    except BaseException:
+        # execvp normally never returns; if it raises, drop the loop guard
+        # so the parent process doesn't carry a stale marker, then re-raise
+        # so the original failure isn't silently swallowed.
+        child_env_marker_unset()
+        raise
 
 
 def child_env_marker_set() -> None:
     """Set the loop-guard env var. Extracted for test seams."""
     os.environ[_REEXEC_DONE_ENV] = "1"
+
+
+def child_env_marker_unset() -> None:
+    """Clear the loop-guard env var. Used when execvp fails so the parent
+    process does not carry a stale marker into subsequent logic."""
+    os.environ.pop(_REEXEC_DONE_ENV, None)
 
 
 def _should_attempt_reexec(argv: Sequence[str] | None) -> bool:
@@ -110,6 +153,8 @@ def _should_attempt_reexec(argv: Sequence[str] | None) -> bool:
 
     args = list(argv) if argv is not None else sys.argv[1:]
     if args and args[0] in _SKIP_FIRST_ARGS:
+        return False
+    if any(arg in _HELP_VERSION_FLAGS for arg in args):
         return False
 
     if not _KVM_DEV.exists():

--- a/src/smolvm/cli/main.py
+++ b/src/smolvm/cli/main.py
@@ -43,6 +43,7 @@ from rich.progress import (
 from rich.table import Table
 from rich.text import Text
 
+from smolvm.cli._kvm_session import maybe_reexec_for_kvm_group
 from smolvm.cli.cleanup import add_cleanup_args, add_delete_args, run_cleanup, run_delete
 from smolvm.cli.output import console_stdout, emit_json, render_empty, render_error, status_style
 from smolvm.cli.version_check import maybe_print_update_notice
@@ -2772,6 +2773,12 @@ def _run_browser(args: argparse.Namespace) -> int:
 
 def main(argv: Sequence[str] | None = None) -> int:
     """CLI entrypoint for `smolvm`."""
+    # Best-effort: if the user has been added to the kvm group but the
+    # current shell session hasn't picked it up yet, re-exec under
+    # `sg kvm -c …` so /dev/kvm becomes accessible without a manual
+    # `newgrp kvm` or relog. Linux-only; no-op everywhere else.
+    maybe_reexec_for_kvm_group(argv)
+
     parser = build_parser()
     args = parser.parse_args(argv)
 

--- a/src/smolvm/host/doctor.py
+++ b/src/smolvm/host/doctor.py
@@ -16,6 +16,7 @@
 
 from __future__ import annotations
 
+import os
 import platform
 import re
 import subprocess
@@ -329,6 +330,73 @@ def _check_kvm_nx_huge_pages() -> DoctorCheck:
     )
 
 
+def _check_kvm_runtime() -> DoctorCheck:
+    """Check that /dev/kvm exists and the current user can read & write it.
+
+    Distinguishes the four states a first-time user actually hits:
+    no /dev/kvm at all (no virt support), /dev/kvm present but the user is
+    not in the kvm group (fresh install), /dev/kvm present and the user is
+    in the kvm group on disk but the current shell session hasn't picked
+    it up yet (the common "I just ran usermod and it still fails" case),
+    or fully accessible.
+    """
+    name = "kvm"
+    if not _KVM_DEV.exists():
+        return DoctorCheck(
+            name=name,
+            status="fail",
+            detail="/dev/kvm not found on this host",
+            fix=(
+                "Run on a host with hardware virtualization (KVM) enabled. "
+                "If this image was built with 'smolvm setup --for-bake', "
+                "/dev/kvm is expected only on the runtime host, not the builder."
+            ),
+        )
+    if not os.access(_KVM_DEV, os.R_OK | os.W_OK):
+        if _user_is_pending_kvm_group():
+            return DoctorCheck(
+                name=name,
+                status="fail",
+                detail=(
+                    "/dev/kvm exists and your user is in the kvm group, "
+                    "but this shell session predates the change"
+                ),
+                fix=(
+                    "Log out of this shell and reconnect to apply the new group, "
+                    "or run any other 'smolvm' command (such as 'smolvm list') — "
+                    "it will auto-activate the group via 'sg kvm' for that run."
+                ),
+            )
+        return DoctorCheck(
+            name=name,
+            status="fail",
+            detail="/dev/kvm exists but your user can't read or write it",
+            fix=(
+                "Add your user to the kvm group, then start a new login session: "
+                "'sudo usermod -aG kvm $USER' and either log out and back in, "
+                "or run 'newgrp kvm' in this shell."
+            ),
+        )
+    return DoctorCheck(name=name, status="pass", detail="/dev/kvm is available")
+
+
+def _user_is_pending_kvm_group() -> bool:
+    """True iff the current user is listed in /etc/group's kvm but the gid
+    is not in the current process's effective group set — i.e. a usermod
+    has been run but no fresh login session has rebuilt the group set."""
+    try:
+        import grp
+        import pwd
+
+        kvm_entry = grp.getgrnam("kvm")
+        current_user = pwd.getpwuid(os.getuid()).pw_name
+    except (KeyError, ImportError):
+        return False
+    if current_user not in kvm_entry.gr_mem:
+        return False
+    return kvm_entry.gr_gid not in os.getgroups()
+
+
 def _check_kvm_permissions() -> DoctorCheck:
     """Firecracker (jailer) needs /dev/kvm with 660 + kvm group ownership."""
     name = "worker:kvm-permissions"
@@ -420,23 +488,7 @@ def generate_doctor_report(backend: str | None = None) -> DoctorReport:
     if resolved == BACKEND_FIRECRACKER:
         host = HostManager()
 
-        kvm_ok = host.check_kvm()
-        checks.append(
-            DoctorCheck(
-                name="kvm",
-                status="pass" if kvm_ok else "fail",
-                detail="/dev/kvm is available" if kvm_ok else "/dev/kvm unavailable",
-                fix=(
-                    None
-                    if kvm_ok
-                    else (
-                        "Run on a KVM-enabled host. If this image was built with "
-                        "'smolvm setup --for-bake', /dev/kvm is expected only on the "
-                        "runtime host, not the builder."
-                    )
-                ),
-            )
-        )
+        checks.append(_check_kvm_runtime())
 
         firecracker_path = host.find_firecracker()
         checks.append(
@@ -512,7 +564,7 @@ def generate_doctor_report(backend: str | None = None) -> DoctorReport:
                     status="pass",
                     detail=f"{qemu_name} ({qemu_path})",
                 )
-                    )
+            )
 
             checks.append(_check_qemu_version(qemu_path))
             if platform.system() == "Darwin":

--- a/src/smolvm/host/doctor.py
+++ b/src/smolvm/host/doctor.py
@@ -346,11 +346,7 @@ def _check_kvm_runtime() -> DoctorCheck:
             name=name,
             status="fail",
             detail="/dev/kvm not found on this host",
-            fix=(
-                "Run on a host with hardware virtualization (KVM) enabled. "
-                "If this image was built with 'smolvm setup --for-bake', "
-                "/dev/kvm is expected only on the runtime host, not the builder."
-            ),
+            fix="Enable hardware virtualization (KVM) on this host or run on a host that has it.",
         )
     if not os.access(_KVM_DEV, os.R_OK | os.W_OK):
         if _user_is_pending_kvm_group():
@@ -382,8 +378,14 @@ def _check_kvm_runtime() -> DoctorCheck:
 
 def _user_is_pending_kvm_group() -> bool:
     """True iff the current user is listed in /etc/group's kvm but the gid
-    is not in the current process's effective group set — i.e. a usermod
-    has been run but no fresh login session has rebuilt the group set."""
+    is not effective for this process — i.e. a usermod has been run but no
+    fresh login session has rebuilt the group set.
+
+    The effective check covers two paths: the kvm gid in the supplementary
+    group list (``os.getgroups()``), and the kvm gid as the process's
+    primary group (``os.getegid()``) — Linux does not always include the
+    primary gid in the supplementary list, so checking only one would
+    falsely flag users whose primary group is kvm."""
     try:
         import grp
         import pwd
@@ -394,7 +396,7 @@ def _user_is_pending_kvm_group() -> bool:
         return False
     if current_user not in kvm_entry.gr_mem:
         return False
-    return kvm_entry.gr_gid not in os.getgroups()
+    return kvm_entry.gr_gid not in os.getgroups() and os.getegid() != kvm_entry.gr_gid
 
 
 def _check_kvm_permissions() -> DoctorCheck:

--- a/src/smolvm/host/manager.py
+++ b/src/smolvm/host/manager.py
@@ -118,13 +118,11 @@ class HostManager:
         kvm_path = Path("/dev/kvm")
 
         if not kvm_path.exists():
-            logger.warning("/dev/kvm does not exist")
+            logger.debug("/dev/kvm does not exist")
             return False
 
         if not os.access(kvm_path, os.R_OK | os.W_OK):
-            logger.warning(
-                "/dev/kvm exists but is not readable/writable. Try: sudo usermod -aG kvm $USER"
-            )
+            logger.debug("/dev/kvm exists but is not readable/writable by current user")
             return False
 
         logger.debug("/dev/kvm is available with R/W access")

--- a/tests/test_doctor.py
+++ b/tests/test_doctor.py
@@ -38,8 +38,11 @@ def _pass(name: str) -> DoctorCheck:
 class TestDoctorFirecracker:
     """Firecracker backend diagnostic tests."""
 
+    @patch("smolvm.host.doctor._check_kvm_runtime", new=lambda: _pass("kvm"))
     @patch("smolvm.host.doctor._check_kvm_permissions", new=lambda: _pass("worker:kvm-permissions"))
-    @patch("smolvm.host.doctor._check_kvm_nx_huge_pages", new=lambda: _pass("worker:kvm-nx-huge-pages"))
+    @patch(
+        "smolvm.host.doctor._check_kvm_nx_huge_pages", new=lambda: _pass("worker:kvm-nx-huge-pages")
+    )
     @patch("smolvm.host.doctor._check_thp_disabled", new=lambda: _pass("worker:thp-disabled"))
     @patch("smolvm.host.doctor._check_ksm_disabled", new=lambda: _pass("worker:ksm-disabled"))
     @patch("smolvm.host.doctor._check_swap_disabled", new=lambda: _pass("worker:swap-disabled"))
@@ -74,8 +77,11 @@ class TestDoctorFirecracker:
         assert report.failures == []
         assert report.warnings == []
 
+    @patch("smolvm.host.doctor._check_kvm_runtime", new=lambda: _pass("kvm"))
     @patch("smolvm.host.doctor._check_kvm_permissions", new=lambda: _pass("worker:kvm-permissions"))
-    @patch("smolvm.host.doctor._check_kvm_nx_huge_pages", new=lambda: _pass("worker:kvm-nx-huge-pages"))
+    @patch(
+        "smolvm.host.doctor._check_kvm_nx_huge_pages", new=lambda: _pass("worker:kvm-nx-huge-pages")
+    )
     @patch(
         "smolvm.host.doctor._check_thp_disabled",
         new=lambda: DoctorCheck(
@@ -131,8 +137,11 @@ class TestDoctorFirecracker:
             "worker:thp-disabled",
         }
 
+    @patch("smolvm.host.doctor._check_kvm_runtime", new=lambda: _pass("kvm"))
     @patch("smolvm.host.doctor._check_kvm_permissions", new=lambda: _pass("worker:kvm-permissions"))
-    @patch("smolvm.host.doctor._check_kvm_nx_huge_pages", new=lambda: _pass("worker:kvm-nx-huge-pages"))
+    @patch(
+        "smolvm.host.doctor._check_kvm_nx_huge_pages", new=lambda: _pass("worker:kvm-nx-huge-pages")
+    )
     @patch("smolvm.host.doctor._check_thp_disabled", new=lambda: _pass("worker:thp-disabled"))
     @patch("smolvm.host.doctor._check_ksm_disabled", new=lambda: _pass("worker:ksm-disabled"))
     @patch("smolvm.host.doctor._check_swap_disabled", new=lambda: _pass("worker:swap-disabled"))
@@ -172,8 +181,11 @@ class TestDoctorFirecracker:
         assert "strict mode treats warnings as failures" in output
         assert "\033[" not in output
 
+    @patch("smolvm.host.doctor._check_kvm_runtime", new=lambda: _pass("kvm"))
     @patch("smolvm.host.doctor._check_kvm_permissions", new=lambda: _pass("worker:kvm-permissions"))
-    @patch("smolvm.host.doctor._check_kvm_nx_huge_pages", new=lambda: _pass("worker:kvm-nx-huge-pages"))
+    @patch(
+        "smolvm.host.doctor._check_kvm_nx_huge_pages", new=lambda: _pass("worker:kvm-nx-huge-pages")
+    )
     @patch(
         "smolvm.host.doctor._check_thp_disabled",
         new=lambda: DoctorCheck(
@@ -347,6 +359,76 @@ class TestDoctorQemu:
 
         with pytest.raises(RuntimeError, match="boom"):
             generate_doctor_report(backend="qemu")
+
+
+class TestKvmRuntimeCheck:
+    """Tests for the user-facing kvm doctor row."""
+
+    @patch("smolvm.host.doctor._KVM_DEV")
+    def test_missing_dev_kvm_fails_with_kvm_host_fix(self, mock_dev: MagicMock) -> None:
+        from smolvm.host.doctor import _check_kvm_runtime
+
+        mock_dev.exists.return_value = False
+        result = _check_kvm_runtime()
+
+        assert result.status == "fail"
+        assert "not found" in result.detail
+        assert result.fix is not None and "hardware virtualization" in result.fix
+
+    @patch("smolvm.host.doctor._user_is_pending_kvm_group", return_value=False)
+    @patch("smolvm.host.doctor.os.access", return_value=False)
+    @patch("smolvm.host.doctor._KVM_DEV")
+    def test_inaccessible_dev_kvm_fails_with_usermod_fix(
+        self,
+        mock_dev: MagicMock,
+        _mock_access: MagicMock,
+        _mock_pending: MagicMock,
+    ) -> None:
+        from smolvm.host.doctor import _check_kvm_runtime
+
+        mock_dev.exists.return_value = True
+        result = _check_kvm_runtime()
+
+        assert result.status == "fail"
+        assert "can't read or write" in result.detail
+        assert result.fix is not None
+        assert "usermod -aG kvm" in result.fix
+        assert "newgrp kvm" in result.fix
+
+    @patch("smolvm.host.doctor._user_is_pending_kvm_group", return_value=True)
+    @patch("smolvm.host.doctor.os.access", return_value=False)
+    @patch("smolvm.host.doctor._KVM_DEV")
+    def test_pending_kvm_group_session_fails_with_relog_fix(
+        self,
+        mock_dev: MagicMock,
+        _mock_access: MagicMock,
+        _mock_pending: MagicMock,
+    ) -> None:
+        """User added to kvm group but current shell hasn't picked it up."""
+        from smolvm.host.doctor import _check_kvm_runtime
+
+        result = _check_kvm_runtime()
+
+        assert result.status == "fail"
+        assert "in the kvm group" in result.detail
+        assert "predates the change" in result.detail
+        assert result.fix is not None
+        assert "Log out" in result.fix
+        assert "sg kvm" in result.fix
+
+    @patch("smolvm.host.doctor.os.access", return_value=True)
+    @patch("smolvm.host.doctor._KVM_DEV")
+    def test_accessible_dev_kvm_passes(
+        self,
+        mock_dev: MagicMock,
+        _mock_access: MagicMock,
+    ) -> None:
+        from smolvm.host.doctor import _check_kvm_runtime
+
+        mock_dev.exists.return_value = True
+        result = _check_kvm_runtime()
+
+        assert result.status == "pass"
 
 
 class TestWorkerNodeSecurityChecks:

--- a/tests/test_doctor.py
+++ b/tests/test_doctor.py
@@ -407,6 +407,7 @@ class TestKvmRuntimeCheck:
         """User added to kvm group but current shell hasn't picked it up."""
         from smolvm.host.doctor import _check_kvm_runtime
 
+        mock_dev.exists.return_value = True
         result = _check_kvm_runtime()
 
         assert result.status == "fail"

--- a/tests/test_kvm_session.py
+++ b/tests/test_kvm_session.py
@@ -19,14 +19,30 @@ from __future__ import annotations
 from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
+import pytest
+
 from smolvm.cli import _kvm_session
 
 
-def _mock_kvm_grp(members: list[str], gid: int = 999) -> MagicMock:
+@pytest.fixture(autouse=True)
+def _reset_reexec_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Strip both kvm-reexec env vars before every test.
+
+    Several tests in this module exercise the real ``_should_attempt_reexec``
+    flow and would short-circuit if a previous test left
+    ``SMOLVM_KVM_REEXEC_DONE`` or ``SMOLVM_NO_KVM_REEXEC`` set in this
+    process — notably the exec-path test below, which mocks ``os.execvp`` and
+    so doesn't actually replace the process the way real execvp would.
+    """
+    monkeypatch.delenv("SMOLVM_KVM_REEXEC_DONE", raising=False)
+    monkeypatch.delenv("SMOLVM_NO_KVM_REEXEC", raising=False)
+
+
+def _mock_kvm_grp(members: list[str], gid: int = 999) -> SimpleNamespace:
     return SimpleNamespace(gr_mem=members, gr_gid=gid)
 
 
-def _mock_pwd_user(name: str) -> MagicMock:
+def _mock_pwd_user(name: str) -> SimpleNamespace:
     return SimpleNamespace(pw_name=name)
 
 
@@ -72,11 +88,29 @@ class TestShouldAttemptReexec:
     def test_help_short_circuits(self, _mock_system: MagicMock) -> None:
         assert _kvm_session._should_attempt_reexec(["--help"]) is False
 
+    @patch("smolvm.cli._kvm_session.platform.system", return_value="Linux")
+    def test_verb_level_help_short_circuits(self, _mock_system: MagicMock) -> None:
+        # ``smolvm create --help`` argparse's into ["create", "--help"] —
+        # this should not trigger a re-exec even though ``create`` is a
+        # kvm-using verb, because no kvm work will actually run.
+        assert _kvm_session._should_attempt_reexec(["create", "--help"]) is False
+        assert _kvm_session._should_attempt_reexec(["snapshot", "create", "-h"]) is False
+        assert _kvm_session._should_attempt_reexec(["create", "--name", "x", "-V"]) is False
+
+    @patch("smolvm.cli._kvm_session.platform.system", return_value="Linux")
+    def test_read_only_verbs_skip(self, _mock_system: MagicMock) -> None:
+        # Read-only / VM-process-targeted verbs don't need /dev/kvm; a
+        # re-exec for them would just print a confusing notice.
+        for verb in ("list", "info", "env", "ssh", "stop", "pause", "delete", "cleanup"):
+            assert _kvm_session._should_attempt_reexec([verb]) is False, (
+                f"expected {verb!r} to skip re-exec"
+            )
+
     @patch("smolvm.cli._kvm_session._KVM_DEV")
     @patch("smolvm.cli._kvm_session.platform.system", return_value="Linux")
     def test_no_dev_kvm_skips(self, _mock_system: MagicMock, mock_dev: MagicMock) -> None:
         mock_dev.exists.return_value = False
-        assert _kvm_session._should_attempt_reexec(["list"]) is False
+        assert _kvm_session._should_attempt_reexec(["create"]) is False
 
     @patch("smolvm.cli._kvm_session.os.access", return_value=True)
     @patch("smolvm.cli._kvm_session._KVM_DEV")
@@ -88,7 +122,7 @@ class TestShouldAttemptReexec:
         _mock_access: MagicMock,
     ) -> None:
         mock_dev.exists.return_value = True
-        assert _kvm_session._should_attempt_reexec(["list"]) is False
+        assert _kvm_session._should_attempt_reexec(["create"]) is False
 
     @patch("smolvm.cli._kvm_session.os.getuid", return_value=1000)
     @patch("smolvm.cli._kvm_session.os.access", return_value=False)
@@ -108,7 +142,7 @@ class TestShouldAttemptReexec:
             patch("grp.getgrnam", return_value=_mock_kvm_grp(members=["other"])),
             patch("pwd.getpwuid", return_value=_mock_pwd_user("alice")),
         ):
-            assert _kvm_session._should_attempt_reexec(["list"]) is False
+            assert _kvm_session._should_attempt_reexec(["create"]) is False
 
     @patch("smolvm.cli._kvm_session.os.getgroups", return_value=[999])
     @patch("smolvm.cli._kvm_session.os.getuid", return_value=1000)
@@ -134,7 +168,7 @@ class TestShouldAttemptReexec:
             ),
             patch("pwd.getpwuid", return_value=_mock_pwd_user("alice")),
         ):
-            assert _kvm_session._should_attempt_reexec(["list"]) is False
+            assert _kvm_session._should_attempt_reexec(["create"]) is False
 
     @patch("smolvm.cli._kvm_session.os.getgroups", return_value=[1000])
     @patch("smolvm.cli._kvm_session.os.getuid", return_value=1000)
@@ -157,7 +191,7 @@ class TestShouldAttemptReexec:
             ),
             patch("pwd.getpwuid", return_value=_mock_pwd_user("alice")),
         ):
-            assert _kvm_session._should_attempt_reexec(["list"]) is True
+            assert _kvm_session._should_attempt_reexec(["create"]) is True
 
 
 class TestMaybeReexec:
@@ -207,3 +241,25 @@ class TestMaybeReexec:
         import sys
 
         assert sys.executable in argv[3]
+
+    @patch(
+        "smolvm.cli._kvm_session.os.execvp",
+        side_effect=OSError("sg vanished between which() and execvp()"),
+    )
+    @patch("smolvm.cli._kvm_session.shutil.which", return_value="/usr/bin/sg")
+    @patch("smolvm.cli._kvm_session._should_attempt_reexec", return_value=True)
+    def test_exec_failure_clears_loop_guard_and_reraises(
+        self,
+        _mock_should: MagicMock,
+        _mock_which: MagicMock,
+        _mock_execvp: MagicMock,
+    ) -> None:
+        # If execvp raises, the loop-guard env var must not linger in this
+        # process — otherwise subsequent invocations within the same parent
+        # would silently skip the re-exec on a stale marker. The original
+        # exception must still propagate so the user sees the real failure.
+        import os
+
+        with pytest.raises(OSError, match="vanished"):
+            _kvm_session.maybe_reexec_for_kvm_group([])
+        assert os.environ.get("SMOLVM_KVM_REEXEC_DONE") is None

--- a/tests/test_kvm_session.py
+++ b/tests/test_kvm_session.py
@@ -1,0 +1,209 @@
+# Copyright 2026 Celesto AI
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for the kvm-group session re-exec helper."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+from smolvm.cli import _kvm_session
+
+
+def _mock_kvm_grp(members: list[str], gid: int = 999) -> MagicMock:
+    return SimpleNamespace(gr_mem=members, gr_gid=gid)
+
+
+def _mock_pwd_user(name: str) -> MagicMock:
+    return SimpleNamespace(pw_name=name)
+
+
+class TestShouldAttemptReexec:
+    """Cover every branch of the gate function."""
+
+    @patch("smolvm.cli._kvm_session.platform.system", return_value="Darwin")
+    def test_macos_skips(self, _mock_system: MagicMock) -> None:
+        # macOS users must never see this code path attempt anything — no
+        # /dev/kvm, no `sg`, no `kvm` group. Returning False here is the
+        # whole reason we can ship the import in cross-platform main.py.
+        assert _kvm_session._should_attempt_reexec([]) is False
+
+    @patch.dict(
+        "smolvm.cli._kvm_session.os.environ",
+        {"SMOLVM_KVM_REEXEC_DONE": "1"},
+        clear=False,
+    )
+    @patch("smolvm.cli._kvm_session.platform.system", return_value="Linux")
+    def test_loop_guard_env_skips(self, _mock_system: MagicMock) -> None:
+        assert _kvm_session._should_attempt_reexec([]) is False
+
+    @patch.dict(
+        "smolvm.cli._kvm_session.os.environ",
+        {"SMOLVM_NO_KVM_REEXEC": "1"},
+        clear=False,
+    )
+    @patch("smolvm.cli._kvm_session.platform.system", return_value="Linux")
+    def test_user_disable_env_skips(self, _mock_system: MagicMock) -> None:
+        assert _kvm_session._should_attempt_reexec([]) is False
+
+    @patch("smolvm.cli._kvm_session.platform.system", return_value="Linux")
+    def test_doctor_subcommand_skips(self, _mock_system: MagicMock) -> None:
+        # Doctor is diagnostic — silently re-execing would mask the very
+        # state the user invoked it to inspect.
+        assert _kvm_session._should_attempt_reexec(["doctor"]) is False
+
+    @patch("smolvm.cli._kvm_session.platform.system", return_value="Linux")
+    def test_setup_subcommand_skips(self, _mock_system: MagicMock) -> None:
+        assert _kvm_session._should_attempt_reexec(["setup"]) is False
+
+    @patch("smolvm.cli._kvm_session.platform.system", return_value="Linux")
+    def test_help_short_circuits(self, _mock_system: MagicMock) -> None:
+        assert _kvm_session._should_attempt_reexec(["--help"]) is False
+
+    @patch("smolvm.cli._kvm_session._KVM_DEV")
+    @patch("smolvm.cli._kvm_session.platform.system", return_value="Linux")
+    def test_no_dev_kvm_skips(self, _mock_system: MagicMock, mock_dev: MagicMock) -> None:
+        mock_dev.exists.return_value = False
+        assert _kvm_session._should_attempt_reexec(["list"]) is False
+
+    @patch("smolvm.cli._kvm_session.os.access", return_value=True)
+    @patch("smolvm.cli._kvm_session._KVM_DEV")
+    @patch("smolvm.cli._kvm_session.platform.system", return_value="Linux")
+    def test_already_accessible_skips(
+        self,
+        _mock_system: MagicMock,
+        mock_dev: MagicMock,
+        _mock_access: MagicMock,
+    ) -> None:
+        mock_dev.exists.return_value = True
+        assert _kvm_session._should_attempt_reexec(["list"]) is False
+
+    @patch("smolvm.cli._kvm_session.os.getuid", return_value=1000)
+    @patch("smolvm.cli._kvm_session.os.access", return_value=False)
+    @patch("smolvm.cli._kvm_session._KVM_DEV")
+    @patch("smolvm.cli._kvm_session.platform.system", return_value="Linux")
+    def test_user_not_in_kvm_group_skips(
+        self,
+        _mock_system: MagicMock,
+        mock_dev: MagicMock,
+        _mock_access: MagicMock,
+        _mock_uid: MagicMock,
+    ) -> None:
+        # Re-execing under `sg kvm` for a user who is *not* a kvm member
+        # would prompt for the group password — never acceptable mid-CLI.
+        mock_dev.exists.return_value = True
+        with (
+            patch("grp.getgrnam", return_value=_mock_kvm_grp(members=["other"])),
+            patch("pwd.getpwuid", return_value=_mock_pwd_user("alice")),
+        ):
+            assert _kvm_session._should_attempt_reexec(["list"]) is False
+
+    @patch("smolvm.cli._kvm_session.os.getgroups", return_value=[999])
+    @patch("smolvm.cli._kvm_session.os.getuid", return_value=1000)
+    @patch("smolvm.cli._kvm_session.os.access", return_value=False)
+    @patch("smolvm.cli._kvm_session._KVM_DEV")
+    @patch("smolvm.cli._kvm_session.platform.system", return_value="Linux")
+    def test_kvm_already_in_effective_groups_skips(
+        self,
+        _mock_system: MagicMock,
+        mock_dev: MagicMock,
+        _mock_access: MagicMock,
+        _mock_uid: MagicMock,
+        _mock_groups: MagicMock,
+    ) -> None:
+        # The group is already in our effective set but /dev/kvm is still
+        # denied — that's a different problem (mode bits, ACLs); re-exec
+        # would loop or hide it. Doctor will surface the real reason.
+        mock_dev.exists.return_value = True
+        with (
+            patch(
+                "grp.getgrnam",
+                return_value=_mock_kvm_grp(members=["alice"], gid=999),
+            ),
+            patch("pwd.getpwuid", return_value=_mock_pwd_user("alice")),
+        ):
+            assert _kvm_session._should_attempt_reexec(["list"]) is False
+
+    @patch("smolvm.cli._kvm_session.os.getgroups", return_value=[1000])
+    @patch("smolvm.cli._kvm_session.os.getuid", return_value=1000)
+    @patch("smolvm.cli._kvm_session.os.access", return_value=False)
+    @patch("smolvm.cli._kvm_session._KVM_DEV")
+    @patch("smolvm.cli._kvm_session.platform.system", return_value="Linux")
+    def test_pending_kvm_membership_qualifies(
+        self,
+        _mock_system: MagicMock,
+        mock_dev: MagicMock,
+        _mock_access: MagicMock,
+        _mock_uid: MagicMock,
+        _mock_groups: MagicMock,
+    ) -> None:
+        mock_dev.exists.return_value = True
+        with (
+            patch(
+                "grp.getgrnam",
+                return_value=_mock_kvm_grp(members=["alice"], gid=999),
+            ),
+            patch("pwd.getpwuid", return_value=_mock_pwd_user("alice")),
+        ):
+            assert _kvm_session._should_attempt_reexec(["list"]) is True
+
+
+class TestMaybeReexec:
+    """Cover the outer driver: skip path, missing-sg path, and exec path."""
+
+    @patch("smolvm.cli._kvm_session._should_attempt_reexec", return_value=False)
+    @patch("smolvm.cli._kvm_session.os.execvp")
+    def test_skip_path_does_not_exec(
+        self,
+        mock_execvp: MagicMock,
+        _mock_should: MagicMock,
+    ) -> None:
+        _kvm_session.maybe_reexec_for_kvm_group([])
+        mock_execvp.assert_not_called()
+
+    @patch("smolvm.cli._kvm_session.shutil.which", return_value=None)
+    @patch("smolvm.cli._kvm_session._should_attempt_reexec", return_value=True)
+    @patch("smolvm.cli._kvm_session.os.execvp")
+    def test_missing_sg_returns_silently(
+        self,
+        mock_execvp: MagicMock,
+        _mock_should: MagicMock,
+        _mock_which: MagicMock,
+    ) -> None:
+        # If `sg` is unavailable we surface nothing and let the regular
+        # kvm-permission failure carry the message.
+        _kvm_session.maybe_reexec_for_kvm_group([])
+        mock_execvp.assert_not_called()
+
+    @patch("smolvm.cli._kvm_session.shutil.which", return_value="/usr/bin/sg")
+    @patch("smolvm.cli._kvm_session._should_attempt_reexec", return_value=True)
+    @patch("smolvm.cli._kvm_session.os.execvp")
+    def test_exec_path_invokes_sg_kvm(
+        self,
+        mock_execvp: MagicMock,
+        _mock_should: MagicMock,
+        _mock_which: MagicMock,
+    ) -> None:
+        _kvm_session.maybe_reexec_for_kvm_group([])
+
+        mock_execvp.assert_called_once()
+        prog, argv = mock_execvp.call_args.args
+        assert prog == "/usr/bin/sg"
+        assert argv[:3] == ["/usr/bin/sg", "kvm", "-c"]
+        # The inner command must invoke the same Python interpreter so
+        # that the re-exec preserves the user's installed smolvm.
+        import sys
+
+        assert sys.executable in argv[3]


### PR DESCRIPTION
## Why

First-time install on a fresh KVM host (e.g. a new GCP nested-virt VM) fails in a confusing way:

1. User runs the installer → doctor says `/dev/kvm` is unavailable.
2. User runs `sudo usermod -aG kvm $USER` as suggested.
3. User re-runs the installer in the same SSH session → **still fails**, because `usermod` only takes effect for new login sessions.
4. User has to figure out on their own that they need to log out and back in.

That is too many sharp edges for "give an AI agent its own computer."

## What changed

A three-layer fix so the failure mode disappears for every realistic path:

### 1. udev rule via `smolvm setup` (Linux only)
`scripts/system-setup.sh` now installs `/etc/udev/rules.d/65-smolvm-kvm.rules`:
```
KERNEL=="kvm", GROUP="kvm", MODE="0660", TAG+="uaccess"
```
Then `udevadm control --reload && udevadm trigger /dev/kvm` so the bits apply in the current session. Normalizes `/dev/kvm` ownership across distros and gives desktop users a per-user POSIX ACL via systemd-logind without joining the kvm group at all. Idempotent — re-running setup is a no-op when the rule already matches.

### 2. Runtime safety net: `sg kvm -c` re-exec from the CLI entrypoint (Linux only)
New `src/smolvm/cli/_kvm_session.py` detects "user is listed in `/etc/group`'s `kvm` but the gid is not in the current process's effective group set" and `os.execvp("sg", ["sg", "kvm", "-c", "<python> <argv>"])`. The rest of the run executes with the kvm group active, so `/dev/kvm` is accessible — no manual `newgrp` or relog.

Guards:
- Linux-only via `platform.system()` short-circuit.
- Loop guard via `SMOLVM_KVM_REEXEC_DONE=1`.
- User escape hatch via `SMOLVM_NO_KVM_REEXEC=1`.
- Diagnostic commands (`doctor`, `setup`, `--help`, `--version`) deliberately don't re-exec — they should keep reporting reality, not silently mutate the process's gid.
- Skips when the user isn't actually in `kvm` per `/etc/group` (avoids ever prompting for the group password).
- Skips when `kvm` is already effective (means a different problem; let doctor surface it).

### 3. Smarter doctor row
`src/smolvm/host/doctor.py:_check_kvm_runtime` now distinguishes the four real states instead of collapsing everything into one generic "run on a KVM-enabled host" message:

| State | New message |
|---|---|
| `/dev/kvm` missing | "Run on a host with hardware virtualization (KVM) enabled…" |
| exists, user not in kvm group | "sudo usermod -aG kvm $USER, then log out and back in (or `newgrp kvm`)" |
| exists, user in kvm on disk but stale session | "Log out and reconnect, or run any other 'smolvm' command — it will auto-activate the group via 'sg kvm' for that run" |
| accessible | pass |

Also demotes a `logger.warning` in `host/manager.py:check_kvm()` to `logger.debug` so it stops leaking above the doctor panel during `install.sh`.

## macOS

Untouched. Verified:
- `_kvm_session.maybe_reexec_for_kvm_group` short-circuits on `platform.system() != "Linux"` *before* touching `grp`/`pwd` (which exist on Darwin but are conceptually Linux-flavored here).
- The udev rule lives in `scripts/system-setup.sh` (Linux) — the macOS path uses `system-setup-macos.sh` and is not modified.
- The new doctor branch is already inside a firecracker-backend block that never runs on Darwin.
- `uv run smolvm --help` works on macOS; `from smolvm.cli._kvm_session import maybe_reexec_for_kvm_group; maybe_reexec_for_kvm_group(['doctor'])` returns cleanly.

## Test plan

- [x] `pytest tests/test_kvm_session.py tests/test_doctor.py tests/test_host.py` — 46 passed (14 new helper tests + 1 new doctor branch test + existing coverage).
- [x] Full unit suite (excluding pre-existing-broken `test_async_lifecycle.py`): 733 passed, 13 skipped.
- [x] `ruff check` clean on every file in the diff.
- [x] `bash -n scripts/system-setup.sh` syntax-clean; `shellcheck` clean.
- [x] macOS smoke: `smolvm --help` runs; helper module imports without error.
- [ ] Reproduce the original GCP-nested-KVM scenario end-to-end on a fresh VM and confirm `install.sh` finishes green without the user having to re-SSH.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * CLI automatically activates KVM group membership without requiring manual re-login or shell group refresh.
  * Setup script now automatically installs and applies udev rules for KVM device access.

* **Bug Fixes**
  * Improved KVM diagnostics to distinguish between missing hardware virtualization, permission issues, and pending group membership.

* **Tests**
  * Added comprehensive test coverage for KVM session management and diagnostics.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->