### PR TITLE
[codex] add sandbox file upload

### DIFF
--- a/README.md
+++ b/README.md
@@ -192,6 +192,27 @@ with SmolVM(mounts=["~/Projects/my-app"], writable_mounts=True) as vm:
     vm.run("echo hello > /workspace/from-sandbox.txt")
 ```
 
+## Upload a file
+
+You can copy one file into a running sandbox without mounting a whole folder.
+This is useful when an agent needs a config file, script, or small input file.
+
+```bash
+smolvm file upload my-sandbox ./prompt.txt /tmp/prompt.txt
+smolvm ssh my-sandbox
+cat /tmp/prompt.txt
+```
+
+The same works from Python:
+
+```python
+from smolvm import SmolVM
+
+vm = SmolVM.from_id("my-sandbox")
+vm.upload_file("./prompt.txt", "/tmp/prompt.txt")
+vm.close()
+```
+
 
 ## Examples
 

--- a/README.md
+++ b/README.md
@@ -217,6 +217,9 @@ vm.upload_file("./prompt.txt", "/tmp/prompt.txt")
 vm.close()
 ```
 
+The destination must be an absolute path inside the sandbox (starting
+with `/`), and any existing file at that path is overwritten.
+
 
 ## Examples
 

--- a/README.md
+++ b/README.md
@@ -198,8 +198,12 @@ You can copy one file into a running sandbox without mounting a whole folder.
 This is useful when an agent needs a config file, script, or small input file.
 
 ```bash
+# Copy a file from your machine into the sandbox.
 smolvm file upload my-sandbox ./prompt.txt /tmp/prompt.txt
+
+# Open a shell in the sandbox to confirm the file is there.
 smolvm ssh my-sandbox
+# Then, inside the sandbox shell:
 cat /tmp/prompt.txt
 ```
 

--- a/src/smolvm/cli/main.py
+++ b/src/smolvm/cli/main.py
@@ -2538,7 +2538,7 @@ def _run_file(args: argparse.Namespace) -> int:
         render_error("Usage: smolvm file {upload} ...")
         return 2
 
-    json_output = getattr(args, "json", False)
+    json_output = args.json
     command_name = f"file.{args.file_action}"
     vm: SmolVM | None = None
     try:

--- a/src/smolvm/cli/main.py
+++ b/src/smolvm/cli/main.py
@@ -233,6 +233,14 @@ class SnapshotRestorePayload(TypedDict):
     vm: SnapshotRestoreVmPayload
 
 
+class FileUploadPayload(TypedDict):
+    """JSON payload for ``smolvm file upload``."""
+
+    vm_id: str
+    local_path: str
+    guest_path: str
+
+
 class BrowserRow(TypedDict):
     """Machine-readable data for a listed browser session."""
 
@@ -873,6 +881,35 @@ def build_parser() -> argparse.ArgumentParser:
     ssh_parser.add_argument("vm_id", metavar="sandbox", help="Name or ID of the sandbox.")
     _add_ssh_auth_args(ssh_parser)
     _add_boot_timeout_arg(ssh_parser)
+
+    file_parser = subparsers.add_parser(
+        "file",
+        help="Copy files into a sandbox.",
+    )
+    file_sub = file_parser.add_subparsers(dest="file_action")
+
+    file_upload = file_sub.add_parser(
+        "upload",
+        help="Upload one local file into a running sandbox.",
+    )
+    file_upload.add_argument("vm_id", metavar="sandbox", help="Name or ID of the sandbox.")
+    file_upload.add_argument("local_path", metavar="local-path", help="File on this machine.")
+    file_upload.add_argument(
+        "guest_path",
+        metavar="guest-path",
+        help="Destination path in the sandbox.",
+    )
+    file_upload.add_argument(
+        "--no-create-dirs",
+        action="store_true",
+        help="Do not create the destination directory in the sandbox.",
+    )
+    file_upload.add_argument(
+        "--json",
+        action="store_true",
+        help="Emit machine-readable JSON output.",
+    )
+    _add_ssh_auth_args(file_upload)
 
     browser_parser = subparsers.add_parser(
         "browser",
@@ -2478,6 +2515,65 @@ def _run_env(args: argparse.Namespace) -> int:
             vm.close()
 
 
+def _render_file_upload(data: FileUploadPayload) -> None:
+    """Render a human-facing file upload result."""
+    console = console_stdout()
+    console.print(
+        Panel.fit(
+            (
+                f"Uploaded '{data['local_path']}' to '{data['guest_path']}' "
+                f"on '{data['vm_id']}'."
+            ),
+            title="File Uploaded",
+            border_style="green",
+        )
+    )
+
+
+def _run_file(args: argparse.Namespace) -> int:
+    """Handle ``smolvm file`` commands."""
+    from smolvm.facade import SmolVM
+
+    if args.file_action is None:
+        render_error("Usage: smolvm file {upload} ...")
+        return 2
+
+    json_output = getattr(args, "json", False)
+    command_name = f"file.{args.file_action}"
+    vm: SmolVM | None = None
+    try:
+        vm = SmolVM.from_id(
+            args.vm_id,
+            ssh_user=args.ssh_user,
+            ssh_key_path=args.ssh_key,
+        )
+
+        if args.file_action == "upload":
+            guest_path = vm.upload_file(
+                args.local_path,
+                args.guest_path,
+                make_dirs=not args.no_create_dirs,
+            )
+            data: FileUploadPayload = {
+                "vm_id": args.vm_id,
+                "local_path": str(Path(args.local_path).expanduser()),
+                "guest_path": guest_path,
+            }
+            if json_output:
+                emit_json(command_name, 0, data=data)
+            else:
+                _render_file_upload(data)
+            return 0
+
+        render_error("Usage: smolvm file {upload} ...")
+        return 2
+    except Exception as exc:
+        return _emit_cli_error(command_name, 1, exc, json_output=json_output)
+    finally:
+        if vm is not None:
+            vm.close()
+
+
 def _run_ssh(args: argparse.Namespace) -> int:
     """Handle ``smolvm ssh``."""
     from smolvm.facade import SmolVM
@@ -2888,6 +2984,9 @@ def main(argv: Sequence[str] | None = None) -> int:
 
     if args.command == "ssh":
         return _run_ssh(args)
+
+    if args.command == "file":
+        return _run_file(args)
 
     if args.command == "doctor":
         return run_doctor(

--- a/src/smolvm/facade.py
+++ b/src/smolvm/facade.py
@@ -1248,10 +1248,12 @@ class SmolVM:
     ) -> str:
         """Upload one local file into a running VM.
 
+        Overwrites the destination if it already exists.
+
         Args:
             local_path: File on the host machine.
-            guest_path: Destination path inside the guest. If it ends with
-                ``/``, the local filename is appended.
+            guest_path: Absolute POSIX path inside the guest. If it ends
+                with ``/``, the local filename is appended.
             make_dirs: Create the destination parent directory first.
 
         Returns:
@@ -1259,16 +1261,25 @@ class SmolVM:
 
         Raises:
             ValueError: If *local_path* is missing, is not a file, or if
-                *guest_path* is empty.
+                *guest_path* is empty or not an absolute POSIX path.
             SmolVMError: If the VM is not running or file transfer fails.
         """
         source = Path(local_path).expanduser()
         if not source.exists():
-            raise ValueError(f"local_path does not exist: {source}")
+            raise ValueError(
+                f"Local file not found: {source}. Check the path and try again."
+            )
         if not source.is_file():
-            raise ValueError(f"local_path must be a file: {source}")
+            raise ValueError(
+                f"Not a file: {source}. Pass a path to a single file, not a directory."
+            )
         if not guest_path:
-            raise ValueError("guest_path cannot be empty")
+            raise ValueError("Destination path in the sandbox cannot be empty.")
+        if not guest_path.startswith("/"):
+            raise ValueError(
+                f"Destination path in the sandbox must be absolute "
+                f"(start with '/'): {guest_path!r}."
+            )
 
         destination = guest_path
         if destination.endswith("/"):
@@ -1278,11 +1289,13 @@ class SmolVM:
         if make_dirs:
             parent = _guest_parent_dir(destination)
             if parent:
-                result = ssh.run(f"mkdir -p -- {shlex.quote(parent)}", timeout=30, shell="raw")
+                result = ssh.run(
+                    f"mkdir -p -- {shlex.quote(parent)}", timeout=30, shell="raw"
+                )
                 if result.exit_code != 0:
                     stderr = result.stderr.strip()
                     raise SmolVMError(
-                        f"Failed to create guest directory '{parent}': {stderr}",
+                        f"Could not create directory {parent!r} in the sandbox: {stderr}",
                         {"vm_id": self._vm_id, "guest_path": destination},
                     )
         ssh.put_file(source, destination)
@@ -2076,30 +2089,20 @@ modprobe 9pnet_virtio""".strip()
 
     def _ensure_ssh_for_file_transfer(self) -> SSHClient:
         """Return a ready SSH client for file transfer operations."""
-        return self._ensure_ssh_for_operation(
-            action="transfer files",
-            unavailable_prefix="Cannot transfer files",
-        )
+        return self._ensure_ssh_for_operation(action="transfer files")
 
     def _ensure_ssh_for_env(self) -> SSHClient:
         """Return a ready SSH client for env operations on a running VM."""
-        return self._ensure_ssh_for_operation(
-            action="manage environment variables",
-            unavailable_prefix="Cannot manage environment variables",
-        )
+        return self._ensure_ssh_for_operation(action="manage environment variables")
 
-    def _ensure_ssh_for_operation(
-        self,
-        *,
-        action: str,
-        unavailable_prefix: str,
-    ) -> SSHClient:
+    def _ensure_ssh_for_operation(self, *, action: str) -> SSHClient:
         """Return a ready SSH client for operations that need guest SSH."""
+        prefix = f"Cannot {action}"
         self._refresh_info()
 
         if self._info.status != VMState.RUNNING:
             raise SmolVMError(
-                f"{unavailable_prefix}: VM is {self._info.status.value}",
+                f"{prefix}: VM is {self._info.status.value}",
                 {"vm_id": self._vm_id},
             )
         if not self.can_run_commands():
@@ -2113,7 +2116,7 @@ modprobe 9pnet_virtio""".strip()
             )
         if self._info.network is None:
             raise SmolVMError(
-                f"{unavailable_prefix}: VM has no network configuration",
+                f"{prefix}: VM has no network configuration",
                 {"vm_id": self._vm_id},
             )
 
@@ -2122,7 +2125,7 @@ modprobe 9pnet_virtio""".strip()
 
         if self._ssh is None:
             raise SmolVMError(
-                f"Cannot {action}: SSH client is not initialized",
+                f"{prefix}: SSH client is not initialized",
                 {"vm_id": self._vm_id},
             )
 

--- a/src/smolvm/facade.py
+++ b/src/smolvm/facade.py
@@ -343,6 +343,17 @@ def _parse_mount_specs(
     return mounts
 
 
+def _guest_parent_dir(path: str) -> str:
+    """Return the POSIX parent directory for a guest path, if it has one."""
+    normalized = path.rstrip("/")
+    if not normalized:
+        return ""
+    if "/" not in normalized:
+        return ""
+    parent = normalized.rsplit("/", 1)[0]
+    return parent or "/"
+
+
 def _build_auto_config_image_name(
     guest_os: GuestOS,
     *,
@@ -1228,6 +1239,55 @@ class SmolVM:
         ssh = self._ensure_ssh_for_env()
         return read_env_vars(ssh)
 
+    def upload_file(
+        self,
+        local_path: str | Path,
+        guest_path: str,
+        *,
+        make_dirs: bool = True,
+    ) -> str:
+        """Upload one local file into a running VM.
+
+        Args:
+            local_path: File on the host machine.
+            guest_path: Destination path inside the guest. If it ends with
+                ``/``, the local filename is appended.
+            make_dirs: Create the destination parent directory first.
+
+        Returns:
+            The resolved guest destination path.
+
+        Raises:
+            ValueError: If *local_path* is missing, is not a file, or if
+                *guest_path* is empty.
+            SmolVMError: If the VM is not running or file transfer fails.
+        """
+        source = Path(local_path).expanduser()
+        if not source.exists():
+            raise ValueError(f"local_path does not exist: {source}")
+        if not source.is_file():
+            raise ValueError(f"local_path must be a file: {source}")
+        if not guest_path:
+            raise ValueError("guest_path cannot be empty")
+
+        destination = guest_path
+        if destination.endswith("/"):
+            destination = f"{destination}{source.name}"
+
+        ssh = self._ensure_ssh_for_file_transfer()
+        if make_dirs:
+            parent = _guest_parent_dir(destination)
+            if parent:
+                result = ssh.run(f"mkdir -p -- {shlex.quote(parent)}", timeout=30, shell="raw")
+                if result.exit_code != 0:
+                    stderr = result.stderr.strip()
+                    raise SmolVMError(
+                        f"Failed to create guest directory '{parent}': {stderr}",
+                        {"vm_id": self._vm_id, "guest_path": destination},
+                    )
+        ssh.put_file(source, destination)
+        return destination
+
     def wait_for_ssh(
         self,
         timeout: float = 60.0,
@@ -2014,13 +2074,32 @@ modprobe 9pnet_virtio""".strip()
         if hasattr(self, "_probed_endpoint"):
             self._probed_endpoint = None
 
+    def _ensure_ssh_for_file_transfer(self) -> SSHClient:
+        """Return a ready SSH client for file transfer operations."""
+        return self._ensure_ssh_for_operation(
+            action="transfer files",
+            unavailable_prefix="Cannot transfer files",
+        )
+
     def _ensure_ssh_for_env(self) -> SSHClient:
         """Return a ready SSH client for env operations on a running VM."""
+        return self._ensure_ssh_for_operation(
+            action="manage environment variables",
+            unavailable_prefix="Cannot manage environment variables",
+        )
+
+    def _ensure_ssh_for_operation(
+        self,
+        *,
+        action: str,
+        unavailable_prefix: str,
+    ) -> SSHClient:
+        """Return a ready SSH client for operations that need guest SSH."""
         self._refresh_info()
 
         if self._info.status != VMState.RUNNING:
             raise SmolVMError(
-                f"Cannot manage environment variables: VM is {self._info.status.value}",
+                f"{unavailable_prefix}: VM is {self._info.status.value}",
                 {"vm_id": self._vm_id},
             )
         if not self.can_run_commands():
@@ -2034,7 +2113,7 @@ modprobe 9pnet_virtio""".strip()
             )
         if self._info.network is None:
             raise SmolVMError(
-                "Cannot manage environment variables: VM has no network configuration",
+                f"{unavailable_prefix}: VM has no network configuration",
                 {"vm_id": self._vm_id},
             )
 
@@ -2043,7 +2122,7 @@ modprobe 9pnet_virtio""".strip()
 
         if self._ssh is None:
             raise SmolVMError(
-                "Cannot manage environment variables: SSH client is not initialized",
+                f"Cannot {action}: SSH client is not initialized",
                 {"vm_id": self._vm_id},
             )
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -438,6 +438,23 @@ class TestCliFile:
             make_dirs=False,
         )
 
+    def test_file_upload_closes_vm_on_failure(
+        self,
+        mock_vm_cls: MagicMock,
+        tmp_path: Path,
+    ) -> None:
+        """If `upload_file` raises, the CLI must still close the VM and return nonzero."""
+        source = tmp_path / "note.txt"
+        source.write_text("hello")
+        vm = MagicMock()
+        vm.upload_file.side_effect = RuntimeError("boom")
+        mock_vm_cls.from_id.return_value = vm
+
+        ret = main(["file", "upload", "vm001", str(source), "/tmp/"])
+
+        assert ret != 0
+        vm.close.assert_called_once()
+
 
 class TestCliCreate:
     """Tests for `smolvm create`."""

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -355,6 +355,90 @@ class TestCliEnv:
         vm.close.assert_called_once()
 
 
+class TestCliFile:
+    """Tests for `smolvm file` subcommands."""
+
+    @pytest.fixture
+    def mock_vm_cls(self) -> MagicMock:
+        with patch("smolvm.facade.SmolVM") as m:
+            yield m
+
+    def test_file_upload_success(
+        self,
+        mock_vm_cls: MagicMock,
+        tmp_path: Path,
+        capsys: pytest.CaptureFixture,
+    ) -> None:
+        """`smolvm file upload` should copy a local file into a sandbox."""
+        source = tmp_path / "note.txt"
+        source.write_text("hello")
+        vm = MagicMock()
+        vm.upload_file.return_value = "/tmp/note.txt"
+        mock_vm_cls.from_id.return_value = vm
+
+        ret = main(["file", "upload", "vm001", str(source), "/tmp/"])
+
+        assert ret == 0
+        mock_vm_cls.from_id.assert_called_once_with(
+            "vm001",
+            ssh_user="root",
+            ssh_key_path=None,
+        )
+        vm.upload_file.assert_called_once_with(
+            str(source),
+            "/tmp/",
+            make_dirs=True,
+        )
+        vm.close.assert_called_once()
+        assert "Uploaded" in capsys.readouterr().out
+
+    def test_file_upload_json(
+        self,
+        mock_vm_cls: MagicMock,
+        tmp_path: Path,
+        capsys: pytest.CaptureFixture,
+    ) -> None:
+        """`smolvm file upload --json` should emit the upload destination."""
+        source = tmp_path / "note.txt"
+        source.write_text("hello")
+        vm = MagicMock()
+        vm.upload_file.return_value = "/tmp/note.txt"
+        mock_vm_cls.from_id.return_value = vm
+
+        ret = main(["file", "upload", "vm001", str(source), "/tmp/", "--json"])
+
+        assert ret == 0
+        payload = json.loads(capsys.readouterr().out)
+        assert payload["command"] == "file.upload"
+        assert payload["ok"] is True
+        assert payload["data"]["vm_id"] == "vm001"
+        assert payload["data"]["local_path"] == str(source)
+        assert payload["data"]["guest_path"] == "/tmp/note.txt"
+
+    def test_file_upload_can_skip_directory_creation(
+        self,
+        mock_vm_cls: MagicMock,
+        tmp_path: Path,
+    ) -> None:
+        """`--no-create-dirs` should pass make_dirs=False."""
+        source = tmp_path / "note.txt"
+        source.write_text("hello")
+        vm = MagicMock()
+        vm.upload_file.return_value = "/tmp/note.txt"
+        mock_vm_cls.from_id.return_value = vm
+
+        ret = main(
+            ["file", "upload", "vm001", str(source), "/tmp/note.txt", "--no-create-dirs"]
+        )
+
+        assert ret == 0
+        vm.upload_file.assert_called_once_with(
+            str(source),
+            "/tmp/note.txt",
+            make_dirs=False,
+        )
+
+
 class TestCliCreate:
     """Tests for `smolvm create`."""
 

--- a/tests/test_facade.py
+++ b/tests/test_facade.py
@@ -2201,5 +2201,95 @@ class TestVMFileUpload:
 
         vm = SmolVM(sample_config)
 
-        with pytest.raises(ValueError, match="local_path must be a file"):
+        with pytest.raises(ValueError, match="Not a file"):
             vm.upload_file(tmp_path, "/tmp/uploaded")
+
+    @patch("smolvm.facade.SmolVMManager")
+    def test_upload_file_rejects_relative_guest_path(
+        self,
+        mock_sdk_cls: MagicMock,
+        sample_config: VMConfig,
+        tmp_path: Path,
+    ) -> None:
+        source = tmp_path / "note.txt"
+        source.write_text("hello")
+
+        mock_sdk = MagicMock()
+        mock_sdk.create.return_value = MagicMock(vm_id="vm001", status=VMState.RUNNING)
+        mock_sdk_cls.return_value = mock_sdk
+
+        vm = SmolVM(sample_config)
+
+        with pytest.raises(ValueError, match="must be absolute"):
+            vm.upload_file(source, "~/note.txt")
+
+    @patch("smolvm.facade.SmolVMManager")
+    def test_upload_file_quotes_paths_with_spaces(
+        self,
+        mock_sdk_cls: MagicMock,
+        sample_config: VMConfig,
+        tmp_path: Path,
+    ) -> None:
+        source = tmp_path / "note.txt"
+        source.write_text("hello")
+
+        config = sample_config.model_copy(update={"ssh_capable": True})
+        running_info = MagicMock(vm_id="vm001", status=VMState.RUNNING)
+        running_info.config = config
+        running_info.network.guest_ip = "172.16.0.2"
+        running_info.network.ssh_host_port = None
+
+        mock_sdk = MagicMock()
+        mock_sdk.create.return_value = running_info
+        mock_sdk.get.return_value = running_info
+        mock_sdk_cls.return_value = mock_sdk
+
+        ssh = MagicMock()
+        ssh.run.return_value = MagicMock(exit_code=0, stderr="")
+
+        vm = SmolVM(config)
+        vm._ssh = ssh
+        vm._ssh_ready = True
+
+        guest_path = vm.upload_file(source, "/tmp/with space/note.txt")
+
+        assert guest_path == "/tmp/with space/note.txt"
+        ssh.run.assert_called_once_with(
+            "mkdir -p -- '/tmp/with space'",
+            timeout=30,
+            shell="raw",
+        )
+        ssh.put_file.assert_called_once_with(source, "/tmp/with space/note.txt")
+
+    @patch("smolvm.facade.SmolVMManager")
+    def test_upload_file_raises_when_mkdir_fails(
+        self,
+        mock_sdk_cls: MagicMock,
+        sample_config: VMConfig,
+        tmp_path: Path,
+    ) -> None:
+        source = tmp_path / "note.txt"
+        source.write_text("hello")
+
+        config = sample_config.model_copy(update={"ssh_capable": True})
+        running_info = MagicMock(vm_id="vm001", status=VMState.RUNNING)
+        running_info.config = config
+        running_info.network.guest_ip = "172.16.0.2"
+        running_info.network.ssh_host_port = None
+
+        mock_sdk = MagicMock()
+        mock_sdk.create.return_value = running_info
+        mock_sdk.get.return_value = running_info
+        mock_sdk_cls.return_value = mock_sdk
+
+        ssh = MagicMock()
+        ssh.run.return_value = MagicMock(exit_code=1, stderr="permission denied")
+
+        vm = SmolVM(config)
+        vm._ssh = ssh
+        vm._ssh_ready = True
+
+        with pytest.raises(SmolVMError, match="permission denied"):
+            vm.upload_file(source, "/root/forbidden/note.txt")
+
+        ssh.put_file.assert_not_called()

--- a/tests/test_facade.py
+++ b/tests/test_facade.py
@@ -2112,3 +2112,94 @@ class TestVMEnvManagement:
         vm.close()
 
         mock_sdk.close.assert_called_once()
+
+
+class TestVMFileUpload:
+    """Tests for facade-level guest file upload."""
+
+    @patch("smolvm.facade.SmolVMManager")
+    def test_upload_file_creates_parent_and_puts_file(
+        self,
+        mock_sdk_cls: MagicMock,
+        sample_config: VMConfig,
+        tmp_path: Path,
+    ) -> None:
+        source = tmp_path / "note.txt"
+        source.write_text("hello")
+
+        config = sample_config.model_copy(update={"ssh_capable": True})
+        running_info = MagicMock(vm_id="vm001", status=VMState.RUNNING)
+        running_info.config = config
+        running_info.network.guest_ip = "172.16.0.2"
+        running_info.network.ssh_host_port = None
+
+        mock_sdk = MagicMock()
+        mock_sdk.create.return_value = running_info
+        mock_sdk.get.return_value = running_info
+        mock_sdk_cls.return_value = mock_sdk
+
+        ssh = MagicMock()
+        ssh.run.return_value = MagicMock(exit_code=0, stderr="")
+
+        vm = SmolVM(config)
+        vm._ssh = ssh
+        vm._ssh_ready = True
+
+        guest_path = vm.upload_file(source, "/tmp/smolvm/note.txt")
+
+        assert guest_path == "/tmp/smolvm/note.txt"
+        ssh.run.assert_called_once_with(
+            "mkdir -p -- /tmp/smolvm",
+            timeout=30,
+            shell="raw",
+        )
+        ssh.put_file.assert_called_once_with(source, "/tmp/smolvm/note.txt")
+
+    @patch("smolvm.facade.SmolVMManager")
+    def test_upload_file_appends_name_for_guest_directory(
+        self,
+        mock_sdk_cls: MagicMock,
+        sample_config: VMConfig,
+        tmp_path: Path,
+    ) -> None:
+        source = tmp_path / "note.txt"
+        source.write_text("hello")
+
+        config = sample_config.model_copy(update={"ssh_capable": True})
+        running_info = MagicMock(vm_id="vm001", status=VMState.RUNNING)
+        running_info.config = config
+        running_info.network.guest_ip = "172.16.0.2"
+        running_info.network.ssh_host_port = None
+
+        mock_sdk = MagicMock()
+        mock_sdk.create.return_value = running_info
+        mock_sdk.get.return_value = running_info
+        mock_sdk_cls.return_value = mock_sdk
+
+        ssh = MagicMock()
+        ssh.run.return_value = MagicMock(exit_code=0, stderr="")
+
+        vm = SmolVM(config)
+        vm._ssh = ssh
+        vm._ssh_ready = True
+
+        guest_path = vm.upload_file(source, "/tmp/uploads/")
+
+        assert guest_path == "/tmp/uploads/note.txt"
+        ssh.put_file.assert_called_once_with(source, "/tmp/uploads/note.txt")
+
+    @patch("smolvm.facade.SmolVMManager")
+    def test_upload_file_rejects_directory(
+        self,
+        mock_sdk_cls: MagicMock,
+        sample_config: VMConfig,
+        tmp_path: Path,
+    ) -> None:
+        mock_sdk = MagicMock()
+        mock_sdk.create.return_value = MagicMock(vm_id="vm001", status=VMState.RUNNING)
+        mock_sdk_cls.return_value = mock_sdk
+
+        vm = SmolVM(sample_config)
+
+        with pytest.raises(ValueError, match="local_path must be a file"):
+            vm.upload_file(tmp_path, "/tmp/uploaded")

--- a/tests/test_facade.py
+++ b/tests/test_facade.py
@@ -2189,6 +2189,39 @@ class TestVMFileUpload:
         ssh.put_file.assert_called_once_with(source, "/tmp/uploads/note.txt")
 
     @patch("smolvm.facade.SmolVMManager")
+    def test_upload_file_skips_mkdir_when_make_dirs_false(
+        self,
+        mock_sdk_cls: MagicMock,
+        sample_config: VMConfig,
+        tmp_path: Path,
+    ) -> None:
+        source = tmp_path / "note.txt"
+        source.write_text("hello")
+
+        config = sample_config.model_copy(update={"ssh_capable": True})
+        running_info = MagicMock(vm_id="vm001", status=VMState.RUNNING)
+        running_info.config = config
+        running_info.network.guest_ip = "172.16.0.2"
+        running_info.network.ssh_host_port = None
+
+        mock_sdk = MagicMock()
+        mock_sdk.create.return_value = running_info
+        mock_sdk.get.return_value = running_info
+        mock_sdk_cls.return_value = mock_sdk
+
+        ssh = MagicMock()
+
+        vm = SmolVM(config)
+        vm._ssh = ssh
+        vm._ssh_ready = True
+
+        guest_path = vm.upload_file(source, "/tmp/path/note.txt", make_dirs=False)
+
+        assert guest_path == "/tmp/path/note.txt"
+        ssh.run.assert_not_called()
+        ssh.put_file.assert_called_once_with(source, "/tmp/path/note.txt")
+
+    @patch("smolvm.facade.SmolVMManager")
     def test_upload_file_rejects_directory(
         self,
         mock_sdk_cls: MagicMock,


### PR DESCRIPTION
## Summary

Adds a first file-upload surface for running sandboxes:

- exposes `SmolVM.upload_file(local_path, guest_path, make_dirs=True)`
- adds `smolvm file upload <sandbox> <local-path> <guest-path>` with JSON output and SSH auth flags
- documents CLI and Python usage in the README
- adds focused facade and CLI tests for upload behavior

## Context

This covers the file upload part of #114's filesystem track without changing the existing workspace mount behavior. Uploads use the existing SSH/SFTP path, create the guest parent directory by default, and append the local filename when the guest path ends in `/`.

## Validation

- `python3` AST syntax check passed for the changed Python files.
- `git diff --check` passed for the changed files.
- `uv run pytest ...` and `uv run ruff check ...` could not be run in this sandbox because `uv` is not installed; `python3 -m pytest` and `python3 -m ruff` also could not run because those modules are missing.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added file upload support with CLI command `smolvm file upload <sandbox> <src> <dest>` and Python method `SmolVM.upload_file()`
  * Supports automatic destination directory creation with optional `--no-create-dirs` flag; JSON output available via `--json`

* **Documentation**
  * Added guide for uploading files to running sandboxes with example CLI and Python workflows

<!-- end of auto-generated comment: release notes by coderabbit.ai -->