### PR TITLE
chore(deps): bump netlink stack and drop unused nix dep

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,12 +3,6 @@
 version = 4
 
 [[package]]
-name = "anyhow"
-version = "1.0.102"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
-
-[[package]]
 name = "arc-swap"
 version = "1.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -18,22 +12,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "autocfg"
-version = "1.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
-
-[[package]]
 name = "bitflags"
 version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "843867be96c8daad0d758b57df9392b6d8d271134fce549de6ce169ff98a92af"
-
-[[package]]
-name = "byteorder"
-version = "1.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "bytes"
@@ -166,15 +148,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
 
 [[package]]
-name = "memoffset"
-version = "0.9.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "488016bfae457b036d996092f6cb448677611ce4449e970ceaf42695203f218a"
-dependencies = [
- "autocfg",
-]
-
-[[package]]
 name = "mio"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -187,46 +160,30 @@ dependencies = [
 
 [[package]]
 name = "netlink-packet-core"
-version = "0.7.0"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72724faf704479d67b388da142b186f916188505e7e0b26719019c525882eda4"
+checksum = "3463cbb78394cb0141e2c926b93fc2197e473394b761986eca3b9da2c63ae0f4"
 dependencies = [
- "anyhow",
- "byteorder",
- "netlink-packet-utils",
+ "paste",
 ]
 
 [[package]]
 name = "netlink-packet-route"
-version = "0.19.0"
+version = "0.30.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "74c171cd77b4ee8c7708da746ce392440cb7bcf618d122ec9ecc607b12938bf4"
+checksum = "be8919612f6028ab4eacbbfe1234a9a43e3722c6e0915e7ff519066991905092"
 dependencies = [
- "anyhow",
- "byteorder",
+ "bitflags",
  "libc",
  "log",
  "netlink-packet-core",
- "netlink-packet-utils",
-]
-
-[[package]]
-name = "netlink-packet-utils"
-version = "0.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ede8a08c71ad5a95cdd0e4e52facd37190977039a4704eb82a283f713747d34"
-dependencies = [
- "anyhow",
- "byteorder",
- "paste",
- "thiserror 1.0.69",
 ]
 
 [[package]]
 name = "netlink-proto"
-version = "0.11.5"
+version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72452e012c2f8d612410d89eea01e2d9b56205274abb35d53f60200b2ec41d60"
+checksum = "b65d130ee111430e47eed7896ea43ca693c387f097dd97376bffafbf25812128"
 dependencies = [
  "bytes",
  "futures",
@@ -251,17 +208,6 @@ dependencies = [
 
 [[package]]
 name = "nix"
-version = "0.27.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2eb04e9c688eff1c89d72b407f168cf79bb9e867a9d3323ed6c01519eb9cc053"
-dependencies = [
- "bitflags",
- "cfg-if",
- "libc",
-]
-
-[[package]]
-name = "nix"
 version = "0.30.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "74523f3a35e05aba87a1d978330aef40f67b0304ac79c1c00b294c9830543db6"
@@ -270,7 +216,6 @@ dependencies = [
  "cfg-if",
  "cfg_aliases",
  "libc",
- "memoffset",
 ]
 
 [[package]]
@@ -386,18 +331,18 @@ dependencies = [
 
 [[package]]
 name = "rtnetlink"
-version = "0.14.1"
+version = "0.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b684475344d8df1859ddb2d395dd3dac4f8f3422a1aa0725993cb375fc5caba5"
+checksum = "dc19f84f710fa2f337617f9bc0400260a94224bde7bae28fd8879f3771ca5784"
 dependencies = [
- "futures",
+ "futures-channel",
+ "futures-util",
  "log",
  "netlink-packet-core",
  "netlink-packet-route",
- "netlink-packet-utils",
  "netlink-proto",
  "netlink-sys",
- "nix 0.27.1",
+ "nix",
  "thiserror 1.0.69",
  "tokio",
 ]
@@ -422,7 +367,6 @@ dependencies = [
  "libc",
  "log",
  "netlink-packet-route",
- "nix 0.30.1",
  "pyo3",
  "pyo3-log",
  "rtnetlink",

--- a/smolvm-core/Cargo.toml
+++ b/smolvm-core/Cargo.toml
@@ -28,8 +28,7 @@ pyo3-log = "0.13"
 log = "0.4"
 
 [target.'cfg(target_os = "linux")'.dependencies]
-nix = { version = "0.30", features = ["ioctl", "net", "user"] }
-rtnetlink = "0.14"
-netlink-packet-route = "0.19"
+rtnetlink = "0.21"
+netlink-packet-route = "0.30"
 tokio = { version = "1", features = ["rt", "net", "macros"] }
 futures-util = "0.3"

--- a/smolvm-core/src/route.rs
+++ b/smolvm-core/src/route.rs
@@ -44,6 +44,8 @@ async fn get_link_index(
 
 /// Set a network interface to UP state.
 pub fn set_link_up(name: &str) -> Result<(), NetlinkError> {
+    use rtnetlink::LinkUnspec;
+
     with_netlink(async {
         let (connection, handle, _) = rtnetlink::new_connection()
             .map_err(|e| NetlinkError::Other(format!("netlink: {}", e)))?;
@@ -52,8 +54,7 @@ pub fn set_link_up(name: &str) -> Result<(), NetlinkError> {
         let index = get_link_index(&handle, name).await?;
         handle
             .link()
-            .set(index)
-            .up()
+            .set(LinkUnspec::new_with_index(index).up().build())
             .execute()
             .await
             .map_err(|e| NetlinkError::Other(format!("set_link_up {}: {}", name, e)))?;
@@ -123,6 +124,8 @@ pub fn add_addr(name: &str, ip: &str, prefix_len: u8) -> Result<(), NetlinkError
 
 /// Add a route: dest/prefix_len via device.
 pub fn add_route(dest: &str, prefix_len: u8, dev: &str) -> Result<(), NetlinkError> {
+    use rtnetlink::RouteMessageBuilder;
+
     let dest_addr: Ipv4Addr = dest
         .parse()
         .map_err(|e| NetlinkError::Other(format!("invalid dest {}: {}", dest, e)))?;
@@ -133,12 +136,13 @@ pub fn add_route(dest: &str, prefix_len: u8, dev: &str) -> Result<(), NetlinkErr
         tokio::spawn(connection);
 
         let index = get_link_index(&handle, dev).await?;
-        handle
-            .route()
-            .add()
-            .v4()
+        let route = RouteMessageBuilder::<Ipv4Addr>::new()
             .destination_prefix(dest_addr, prefix_len)
             .output_interface(index)
+            .build();
+        handle
+            .route()
+            .add(route)
             .execute()
             .await
             .map_err(|e| {
@@ -157,6 +161,8 @@ pub fn add_route(dest: &str, prefix_len: u8, dev: &str) -> Result<(), NetlinkErr
 
 /// Get the default outbound network interface name.
 pub fn get_default_interface() -> Result<String, NetlinkError> {
+    use rtnetlink::RouteMessageBuilder;
+
     with_netlink(async {
         let (connection, handle, _) = rtnetlink::new_connection()
             .map_err(|e| NetlinkError::Other(format!("netlink: {}", e)))?;
@@ -165,7 +171,8 @@ pub fn get_default_interface() -> Result<String, NetlinkError> {
         use futures_util::TryStreamExt;
         use netlink_packet_route::route::RouteAttribute;
 
-        let mut routes = handle.route().get(rtnetlink::IpVersion::V4).execute();
+        let route_filter = RouteMessageBuilder::<Ipv4Addr>::new().build();
+        let mut routes = handle.route().get(route_filter).execute();
         while let Some(route) = routes.try_next().await.map_err(|e| {
             NetlinkError::Other(format!("get routes: {}", e))
         })? {

--- a/smolvm-core/src/tap.rs
+++ b/smolvm-core/src/tap.rs
@@ -1,7 +1,6 @@
 //! TAP device creation and deletion via ioctl + netlink.
 
 use crate::error::NetlinkError;
-use std::ffi::CString;
 use std::os::fd::AsRawFd;
 
 /// Maximum retry attempts for EBUSY on TUNSETPERSIST.
@@ -108,7 +107,7 @@ fn create_once(name: &str, owner_uid: u32) -> Result<(), NetlinkError> {
 
 /// Delete a TAP device via netlink.
 pub fn delete(name: &str) -> Result<(), NetlinkError> {
-    use crate::route::{runtime, with_netlink};
+    use crate::route::with_netlink;
 
     with_netlink(async {
         let (connection, handle, _) = rtnetlink::new_connection().map_err(|e| {

--- a/src/smolvm/host/network.py
+++ b/src/smolvm/host/network.py
@@ -63,8 +63,9 @@ def _mark_native_unprivileged() -> None:
     if not _native_unprivileged:
         _native_unprivileged = True
         logger.warning(
-            "Native networking lacks CAP_NET_ADMIN; using sudo path for the "
-            "rest of this process"
+            "Using the slower networking path. VMs will still work; "
+            "each is a fraction of a second slower to start. "
+            "Run with sudo to use the faster path."
         )
 
 # SmolVM-managed nftables objects


### PR DESCRIPTION
Closes #213.

## Summary

- Bump `rtnetlink` 0.14 → 0.21 and `netlink-packet-route` 0.19 → 0.30 in lockstep (rtnetlink 0.21 requires `^0.30`).
- Drop `nix` dependency — declared in `smolvm-core/Cargo.toml` but never `use`d in any source file; `tap.rs` uses `libc` directly.
- Port three call sites in `smolvm-core/src/route.rs` to the newer rtnetlink builder API: `set_link_up` (now uses `LinkUnspec::new_with_index`), `add_route` and `get_default_interface` (both now build via `RouteMessageBuilder`). `tap.rs` needed no API porting.
- Drop two pre-existing unused imports in `tap.rs` (`std::ffi::CString`, `crate::route::runtime`) so the build is warning-clean.
- Rewrite the unprivileged-fallback warning to be impact-driven and jargon-free.

## Why

Issue #213. On Linux ≥ 7.0 the kernel's `IFLA_INET6_CONF` block grew to 240 bytes; `netlink-packet-route` 0.19 expected 236 and emitted a parse warning on every native link lookup. The bumped crate knows about the newer struct and stays silent.

## UX warning rewrite

The fallback warning that fires once per process when SmolVM lacks networking permission used to read:

> Native networking lacks CAP_NET_ADMIN; using sudo path for the rest of this process

Three pieces of implementation jargon in one line, no read on whether anything was wrong. Replaced with:

> Using the slower networking path. VMs will still work; each is a fraction of a second slower to start. Run with sudo to use the faster path.

Answers what the user actually needs: *will it work* (yes), *what's the impact* (slight start latency), *how to make it faster* (run with sudo).

## Audit of all Rust deps

Verified each dependency's pinned version against the latest on crates.io:

| Crate | Pinned | Latest | Action |
|---|---|---|---|
| pyo3 | 0.28 | 0.28.3 | already current |
| libc | 0.2 | 0.2.186 | already current |
| thiserror | 2 | 2.0.18 | already current |
| pyo3-log | 0.13 | 0.13.3 | already current |
| log | 0.4 | 0.4.29 | already current |
| nix | 0.30 | 0.31.2 | **removed (unused)** |
| rtnetlink | 0.14 | 0.21.0 | **bumped** |
| netlink-packet-route | 0.19 | 0.30.0 | **bumped** |
| tokio | 1 | 1.52.1 | already current |
| futures-util | 0.3 | 0.3.32 | already current |

## Test plan

- [x] `cargo check -p smolvm-core --release` — compiles clean, **zero warnings**.
- [x] `PATH=$HOME/.cargo/bin:$PATH uv run --with maturin maturin develop --release` — wheel builds clean.
- [x] `uv run --with pytest pytest tests/test_network.py -q` — 17/17 green.
- [x] `uv run python -c "import smolvm_core; print(smolvm_core.get_default_interface())"` — exercises the new `RouteMessageBuilder`-based API path; returns the host's actual default interface; **zero `IFLA_INET6_CONF` warnings emitted** with logging at WARNING level.
- [ ] CI green.
- [ ] End-to-end `smolvm create --os debian` smoke test on a real host — recommend reviewer runs locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)