### PR TITLE
fix(cli): auto-select QEMU for `smolvm create --mount` (no --backend)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,7 +28,7 @@ classifiers = [
     "Topic :: System :: Emulators",
 ]
 dependencies = [
-    "smolvm-core~=0.0.10",
+    "smolvm-core~=0.0.11",
     "paramiko>=3.0",
     "pycdlib>=1.14.0",
     "pydantic>=2.0",

--- a/src/smolvm/cli/main.py
+++ b/src/smolvm/cli/main.py
@@ -1570,6 +1570,13 @@ def _run_create(args: argparse.Namespace) -> int:
 
     vm: SmolVM | None = None
     try:
+        # Workspace mounts ride a virtio-9p share, which only the QEMU backend
+        # exposes today. Auto-pick QEMU when the user asked for --mount but did
+        # not pin a backend; an explicit --backend other than 'auto' is left
+        # alone so the downstream check still catches incompatible combos.
+        if args.mounts and args.backend in (None, "auto"):
+            args.backend = "qemu"
+
         resolved_backend = resolve_backend(args.backend)
         image_uri: str | None = getattr(args, "image", None)
         use_s3_image = image_uri is not None

--- a/tests/test_workspace.py
+++ b/tests/test_workspace.py
@@ -574,6 +574,90 @@ class TestCliMountFlag:
         args = parser.parse_args(["create"])
         assert args.mounts is None
 
+    @patch("smolvm.facade.SmolVM")
+    @patch("smolvm.facade._build_auto_config")
+    def test_create_with_mount_and_no_backend_selects_qemu(
+        self,
+        mock_build_auto_config: MagicMock,
+        mock_smolvm_cls: MagicMock,
+        tmp_path: Path,
+    ) -> None:
+        """`smolvm create --mount /path` (no --backend) must auto-select QEMU
+        at the CLI layer. Without this, _build_auto_config gets backend=None,
+        resolves to the platform default (firecracker on Linux), and the
+        downstream guard rejects the mount + firecracker combo with a
+        confusing 'Re-run without --backend' message — the user already did."""
+        from smolvm.cli.main import _run_create, build_parser
+
+        kernel = tmp_path / "vmlinux"
+        rootfs = tmp_path / "rootfs.ext4"
+        kernel.touch()
+        rootfs.touch()
+
+        mock_build_auto_config.return_value = (
+            VMConfig(
+                vm_id="vm-mnt",
+                kernel_path=kernel,
+                rootfs_path=rootfs,
+                backend="qemu",
+            ),
+            None,
+        )
+        mock_smolvm_cls.return_value.vm_id = "vm-mnt"
+        mock_smolvm_cls.return_value.info.status = VMState.RUNNING
+
+        parser = build_parser()
+        args = parser.parse_args(
+            ["create", "--mount", str(tmp_path / "project"), "--json"]
+        )
+
+        _run_create(args)
+
+        assert args.backend == "qemu"
+        assert mock_build_auto_config.call_args.kwargs["backend"] == "qemu"
+
+    @patch("smolvm.facade.SmolVM")
+    @patch("smolvm.facade._build_auto_config")
+    def test_create_with_mount_and_explicit_firecracker_left_alone(
+        self,
+        mock_build_auto_config: MagicMock,
+        mock_smolvm_cls: MagicMock,
+        tmp_path: Path,
+    ) -> None:
+        """Explicit `--backend firecracker --mount /path` must NOT be silently
+        upgraded; the downstream guard should still fire so the user sees the
+        incompatibility they explicitly requested."""
+        from smolvm.cli.main import _run_create, build_parser
+
+        kernel = tmp_path / "vmlinux"
+        rootfs = tmp_path / "rootfs.ext4"
+        kernel.touch()
+        rootfs.touch()
+
+        mock_build_auto_config.return_value = (
+            VMConfig(
+                vm_id="vm-mnt",
+                kernel_path=kernel,
+                rootfs_path=rootfs,
+                backend="firecracker",
+            ),
+            None,
+        )
+        mock_smolvm_cls.return_value.vm_id = "vm-mnt"
+        mock_smolvm_cls.return_value.info.status = VMState.RUNNING
+
+        parser = build_parser()
+        args = parser.parse_args([
+            "create",
+            "--mount", str(tmp_path / "project"),
+            "--backend", "firecracker",
+            "--json",
+        ])
+
+        _run_create(args)
+
+        assert args.backend == "firecracker"
+
 
 # ── Mount spec parsing ──────────────────────────────────────────────
 


### PR DESCRIPTION
## The bug

```
$ smolvm create --mount /path --json
{
  "ok": false,
  "error": {
    "message": "Workspace mounts (virtio-9p) are only supported with the QEMU backend (got backend='firecracker'). Re-run without --backend (SmolVM will auto-select QEMU when --mount is used) or pass --backend qemu explicitly.",
    "type": "runtime_error"
  }
}
```

The error tells the user to "re-run without `--backend`" — but the user never passed it. Confusing, paradoxical, and broken.

## Root cause

Three layers were talking past each other:

1. **\`resolve_backend(None)\`** in \`runtime/backends.py\` silently returns the platform default (\`"firecracker"\` on Linux).
2. **\`_build_auto_config\`** in \`facade.py\` stamps that resolved backend into the \`VMConfig\` so the config no longer remembers the user didn't ask for it.
3. **\`SmolVM.__init__\`** has an auto-fallback safety net at \`facade.py:756-763\` that picks QEMU when mounts are requested — but only fires if \`config.backend is None\`. By the time it runs, layer 2 has already pinned firecracker, so it never fires.

The sibling \`_run_start\` (used by \`smolvm <preset> start\`) already does the right thing at the CLI layer:

\`\`\`python
backend = args.backend or "qemu"
\`\`\`

\`_run_create\` skipped this step.

## Fix

Four lines at the top of \`_run_create\` mirror the preset behavior:

\`\`\`python
if args.mounts and args.backend in (None, "auto"):
    args.backend = "qemu"
\`\`\`

The same value then flows consistently into \`_build_auto_config\`, the \`VMConfig\`, and \`SmolVM\`. The downstream guard at \`vm.py:810\` still fires for its real intended case — someone who *explicitly* writes \`--backend firecracker --mount /path\`.

## Bundled fix: smolvm-core dependency pin

While verifying CI, found that main has been red since #217 (the smolvm-core 0.0.10 → 0.0.11 bump) because the pin in \`pyproject.toml\` was never updated. The \`pytest.yml\` smoke test extracts the expected smolvm-core version with a regex on the pin string (gets \`0.0.10\`), but the install resolves \`~=0.0.10\` to the latest matching (\`0.0.11\`); the assertion that they match then fails. Bumped the pin from \`~=0.0.10\` to \`~=0.0.11\` so CI is green again.

## Test plan

- [x] Repro: \`smolvm create --mount /tmp/foo --json\` no longer hits the paradox error; now correctly tries QEMU and surfaces a real downstream error if QEMU isn't installed.
- [x] Two regression tests in \`tests/test_workspace.py::TestCliMountFlag\`:
  - \`test_create_with_mount_and_no_backend_selects_qemu\` — pins the auto-selection.
  - \`test_create_with_mount_and_explicit_firecracker_left_alone\` — pins that explicit \`--backend firecracker\` is NOT silently upgraded.
- [x] \`uv run --with pytest pytest tests/test_workspace.py -q\` — 36/36 green.
- [ ] CI green (was failing for the unrelated pin reason; bundled fix should clear it).

🤖 Generated with [Claude Code](https://claude.com/claude-code)