### PR TITLE
feat(presets): add `smolvm pi start` for the Pi coding agent

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -361,7 +361,7 @@ checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
 
 [[package]]
 name = "smolvm-core"
-version = "0.0.10"
+version = "0.0.11"
 dependencies = [
  "futures-util",
  "libc",

--- a/README.md
+++ b/README.md
@@ -111,6 +111,8 @@ With a single command you get a claude/codex pre-installed sandbox ready with gi
 smolvm codex start  # start a new environment with codex preinstalled
 
 smolvm claude start  # start a new environment with codex preinstalled
+
+smolvm pi start  # start a new environment with the Pi coding agent preinstalled
 ```
 
 

--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ With a single command you get a claude/codex pre-installed sandbox ready with gi
 ```bash
 smolvm codex start  # start a new environment with codex preinstalled
 
-smolvm claude start  # start a new environment with codex preinstalled
+smolvm claude start  # start a new environment with claude preinstalled
 
 smolvm pi start  # start a new environment with the Pi coding agent preinstalled
 ```

--- a/src/smolvm/presets/__init__.py
+++ b/src/smolvm/presets/__init__.py
@@ -26,8 +26,9 @@ from smolvm.presets._install import apply_preset, collect_host_env
 from smolvm.presets._types import HostConfigCopy, HostKeychainSecret, Preset
 from smolvm.presets.claude_code import CLAUDE_CODE_PRESET
 from smolvm.presets.codex import CODEX_PRESET
+from smolvm.presets.pi import PI_PRESET
 
-_BUILTIN_PRESETS: tuple[Preset, ...] = (CODEX_PRESET, CLAUDE_CODE_PRESET)
+_BUILTIN_PRESETS: tuple[Preset, ...] = (CODEX_PRESET, CLAUDE_CODE_PRESET, PI_PRESET)
 
 _REGISTRY: dict[str, Preset] = {p.name: p for p in _BUILTIN_PRESETS}
 
@@ -74,6 +75,7 @@ __all__ = [
     "CLAUDE_CODE_PRESET",
     "CODEX_PRESET",
     "GIT_HOST_CONFIGS",
+    "PI_PRESET",
     "HostConfigCopy",
     "HostKeychainSecret",
     "Preset",

--- a/src/smolvm/presets/claude_code.py
+++ b/src/smolvm/presets/claude_code.py
@@ -28,7 +28,11 @@ from smolvm.presets._types import HostConfigCopy, HostKeychainSecret, Preset
 # with "claude command not found at /root/.local/bin/claude" on first
 # start. Removing the key lets claude re-detect the install method
 # fresh on the guest. python3 ships in the Ubuntu cloud image.
-_RESET_INSTALL_METHOD = r"""
+#
+# Public so the Pi preset can append the same cleanup when it
+# forwards ~/.claude.json (Pi delegates Claude Pro/Max auth through
+# Claude Code's on-disk config).
+CLAUDE_RESET_INSTALL_METHOD = r"""
 if [ -f /root/.claude.json ]; then
   python3 - <<'PY' || true
 import json, pathlib
@@ -44,30 +48,34 @@ PY
 fi
 """
 
+# On macOS, claude stores its OAuth tokens in the keychain (not in
+# ~/.claude/.credentials.json — that file does not exist on a
+# signed-in Mac). Pull the keychain item into the guest as the
+# credentials file Linux claude reads at startup; without this the
+# guest greets the user by name (from oauthAccount in the copied
+# ~/.claude.json) but says "Not logged in". The keychain item is
+# named "Claude Code-credentials" and its value is already the JSON
+# body credentials.json expects.
+#
+# Public so the Pi preset can reuse the same secret — Pi reads
+# ~/.claude/.credentials.json when delegating to the Claude
+# subscription, so the keychain extraction has to happen there too.
+CLAUDE_CODE_KEYCHAIN_SECRET = HostKeychainSecret(
+    service="Claude Code-credentials",
+    guest_path="/root/.claude/.credentials.json",
+)
+
 CLAUDE_CODE_PRESET = Preset(
     name="claude-code",
     aliases=("claude",),
     summary="Start a sandbox with Anthropic's Claude Code CLI preinstalled.",
     setup_script=NODE20_BOOTSTRAP,
-    install_script=npm_install_global("@anthropic-ai/claude-code") + _RESET_INSTALL_METHOD,
+    install_script=npm_install_global("@anthropic-ai/claude-code") + CLAUDE_RESET_INSTALL_METHOD,
     host_env_vars=("ANTHROPIC_API_KEY",),
     host_configs=(
         HostConfigCopy(host_path="~/.claude.json", guest_path="/root/.claude.json"),
         HostConfigCopy(host_path="~/.claude", guest_path="/root/.claude"),
     ),
-    # On macOS, claude stores its OAuth tokens in the keychain (not in
-    # ~/.claude/.credentials.json — that file does not exist on a
-    # signed-in Mac). Pull the keychain item into the guest as the
-    # credentials file Linux claude reads at startup; without this the
-    # guest greets the user by name (from oauthAccount in the copied
-    # ~/.claude.json) but says "Not logged in". The keychain item is
-    # named "Claude Code-credentials" and its value is already the JSON
-    # body credentials.json expects.
-    host_keychain_secrets=(
-        HostKeychainSecret(
-            service="Claude Code-credentials",
-            guest_path="/root/.claude/.credentials.json",
-        ),
-    ),
+    host_keychain_secrets=(CLAUDE_CODE_KEYCHAIN_SECRET,),
     launch_command="claude",
 )

--- a/src/smolvm/presets/pi.py
+++ b/src/smolvm/presets/pi.py
@@ -1,0 +1,51 @@
+# Copyright 2026 Celesto AI
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Pi coding agent preset (https://pi.dev/)."""
+
+from __future__ import annotations
+
+from smolvm.presets._scripts import NODE20_BOOTSTRAP, npm_install_global
+from smolvm.presets._types import HostConfigCopy, HostKeychainSecret, Preset
+from smolvm.presets.claude_code import _RESET_INSTALL_METHOD
+
+# Pi is a meta-harness: its `/login` flow lists "OpenAI ChatGPT Plus/Pro
+# (Codex)" and "Anthropic Claude Pro/Max" as subscription providers, and
+# in practice Pi reuses each provider CLI's on-disk credentials when the
+# user is already logged in there. So forward the union of codex's and
+# claude-code's host-config bundles plus Pi's own ~/.pi (which contains
+# settings, sessions, and ~/.pi/agent/auth.json — Pi's own OAuth tokens).
+# We also append claude-code's _RESET_INSTALL_METHOD so the copied
+# ~/.claude.json doesn't carry a host-specific installMethod into the
+# guest.
+PI_PRESET = Preset(
+    name="pi",
+    summary="Start a sandbox with the Pi coding agent preinstalled.",
+    setup_script=NODE20_BOOTSTRAP,
+    install_script=npm_install_global("@mariozechner/pi-coding-agent") + _RESET_INSTALL_METHOD,
+    host_env_vars=("ANTHROPIC_API_KEY", "OPENAI_API_KEY"),
+    host_configs=(
+        HostConfigCopy(host_path="~/.pi", guest_path="/root/.pi"),
+        HostConfigCopy(host_path="~/.codex", guest_path="/root/.codex"),
+        HostConfigCopy(host_path="~/.claude.json", guest_path="/root/.claude.json"),
+        HostConfigCopy(host_path="~/.claude", guest_path="/root/.claude"),
+    ),
+    host_keychain_secrets=(
+        HostKeychainSecret(
+            service="Claude Code-credentials",
+            guest_path="/root/.claude/.credentials.json",
+        ),
+    ),
+    launch_command="pi",
+)

--- a/src/smolvm/presets/pi.py
+++ b/src/smolvm/presets/pi.py
@@ -17,8 +17,8 @@
 from __future__ import annotations
 
 from smolvm.presets._scripts import NODE20_BOOTSTRAP, npm_install_global
-from smolvm.presets._types import HostConfigCopy, HostKeychainSecret, Preset
-from smolvm.presets.claude_code import _RESET_INSTALL_METHOD
+from smolvm.presets._types import HostConfigCopy, Preset
+from smolvm.presets.claude_code import CLAUDE_CODE_KEYCHAIN_SECRET, CLAUDE_RESET_INSTALL_METHOD
 
 # Pi is a meta-harness: its `/login` flow lists "OpenAI ChatGPT Plus/Pro
 # (Codex)" and "Anthropic Claude Pro/Max" as subscription providers, and
@@ -26,14 +26,16 @@ from smolvm.presets.claude_code import _RESET_INSTALL_METHOD
 # user is already logged in there. So forward the union of codex's and
 # claude-code's host-config bundles plus Pi's own ~/.pi (which contains
 # settings, sessions, and ~/.pi/agent/auth.json — Pi's own OAuth tokens).
-# We also append claude-code's _RESET_INSTALL_METHOD so the copied
+# We also append claude_code's reset snippet so the copied
 # ~/.claude.json doesn't carry a host-specific installMethod into the
 # guest.
 PI_PRESET = Preset(
     name="pi",
     summary="Start a sandbox with the Pi coding agent preinstalled.",
     setup_script=NODE20_BOOTSTRAP,
-    install_script=npm_install_global("@mariozechner/pi-coding-agent") + _RESET_INSTALL_METHOD,
+    install_script=(
+        npm_install_global("@mariozechner/pi-coding-agent") + CLAUDE_RESET_INSTALL_METHOD
+    ),
     host_env_vars=("ANTHROPIC_API_KEY", "OPENAI_API_KEY"),
     host_configs=(
         HostConfigCopy(host_path="~/.pi", guest_path="/root/.pi"),
@@ -41,11 +43,6 @@ PI_PRESET = Preset(
         HostConfigCopy(host_path="~/.claude.json", guest_path="/root/.claude.json"),
         HostConfigCopy(host_path="~/.claude", guest_path="/root/.claude"),
     ),
-    host_keychain_secrets=(
-        HostKeychainSecret(
-            service="Claude Code-credentials",
-            guest_path="/root/.claude/.credentials.json",
-        ),
-    ),
+    host_keychain_secrets=(CLAUDE_CODE_KEYCHAIN_SECRET,),
     launch_command="pi",
 )

--- a/tests/test_presets.py
+++ b/tests/test_presets.py
@@ -26,6 +26,7 @@ from smolvm.presets import (
     CLAUDE_CODE_PRESET,
     CODEX_PRESET,
     GIT_HOST_CONFIGS,
+    PI_PRESET,
     HostConfigCopy,
     HostKeychainSecret,
     Preset,
@@ -67,13 +68,13 @@ def _isolate_home(
 class TestRegistry:
     """Built-in preset registration."""
 
-    def test_codex_and_claude_code_registered(self) -> None:
-        assert preset_names() == ["claude-code", "codex"]
+    def test_builtin_presets_registered(self) -> None:
+        assert preset_names() == ["claude-code", "codex", "pi"]
 
     def test_list_presets_sorted_by_name(self) -> None:
         names = [p.name for p in list_presets()]
         assert names == sorted(names)
-        assert {p.name for p in list_presets()} == {"codex", "claude-code"}
+        assert {p.name for p in list_presets()} == {"codex", "claude-code", "pi"}
 
     def test_get_preset_returns_codex(self) -> None:
         assert get_preset("codex") is CODEX_PRESET
@@ -81,8 +82,11 @@ class TestRegistry:
     def test_get_preset_returns_claude_code(self) -> None:
         assert get_preset("claude-code") is CLAUDE_CODE_PRESET
 
+    def test_get_preset_returns_pi(self) -> None:
+        assert get_preset("pi") is PI_PRESET
+
     def test_unknown_preset_lists_available(self) -> None:
-        with pytest.raises(KeyError, match="Available: claude-code, codex"):
+        with pytest.raises(KeyError, match="Available: claude-code, codex, pi"):
             get_preset("hermes")
 
 
@@ -185,6 +189,48 @@ class TestClaudeCodePreset:
             check=False,
         )
         assert completed.returncode == 0, completed.stderr
+
+
+class TestPiPreset:
+    """Pi preset wires up the right keys, paths, and install command."""
+
+    def test_pi_preset_shape(self) -> None:
+        assert PI_PRESET.name == "pi"
+        assert PI_PRESET.aliases == ()
+        assert PI_PRESET.launch_command == "pi"
+        assert PI_PRESET.host_env_vars == ("ANTHROPIC_API_KEY", "OPENAI_API_KEY")
+
+    def test_pi_forwards_union_of_provider_credentials(self) -> None:
+        """Pi reuses on-disk credentials from codex and claude-code in
+        addition to its own ~/.pi config, so a prior `codex login` or
+        `claude login` on the host carries through into the guest."""
+        guest_paths = {cfg.host_path: cfg.guest_path for cfg in PI_PRESET.host_configs}
+        assert guest_paths == {
+            "~/.pi": "/root/.pi",
+            "~/.codex": "/root/.codex",
+            "~/.claude.json": "/root/.claude.json",
+            "~/.claude": "/root/.claude",
+        }
+
+    def test_pi_pulls_oauth_from_macos_keychain(self) -> None:
+        """Match claude-code: on macOS the Claude Code OAuth tokens live
+        in the keychain, and Pi reads ~/.claude/.credentials.json when
+        delegating to the Claude Pro/Max subscription."""
+        assert PI_PRESET.host_keychain_secrets == (
+            HostKeychainSecret(
+                service="Claude Code-credentials",
+                guest_path="/root/.claude/.credentials.json",
+            ),
+        )
+
+    def test_pi_install_runs_npm_install(self) -> None:
+        assert "@mariozechner/pi-coding-agent" in PI_PRESET.install_script
+        assert "npm install -g" in PI_PRESET.install_script
+
+    def test_pi_setup_uses_node20_bootstrap(self) -> None:
+        from smolvm.presets._scripts import NODE20_BOOTSTRAP
+
+        assert PI_PRESET.setup_script == NODE20_BOOTSTRAP
 
 
 class TestNpmInstallGlobalSafety:

--- a/tests/test_presets.py
+++ b/tests/test_presets.py
@@ -119,12 +119,11 @@ class TestClaudeCodePreset:
         Claude Code on macOS keeps tokens in the keychain (not in
         ``~/.claude/.credentials.json``); without this entry the guest
         sees the user's profile but says "Not logged in"."""
-        assert CLAUDE_CODE_PRESET.host_keychain_secrets == (
-            HostKeychainSecret(
-                service="Claude Code-credentials",
-                guest_path="/root/.claude/.credentials.json",
-            ),
-        )
+        from smolvm.presets.claude_code import CLAUDE_CODE_KEYCHAIN_SECRET
+
+        assert CLAUDE_CODE_PRESET.host_keychain_secrets == (CLAUDE_CODE_KEYCHAIN_SECRET,)
+        assert CLAUDE_CODE_KEYCHAIN_SECRET.service == "Claude Code-credentials"
+        assert CLAUDE_CODE_KEYCHAIN_SECRET.guest_path == "/root/.claude/.credentials.json"
 
     def test_claude_code_install_runs_npm_install(self) -> None:
         assert "@anthropic-ai/claude-code" in CLAUDE_CODE_PRESET.install_script
@@ -156,9 +155,9 @@ class TestClaudeCodePreset:
 
         # Extract just the cleanup snippet (after the npm install line)
         # and rewrite the hard-coded /root/ path to our temp dir.
-        from smolvm.presets.claude_code import _RESET_INSTALL_METHOD
+        from smolvm.presets.claude_code import CLAUDE_RESET_INSTALL_METHOD
 
-        snippet = _RESET_INSTALL_METHOD.replace("/root/", f"{root}/")
+        snippet = CLAUDE_RESET_INSTALL_METHOD.replace("/root/", f"{root}/")
         completed = subprocess.run(
             ["bash", "-c", f"set -euo pipefail; {snippet}"],
             capture_output=True,
@@ -178,10 +177,10 @@ class TestClaudeCodePreset:
         copied (e.g. a fresh user with no host config)."""
         import subprocess
 
-        from smolvm.presets.claude_code import _RESET_INSTALL_METHOD
+        from smolvm.presets.claude_code import CLAUDE_RESET_INSTALL_METHOD
 
         # Point at an empty dir — the file does not exist.
-        snippet = _RESET_INSTALL_METHOD.replace("/root/", f"{tmp_path}/")
+        snippet = CLAUDE_RESET_INSTALL_METHOD.replace("/root/", f"{tmp_path}/")
         completed = subprocess.run(
             ["bash", "-c", f"set -euo pipefail; {snippet}"],
             capture_output=True,
@@ -203,29 +202,39 @@ class TestPiPreset:
     def test_pi_forwards_union_of_provider_credentials(self) -> None:
         """Pi reuses on-disk credentials from codex and claude-code in
         addition to its own ~/.pi config, so a prior `codex login` or
-        `claude login` on the host carries through into the guest."""
-        guest_paths = {cfg.host_path: cfg.guest_path for cfg in PI_PRESET.host_configs}
-        assert guest_paths == {
-            "~/.pi": "/root/.pi",
-            "~/.codex": "/root/.codex",
-            "~/.claude.json": "/root/.claude.json",
-            "~/.claude": "/root/.claude",
-        }
+        `claude login` on the host carries through into the guest.
+
+        Compared as an ordered list of (host, guest) pairs so a
+        duplicate ``HostConfigCopy`` cannot silently dedupe through a
+        dict-based assertion."""
+        pairs = [(cfg.host_path, cfg.guest_path) for cfg in PI_PRESET.host_configs]
+        assert pairs == [
+            ("~/.pi", "/root/.pi"),
+            ("~/.codex", "/root/.codex"),
+            ("~/.claude.json", "/root/.claude.json"),
+            ("~/.claude", "/root/.claude"),
+        ]
 
     def test_pi_pulls_oauth_from_macos_keychain(self) -> None:
-        """Match claude-code: on macOS the Claude Code OAuth tokens live
-        in the keychain, and Pi reads ~/.claude/.credentials.json when
-        delegating to the Claude Pro/Max subscription."""
-        assert PI_PRESET.host_keychain_secrets == (
-            HostKeychainSecret(
-                service="Claude Code-credentials",
-                guest_path="/root/.claude/.credentials.json",
-            ),
-        )
+        """Pi delegates Claude Pro/Max auth through Claude Code's
+        ~/.claude/.credentials.json, so it must reuse the same keychain
+        extraction."""
+        from smolvm.presets.claude_code import CLAUDE_CODE_KEYCHAIN_SECRET
+
+        assert PI_PRESET.host_keychain_secrets == (CLAUDE_CODE_KEYCHAIN_SECRET,)
 
     def test_pi_install_runs_npm_install(self) -> None:
         assert "@mariozechner/pi-coding-agent" in PI_PRESET.install_script
         assert "npm install -g" in PI_PRESET.install_script
+
+    def test_pi_install_strips_claude_install_method(self) -> None:
+        """Pi forwards ~/.claude.json, so its install must append the
+        same installMethod cleanup that claude-code uses — otherwise
+        the host's ``installMethod`` value carries into the guest and
+        breaks claude/Pi's claude-subscription path on first launch."""
+        from smolvm.presets.claude_code import CLAUDE_RESET_INSTALL_METHOD
+
+        assert CLAUDE_RESET_INSTALL_METHOD in PI_PRESET.install_script
 
     def test_pi_setup_uses_node20_bootstrap(self) -> None:
         from smolvm.presets._scripts import NODE20_BOOTSTRAP


### PR DESCRIPTION
## Summary

Adds a third coding-agent preset alongside `smolvm codex start` and `smolvm claude start` for the Pi coding agent (https://pi.dev/, npm `@mariozechner/pi-coding-agent`). Pi is a multi-provider terminal harness that delegates to other provider CLIs' on-disk credentials, so the preset forwards the union of codex's and claude-code's host configs (`~/.codex`, `~/.claude.json`, `~/.claude`, the macOS Claude Code keychain entry) plus Pi's own `~/.pi/`, and forwards both `ANTHROPIC_API_KEY` and `OPENAI_API_KEY` — meaning a prior `codex login` or `claude login` on the host carries through into the guest with no re-auth. Wires up via the existing dynamic preset registry, so no parser/dispatcher changes were needed.

## Related Issues

- Closes #

## Testing

- `uv run --with pytest pytest tests/test_presets.py` — 56/56 pass
- `uv run --with ruff ruff check` on changed files — clean
- `uv run smolvm --help` and `uv run smolvm pi start --help` — `pi` registered, help renders

## Checklist

- [x] Scope is focused and limited to this change
- [x] Tests added/updated for behavior changes
- [x] Docs updated for user-visible changes
- [x] No secrets or sensitive data included

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Pi coding agent preset is now available. Users can provision a new sandbox environment with the Pi coding agent preinstalled using the `smolvm pi start` command.

* **Documentation**
  * README CLI documentation updated to include the new Pi preset command example and clarified that Claude is the default agent for the `smolvm claude start` command.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->