### PR TITLE
fix(network): restore EPERM fallback when native ioctl lacks CAP_NET_ADMIN

### DIFF
--- a/src/smolvm/host/network.py
+++ b/src/smolvm/host/network.py
@@ -39,6 +39,13 @@ logger = logging.getLogger(__name__)
 DEFAULT_HOST_IP = "172.16.0.1"
 DEFAULT_NETMASK = "16"
 
+# Matches the native EPERM signal precisely (\b prevents "errno 13" matching).
+_EPERM_RE = re.compile(r"\berrno 1\b|Operation not permitted")
+
+
+def _is_eperm(err: str) -> bool:
+    return bool(_EPERM_RE.search(err))
+
 # SmolVM-managed nftables objects
 _NFT_NAT_FAMILY = "ip"
 _NFT_NAT_TABLE = "smolvm_nat"
@@ -156,8 +163,14 @@ class NetworkManager:
                         )
                         time.sleep(delay)
                         continue
+                    if _is_eperm(err):
+                        logger.warning(
+                            "Native create_tap lacks CAP_NET_ADMIN; falling back to sudo"
+                        )
+                        break
                     raise SmolVMError(err) from e
-            return
+            else:
+                return
 
         max_busy_retries = 3
         for attempt in range(max_busy_retries + 1):
@@ -242,11 +255,19 @@ class NetworkManager:
                 native.flush_addrs(tap_name)
                 native.add_addr(tap_name, host_ip, int(netmask))
                 native.set_link_up(tap_name)
+                self._write_sysctl(f"net/ipv4/conf/{tap_name}/route_localnet", "1")
+                return
             except OSError as e:
-                if "RTNETLINK answers: File exists" not in str(e) and "File exists" not in str(e):
-                    raise SmolVMError(str(e)) from e
-            self._write_sysctl(f"net/ipv4/conf/{tap_name}/route_localnet", "1")
-            return
+                err = str(e)
+                if "RTNETLINK answers: File exists" in err or "File exists" in err:
+                    self._write_sysctl(f"net/ipv4/conf/{tap_name}/route_localnet", "1")
+                    return
+                if _is_eperm(err):
+                    logger.warning(
+                        "Native configure_tap lacks CAP_NET_ADMIN; falling back to sudo"
+                    )
+                else:
+                    raise SmolVMError(err) from e
 
         batch = [
             f"addr flush dev {tap_name}",
@@ -304,10 +325,17 @@ class NetworkManager:
         if HAS_NETLINK:
             try:
                 native.add_route(ip_address, 32, device)
+                return
             except OSError as e:
-                if "File exists" not in str(e):
-                    raise SmolVMError(str(e)) from e
-            return
+                err = str(e)
+                if "File exists" in err:
+                    return
+                if _is_eperm(err):
+                    logger.warning(
+                        "Native add_route lacks CAP_NET_ADMIN; falling back to sudo"
+                    )
+                else:
+                    raise SmolVMError(err) from e
 
         try:
             run_command(["ip", "route", "add", f"{ip_address}/32", "dev", device])
@@ -339,11 +367,18 @@ class NetworkManager:
         if HAS_NETLINK:
             try:
                 native.delete_tap(tap_name)
+                return
             except OSError as e:
                 err = str(e)
-                if "Cannot find device" not in err and "No such device" not in err:
+                if "Cannot find device" in err or "No such device" in err:
+                    return
+                if _is_eperm(err):
+                    logger.warning(
+                        "Native delete_tap lacks CAP_NET_ADMIN; falling back to sudo"
+                    )
+                else:
                     logger.warning("Failed to delete TAP %s: %s", tap_name, e)
-            return
+                    return
 
         try:
             run_command(["ip", "link", "delete", tap_name])

--- a/src/smolvm/host/network.py
+++ b/src/smolvm/host/network.py
@@ -46,6 +46,27 @@ _EPERM_RE = re.compile(r"\berrno 1\b|Operation not permitted")
 def _is_eperm(err: str) -> bool:
     return bool(_EPERM_RE.search(err))
 
+
+# Once the native ioctl path returns EPERM, every later call in this process
+# will too — short-circuit straight to the subprocess path and stop emitting
+# duplicate warnings (and stop triggering noisy IFLA_INET6_CONF parse warnings
+# from the netlink crate, which happen during the native link lookups).
+_native_unprivileged = False
+
+
+def _native_available() -> bool:
+    return HAS_NETLINK and not _native_unprivileged
+
+
+def _mark_native_unprivileged() -> None:
+    global _native_unprivileged
+    if not _native_unprivileged:
+        _native_unprivileged = True
+        logger.warning(
+            "Native networking lacks CAP_NET_ADMIN; using sudo path for the "
+            "rest of this process"
+        )
+
 # SmolVM-managed nftables objects
 _NFT_NAT_FAMILY = "ip"
 _NFT_NAT_TABLE = "smolvm_nat"
@@ -138,7 +159,7 @@ class NetworkManager:
 
         logger.info("Creating TAP device: %s (user: %s)", tap_name, user)
 
-        if HAS_NETLINK:
+        if _native_available():
             import pwd
 
             try:
@@ -164,9 +185,7 @@ class NetworkManager:
                         time.sleep(delay)
                         continue
                     if _is_eperm(err):
-                        logger.warning(
-                            "Native create_tap lacks CAP_NET_ADMIN; falling back to sudo"
-                        )
+                        _mark_native_unprivileged()
                         break
                     raise SmolVMError(err) from e
             else:
@@ -250,7 +269,7 @@ class NetworkManager:
 
         logger.info("Configuring TAP %s with IP %s/%s", tap_name, host_ip, netmask)
 
-        if HAS_NETLINK:
+        if _native_available():
             try:
                 native.flush_addrs(tap_name)
                 native.add_addr(tap_name, host_ip, int(netmask))
@@ -263,9 +282,7 @@ class NetworkManager:
                     self._write_sysctl(f"net/ipv4/conf/{tap_name}/route_localnet", "1")
                     return
                 if _is_eperm(err):
-                    logger.warning(
-                        "Native configure_tap lacks CAP_NET_ADMIN; falling back to sudo"
-                    )
+                    _mark_native_unprivileged()
                 else:
                     raise SmolVMError(err) from e
 
@@ -322,7 +339,7 @@ class NetworkManager:
 
         logger.info("Adding route: %s via %s", ip_address, device)
 
-        if HAS_NETLINK:
+        if _native_available():
             try:
                 native.add_route(ip_address, 32, device)
                 return
@@ -331,9 +348,7 @@ class NetworkManager:
                 if "File exists" in err:
                     return
                 if _is_eperm(err):
-                    logger.warning(
-                        "Native add_route lacks CAP_NET_ADMIN; falling back to sudo"
-                    )
+                    _mark_native_unprivileged()
                 else:
                     raise SmolVMError(err) from e
 
@@ -364,7 +379,7 @@ class NetworkManager:
 
         logger.info("Cleaning up TAP device: %s", tap_name)
 
-        if HAS_NETLINK:
+        if _native_available():
             try:
                 native.delete_tap(tap_name)
                 return
@@ -373,9 +388,7 @@ class NetworkManager:
                 if "Cannot find device" in err or "No such device" in err:
                     return
                 if _is_eperm(err):
-                    logger.warning(
-                        "Native delete_tap lacks CAP_NET_ADMIN; falling back to sudo"
-                    )
+                    _mark_native_unprivileged()
                 else:
                     logger.warning("Failed to delete TAP %s: %s", tap_name, e)
                     return

--- a/tests/test_network.py
+++ b/tests/test_network.py
@@ -153,6 +153,48 @@ class TestTapManagement:
         assert mock_run_command.call_count == 4
         assert mock_sleep.call_count == 3
 
+    @patch("smolvm.host.network.run_command")
+    @patch("smolvm.host.network.native")
+    def test_create_tap_falls_back_to_subprocess_on_eperm(
+        self, mock_native: MagicMock, mock_run_command: MagicMock
+    ) -> None:
+        """When the native ioctl returns EPERM, fall through to sudo ip path."""
+        mock_native.create_tap.side_effect = OSError("tap2: errno 1")
+        mock_run_command.return_value = MagicMock(stdout="")
+
+        with patch("smolvm.host.network.HAS_NETLINK", True):
+            nm = NetworkManager()
+            nm.create_tap("tap2", "alice")
+
+        mock_native.create_tap.assert_called_once()
+        mock_run_command.assert_called_once_with(
+            ["ip", "tuntap", "add", "tap2", "mode", "tap", "user", "alice"]
+        )
+
+
+class TestEpermDetector:
+    """Pin the regex so 'errno 13' (EACCES) and friends do not match EPERM."""
+
+    def test_matches_bare_errno_1(self) -> None:
+        from smolvm.host.network import _is_eperm
+
+        assert _is_eperm("tap2: errno 1")
+
+    def test_matches_operation_not_permitted(self) -> None:
+        from smolvm.host.network import _is_eperm
+
+        assert _is_eperm("Operation not permitted")
+
+    def test_does_not_match_errno_13(self) -> None:
+        from smolvm.host.network import _is_eperm
+
+        assert not _is_eperm("tap2: errno 13")
+
+    def test_does_not_match_errno_100(self) -> None:
+        from smolvm.host.network import _is_eperm
+
+        assert not _is_eperm("tap2: errno 100")
+
 
 class TestLocalPortForwarding:
     """Tests for localhost-only forwarding rule setup/cleanup."""

--- a/tests/test_network.py
+++ b/tests/test_network.py
@@ -29,6 +29,16 @@ def _disable_native_extension():
         yield
 
 
+@pytest.fixture(autouse=True)
+def _reset_native_unprivileged_flag():
+    """Reset the cached EPERM flag so tests don't leak state into each other."""
+    import smolvm.host.network as net
+
+    net._native_unprivileged = False
+    yield
+    net._native_unprivileged = False
+
+
 def _collect_nft_scripts(mock_run_command: MagicMock) -> str:
     scripts: list[str] = []
     for call in mock_run_command.call_args_list:
@@ -170,6 +180,26 @@ class TestTapManagement:
         mock_run_command.assert_called_once_with(
             ["ip", "tuntap", "add", "tap2", "mode", "tap", "user", "alice"]
         )
+
+    @patch("smolvm.host.network.run_command")
+    @patch("smolvm.host.network.native")
+    def test_native_unprivileged_flag_skips_subsequent_native_attempts(
+        self, mock_native: MagicMock, mock_run_command: MagicMock
+    ) -> None:
+        """After one EPERM, later calls must not even try the native path."""
+        mock_native.create_tap.side_effect = OSError("tap2: errno 1")
+        mock_run_command.return_value = MagicMock(stdout="")
+
+        with patch("smolvm.host.network.HAS_NETLINK", True):
+            nm = NetworkManager()
+            nm.create_tap("tap2", "alice")  # trips EPERM, sets flag
+            nm.create_tap("tap3", "alice")  # must skip native entirely
+            nm.add_route("172.16.0.5", "tap3")  # also must skip native
+
+        # native.create_tap was tried exactly once; the second create_tap and the
+        # add_route both short-circuited before touching the native module.
+        assert mock_native.create_tap.call_count == 1
+        mock_native.add_route.assert_not_called()
 
 
 class TestEpermDetector:


### PR DESCRIPTION
## Summary

- The native Rust path in `create_tap`, `configure_tap`, `add_route`, and `cleanup_tap` was bubbling `errno 1` (EPERM) up to the user instead of falling through to the existing `sudo ip ...` / `sudo nft ...` subprocess path. Users without `CAP_NET_ADMIN` saw `Failed to create VM ...: tap2: errno 1`.
- This is a regression of fc570c8 ("graceful EPERM fallback for all native operations"); the fallback was lost when `network.py` moved into `host/network.py`.
- Restored the fallback in all four call sites. Added a small `_is_eperm()` regex helper so the substring check does **not** misfire on `errno 13` (EACCES) or `errno 100` (the original fc570c8 patch had this latent bug).

## Test plan

- [x] `uv run --with pytest pytest tests/test_network.py::TestTapManagement tests/test_network.py::TestEpermDetector -x -q` — 8/8 green.
- [x] Reproduced the original failure (`smolvm create --json` as unprivileged user with native extension installed → `tap2: errno 1`); confirmed the patched build creates the VM successfully via the sudo fallback.
- [ ] CI green.

## Notes

The `IFLA_INET6_CONF` warning from `netlink-packet-route` (`expecting 236, got 240`) seen in the same output is unrelated and harmless — kernel ≥ 7.0 added 4 bytes to the IPv6 link config struct that the pinned crate doesn't know about. Worth a follow-up to bump the crate, but not part of this fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)