### PR TITLE
docs(readme): revamp intro and features section

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@
 ---
 
 SmolVM gives AI agents their own disposable computer. 
-Each microVM boots in milliseconds, runs any code or software you throw at it, persists files and state across sessions, and disappears when you're done — built for scale in production.
+Each microVM boots in milliseconds, runs any code or software you throw at it, persists files and state across sessions, and disappears when you're done — ready to handle thousands of sandboxes in production.
 
 
 ## Features
@@ -27,7 +27,7 @@ Each microVM boots in milliseconds, runs any code or software you throw at it, p
 | Feature | What it means for you |
 | --- | --- |
 | **[Sub-second boot](#performance)** | Your agent has a running VM before the API call returns (~500 ms). |
-| **[Hardware isolation](#security)** | Real VM boundaries, not containers. Untrusted code can't escape. |
+| **[Hardware isolation](#security)** | Each sandbox runs in its own virtual machine with hardware-level separation. Untrusted code can't escape or access your system. |
 | **[Network controls](#network-controls)** | Lock down egress to specific domains so agents can't call home. |
 | **[Browser sessions](#browser-sessions)** | Agents get a full browser they can see and control in real time. |
 | **[File sharing](#mount-host-directories)** | Share local directories with the sandbox, read-only or writable. |

--- a/README.md
+++ b/README.md
@@ -19,19 +19,21 @@
 ---
 
 SmolVM gives AI agents their own disposable computer. 
-Each microVM boots in milliseconds, runs any code or software you throw at it, keeps state when you need it, and vanishes when you don't — nothing touches your host.
+Each microVM boots in milliseconds, runs any code or software you throw at it, persists files and state across sessions, and disappears when you're done — built for scale in production.
 
 
 ## Features
 
-- **Sub-second boot** — VMs ready in ~500 ms.
-- **Hardware isolation** — Stronger security than containers.
-- **Network controls** — Domain allowlists for egress filtering.
-- **Browser sessions** — Full browser agents can see and control.
-- **Host mounts** — Give sandboxes read access to local directories.
-- **Snapshots** — Save and restore VM state instantly.
-- **Coding agents** — Start enviornment with a pre-installed coding agent.
-- **OpenClaw** — GUI Linux apps inside a sandbox.
+| Feature | What it means for you |
+| --- | --- |
+| **[Sub-second boot](#performance)** | Your agent has a running VM before the API call returns (~500 ms). |
+| **[Hardware isolation](#security)** | Real VM boundaries, not containers. Untrusted code can't escape. |
+| **[Network controls](#network-controls)** | Lock down egress to specific domains so agents can't call home. |
+| **[Browser sessions](#browser-sessions)** | Agents get a full browser they can see and control in real time. |
+| **[File sharing](#mount-host-directories)** | Share local directories with the sandbox, read-only or writable. |
+| **Snapshots** | Pause a sandbox and resume it later with everything intact. |
+| **[Coding agents](#coding-agents)** | One command to launch a sandbox with Claude Code, Codex, or Pi pre-installed. |
+| **[OpenClaw](examples/openclaw.py)** | Run GUI Linux apps (IDEs, browsers, tools) inside an isolated sandbox. |
 
 
 ## Use cases

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@
 ---
 
 SmolVM gives AI agents their own disposable computer. 
-Each [microVM](# "a lightweight virtual machine") boots in milliseconds, runs any code or software you throw at it, persists files and state across sessions, and disappears when you're done — ready to handle thousands of sandboxes in production.
+Each microVM boots in milliseconds, runs any code or software you throw at it, persists files and state across sessions, and disappears when you're done — ready to handle thousands of sandboxes in production.
 
 
 ## Features

--- a/README.md
+++ b/README.md
@@ -26,8 +26,8 @@ Each microVM boots in milliseconds, runs any code or software you throw at it, p
 
 | Feature | What it means for you |
 | :--- | :--- |
-| **[Sub-second boot](#performance)** &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; | Your agent has a running VM before the API call returns (~500 ms). |
-| **[Hardware isolation](#security)** | Each sandbox runs in its own virtual machine with hardware-level separation. Untrusted code can't escape or access your system. |
+| **[Sub-second boot](#performance)** | Your agent has a running VM before the API call returns (~500 ms). |
+| **[Hardware&nbsp;isolation](#security)** &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; | Each sandbox runs in its own virtual machine with hardware-level separation. Untrusted code can't escape or access your system. |
 | **[Network controls](#network-controls)** | Lock down egress to specific domains so agents can't call home. |
 | **[Browser sessions](#browser-sessions)** | Agents get a full browser they can see and control in real time. |
 | **[File sharing](#mount-host-directories)** | Share local directories with the sandbox, read-only or writable. |

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Each microVM boots in milliseconds, runs any code or software you throw at it, p
 
 ## Features
 
-| Feature &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; | What it means for you |
+| Feature &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; | What it means for you |
 | --- | --- |
 | **[Sub-second boot](#performance)** | Your agent has a running VM before the API call returns (~500 ms). |
 | **[Hardware isolation](#security)** | Each sandbox runs in its own virtual machine with hardware-level separation. Untrusted code can't escape or access your system. |

--- a/README.md
+++ b/README.md
@@ -24,9 +24,9 @@ Each microVM boots in milliseconds, runs any code or software you throw at it, p
 
 ## Features
 
-| Feature &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; | What it means for you |
-| --- | --- |
-| **[Sub-second boot](#performance)** | Your agent has a running VM before the API call returns (~500 ms). |
+| Feature | What it means for you |
+| :--- | :--- |
+| **[Sub-second boot](#performance)** &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; | Your agent has a running VM before the API call returns (~500 ms). |
 | **[Hardware isolation](#security)** | Each sandbox runs in its own virtual machine with hardware-level separation. Untrusted code can't escape or access your system. |
 | **[Network controls](#network-controls)** | Lock down egress to specific domains so agents can't call home. |
 | **[Browser sessions](#browser-sessions)** | Agents get a full browser they can see and control in real time. |

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
 [![License](https://img.shields.io/badge/License-Apache_2.0-orange.svg)](https://opensource.org/licenses/Apache-2.0)
 [![Python 3.10+](https://img.shields.io/badge/python-3.10+-orange.svg)](https://www.python.org/downloads/)
 
-[Quick start](#quickstart) • [Examples](#examples) • [Features](#features) • [Performance](#performance) • [Docs](https://docs.celesto.ai) • [Community Slack](https://join.slack.com/t/celestoai/shared_invite/zt-3qc7h8gno-Nb5_PElEWHDNnGqdVzC~4Q) 
+[Quick start](#quickstart) • [Examples](#examples) • [Features](https://docs.celesto.ai/smolvm/features) • [Performance](#performance) • [Docs](https://docs.celesto.ai) • [Community Slack](https://join.slack.com/t/celestoai/shared_invite/zt-3qc7h8gno-Nb5_PElEWHDNnGqdVzC~4Q) 
 
 </div>
 
@@ -21,6 +21,7 @@
 SmolVM gives AI agents their own disposable computer. 
 Each microVM boots in milliseconds, runs any code or software you throw at it, persists files and state across sessions, and disappears when you're done — ready to handle thousands of sandboxes in production.
 
+<br>
 
 | Feature | What it means for you |
 | :--- | :--- |

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Each microVM boots in milliseconds, runs any code or software you throw at it, p
 | **[Sub-second boot](#performance)** | Your agent has a running VM before the API call returns (~500 ms). |
 | **[Hardware&nbsp;isolation](#security)** &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; | Each sandbox runs in its own virtual machine with hardware-level separation. Untrusted code can't escape or access your system. |
 | **[Network controls](#network-controls)** | Lock down egress to specific domains so agents can't call home. |
-| **[Browser sessions](#browser-sessions)** | Agents get a full browser they can see and control in real time. |
+| **[Browser sandbox](#browser-sandbox)** | Agents get a full browser they can see and control in real time. |
 | **[File sharing](#mount-host-directories)** | Share local directories with the sandbox, read-only or writable. |
 | **Snapshots** | Pause a sandbox and resume it later with everything intact. |
 | **[Coding agents](#coding-agents)** | One command to launch a sandbox with Claude Code, Codex, or Pi pre-installed. |
@@ -117,7 +117,7 @@ smolvm pi start  # start a new environment with the Pi coding agent preinstalled
 ```
 
 
-## Browser sessions
+## Browser sandbox
 
 SmolVM can also start a full browser inside a sandbox. This is useful when agents need to navigate websites, fill out forms, or take screenshots.
 

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@
 ---
 
 SmolVM gives AI agents their own disposable computer. 
-Each microVM boots in milliseconds, runs any code or software you throw at it, persists files and state across sessions, and disappears when you're done — ready to handle thousands of sandboxes in production.
+Each [microVM](# "a lightweight virtual machine") boots in milliseconds, runs any code or software you throw at it, persists files and state across sessions, and disappears when you're done — ready to handle thousands of sandboxes in production.
 
 
 ## Features

--- a/README.md
+++ b/README.md
@@ -66,9 +66,9 @@ On supported Linux and macOS systems, `pip install smolvm` also pulls in the mat
 
 Linux may prompt for `sudo` during setup so it can install host dependencies and configure runtime permissions.
 
-</details>
-
 For golden-AMI builds, two-stage deploys, pinning the Firecracker version, and other non-default install paths, see [docs/installation.md](docs/installation.md).
+
+</details>
 
 ### Start a sandbox in Python
 

--- a/README.md
+++ b/README.md
@@ -22,8 +22,6 @@ SmolVM gives AI agents their own disposable computer.
 Each microVM boots in milliseconds, runs any code or software you throw at it, persists files and state across sessions, and disappears when you're done — ready to handle thousands of sandboxes in production.
 
 
-## Features
-
 | Feature | What it means for you |
 | :--- | :--- |
 | **[Sub-second boot](#performance)** | Your agent has a running VM before the API call returns (~500 ms). |

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Each microVM boots in milliseconds, runs any code or software you throw at it, p
 
 ## Features
 
-| Feature &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; | What it means for you |
+| Feature &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; | What it means for you |
 | --- | --- |
 | **[Sub-second boot](#performance)** | Your agent has a running VM before the API call returns (~500 ms). |
 | **[Hardware isolation](#security)** | Each sandbox runs in its own virtual machine with hardware-level separation. Untrusted code can't escape or access your system. |

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Each microVM boots in milliseconds, runs any code or software you throw at it, p
 
 ## Features
 
-| Feature | What it means for you |
+| Feature &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; | What it means for you |
 | --- | --- |
 | **[Sub-second boot](#performance)** | Your agent has a running VM before the API call returns (~500 ms). |
 | **[Hardware isolation](#security)** | Each sandbox runs in its own virtual machine with hardware-level separation. Untrusted code can't escape or access your system. |


### PR DESCRIPTION
## Summary

- Updated the intro tagline to emphasize file/state persistence and production readiness.
- Rewrote the features list as a table with benefit-first descriptions and links to the corresponding README sections.
- Fixed "enviornment" typo and renamed "Host mounts" to "File sharing."

## Related Issues

- N/A

## Testing

- Not run — docs-only change, no code affected.

## Checklist

- [x] Scope is focused and limited to this change
- [ ] Tests added/updated for behavior changes
- [x] Docs updated for user-visible changes
- [x] No secrets or sensitive data included

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated microVM lifecycle description to emphasize persistent file/state management and production scalability.
  * Restructured Features section from a list into an organized table with navigation anchors and example references.
  * Renamed "Host mounts" to "File sharing" with refined feature descriptions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->