### PR TITLE
fix(setup): make runtime sudoers parse under sudo-rs

### DIFF
--- a/scripts/internal/configure-runtime-sudoers.sh
+++ b/scripts/internal/configure-runtime-sudoers.sh
@@ -135,11 +135,13 @@ install_loopfs_helper() {
 
 render_sudoers() {
     local target_file="$1"
+    # Note: trailing-`*` wildcards only — sudo-rs (Ubuntu 25.10+ default) rejects
+    # wildcards embedded inside argument values, so we cannot pin the route_localnet
+    # sysctl to a per-tap pattern. Sysctl is widened to match the ip/nft scope.
     cat > "${target_file}" <<EOF
 # Managed by SmolVM (${SCRIPT_NAME}) for user ${RUNTIME_USER}
 # Allows only commands needed by SmolVM runtime networking, Firecracker, and image mount helper.
-Defaults:${RUNTIME_USER} !requiretty
-Cmnd_Alias SMOLVM_NET_CMDS = ${IP_BIN} *, ${NFT_BIN} *, ${SYSCTL_BIN} net.ipv4.ip_forward, ${SYSCTL_BIN} -w net.ipv4.ip_forward=1, ${SYSCTL_BIN} -w net.ipv4.conf.*.route_localnet=1
+Cmnd_Alias SMOLVM_NET_CMDS = ${IP_BIN} *, ${NFT_BIN} *, ${SYSCTL_BIN} *
 Cmnd_Alias SMOLVM_VM_CMDS = ${FIRECRACKER_BIN} *, /bin/kill -9 *, /usr/bin/kill -9 *
 Cmnd_Alias SMOLVM_IMG_CMDS = ${LOOPFS_HELPER_DST} *
 ${RUNTIME_USER} ALL=(root) NOPASSWD: SMOLVM_NET_CMDS, SMOLVM_VM_CMDS, SMOLVM_IMG_CMDS


### PR DESCRIPTION
## Summary
- Ubuntu 25.10 ships `sudo-rs` as the default `sudo`. Its `visudo` rejects two things our generated runtime sudoers file uses, so `smolvm setup` fails before anything can run:
  - `Defaults:user !requiretty` — unknown setting
  - `sysctl -w net.ipv4.conf.*.route_localnet=1` — wildcards inside command argument values are not allowed (only trailing `*`)
- Dropped the `!requiretty` line (redundant on Debian/Ubuntu native sudo, where the default is already off) and widened the pinned `sysctl` rules to `${SYSCTL_BIN} *`, matching the existing scope of `${IP_BIN} *` / `${NFT_BIN} *`.

## Reproduction
On Ubuntu 25.10:
```
$ smolvm setup
…
/tmp/tmp.Dnh4i1NhhG:3:19: syntax error: unknown setting: 'requiretty'
Defaults:celesto !requiretty
                  ^~~~~~~~~~
/tmp/tmp.Dnh4i1NhhG:4:144: syntax error: wildcards are not allowed in command arguments
…
visudo: invalid sudoers file
```

## Test plan
Validated the rendered sudoers file with `visudo -cf` in throwaway containers:

| Scenario | Distro | sudo flavor | Expected | Actual |
|---|---|---|---|---|
| Old file (pre-fix) | Ubuntu 25.10 | sudo-rs 0.2.8 | FAIL | ✅ reproduces the same `requiretty` error |
| New file (post-fix) | Ubuntu 25.10 | sudo-rs 0.2.8 | OK | ✅ parsed OK |
| New file (post-fix) | Ubuntu 22.04 | sudo 1.9.9 | OK | ✅ parsed OK |
| New file (post-fix) | Ubuntu 24.04 | sudo 1.9.15p5 | OK | ✅ parsed OK |

- [ ] Re-run `sudo bash scripts/system-setup.sh --configure-runtime --runtime-user <user>` on the Ubuntu 25.10 host that hit the original failure.
- [ ] Confirm `smolvm doctor` (or `--check-only`) passes the runtime sudo access self-test on the same host.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated system command permissions configuration to broaden sysctl access scope.
  * Added documentation noting permission limitations for network configuration settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->