### PR TITLE
feat(cli): add --writable-mounts so guest writes reach the host

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,7 +156,7 @@ See [docs/concepts/network-egress-controls.md](docs/deep-dive/network-egress-con
 
 ## Mount host directories
 
-You can give a sandbox read access to a folder on your machine. This is useful when an agent needs to work with an existing project without copying files back and forth.
+You can give a sandbox access to a folder on your machine. This is useful when an agent needs to work with an existing project without copying files back and forth.
 
 ```bash
 smolvm create --mount ~/Projects/my-app
@@ -164,7 +164,7 @@ smolvm ssh my-sandbox
 ls /workspace   # your host files appear here
 ```
 
-The host folder is read-only — the sandbox can read every file, but changes stay inside the sandbox and never touch the originals. If the agent creates or edits files under `/workspace`, those changes live only in the VM's overlay layer.
+By default the host folder is read-only — the sandbox can read every file, but changes stay inside the sandbox and never touch the originals. If the agent creates or edits files under `/workspace`, those changes live only in the VM's overlay layer.
 
 Mount at a custom path, or mount multiple directories:
 
@@ -172,17 +172,22 @@ Mount at a custom path, or mount multiple directories:
 smolvm create --mount ~/Projects/my-app:/code --mount ~/data:/mnt/data
 ```
 
+When you do want the sandbox to edit your host files, add `--writable-mounts`:
+
+```bash
+smolvm create --mount ~/Projects/my-app --writable-mounts
+```
+
+Every directory passed with `--mount` becomes writable; writes from the guest are visible on the host immediately. The flag applies to all mounts on that command, so don't pair a folder you want the sandbox to modify with one you want kept untouched.
+
 The same works from Python:
 
 ```python
 from smolvm import SmolVM
 
-with SmolVM(mounts=["~/Projects/my-app"]) as vm:
-    result = vm.run("ls /workspace")
-    print(result.stdout)
+with SmolVM(mounts=["~/Projects/my-app"], writable_mounts=True) as vm:
+    vm.run("echo hello > /workspace/from-sandbox.txt")
 ```
-
-> **Note:** This feature is read-only for now. Any changes you make inside the sandbox do not travel back to the host. Write-back support is planned for a future release.
 
 
 ## Examples

--- a/src/smolvm/cli/main.py
+++ b/src/smolvm/cli/main.py
@@ -417,6 +417,16 @@ def _add_preset_parsers(
             ),
         )
         start_p.add_argument(
+            "--writable-mounts",
+            action="store_true",
+            dest="writable_mounts",
+            help=(
+                "Allow the sandbox to write back to mounted host directories. "
+                "Default is read-only with a writable in-VM overlay; writes "
+                "from the guest do not reach the host."
+            ),
+        )
+        start_p.add_argument(
             "--install-timeout",
             type=_positive_float,
             default=600.0,
@@ -723,9 +733,20 @@ def build_parser() -> argparse.ArgumentParser:
         help=(
             "Host directory to mount inside the sandbox. "
             "Defaults to /workspace if no guest path is given. "
-            "The host directory stays read-only; writes go to an "
-            "overlay and do not affect the host. "
+            "The host directory stays read-only by default; writes go "
+            "to an overlay and do not affect the host. "
+            "Pass --writable-mounts to allow guest writes to reach the host. "
             "Can be repeated for multiple mounts."
+        ),
+    )
+    create_parser.add_argument(
+        "--writable-mounts",
+        action="store_true",
+        dest="writable_mounts",
+        help=(
+            "Allow the sandbox to write back to mounted host directories. "
+            "Default is read-only with a writable in-VM overlay; writes "
+            "from the guest do not reach the host."
         ),
     )
     _add_boot_timeout_arg(create_parser)
@@ -1498,6 +1519,7 @@ def _build_and_boot_with_progress(
     build_fn: object,
     boot_timeout: int,
     mounts: list[str] | None = None,
+    writable_mounts: bool = False,
 ) -> object:
     """Build a VM config and boot it, showing a Rich progress bar.
 
@@ -1547,7 +1569,12 @@ def _build_and_boot_with_progress(
         def on_phase(phase: str) -> None:
             progress.update(boot_task, description=phase)
 
-        vm = SmolVM(config, ssh_key_path=ssh_key_path, mounts=mounts)
+        vm = SmolVM(
+            config,
+            ssh_key_path=ssh_key_path,
+            mounts=mounts,
+            writable_mounts=writable_mounts,
+        )
         vm.start(boot_timeout=boot_timeout, on_progress=on_phase)
         # Idempotent: a no-op when start() already waited (mounts/env_vars
         # path), and the on_progress flips the label only when a real wait
@@ -1621,6 +1648,7 @@ def _run_create(args: argparse.Namespace) -> int:
                     ),
                     boot_timeout=args.boot_timeout,
                     mounts=args.mounts,
+                    writable_mounts=args.writable_mounts,
                 )
             else:
                 config, ssh_key_path = _build_s3_image_config(
@@ -1630,7 +1658,12 @@ def _run_create(args: argparse.Namespace) -> int:
                     memory=args.memory_mib,
                     ssh_key_path=None,
                 )
-                vm = SmolVM(config, ssh_key_path=ssh_key_path, mounts=args.mounts)
+                vm = SmolVM(
+                    config,
+                    ssh_key_path=ssh_key_path,
+                    mounts=args.mounts,
+                    writable_mounts=args.writable_mounts,
+                )
                 vm.start(boot_timeout=args.boot_timeout)
                 vm.wait_for_ssh(timeout=args.boot_timeout)
         else:
@@ -1650,6 +1683,7 @@ def _run_create(args: argparse.Namespace) -> int:
                     ),
                     boot_timeout=args.boot_timeout,
                     mounts=args.mounts,
+                    writable_mounts=args.writable_mounts,
                 )
             else:
                 config, ssh_key_path = _build_auto_config(
@@ -1660,7 +1694,12 @@ def _run_create(args: argparse.Namespace) -> int:
                     disk_size_mib=args.disk_size_mib,
                     ssh_key_path=None,
                 )
-                vm = SmolVM(config, ssh_key_path=ssh_key_path, mounts=args.mounts)
+                vm = SmolVM(
+                    config,
+                    ssh_key_path=ssh_key_path,
+                    mounts=args.mounts,
+                    writable_mounts=args.writable_mounts,
+                )
                 vm.start(boot_timeout=args.boot_timeout)
                 vm.wait_for_ssh(timeout=args.boot_timeout)
 
@@ -1780,6 +1819,7 @@ def _run_start(args: argparse.Namespace) -> int:
                 ),
                 boot_timeout=args.boot_timeout,
                 mounts=args.mounts,
+                writable_mounts=args.writable_mounts,
             )
             apply_summary = _apply_preset_with_progress(
                 console=console,
@@ -1797,7 +1837,12 @@ def _run_start(args: argparse.Namespace) -> int:
                 disk_size_mib=disk_size_mib,
                 ssh_key_path=None,
             )
-            vm = SmolVM(config, ssh_key_path=ssh_key_path, mounts=args.mounts)
+            vm = SmolVM(
+                config,
+                ssh_key_path=ssh_key_path,
+                mounts=args.mounts,
+                writable_mounts=args.writable_mounts,
+            )
             vm.start(boot_timeout=args.boot_timeout)
             vm.wait_for_ssh(timeout=args.boot_timeout)
             ssh = vm._ensure_ssh_for_env()

--- a/src/smolvm/facade.py
+++ b/src/smolvm/facade.py
@@ -316,11 +316,16 @@ def _resolve_auto_config_public_key(ssh_key_path: str | None) -> tuple[str, Path
     return ssh_key_path, public_key
 
 
-def _parse_mount_specs(specs: list[str]) -> list[WorkspaceMount]:
+def _parse_mount_specs(
+    specs: list[str], *, writable: bool = False
+) -> list[WorkspaceMount]:
     """Parse ``HOST_PATH[:GUEST_PATH]`` strings into WorkspaceMount objects.
 
     If no guest path is given, the mount defaults to ``/workspace``
     (for a single mount) or ``/workspace-N`` (for multiples).
+
+    When ``writable`` is True, every parsed mount is marked writable so
+    guest writes propagate to the host directory.
     """
     mounts: list[WorkspaceMount] = []
     for index, spec in enumerate(specs):
@@ -330,7 +335,11 @@ def _parse_mount_specs(specs: list[str]) -> list[WorkspaceMount]:
         else:
             host_str = spec
             guest_path = "/workspace" if len(specs) == 1 else f"/workspace-{index}"
-        mounts.append(WorkspaceMount(host_path=Path(host_str), guest_path=guest_path))
+        mounts.append(
+            WorkspaceMount(
+                host_path=Path(host_str), guest_path=guest_path, writable=writable
+            )
+        )
     return mounts
 
 
@@ -726,6 +735,7 @@ class SmolVM:
         ssh_key_path: str | None = None,
         internet_settings: InternetSettings | dict[str, Any] | None = None,
         mounts: list[str] | None = None,
+        writable_mounts: bool = False,
     ) -> None:
         if config is not None and vm_id is not None:
             raise ValueError("Provide either config or vm_id, not both.")
@@ -802,7 +812,7 @@ class SmolVM:
         if mounts is not None:
             if vm_id is not None:
                 raise ValueError("mounts cannot be set when reconnecting to an existing VM.")
-            workspace_mounts = _parse_mount_specs(mounts)
+            workspace_mounts = _parse_mount_specs(mounts, writable=writable_mounts)
             if config is not None:
                 if config.workspace_mounts:
                     raise ValueError(
@@ -810,6 +820,8 @@ class SmolVM:
                         "pass it in one place only."
                     )
                 config = config.model_copy(update={"workspace_mounts": workspace_mounts})
+        elif writable_mounts:
+            raise ValueError("writable_mounts requires --mount; nothing to make writable.")
 
         self._ssh_user = ssh_user
         self._ssh_key_path = ssh_key_path
@@ -1857,27 +1869,37 @@ class SmolVM:
                 {"vm_id": self._vm_id, "ssh_user": self._ssh_user},
             )
 
-        self._ensure_9p_workspace_support()
+        needs_overlay = any(not ws.writable for ws in workspace_mounts)
+        self._ensure_9p_workspace_support(need_overlay=needs_overlay)
 
         for index, ws in enumerate(workspace_mounts):
             tag = ws.resolved_tag(index)
             guest_path = shlex.quote(ws.guest_path)
-            lower = shlex.quote(f"/mnt/.smolvm-ws-{tag}")
-            upper = shlex.quote(f"/tmp/.smolvm-ws-{tag}-upper")
-            work = shlex.quote(f"/tmp/.smolvm-ws-{tag}-work")
             qtag = shlex.quote(tag)
 
-            mount_script = (
-                f"modprobe 9p 2>/dev/null; "
-                f"modprobe 9pnet_virtio 2>/dev/null; "
-                f"modprobe overlay 2>/dev/null; "
-                f"mkdir -p {lower} {upper} {work} {guest_path} && "
-                f"mount -t 9p -o trans=virtio,version=9p2000.L,ro "
-                f"{qtag} {lower} && "
-                f"mount -t overlay overlay "
-                f"-o lowerdir={lower},upperdir={upper},workdir={work} "
-                f"{guest_path}"
-            )
+            if ws.writable:
+                mount_script = (
+                    f"modprobe 9p 2>/dev/null; "
+                    f"modprobe 9pnet_virtio 2>/dev/null; "
+                    f"mkdir -p {guest_path} && "
+                    f"mount -t 9p -o trans=virtio,version=9p2000.L,rw "
+                    f"{qtag} {guest_path}"
+                )
+            else:
+                lower = shlex.quote(f"/mnt/.smolvm-ws-{tag}")
+                upper = shlex.quote(f"/tmp/.smolvm-ws-{tag}-upper")
+                work = shlex.quote(f"/tmp/.smolvm-ws-{tag}-work")
+                mount_script = (
+                    f"modprobe 9p 2>/dev/null; "
+                    f"modprobe 9pnet_virtio 2>/dev/null; "
+                    f"modprobe overlay 2>/dev/null; "
+                    f"mkdir -p {lower} {upper} {work} {guest_path} && "
+                    f"mount -t 9p -o trans=virtio,version=9p2000.L,ro "
+                    f"{qtag} {lower} && "
+                    f"mount -t overlay overlay "
+                    f"-o lowerdir={lower},upperdir={upper},workdir={work} "
+                    f"{guest_path}"
+                )
             result = self._ssh.run(mount_script, timeout=15)
             if result.exit_code != 0:
                 stderr = result.stderr.strip()
@@ -1898,26 +1920,30 @@ class SmolVM:
                     },
                 )
             logger.info(
-                "VM %s: mounted workspace '%s' at %s (overlay)",
+                "VM %s: mounted workspace '%s' at %s (%s)",
                 self._vm_id,
                 tag,
                 ws.guest_path,
+                "writable" if ws.writable else "overlay",
             )
 
-    def _ensure_9p_workspace_support(self) -> None:
+    def _ensure_9p_workspace_support(self, *, need_overlay: bool = True) -> None:
         """Best-effort repair for Ubuntu cloud images missing 9p modules."""
         assert self._ssh is not None  # noqa: S101 — caller guarantees SSH ready
 
+        overlay_probe = " && modprobe overlay 2>/dev/null" if need_overlay else ""
         probe_script = (
             "modprobe 9p 2>/dev/null && "
-            "modprobe 9pnet_virtio 2>/dev/null && "
-            "modprobe overlay 2>/dev/null"
+            "modprobe 9pnet_virtio 2>/dev/null"
+            f"{overlay_probe}"
         )
         probe = self._ssh.run(probe_script, timeout=15)
         if probe.exit_code == 0:
             return
 
-        install_script = r"""
+        overlay_modprobe = "\nmodprobe overlay" if need_overlay else ""
+        install_script = (
+            r"""
 set -eu
 . /etc/os-release 2>/dev/null || ID=
 if [ "${ID:-}" != "ubuntu" ] || ! command -v apt-get >/dev/null 2>&1; then
@@ -1937,9 +1963,9 @@ APT_OPTS='-o DPkg::Lock::Timeout=120 -o Acquire::Retries=3'
 apt-get $APT_OPTS update -qq
 apt-get $APT_OPTS install -y -qq "linux-modules-extra-$(uname -r)"
 modprobe 9p
-modprobe 9pnet_virtio
-modprobe overlay
-""".strip()
+modprobe 9pnet_virtio""".strip()
+            + overlay_modprobe
+        )
         install = self._ssh.run(install_script, timeout=240)
         if install.exit_code == 0:
             logger.info(
@@ -1948,8 +1974,9 @@ modprobe overlay
             )
             return
 
+        missing = "9p or overlay" if need_overlay else "9p"
         raise SmolVMError(
-            "Cannot mount workspaces: guest is missing 9p or overlay kernel support. "
+            f"Cannot mount workspaces: guest is missing {missing} kernel support. "
             "Ubuntu guests can usually be repaired by installing "
             "linux-modules-extra-$(uname -r); this guest could not be repaired "
             "automatically.",

--- a/src/smolvm/facade.py
+++ b/src/smolvm/facade.py
@@ -713,6 +713,16 @@ class SmolVM:
             :class:`~smolvm.types.InternetSettings` instance or a dict
             (e.g. ``{"allowed_domains": ["https://example.com/"]}``).
             When set, only the listed domains are reachable from the VM.
+        mounts: Host directories to mount inside the guest, as
+            ``HOST_PATH[:GUEST_PATH]`` strings. Equivalent to passing
+            ``WorkspaceMount`` instances on a :class:`VMConfig`.
+        writable_mounts: When ``True``, every entry in *mounts* is
+            exposed read-write so guest writes propagate to the host
+            directory. Default ``False`` keeps the host read-only with
+            a writable in-VM overlay (changes stay inside the VM).
+            For per-mount control, set
+            :attr:`~smolvm.types.WorkspaceMount.writable` directly on
+            ``config.workspace_mounts`` instead.
 
     Raises:
         ValueError: If both *config* and *vm_id* are given, or if auto-config-only
@@ -821,7 +831,11 @@ class SmolVM:
                     )
                 config = config.model_copy(update={"workspace_mounts": workspace_mounts})
         elif writable_mounts:
-            raise ValueError("writable_mounts requires --mount; nothing to make writable.")
+            raise ValueError(
+                "writable_mounts requires the mounts= argument; nothing to "
+                "make writable. Alternatively, set "
+                "WorkspaceMount(writable=True) on config.workspace_mounts."
+            )
 
         self._ssh_user = ssh_user
         self._ssh_key_path = ssh_key_path

--- a/src/smolvm/types.py
+++ b/src/smolvm/types.py
@@ -124,21 +124,29 @@ class VsockConfig(BaseModel):
 
 
 class WorkspaceMount(BaseModel):
-    """Host directory to mount inside the guest via virtio-9p + overlayfs.
+    """Host directory to mount inside the guest via virtio-9p.
 
-    The host directory is exposed read-only through QEMU's virtio-9p
-    passthrough.  An overlayfs layer on top lets the guest read and write
-    freely — but changes stay inside the VM and never touch the host.
+    By default the host directory is exposed read-only through QEMU's
+    virtio-9p passthrough, with an overlayfs layer on top so the guest
+    can read and write freely — changes stay inside the VM and never
+    touch the host.
+
+    When ``writable`` is True the host directory is exposed read-write
+    and mounted directly at ``guest_path`` (no overlay), so writes from
+    the guest are visible on the host.
 
     Attributes:
         host_path: Absolute path to a directory on the host.
         guest_path: Mount point inside the guest (default ``/workspace``).
         mount_tag: 9p mount tag passed to QEMU.  Auto-generated when omitted.
+        writable: When True, guest writes propagate to the host directory.
+            Default False (read-only host, writable overlay in guest).
     """
 
     host_path: Path
     guest_path: str = "/workspace"
     mount_tag: str | None = None
+    writable: bool = False
 
     @field_validator("host_path")
     @classmethod

--- a/src/smolvm/vm.py
+++ b/src/smolvm/vm.py
@@ -1614,13 +1614,13 @@ class SmolVMManager:
             tag = ws.resolved_tag(index)
             fsdev_id = f"fsdev-{tag}"
             workspace_fsdev_ids.append((fsdev_id, tag))
-            cmd.extend(
-                [
-                    "-fsdev",
-                    f"local,id={fsdev_id},path={ws.host_path},"
-                    f"security_model=mapped-xattr,readonly=on",
-                ]
+            fsdev_opts = (
+                f"local,id={fsdev_id},path={ws.host_path},"
+                f"security_model=mapped-xattr"
             )
+            if not ws.writable:
+                fsdev_opts += ",readonly=on"
+            cmd.extend(["-fsdev", fsdev_opts])
 
         if control_socket_path is not None:
             cmd.extend(

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -394,7 +394,12 @@ class TestCliCreate:
             ssh_key_path=None,
             on_download=ANY,
         )
-        mock_vm_cls.assert_called_once_with(config, ssh_key_path="/tmp/id_ed25519", mounts=None)
+        mock_vm_cls.assert_called_once_with(
+            config,
+            ssh_key_path="/tmp/id_ed25519",
+            mounts=None,
+            writable_mounts=False,
+        )
         vm.start.assert_called_once_with(boot_timeout=30.0, on_progress=ANY)
         vm.wait_for_ssh.assert_called_once_with(timeout=30.0, on_progress=ANY)
         vm.close.assert_called_once()
@@ -459,7 +464,12 @@ class TestCliCreate:
             ssh_key_path=None,
             on_download=ANY,
         )
-        mock_vm_cls.assert_called_once_with(config, ssh_key_path="/tmp/id_ed25519", mounts=None)
+        mock_vm_cls.assert_called_once_with(
+            config,
+            ssh_key_path="/tmp/id_ed25519",
+            mounts=None,
+            writable_mounts=False,
+        )
         vm.start.assert_called_once_with(boot_timeout=45.0, on_progress=ANY)
         vm.wait_for_ssh.assert_called_once_with(timeout=45.0, on_progress=ANY)
         vm.stop.assert_not_called()
@@ -511,7 +521,12 @@ class TestCliCreate:
             ssh_key_path=None,
             on_download=ANY,
         )
-        mock_vm_cls.assert_called_once_with(config, ssh_key_path="/tmp/id_ed25519", mounts=None)
+        mock_vm_cls.assert_called_once_with(
+            config,
+            ssh_key_path="/tmp/id_ed25519",
+            mounts=None,
+            writable_mounts=False,
+        )
         vm.start.assert_called_once_with(boot_timeout=30.0, on_progress=ANY)
         vm.wait_for_ssh.assert_called_once_with(timeout=30.0, on_progress=ANY)
         vm.close.assert_called_once()
@@ -2344,7 +2359,12 @@ class TestCliStart:
             ssh_key_path=None,
             on_download=ANY,
         )
-        mock_vm_cls.assert_called_once_with(config, ssh_key_path="/tmp/id_ed25519", mounts=None)
+        mock_vm_cls.assert_called_once_with(
+            config,
+            ssh_key_path="/tmp/id_ed25519",
+            mounts=None,
+            writable_mounts=False,
+        )
         vm.start.assert_called_once_with(boot_timeout=30.0, on_progress=ANY)
         vm.wait_for_ssh.assert_called_once_with(timeout=30.0, on_progress=ANY)
         mock_apply.assert_called_once()

--- a/tests/test_workspace.py
+++ b/tests/test_workspace.py
@@ -68,6 +68,14 @@ class TestWorkspaceMountValidation:
         assert ws.resolved_tag(0) == "workspace0"
         assert ws.resolved_tag(3) == "workspace3"
 
+    def test_writable_defaults_to_false(self, tmp_path: Path) -> None:
+        ws = WorkspaceMount(host_path=tmp_path)
+        assert ws.writable is False
+
+    def test_writable_can_be_set(self, tmp_path: Path) -> None:
+        ws = WorkspaceMount(host_path=tmp_path, writable=True)
+        assert ws.writable is True
+
     def test_missing_host_path_loads_under_validate_paths_false(self, tmp_path: Path) -> None:
         """Persisted configs reload even when the host path was deleted.
 
@@ -232,6 +240,58 @@ def test_start_qemu_includes_9p_workspace_args(
 
     # Find the virtio-9p device (aarch64 → virtio-9p-device)
     assert "virtio-9p-device,fsdev=fsdev-workspace0,mount_tag=workspace0" in cmd
+
+
+@patch("smolvm.vm.subprocess.Popen")
+@patch.object(
+    SmolVMManager,
+    "_find_qemu_binary",
+    return_value=Path("/opt/homebrew/bin/qemu-system-aarch64"),
+)
+def test_start_qemu_writable_mount_omits_readonly(
+    _mock_find_qemu_binary: MagicMock,
+    mock_popen: MagicMock,
+    tmp_path: Path,
+) -> None:
+    """A writable mount must NOT pass readonly=on to QEMU's -fsdev."""
+    kernel = tmp_path / "vmlinux"
+    rootfs = tmp_path / "rootfs.ext4"
+    kernel.touch()
+    rootfs.touch()
+
+    ws_dir = tmp_path / "project"
+    ws_dir.mkdir()
+
+    config = VMConfig(
+        vm_id="vm-ws-rw",
+        kernel_path=kernel,
+        rootfs_path=rootfs,
+        backend="qemu",
+        boot_args="console=ttyAMA0 reboot=k panic=1 init=/init",
+        workspace_mounts=[WorkspaceMount(host_path=ws_dir, writable=True)],
+    )
+
+    sdk = SmolVMManager(
+        data_dir=tmp_path / "data",
+        socket_dir=tmp_path / "sockets",
+        backend="qemu",
+    )
+    with patch.object(SmolVMManager, "_create_qemu_overlay_disk") as mock_convert:
+        mock_convert.side_effect = lambda source, target: target.touch()
+        vm_info = sdk.create(config)
+
+    proc = MagicMock()
+    proc.pid = 12345
+    mock_popen.return_value = proc
+
+    with patch("smolvm.vm.platform.system", return_value="Darwin"):
+        sdk._start_qemu(vm_info, tmp_path / "vm-ws-rw.log")
+
+    cmd = mock_popen.call_args.args[0]
+    fsdev_arg = cmd[cmd.index("-fsdev") + 1]
+    assert f"path={ws_dir.resolve()}" in fsdev_arg
+    assert "security_model=mapped-xattr" in fsdev_arg
+    assert "readonly" not in fsdev_arg
 
 
 @patch("smolvm.vm.subprocess.Popen")
@@ -574,6 +634,24 @@ class TestCliMountFlag:
         args = parser.parse_args(["create"])
         assert args.mounts is None
 
+    def test_writable_mounts_defaults_to_false(self) -> None:
+        from smolvm.cli.main import build_parser
+
+        parser = build_parser()
+        args = parser.parse_args(["create", "--mount", "/tmp/project"])
+        assert args.writable_mounts is False
+
+    def test_writable_mounts_flag_sets_true(self) -> None:
+        from smolvm.cli.main import build_parser
+
+        parser = build_parser()
+        args = parser.parse_args([
+            "create",
+            "--mount", "/tmp/project",
+            "--writable-mounts",
+        ])
+        assert args.writable_mounts is True
+
     @patch("smolvm.facade.SmolVM")
     @patch("smolvm.facade._build_auto_config")
     def test_create_with_mount_and_no_backend_selects_qemu(
@@ -701,6 +779,22 @@ class TestParseMountSpecs:
         mounts = _parse_mount_specs([str(d1), f"{d2}:/data"])
         assert mounts[0].guest_path == "/workspace-0"
         assert mounts[1].guest_path == "/data"
+
+    def test_writable_flag_propagates_to_all_mounts(self, tmp_path: Path) -> None:
+        from smolvm.facade import _parse_mount_specs
+
+        d1 = tmp_path / "a"
+        d2 = tmp_path / "b"
+        d1.mkdir()
+        d2.mkdir()
+        mounts = _parse_mount_specs([str(d1), f"{d2}:/data"], writable=True)
+        assert all(m.writable for m in mounts)
+
+    def test_writable_defaults_to_false(self, tmp_path: Path) -> None:
+        from smolvm.facade import _parse_mount_specs
+
+        mounts = _parse_mount_specs([str(tmp_path)])
+        assert mounts[0].writable is False
 
 
 # ── Facade guards ───────────────────────────────────────────────────
@@ -830,3 +924,40 @@ class TestFacadeWorkspaceGuards:
             vm._mount_workspaces()
 
         assert vm._ssh.run.call_count == 2
+
+    def test_mount_workspaces_writable_uses_rw_without_overlay(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        """Writable mounts must mount 9p directly with rw and skip overlayfs."""
+        ws_dir = tmp_path / "project"
+        ws_dir.mkdir()
+        kernel = tmp_path / "vmlinux"
+        rootfs = tmp_path / "rootfs.ext4"
+        kernel.touch()
+        rootfs.touch()
+        config = VMConfig(
+            vm_id="vm-rw",
+            kernel_path=kernel,
+            rootfs_path=rootfs,
+            backend="qemu",
+            workspace_mounts=[WorkspaceMount(host_path=ws_dir, writable=True)],
+        )
+
+        vm = object.__new__(SmolVM)
+        vm._vm_id = "vm-rw"
+        vm._ssh_user = "root"
+        vm._info = MagicMock(config=config)
+        vm._ssh = MagicMock()
+        vm._ssh.run.side_effect = [
+            CommandResult(exit_code=0, stdout="", stderr=""),  # probe (no overlay)
+            CommandResult(exit_code=0, stdout="", stderr=""),  # mount
+        ]
+
+        vm._mount_workspaces()
+
+        probe_script = vm._ssh.run.call_args_list[0].args[0]
+        mount_script = vm._ssh.run.call_args_list[1].args[0]
+        assert "modprobe overlay" not in probe_script
+        assert "version=9p2000.L,rw" in mount_script
+        assert "mount -t overlay" not in mount_script


### PR DESCRIPTION
## Summary

Adds an opt-in `--writable-mounts` flag to `smolvm create` (and preset
`start` commands) so the sandbox can write back to mounted host
directories. Default behavior is unchanged: read-only host with a
writable in-VM overlay. With the flag, every `--mount` on that command
is exposed read-write — the QEMU `-fsdev` no longer carries `readonly=on`,
and the guest mounts the 9p share directly with `rw` (no overlayfs), so
guest writes appear on the host.

## Related Issues

- Closes #

## Testing

- `uv run --with pytest pytest -q --ignore=tests/test_async_lifecycle.py` → 752 passed, 13 skipped
- `uv run --with ruff ruff check` → no new errors introduced (pre-existing E501s only)
- `uv run mypy src` — not run

## Checklist

- [x] Scope is focused and limited to this change
- [x] Tests added/updated for behavior changes (8 new in `tests/test_workspace.py`)
- [x] Docs updated for user-visible changes (README mount section)
- [x] No secrets or sensitive data included

🤖 Generated with [Claude Code](https://claude.com/claude-code)