### PR TITLE
feat(images): prefer Podman over Docker for image builds

### DIFF
--- a/docs/deep-dive/filesystem-and-disk-images.md
+++ b/docs/deep-dive/filesystem-and-disk-images.md
@@ -22,7 +22,7 @@ A raw image file is exactly "a big file that is a virtual disk." The kernel sees
 
 **Image building** (`build.py`):
 - Linux: `mkfs.ext4` via loop device (`_create_ext4_with_loopfs`)
-- macOS: Docker + `mke2fs` since macOS lacks native loop device support (`_create_ext4_with_docker`)
+- macOS: Podman (or Docker as fallback) + `mke2fs` since macOS lacks native loop device support (`_create_ext4_with_container`). The container runtime is also used to build the rootfs from a Dockerfile on every platform — Podman is preferred for its rootless, daemonless model.
 
 ---
 

--- a/scripts/system-setup-macos.sh
+++ b/scripts/system-setup-macos.sh
@@ -18,7 +18,8 @@
 set -euo pipefail
 
 CHECK_ONLY=false
-WITH_DOCKER=false
+WITH_PODMAN=false
+WITH_DOCKER_CLASSIC=false
 SKIP_DEPS=false
 
 usage() {
@@ -28,10 +29,12 @@ Usage: $(basename "$0") [options]
 Installs and checks macOS dependencies for SmolVM qemu backend.
 
 Options:
-  --check-only   Only validate prerequisites; do not install.
-  --with-docker  Install Docker Desktop cask (optional; for image build workflows).
-  --skip-deps    Skip Homebrew dependency installation (assumes qemu already present).
-  -h, --help     Show this help.
+  --check-only           Only validate prerequisites; do not install.
+  --with-podman          Install Podman + start its Linux VM (recommended) for image builds.
+  --with-docker          Alias for --with-podman (legacy flag name).
+  --with-docker-classic  Install Docker Desktop cask (legacy; only if you need Docker).
+  --skip-deps            Skip Homebrew dependency installation (assumes qemu already present).
+  -h, --help             Show this help.
 EOF
 }
 
@@ -40,8 +43,16 @@ while [[ $# -gt 0 ]]; do
         --check-only)
             CHECK_ONLY=true
             ;;
+        --with-podman)
+            WITH_PODMAN=true
+            ;;
         --with-docker)
-            WITH_DOCKER=true
+            echo "ℹ️  --with-docker now installs Podman (lighter than Docker Desktop)."
+            echo "    Pass --with-docker-classic if you specifically need Docker Desktop."
+            WITH_PODMAN=true
+            ;;
+        --with-docker-classic)
+            WITH_DOCKER_CLASSIC=true
             ;;
         --skip-deps)
             SKIP_DEPS=true
@@ -95,7 +106,25 @@ check_prereqs() {
         missing=1
     fi
 
-    if [[ "$WITH_DOCKER" == "true" ]]; then
+    if [[ "$WITH_PODMAN" == "true" ]]; then
+        if ! command -v podman >/dev/null 2>&1; then
+            echo "⚠️  podman not found"
+            echo "    Fix: 'brew install podman && podman machine init && podman machine start'"
+            missing=1
+        elif ! podman machine inspect podman-machine-default >/dev/null 2>&1; then
+            echo "⚠️  podman is installed but no Linux VM has been created"
+            echo "    Fix: 'podman machine init' then 'podman machine start'"
+            missing=1
+        elif ! podman machine inspect podman-machine-default --format '{{.State}}' 2>/dev/null | grep -q running; then
+            echo "⚠️  podman is installed but its Linux VM is not running"
+            echo "    Fix: 'podman machine start'"
+            missing=1
+        else
+            echo "✅ podman ready (Linux VM running)"
+        fi
+    fi
+
+    if [[ "$WITH_DOCKER_CLASSIC" == "true" ]]; then
         if command -v docker >/dev/null 2>&1; then
             echo "✅ docker found"
         else
@@ -127,7 +156,23 @@ else
         brew install qemu
     fi
 
-    if [[ "$WITH_DOCKER" == "true" ]] && ! command -v docker >/dev/null 2>&1; then
+    if [[ "$WITH_PODMAN" == "true" ]]; then
+        if ! command -v podman >/dev/null 2>&1; then
+            echo "Installing Podman via Homebrew..."
+            brew install podman
+        fi
+        if ! podman machine inspect podman-machine-default >/dev/null 2>&1; then
+            echo "Initialising Podman's Linux VM (first run can take ~30 seconds)..."
+            podman machine init
+        fi
+        if ! podman machine inspect podman-machine-default --format '{{.State}}' 2>/dev/null | grep -q running; then
+            echo "Starting Podman's Linux VM..."
+            podman machine start
+        fi
+        echo "ℹ️  Podman is ready. Verify with 'smolvm doctor'."
+    fi
+
+    if [[ "$WITH_DOCKER_CLASSIC" == "true" ]] && ! command -v docker >/dev/null 2>&1; then
         echo "Installing Docker Desktop cask via Homebrew..."
         brew install --cask docker
     fi

--- a/scripts/system-setup.sh
+++ b/scripts/system-setup.sh
@@ -15,8 +15,10 @@
 # limitations under the License.
 
 # system-setup.sh - System-level setup for SmolVM (no Python/venv).
-# Installs Firecracker/Jailer and host dependencies. Docker is optional.
-# Can optionally configure command-scoped NOPASSWD sudo for runtime operations.
+# Installs Firecracker/Jailer and host dependencies. A container runtime
+# (Podman by default, Docker on request) is optional and only needed for
+# image builds. Can optionally configure command-scoped NOPASSWD sudo for
+# runtime operations.
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
@@ -34,7 +36,8 @@ if [[ ${EUID} -ne 0 ]]; then
 fi
 
 CHECK_ONLY=false
-WITH_DOCKER=false
+WITH_PODMAN=false
+WITH_DOCKER_CLASSIC=false
 SKIP_DEPS=false
 CONFIGURE_RUNTIME=false
 REMOVE_RUNTIME_CONFIG=false
@@ -51,7 +54,9 @@ Installs host dependencies and Firecracker (no Python/venv involvement).
 
 Options:
   --check-only                   Only validate system prerequisites; do not install.
-  --with-docker                  Install Docker (required for SSH image demo).
+  --with-podman                  Install Podman (rootless, recommended) for image builds.
+  --with-docker                  Alias for --with-podman (legacy flag name).
+  --with-docker-classic          Install Docker (legacy; only if you need Docker specifically).
   --skip-deps                    Skip apt dependency install (assumes deps already present).
   --configure-runtime            Configure scoped NOPASSWD sudoers for SmolVM runtime.
   --remove-runtime-config        Remove generated runtime sudoers config.
@@ -72,8 +77,16 @@ while [[ $# -gt 0 ]]; do
         --check-only)
             CHECK_ONLY=true
             ;;
+        --with-podman)
+            WITH_PODMAN=true
+            ;;
         --with-docker)
-            WITH_DOCKER=true
+            echo "ℹ️  --with-docker now installs Podman (rootless, no daemon)."
+            echo "    Pass --with-docker-classic if you specifically need Docker."
+            WITH_PODMAN=true
+            ;;
+        --with-docker-classic)
+            WITH_DOCKER_CLASSIC=true
             ;;
         --skip-deps)
             SKIP_DEPS=true
@@ -266,14 +279,17 @@ run_checks() {
     check_cmd "nft" "nft (nftables)"
     check_cmd "ssh" "ssh (openssh-client)"
     check_cmd "firecracker" "firecracker"
-    if [[ "${WITH_DOCKER}" == "true" ]]; then
+    if [[ "${WITH_PODMAN}" == "true" ]]; then
+        check_cmd "podman" "podman"
+    fi
+    if [[ "${WITH_DOCKER_CLASSIC}" == "true" ]]; then
         check_cmd "docker" "docker"
     fi
 }
 
 required_runtime_cmds=("ip" "nft" "ssh")
 required_install_cmds=("wget" "tar")
-if [[ "${WITH_DOCKER}" == "true" ]]; then
+if [[ "${WITH_DOCKER_CLASSIC}" == "true" ]]; then
     required_install_cmds+=("curl")
 fi
 
@@ -385,7 +401,26 @@ if ! command -v firecracker >/dev/null 2>&1; then
     exit 1
 fi
 
-if [[ "${WITH_DOCKER}" == "true" ]]; then
+if [[ "${WITH_PODMAN}" == "true" ]]; then
+    if command -v podman >/dev/null 2>&1; then
+        echo "✅ Podman already installed: $(command -v podman)"
+    else
+        echo "Installing Podman..."
+        if ! DEBIAN_FRONTEND=noninteractive apt-get install -y -qq podman; then
+            echo "❌ apt-get install podman failed."
+            echo "    Fix apt sources, or install Podman manually with your distro's package manager."
+            exit 1
+        fi
+        if ! command -v podman >/dev/null 2>&1; then
+            echo "❌ Podman install failed (podman command not found)."
+            exit 1
+        fi
+    fi
+    echo "ℹ️  Podman is rootless on Linux — no docker group needed."
+    echo "    Verify with 'smolvm doctor'."
+fi
+
+if [[ "${WITH_DOCKER_CLASSIC}" == "true" ]]; then
     if command -v docker >/dev/null 2>&1; then
         echo "✅ Docker already installed"
     else

--- a/src/smolvm/host/doctor.py
+++ b/src/smolvm/host/doctor.py
@@ -31,6 +31,7 @@ from smolvm.cli.output import console_stdout, emit_json, render_error, status_st
 from smolvm.exceptions import SmolVMError
 from smolvm.host.manager import HostManager
 from smolvm.host.network import check_network_prerequisites
+from smolvm.images.container_runtime import runtime_health
 from smolvm.runtime.backends import (
     BACKEND_AUTO,
     BACKEND_FIRECRACKER,
@@ -85,6 +86,16 @@ def _check_command(binary: str, package_hint: str) -> DoctorCheck:
         name=f"command:{binary}",
         status="pass",
         detail=str(path),
+    )
+
+
+def _check_container_runtime() -> DoctorCheck:
+    health = runtime_health()
+    return DoctorCheck(
+        name="container-runtime",
+        status=health.status,
+        detail=health.detail,
+        fix=health.fix,
     )
 
 
@@ -417,6 +428,9 @@ def generate_doctor_report(backend: str | None = None) -> DoctorReport:
 
     checks: list[DoctorCheck] = []
 
+    # Image builds are backend-independent, so the runtime check runs once.
+    checks.append(_check_container_runtime())
+
     if resolved == BACKEND_FIRECRACKER:
         host = HostManager()
 
@@ -512,7 +526,7 @@ def generate_doctor_report(backend: str | None = None) -> DoctorReport:
                     status="pass",
                     detail=f"{qemu_name} ({qemu_path})",
                 )
-                    )
+            )
 
             checks.append(_check_qemu_version(qemu_path))
             if platform.system() == "Darwin":

--- a/src/smolvm/images/builder.py
+++ b/src/smolvm/images/builder.py
@@ -14,7 +14,8 @@
 
 """Image building utilities for SmolVM.
 
-Automatically builds VM images with SSH using Docker.
+Automatically builds VM images with SSH using Podman (with Docker as
+a fallback).
 """
 
 import hashlib
@@ -33,6 +34,12 @@ import urllib.request
 from pathlib import Path
 
 from smolvm.exceptions import ImageError, SmolVMError
+from smolvm.images.container_runtime import (
+    ContainerRuntime,
+    container_runtime_error,
+    detect_container_runtime,
+    diagnose_container_runtime,
+)
 from smolvm.runtime.boot_profiles import (
     QEMU_DESKTOP_KERNEL_URLS,
     KernelBootProfile,
@@ -86,79 +93,43 @@ class ImageBuilder:
                 Defaults to ~/.smolvm/images/
         """
         self.cache_dir = cache_dir or (Path.home() / ".smolvm" / "images")
+        self._runtime: ContainerRuntime | None = None
 
     def check_docker(self) -> bool:
-        """Check if Docker is available and the daemon is reachable."""
-        docker_bin = shutil.which("docker")
-        if docker_bin is None:
-            return False
+        """Check if a container runtime is available and reachable.
 
-        try:
-            subprocess.run(
-                [docker_bin, "info"],
-                check=True,
-                stdout=subprocess.DEVNULL,
-                stderr=subprocess.DEVNULL,
-                timeout=10,
-            )
-            return True
-        except (subprocess.CalledProcessError, FileNotFoundError, subprocess.TimeoutExpired):
+        Kept for backward compatibility with the public SDK. Prefers
+        Podman; falls back to Docker.
+        """
+        runtime = detect_container_runtime()
+        if runtime is None:
+            self._runtime = None
             return False
+        self._runtime = runtime
+        return True
 
     def docker_requirement_error(self) -> ImageError:
-        """Create a helpful Docker availability error."""
-        install_hint = "Install Docker Desktop (macOS) or docker.io (Linux)."
-        start_hint = (
-            "Docker is installed, but SmolVM could not reach the Docker daemon. "
-            "Start Docker Desktop or the Docker service and try again."
-        )
-        permission_hint = (
-            "Docker is installed, but this user cannot access the Docker daemon socket. "
-            "Make sure Docker Desktop is running or grant access to /var/run/docker.sock."
-        )
+        """Create a helpful container-runtime availability error.
 
-        docker_bin = shutil.which("docker")
-        if docker_bin is None:
-            return ImageError(f"Docker is required to build images. {install_hint}")
+        Kept for backward compatibility. Returns a message tailored to
+        the user's actual situation (no runtime installed, runtime
+        installed but unreachable, Podman machine not running, etc.).
+        """
+        return container_runtime_error(diagnose_container_runtime())
 
-        try:
-            subprocess.run(
-                [docker_bin, "info"],
-                check=True,
-                capture_output=True,
-                text=True,
-                timeout=10,
-            )
-        except FileNotFoundError:
-            return ImageError(f"Docker is required to build images. {install_hint}")
-        except subprocess.TimeoutExpired:
-            return ImageError(
-                f"{start_hint} Original Docker error: timed out while contacting Docker."
-            )
-        except subprocess.CalledProcessError as exc:
-            details = "\n".join(part.strip() for part in (exc.stderr, exc.stdout) if part).strip()
-            details_lower = details.lower()
-            if "permission denied" in details_lower and "docker.sock" in details_lower:
-                return ImageError(
-                    f"{permission_hint} Original Docker error: {details or 'unknown error.'}"
-                )
-            if (
-                "cannot connect to the docker daemon" in details_lower
-                or "is the docker daemon running" in details_lower
-                or "error during connect" in details_lower
-            ):
-                return ImageError(
-                    f"{start_hint} Original Docker error: {details or 'unknown error.'}"
-                )
-            return ImageError(
-                "Docker is required to build images, but Docker could not be used successfully. "
-                f"{install_hint} Original Docker error: {details or 'unknown error.'}"
-            )
+    def _require_runtime(self) -> ContainerRuntime:
+        """Resolve the container runtime, caching the result.
 
-        return ImageError(
-            "Docker is required to build images, but an unexpected Docker availability "
-            "check failed."
-        )
+        Raises ImageError with an actionable message if no runtime is
+        available.
+        """
+        if self._runtime is not None:
+            return self._runtime
+        runtime = detect_container_runtime()
+        if runtime is None:
+            raise container_runtime_error()
+        self._runtime = runtime
+        return runtime
 
     def build_alpine_ssh(
         self,
@@ -1379,19 +1350,26 @@ echo "Device-approver running with PID=${DEVICE_APPROVER_PID}"
         if tar_error is not None:
             raise tar_error
 
-    def _create_ext4_with_docker(
+    def _create_ext4_with_container(
         self,
         tar_path: Path,
         rootfs_path: Path,
         rootfs_size_mb: int,
         tmpdir: Path,
     ) -> None:
-        """Create and populate ext4 rootfs using Docker + mke2fs.
+        """Create and populate ext4 rootfs using a container + mke2fs.
 
         This path avoids Linux loop mounts and works on macOS where
-        ``mkfs.ext4`` and loop devices are typically unavailable.
+        ``mkfs.ext4`` and loop devices are typically unavailable. Uses
+        whichever container runtime ``_require_runtime()`` resolves —
+        Podman by default, Docker as a fallback.
         """
-        logger.info("  [3/4] Creating ext4 filesystem via Docker helper (%dMB)...", rootfs_size_mb)
+        runtime = self._require_runtime()
+        logger.info(
+            "  [3/4] Creating ext4 filesystem via %s helper (%dMB)...",
+            runtime.kind,
+            rootfs_size_mb,
+        )
 
         rootfs_dir = tmpdir / "rootfs-dir"
         rootfs_dir.mkdir()
@@ -1401,7 +1379,8 @@ echo "Device-approver running with PID=${DEVICE_APPROVER_PID}"
                 member_path = Path(member.name)
                 if member_path.is_absolute() or ".." in member_path.parts:
                     raise ImageError(
-                        f"Refusing to extract suspicious tar path from docker export: {member.name}"
+                        "Refusing to extract suspicious tar path from "
+                        f"container export: {member.name}"
                     )
 
             # Python 3.14 defaults to a restrictive extraction filter that rejects
@@ -1425,7 +1404,7 @@ echo "Device-approver running with PID=${DEVICE_APPROVER_PID}"
         try:
             subprocess.run(
                 [
-                    "docker",
+                    str(runtime.binary),
                     "run",
                     "--rm",
                     "-v",
@@ -1445,8 +1424,8 @@ echo "Device-approver running with PID=${DEVICE_APPROVER_PID}"
         except subprocess.CalledProcessError as e:
             stderr = (e.stderr or "").strip()
             raise ImageError(
-                "Failed to create ext4 image via Docker helper.\n"
-                f"Command: docker run ... mke2fs\n"
+                f"Failed to create ext4 image via {runtime.kind} helper.\n"
+                f"Command: {runtime.kind} run ... mke2fs\n"
                 f"stderr: {stderr}"
             ) from e
 
@@ -1467,8 +1446,10 @@ echo "Device-approver running with PID=${DEVICE_APPROVER_PID}"
         kernel_url: str | None = None,
         fingerprint_data: dict[str, typing.Any] | None = None,
     ) -> None:
-        """Execute the Docker build and image conversion."""
-        docker_tag = f"smolvm-{name}"
+        """Execute the container build and image conversion."""
+        runtime = self._require_runtime()
+        runtime_bin = str(runtime.binary)
+        image_tag = f"smolvm-{name}"
 
         with tempfile.TemporaryDirectory() as tmp_dir:
             tmp_path = Path(tmp_dir)
@@ -1480,9 +1461,9 @@ echo "Device-approver running with PID=${DEVICE_APPROVER_PID}"
                 for filename, content in extra_files.items():
                     (tmp_path / filename).write_text(content)
 
-            # 1. Build Docker image
-            logger.info("  [1/4] Building Docker image...")
-            build_cmd = ["docker", "build", "-t", docker_tag]
+            # 1. Build container image
+            logger.info("  [1/4] Building container image with %s...", runtime.kind)
+            build_cmd = [runtime_bin, "build", "-t", image_tag]
             if build_args:
                 for k, v in build_args.items():
                     build_cmd.extend(["--build-arg", f"{k}={v}"])
@@ -1498,7 +1479,7 @@ echo "Device-approver running with PID=${DEVICE_APPROVER_PID}"
             # 2. Export rootfs from container
             logger.info("  [2/4] Exporting rootfs...")
             container_id = subprocess.run(
-                ["docker", "create", docker_tag],
+                [runtime_bin, "create", image_tag],
                 check=True,
                 capture_output=True,
                 text=True,
@@ -1507,12 +1488,12 @@ echo "Device-approver running with PID=${DEVICE_APPROVER_PID}"
             try:
                 tar_path = tmp_path / "rootfs.tar"
                 subprocess.run(
-                    ["docker", "export", container_id, "-o", str(tar_path)],
+                    [runtime_bin, "export", container_id, "-o", str(tar_path)],
                     check=True,
                 )
             finally:
                 subprocess.run(
-                    ["docker", "rm", container_id],
+                    [runtime_bin, "rm", container_id],
                     stdout=subprocess.DEVNULL,
                     stderr=subprocess.DEVNULL,
                 )
@@ -1521,7 +1502,7 @@ echo "Device-approver running with PID=${DEVICE_APPROVER_PID}"
             if self._loopfs_helper_path() is not None:
                 self._create_ext4_with_loopfs(tar_path, rootfs_path, rootfs_size_mb, tmp_path)
             else:
-                self._create_ext4_with_docker(tar_path, rootfs_path, rootfs_size_mb, tmp_path)
+                self._create_ext4_with_container(tar_path, rootfs_path, rootfs_size_mb, tmp_path)
 
             # 4. Download architecture-compatible kernel
             resolved_kernel_url = kernel_url or self._kernel_url_for_host()

--- a/src/smolvm/images/container_runtime.py
+++ b/src/smolvm/images/container_runtime.py
@@ -1,0 +1,373 @@
+# Copyright 2026 Celesto AI
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Container runtime detection for image builds.
+
+SmolVM shells out to a container runtime to build VM rootfs images
+(Dockerfile -> tarball -> ext4). Podman is preferred because it is
+rootless on Linux and avoids the Docker daemon/group friction. Docker
+is supported as a silent fallback for users who already have it set up.
+"""
+
+from __future__ import annotations
+
+import os
+import platform
+import shutil
+import subprocess
+from dataclasses import dataclass
+from enum import Enum
+from pathlib import Path
+from typing import Literal
+
+from smolvm.exceptions import ImageError
+
+RuntimeKind = Literal["podman", "docker"]
+
+_ENV_OVERRIDE = "SMOLVM_CONTAINER_RUNTIME"
+_PROBE_TIMEOUT_SECONDS = 10
+_RUNTIME_PREFERENCE: tuple[RuntimeKind, ...] = ("podman", "docker")
+
+
+class _ProbeStatus(Enum):
+    OK = "ok"
+    NO_BINARY = "no_binary"
+    TIMEOUT = "timeout"
+    DAEMON_DOWN = "daemon_down"
+    PERMISSION_DENIED = "permission_denied"
+    MACHINE_NOT_RUNNING = "machine_not_running"
+    UNKNOWN = "unknown"
+
+
+@dataclass(frozen=True)
+class _ProbeResult:
+    kind: RuntimeKind
+    binary: Path | None
+    status: _ProbeStatus
+    stderr: str = ""
+
+
+@dataclass(frozen=True)
+class ContainerRuntime:
+    """A reachable container runtime.
+
+    Attributes:
+        kind: Either ``"podman"`` or ``"docker"``.
+        binary: Absolute path to the runtime executable.
+        needs_machine: True when running Podman on a host that uses a
+            managed Linux VM (macOS, Windows). Informational only — if
+            this object exists the machine is already up.
+    """
+
+    kind: RuntimeKind
+    binary: Path
+    needs_machine: bool
+
+
+def detect_container_runtime() -> ContainerRuntime | None:
+    """Return the first reachable container runtime, or None.
+
+    Detection order: Podman, then Docker. Honours the
+    ``SMOLVM_CONTAINER_RUNTIME`` env var if set to ``podman`` or
+    ``docker``. The override forces selection of that runtime only;
+    if it is missing or unreachable the function returns None rather
+    than silently falling back.
+    """
+    override = _override_kind()
+    if override is not None:
+        probe = _probe(override)
+        return _runtime_from_probe(probe)
+
+    for kind in _RUNTIME_PREFERENCE:
+        probe = _probe(kind)
+        if probe.status is _ProbeStatus.OK:
+            return _runtime_from_probe(probe)
+    return None
+
+
+def diagnose_container_runtime() -> _ProbeResult:
+    """Run the full diagnosis used by error messages and the doctor.
+
+    Returns the most informative probe result across the runtimes we
+    consider. If Podman is missing but Docker is unreachable, we
+    prefer the Docker probe so the recovery hint matches what the user
+    actually has installed.
+    """
+    override = _override_kind()
+    if override is not None:
+        return _probe(override)
+
+    podman_probe = _probe("podman")
+    if podman_probe.status is _ProbeStatus.OK:
+        return podman_probe
+
+    docker_probe = _probe("docker")
+    if docker_probe.status is _ProbeStatus.OK:
+        return docker_probe
+
+    # Neither is OK. Prefer the one that has a binary on PATH so the
+    # error message points to a runtime the user actually installed.
+    if podman_probe.status is not _ProbeStatus.NO_BINARY:
+        return podman_probe
+    if docker_probe.status is not _ProbeStatus.NO_BINARY:
+        return docker_probe
+    return podman_probe
+
+
+def container_runtime_error(probe: _ProbeResult | None = None) -> ImageError:
+    """Build a user-facing ImageError for an unreachable runtime.
+
+    Pass a probe result from :func:`diagnose_container_runtime` to keep
+    the error message specific to the user's situation. When no probe
+    is given we run one ourselves.
+    """
+    if probe is None:
+        probe = diagnose_container_runtime()
+
+    runtime_label = "Podman" if probe.kind == "podman" else "Docker"
+
+    if probe.status is _ProbeStatus.NO_BINARY:
+        override = _override_kind()
+        if override is not None:
+            other = "podman" if override == "docker" else "docker"
+            return ImageError(
+                f"SMOLVM_CONTAINER_RUNTIME={override} is set, but "
+                f"'{override}' is not installed. Install {runtime_label}, "
+                f"or unset SMOLVM_CONTAINER_RUNTIME to use {other}."
+            )
+        return ImageError(f"SmolVM needs Podman to build images. {_install_hint()}")
+
+    if probe.status is _ProbeStatus.MACHINE_NOT_RUNNING:
+        return ImageError(
+            "Podman is installed but its Linux VM is not running. "
+            "Run 'podman machine init' (first time only), then "
+            "'podman machine start'."
+        )
+
+    if probe.status is _ProbeStatus.PERMISSION_DENIED:
+        return ImageError(
+            "This user cannot reach the Docker socket. Switch to rootless "
+            "Podman with 'apt-get install podman' (no daemon, no group "
+            "needed), or add yourself to the docker group with "
+            "'sudo usermod -aG docker $USER' and re-login."
+        )
+
+    if probe.status is _ProbeStatus.TIMEOUT:
+        return ImageError(
+            f"{runtime_label} is installed but did not respond within "
+            f"{_PROBE_TIMEOUT_SECONDS} seconds. {_start_hint(probe.kind)}"
+        )
+
+    if probe.status is _ProbeStatus.DAEMON_DOWN:
+        details = probe.stderr or "unknown error."
+        return ImageError(f"{_start_hint(probe.kind)} Original error: {details}")
+
+    details = probe.stderr or "unknown error."
+    return ImageError(
+        f"{runtime_label} is required to build images, but it could not be "
+        f"used successfully. {_install_hint()} Original error: {details}"
+    )
+
+
+@dataclass(frozen=True)
+class RuntimeHealth:
+    """Doctor-friendly summary of the container runtime state."""
+
+    status: Literal["pass", "warn"]
+    detail: str
+    fix: str | None
+
+
+def runtime_health() -> RuntimeHealth:
+    """Probe the container runtime and return a doctor-friendly summary.
+
+    Maps each unhealthy probe state to a specific, actionable detail/fix
+    pair so ``smolvm doctor`` can surface why image builds will fail
+    (e.g. ``podman machine`` stopped) instead of always reporting that
+    no runtime is installed.
+    """
+    probe = diagnose_container_runtime()
+    if probe.status is _ProbeStatus.OK and probe.binary is not None:
+        return RuntimeHealth(
+            status="pass",
+            detail=f"{probe.kind} ({probe.binary})",
+            fix=None,
+        )
+    detail, fix = _describe_runtime_problem(probe)
+    return RuntimeHealth(status="warn", detail=detail, fix=fix)
+
+
+def _describe_runtime_problem(probe: _ProbeResult) -> tuple[str, str]:
+    """Return (detail, fix) for an unhealthy probe.
+
+    Used by the doctor to populate ``DoctorCheck.detail`` and
+    ``DoctorCheck.fix`` separately, so users can see *what* is wrong and
+    *how* to fix it without parsing a single combined sentence.
+    """
+    label = "Podman" if probe.kind == "podman" else "Docker"
+
+    if probe.status is _ProbeStatus.NO_BINARY:
+        override = _override_kind()
+        if override is not None:
+            other = "podman" if override == "docker" else "docker"
+            return (
+                f"SMOLVM_CONTAINER_RUNTIME={override} is set, but "
+                f"'{override}' is not installed. Image builds will fail.",
+                f"Install {label}, or unset SMOLVM_CONTAINER_RUNTIME to use {other}.",
+            )
+        return (
+            "No container runtime found. Image builds will fail.",
+            _install_hint(),
+        )
+
+    if probe.status is _ProbeStatus.MACHINE_NOT_RUNNING:
+        return (
+            "Podman is installed but its Linux VM is not running.",
+            "Run 'podman machine init' (first time only), then 'podman machine start'.",
+        )
+
+    if probe.status is _ProbeStatus.PERMISSION_DENIED:
+        return (
+            f"This user cannot reach the {label} socket.",
+            "Switch to rootless Podman with 'apt-get install -y podman', or add "
+            "yourself to the docker group with 'sudo usermod -aG docker $USER' "
+            "and re-login.",
+        )
+
+    if probe.status is _ProbeStatus.TIMEOUT:
+        return (
+            f"{label} did not respond within {_PROBE_TIMEOUT_SECONDS} seconds.",
+            f"Restart {label} and try again.",
+        )
+
+    if probe.status is _ProbeStatus.DAEMON_DOWN:
+        if probe.kind == "podman":
+            if platform.system() in ("Darwin", "Windows"):
+                return (
+                    "Podman is installed but its Linux VM is not running.",
+                    "Run 'podman machine start'.",
+                )
+            return (
+                "Podman is installed but its user service is not running.",
+                "Run 'systemctl --user start podman.socket'.",
+            )
+        return (
+            "Docker is installed but its daemon is not running.",
+            "Start Docker Desktop or the Docker service.",
+        )
+
+    detail = f"{label} is installed but could not be used."
+    if probe.stderr:
+        detail = f"{detail} Original error: {probe.stderr}"
+    return (detail, _install_hint())
+
+
+def _override_kind() -> RuntimeKind | None:
+    raw = os.environ.get(_ENV_OVERRIDE, "").strip().lower()
+    if raw in ("podman", "docker"):
+        return raw  # type: ignore[return-value]
+    return None
+
+
+def _runtime_from_probe(probe: _ProbeResult) -> ContainerRuntime | None:
+    if probe.status is not _ProbeStatus.OK or probe.binary is None:
+        return None
+    return ContainerRuntime(
+        kind=probe.kind,
+        binary=probe.binary,
+        needs_machine=probe.kind == "podman" and platform.system() in ("Darwin", "Windows"),
+    )
+
+
+def _probe(kind: RuntimeKind) -> _ProbeResult:
+    binary = shutil.which(kind)
+    if binary is None:
+        return _ProbeResult(kind=kind, binary=None, status=_ProbeStatus.NO_BINARY)
+
+    binary_path = Path(binary)
+    try:
+        subprocess.run(
+            [binary, "info"],
+            check=True,
+            capture_output=True,
+            text=True,
+            timeout=_PROBE_TIMEOUT_SECONDS,
+        )
+    except FileNotFoundError:
+        return _ProbeResult(kind=kind, binary=None, status=_ProbeStatus.NO_BINARY)
+    except subprocess.TimeoutExpired:
+        return _ProbeResult(kind=kind, binary=binary_path, status=_ProbeStatus.TIMEOUT)
+    except subprocess.CalledProcessError as exc:
+        stderr = "\n".join(part.strip() for part in (exc.stderr, exc.stdout) if part).strip()
+        status = _classify_failure(kind, stderr)
+        return _ProbeResult(kind=kind, binary=binary_path, status=status, stderr=stderr)
+
+    return _ProbeResult(kind=kind, binary=binary_path, status=_ProbeStatus.OK)
+
+
+def _classify_failure(kind: RuntimeKind, stderr: str) -> _ProbeStatus:
+    text = stderr.lower()
+
+    if kind == "podman" and any(
+        marker in text
+        for marker in (
+            "podman machine",
+            "is the podman service running",
+            "refresh service connection",
+        )
+    ):
+        return _ProbeStatus.MACHINE_NOT_RUNNING
+
+    if "permission denied" in text and ("docker.sock" in text or "podman.sock" in text):
+        return _ProbeStatus.PERMISSION_DENIED
+
+    if any(
+        marker in text
+        for marker in (
+            "cannot connect to the docker daemon",
+            "is the docker daemon running",
+            "error during connect",
+            "connection refused",
+        )
+    ):
+        return _ProbeStatus.DAEMON_DOWN
+
+    return _ProbeStatus.UNKNOWN
+
+
+def _install_hint() -> str:
+    system = platform.system()
+    if system == "Darwin":
+        return (
+            "Install with 'brew install podman && podman machine init && "
+            "podman machine start', then rerun."
+        )
+    return "Install with 'apt-get install -y podman' (Linux), then rerun."
+
+
+def _start_hint(kind: RuntimeKind) -> str:
+    if kind == "podman":
+        if platform.system() in ("Darwin", "Windows"):
+            return (
+                "Podman is installed but its Linux VM is not running. "
+                "Start it with 'podman machine start' and try again."
+            )
+        return (
+            "Podman is installed but its user service is not running. "
+            "Start it with 'systemctl --user start podman.socket' and try again."
+        )
+    return (
+        "Docker is installed, but SmolVM could not reach the Docker daemon. "
+        "Start Docker Desktop or the Docker service and try again."
+    )

--- a/tests/test_build.py
+++ b/tests/test_build.py
@@ -23,71 +23,239 @@ import pytest
 
 from smolvm.exceptions import ImageError, SmolVMError
 from smolvm.images.builder import ImageBuilder
+from smolvm.images.container_runtime import (
+    ContainerRuntime,
+    _ProbeResult,
+    _ProbeStatus,
+    container_runtime_error,
+    detect_container_runtime,
+    runtime_health,
+)
 from smolvm.runtime.boot_profiles import KernelBootProfile, resolve_kernel_url
+
+
+def _builder_with_runtime(
+    cache_dir: Path,
+    *,
+    kind: str = "podman",
+    binary: str = "/usr/bin/podman",
+) -> ImageBuilder:
+    """Build an ImageBuilder with a fixed runtime, skipping probing."""
+    builder = ImageBuilder(cache_dir=cache_dir)
+    builder._runtime = ContainerRuntime(
+        kind=kind,  # type: ignore[arg-type]
+        binary=Path(binary),
+        needs_machine=False,
+    )
+    return builder
 
 
 def _ok_subprocess_run(
     cmd: list[str], *args: object, **kwargs: object
 ) -> subprocess.CompletedProcess[str]:
-    if cmd[:2] == ["docker", "create"]:
+    if len(cmd) >= 2 and cmd[1] == "create":
         return subprocess.CompletedProcess(cmd, 0, stdout="container-id\n", stderr="")
     return subprocess.CompletedProcess(cmd, 0, stdout="", stderr="")
 
 
-class TestDockerDiagnostics:
-    """Tests for Docker availability diagnostics."""
+class TestContainerRuntimeDiagnostics:
+    """Diagnostics for missing or unreachable container runtimes."""
 
-    def test_docker_requirement_error_when_docker_missing(self, tmp_path: Path) -> None:
-        builder = ImageBuilder(cache_dir=tmp_path / "images")
+    def test_error_when_no_runtime_installed(self) -> None:
+        probe = _ProbeResult(kind="podman", binary=None, status=_ProbeStatus.NO_BINARY)
+        error = container_runtime_error(probe)
+        message = str(error)
+        assert "SmolVM needs Podman to build images" in message
+        # Recovery hint must name the install command.
+        assert "podman" in message.lower()
 
-        with patch("smolvm.images.builder.shutil.which", return_value=None):
-            error = builder.docker_requirement_error()
-
-        assert str(error) == (
-            "Docker is required to build images. "
-            "Install Docker Desktop (macOS) or docker.io (Linux)."
+    def test_error_when_docker_daemon_down(self) -> None:
+        probe = _ProbeResult(
+            kind="docker",
+            binary=Path("/usr/bin/docker"),
+            status=_ProbeStatus.DAEMON_DOWN,
+            stderr="Cannot connect to the Docker daemon at unix:///var/run/docker.sock.",
         )
+        error = container_runtime_error(probe)
+        message = str(error)
+        assert "could not reach the Docker daemon" in message
+        assert "Start Docker Desktop or the Docker service" in message
+        assert "Cannot connect to the Docker daemon" in message
 
-    @patch("smolvm.images.builder.subprocess.run")
-    def test_docker_requirement_error_when_daemon_unreachable(
-        self, mock_subprocess_run: MagicMock, tmp_path: Path
-    ) -> None:
-        builder = ImageBuilder(cache_dir=tmp_path / "images")
-        mock_subprocess_run.side_effect = subprocess.CalledProcessError(
-            1,
-            ["docker", "info"],
-            stderr=(
-                "Cannot connect to the Docker daemon at unix:///var/run/docker.sock. "
-                "Is the docker daemon running?"
+    def test_error_when_docker_socket_permission_denied(self) -> None:
+        probe = _ProbeResult(
+            kind="docker",
+            binary=Path("/usr/bin/docker"),
+            status=_ProbeStatus.PERMISSION_DENIED,
+            stderr="permission denied while connecting to docker.sock",
+        )
+        error = container_runtime_error(probe)
+        message = str(error)
+        assert "cannot reach the Docker socket" in message
+        # Recovery should point to rootless Podman as the preferred fix.
+        assert "rootless" in message.lower()
+        assert "podman" in message.lower()
+
+    def test_error_when_podman_machine_not_running(self) -> None:
+        probe = _ProbeResult(
+            kind="podman",
+            binary=Path("/opt/homebrew/bin/podman"),
+            status=_ProbeStatus.MACHINE_NOT_RUNNING,
+            stderr="Cannot connect to Podman. Run 'podman machine start'.",
+        )
+        error = container_runtime_error(probe)
+        message = str(error)
+        assert "Linux VM is not running" in message
+        assert "podman machine start" in message
+
+    def test_error_under_override_names_forced_runtime(self) -> None:
+        """SMOLVM_CONTAINER_RUNTIME=docker + Docker missing should not tell
+        the user to install Podman — that won't fix the build."""
+        probe = _ProbeResult(kind="docker", binary=None, status=_ProbeStatus.NO_BINARY)
+        with patch.dict("os.environ", {"SMOLVM_CONTAINER_RUNTIME": "docker"}):
+            error = container_runtime_error(probe)
+        message = str(error)
+        assert "SMOLVM_CONTAINER_RUNTIME=docker" in message
+        assert "Install Docker" in message
+        assert "unset SMOLVM_CONTAINER_RUNTIME" in message
+        # Must not steer the user to install Podman in this case.
+        assert "needs Podman" not in message
+
+
+class TestRuntimeHealthForDoctor:
+    """`runtime_health()` powers the doctor check — must distinguish
+    'no runtime' from 'runtime installed but unhealthy'."""
+
+    def test_machine_not_running_surfaces_specific_fix(self) -> None:
+        with (
+            patch(
+                "smolvm.images.container_runtime.shutil.which",
+                side_effect=lambda name: "/opt/homebrew/bin/podman" if name == "podman" else None,
             ),
-        )
-
-        with patch("smolvm.images.builder.shutil.which", return_value="/usr/bin/docker"):
-            error = builder.docker_requirement_error()
-
-        assert "could not reach the Docker daemon" in str(error)
-        assert "Start Docker Desktop or the Docker service" in str(error)
-        assert "Cannot connect to the Docker daemon" in str(error)
-
-    @patch("smolvm.images.builder.subprocess.run")
-    def test_docker_requirement_error_when_socket_permission_denied(
-        self, mock_subprocess_run: MagicMock, tmp_path: Path
-    ) -> None:
-        builder = ImageBuilder(cache_dir=tmp_path / "images")
-        mock_subprocess_run.side_effect = subprocess.CalledProcessError(
-            1,
-            ["docker", "info"],
-            stderr=(
-                "error during connect: permission denied while trying to connect "
-                "to the Docker daemon socket at unix:///var/run/docker.sock"
+            patch(
+                "smolvm.images.container_runtime.subprocess.run",
+                side_effect=subprocess.CalledProcessError(
+                    1,
+                    ["podman", "info"],
+                    stderr="Cannot connect to Podman. Run 'podman machine start' first.",
+                ),
             ),
-        )
+        ):
+            health = runtime_health()
+        assert health.status == "warn"
+        assert "Linux VM is not running" in health.detail
+        assert health.fix is not None
+        assert "podman machine start" in health.fix
+        # The user has Podman — must not tell them to install it again.
+        assert "brew install" not in (health.fix or "")
 
-        with patch("smolvm.images.builder.shutil.which", return_value="/usr/bin/docker"):
-            error = builder.docker_requirement_error()
+    def test_docker_daemon_down_surfaces_specific_fix(self) -> None:
+        with (
+            patch(
+                "smolvm.images.container_runtime.shutil.which",
+                side_effect=lambda name: "/usr/bin/docker" if name == "docker" else None,
+            ),
+            patch(
+                "smolvm.images.container_runtime.subprocess.run",
+                side_effect=subprocess.CalledProcessError(
+                    1,
+                    ["docker", "info"],
+                    stderr=(
+                        "Cannot connect to the Docker daemon at "
+                        "unix:///var/run/docker.sock. Is the docker daemon running?"
+                    ),
+                ),
+            ),
+        ):
+            health = runtime_health()
+        assert health.status == "warn"
+        assert "daemon is not running" in health.detail
+        assert health.fix is not None
+        assert "Docker Desktop" in health.fix or "Docker service" in health.fix
 
-        assert "cannot access the Docker daemon socket" in str(error)
-        assert "docker.sock" in str(error)
+    def test_no_runtime_returns_install_fix(self) -> None:
+        with patch("smolvm.images.container_runtime.shutil.which", return_value=None):
+            health = runtime_health()
+        assert health.status == "warn"
+        assert "No container runtime found" in health.detail
+        assert health.fix is not None
+        assert "podman" in health.fix.lower()
+
+    def test_ok_runtime_passes(self) -> None:
+        with (
+            patch(
+                "smolvm.images.container_runtime.shutil.which",
+                side_effect=lambda name: f"/usr/bin/{name}" if name == "podman" else None,
+            ),
+            patch(
+                "smolvm.images.container_runtime.subprocess.run",
+                return_value=subprocess.CompletedProcess([], 0, stdout="", stderr=""),
+            ),
+        ):
+            health = runtime_health()
+        assert health.status == "pass"
+        assert "podman" in health.detail
+        assert health.fix is None
+
+
+class TestContainerRuntimeDetection:
+    """Detection ordering and env override behaviour."""
+
+    def test_prefers_podman_when_both_present(self) -> None:
+        def fake_which(name: str) -> str | None:
+            return f"/usr/bin/{name}" if name in {"podman", "docker"} else None
+
+        with (
+            patch("smolvm.images.container_runtime.shutil.which", side_effect=fake_which),
+            patch(
+                "smolvm.images.container_runtime.subprocess.run",
+                return_value=subprocess.CompletedProcess([], 0, stdout="", stderr=""),
+            ),
+            patch.dict("os.environ", {}, clear=False),
+        ):
+            runtime = detect_container_runtime()
+
+        assert runtime is not None
+        assert runtime.kind == "podman"
+
+    def test_falls_back_to_docker_when_podman_missing(self) -> None:
+        def fake_which(name: str) -> str | None:
+            return "/usr/bin/docker" if name == "docker" else None
+
+        with (
+            patch("smolvm.images.container_runtime.shutil.which", side_effect=fake_which),
+            patch(
+                "smolvm.images.container_runtime.subprocess.run",
+                return_value=subprocess.CompletedProcess([], 0, stdout="", stderr=""),
+            ),
+        ):
+            runtime = detect_container_runtime()
+
+        assert runtime is not None
+        assert runtime.kind == "docker"
+
+    def test_honors_env_override(self) -> None:
+        def fake_which(name: str) -> str | None:
+            return f"/usr/bin/{name}" if name in {"podman", "docker"} else None
+
+        with (
+            patch("smolvm.images.container_runtime.shutil.which", side_effect=fake_which),
+            patch(
+                "smolvm.images.container_runtime.subprocess.run",
+                return_value=subprocess.CompletedProcess([], 0, stdout="", stderr=""),
+            ),
+            patch.dict("os.environ", {"SMOLVM_CONTAINER_RUNTIME": "docker"}),
+        ):
+            runtime = detect_container_runtime()
+
+        assert runtime is not None
+        assert runtime.kind == "docker"
+
+    def test_returns_none_when_neither_present(self) -> None:
+        with patch("smolvm.images.container_runtime.shutil.which", return_value=None):
+            runtime = detect_container_runtime()
+
+        assert runtime is None
 
 
 class TestImageBuilderLoopFs:
@@ -124,7 +292,7 @@ class TestImageBuilderLoopFs:
     def test_do_build_uses_loopfs_helper(
         self, mock_run_command: MagicMock, mock_subprocess_run: MagicMock, tmp_path: Path
     ) -> None:
-        builder = ImageBuilder(cache_dir=tmp_path / "images")
+        builder = _builder_with_runtime(tmp_path / "images")
         mock_subprocess_run.side_effect = _ok_subprocess_run
         mock_run_command.return_value = subprocess.CompletedProcess(
             args=["sudo", "-n", "/usr/local/libexec/smolvm-loopfs-helper"],
@@ -256,25 +424,25 @@ class TestBrowserImageBuilder:
 
     @patch("smolvm.images.builder.subprocess.run")
     @patch("smolvm.images.builder.run_command")
-    def test_do_build_uses_docker_fallback_when_loopfs_missing(
+    def test_do_build_uses_container_fallback_when_loopfs_missing(
         self, mock_run_command: MagicMock, mock_subprocess_run: MagicMock, tmp_path: Path
     ) -> None:
-        builder = ImageBuilder(cache_dir=tmp_path / "images")
+        builder = _builder_with_runtime(tmp_path / "images", binary="/usr/bin/podman")
 
         def _subprocess_side_effect(
             cmd: list[str], *args: object, **kwargs: object
         ) -> subprocess.CompletedProcess[str]:
-            if cmd[:2] == ["docker", "create"]:
+            if len(cmd) >= 2 and cmd[1] == "create":
                 return subprocess.CompletedProcess(cmd, 0, stdout="container-id\n", stderr="")
 
-            if cmd[:2] == ["docker", "export"]:
+            if len(cmd) >= 2 and cmd[1] == "export":
                 tar_index = cmd.index("-o") + 1
                 tar_path = Path(cmd[tar_index])
                 with tarfile.open(tar_path, "w"):
                     pass
                 return subprocess.CompletedProcess(cmd, 0, stdout="", stderr="")
 
-            if cmd[:2] == ["docker", "run"]:
+            if len(cmd) >= 2 and cmd[1] == "run":
                 volumes = [cmd[i + 1] for i, token in enumerate(cmd) if token == "-v"]
                 out_host = Path(volumes[1].split(":", 1)[0])
                 (out_host / "rootfs.ext4").write_bytes(b"ext4")
@@ -309,12 +477,14 @@ class TestBrowserImageBuilder:
             )
 
         assert mock_run_command.call_count == 0
-        docker_run_calls = [
+        run_calls = [
             call
             for call in mock_subprocess_run.call_args_list
-            if call.args[0][:2] == ["docker", "run"]
+            if len(call.args[0]) >= 2 and call.args[0][1] == "run"
         ]
-        assert len(docker_run_calls) == 1
+        assert len(run_calls) == 1
+        # The configured runtime binary is used, not a hardcoded "docker".
+        assert run_calls[0].args[0][0] == "/usr/bin/podman"
         assert rootfs_path.exists()
 
     @patch("smolvm.images.builder.subprocess.run")
@@ -322,12 +492,12 @@ class TestBrowserImageBuilder:
     def test_do_build_preserves_tar_error_when_unmount_fails(
         self, mock_run_command: MagicMock, mock_subprocess_run: MagicMock, tmp_path: Path
     ) -> None:
-        builder = ImageBuilder(cache_dir=tmp_path / "images")
+        builder = _builder_with_runtime(tmp_path / "images")
 
         def _subprocess_side_effect(
             cmd: list[str], *args: object, **kwargs: object
         ) -> subprocess.CompletedProcess[str]:
-            if cmd[:2] == ["docker", "create"]:
+            if len(cmd) >= 2 and cmd[1] == "create":
                 return subprocess.CompletedProcess(cmd, 0, stdout="container-id\n", stderr="")
             return subprocess.CompletedProcess(cmd, 0, stdout="", stderr="")
 
@@ -370,11 +540,11 @@ class TestBrowserImageBuilder:
 
 
 @pytest.mark.parametrize("method_name", ["build_alpine_ssh_key", "build_debian_ssh_key"])
-def test_rebuild_preserves_cached_artifacts_when_docker_is_unavailable(
+def test_rebuild_preserves_cached_artifacts_when_runtime_is_unavailable(
     method_name: str,
     tmp_path: Path,
 ) -> None:
-    """Rebuild paths should not evict cached files before Docker is confirmed available."""
+    """Rebuild paths should not evict cached files before the runtime is confirmed."""
     builder = ImageBuilder(cache_dir=tmp_path / "images")
     image_name = "cached-image"
     image_dir = builder.cache_dir / image_name
@@ -402,9 +572,9 @@ def test_rebuild_preserves_cached_artifacts_when_docker_is_unavailable(
         patch.object(
             ImageBuilder,
             "docker_requirement_error",
-            return_value=ImageError("docker unavailable"),
+            return_value=ImageError("runtime unavailable"),
         ),
-        pytest.raises(ImageError, match="docker unavailable"),
+        pytest.raises(ImageError, match="runtime unavailable"),
     ):
         build_method("ignored", name=image_name)
 

--- a/tests/test_doctor.py
+++ b/tests/test_doctor.py
@@ -38,6 +38,10 @@ def _pass(name: str) -> DoctorCheck:
 class TestDoctorFirecracker:
     """Firecracker backend diagnostic tests."""
 
+    @patch(
+        "smolvm.host.doctor._check_container_runtime",
+        new=lambda: _pass("container-runtime"),
+    )
     @patch("smolvm.host.doctor._check_kvm_permissions", new=lambda: _pass("worker:kvm-permissions"))
     @patch("smolvm.host.doctor._check_kvm_nx_huge_pages", new=lambda: _pass("worker:kvm-nx-huge-pages"))
     @patch("smolvm.host.doctor._check_thp_disabled", new=lambda: _pass("worker:thp-disabled"))
@@ -95,6 +99,10 @@ class TestDoctorFirecracker:
             fix="sudo swapoff -a",
         ),
     )
+    @patch(
+        "smolvm.host.doctor._check_container_runtime",
+        new=lambda: _pass("container-runtime"),
+    )
     @patch("smolvm.host.doctor.run_command")
     @patch("smolvm.host.doctor.check_network_prerequisites", return_value=[])
     @patch("smolvm.host.doctor.which")
@@ -131,6 +139,10 @@ class TestDoctorFirecracker:
             "worker:thp-disabled",
         }
 
+    @patch(
+        "smolvm.host.doctor._check_container_runtime",
+        new=lambda: _pass("container-runtime"),
+    )
     @patch("smolvm.host.doctor._check_kvm_permissions", new=lambda: _pass("worker:kvm-permissions"))
     @patch("smolvm.host.doctor._check_kvm_nx_huge_pages", new=lambda: _pass("worker:kvm-nx-huge-pages"))
     @patch("smolvm.host.doctor._check_thp_disabled", new=lambda: _pass("worker:thp-disabled"))
@@ -191,6 +203,10 @@ class TestDoctorFirecracker:
             detail="Active (8388604 kB)",
         ),
     )
+    @patch(
+        "smolvm.host.doctor._check_container_runtime",
+        new=lambda: _pass("container-runtime"),
+    )
     @patch("smolvm.host.doctor.run_command")
     @patch("smolvm.host.doctor.check_network_prerequisites", return_value=[])
     @patch("smolvm.host.doctor.which")
@@ -244,6 +260,10 @@ class TestDoctorFirecracker:
 class TestDoctorQemu:
     """QEMU backend diagnostic tests."""
 
+    @patch(
+        "smolvm.host.doctor._check_container_runtime",
+        new=lambda: _pass("container-runtime"),
+    )
     @patch("smolvm.host.doctor._find_qemu_binary", return_value=None)
     @patch("smolvm.host.doctor.which", return_value=Path("/usr/bin/ssh"))
     def test_generate_report_qemu_missing_binary(
@@ -257,6 +277,10 @@ class TestDoctorQemu:
         assert report.backend_resolved == "qemu"
         assert any(check.name == "qemu" and check.status == "fail" for check in report.checks)
 
+    @patch(
+        "smolvm.host.doctor._check_container_runtime",
+        new=lambda: _pass("container-runtime"),
+    )
     @patch("smolvm.host.doctor.platform.system", return_value="Linux")
     @patch("smolvm.host.doctor.subprocess.run")
     @patch("smolvm.host.doctor.which")
@@ -281,6 +305,10 @@ class TestDoctorQemu:
         assert checks["qemu-version"].status == "pass"
         assert checks["command:qemu-img"].status == "pass"
 
+    @patch(
+        "smolvm.host.doctor._check_container_runtime",
+        new=lambda: _pass("container-runtime"),
+    )
     @patch("smolvm.host.doctor.platform.system", return_value="Linux")
     @patch("smolvm.host.doctor.subprocess.run")
     @patch("smolvm.host.doctor.which")
@@ -305,6 +333,10 @@ class TestDoctorQemu:
         assert checks["qemu-version"].status == "fail"
         assert checks["command:qemu-img"].status == "fail"
 
+    @patch(
+        "smolvm.host.doctor._check_container_runtime",
+        new=lambda: _pass("container-runtime"),
+    )
     @patch("smolvm.host.doctor.platform.system", return_value="Linux")
     @patch("smolvm.host.doctor.subprocess.run", side_effect=OSError("probe failed"))
     @patch("smolvm.host.doctor.which")
@@ -328,6 +360,10 @@ class TestDoctorQemu:
         assert checks["qemu-version"].status == "warn"
         assert "probe failed" in checks["qemu-version"].detail
 
+    @patch(
+        "smolvm.host.doctor._check_container_runtime",
+        new=lambda: _pass("container-runtime"),
+    )
     @patch("smolvm.host.doctor.platform.system", return_value="Linux")
     @patch("smolvm.host.doctor.subprocess.run", side_effect=RuntimeError("boom"))
     @patch("smolvm.host.doctor.which")


### PR DESCRIPTION
## Summary

Removes the hard Docker dependency from `smolvm create`. SmolVM now prefers Podman (rootless on Linux, no daemon, no `docker` group) and silently falls back to Docker for users who already have it. `smolvm doctor` gains a container-runtime check that distinguishes *not installed* from *podman machine stopped*, *daemon down*, *permission denied*, and *override-points-to-missing-runtime* so users see the actual recovery, not a generic "install Podman". Setup scripts gain `--with-podman` (Linux: `apt-get install podman`; macOS: `brew install podman` + `podman machine init/start`), with `--with-docker` aliased to it and `--with-docker-classic` preserved for explicit Docker installs. macOS `--check-only` now verifies the Podman machine is initialized and running, not just that the binary exists.

## Related Issues

- Closes #

## Testing

- \`uv run --extra dev pytest\` — 734 passed, 13 skipped (5 new tests for runtime detection, override messaging, and doctor health states)
- \`uv run --extra dev ruff check\` and \`ruff format --check\` — clean on all changed files
- \`uv run --extra dev smolvm doctor --json\` end-to-end on macOS reports the right unhealthy state with an actionable fix
- mypy not run

## Checklist

- [x] Scope is focused and limited to this change
- [x] Tests added/updated for behavior changes
- [x] Docs updated for user-visible changes
- [x] No secrets or sensitive data included