### PR TITLE
feat(presets): add `smolvm openclaw start` and `smolvm hermes start`

### DIFF
--- a/src/smolvm/cli/main.py
+++ b/src/smolvm/cli/main.py
@@ -142,6 +142,7 @@ class StartPresetPayload(TypedDict):
     name: str
     copied_configs: list[str]
     injected_env_keys: list[str]
+    no_env_hint: str | None
 
 
 class StartPayload(TypedDict):
@@ -1809,6 +1810,8 @@ def _render_start_result(data: StartPayload) -> None:
         ", ".join(preset["injected_env_keys"]) if preset["injected_env_keys"] else "-",
     )
     console.print(details)
+    if not preset["injected_env_keys"] and preset.get("no_env_hint"):
+        console.print(f"\n[yellow]{preset['no_env_hint']}[/yellow]")
     console.print(f"Next: [bold]{next_step['ssh_command']}[/bold]")
 
 
@@ -1906,6 +1909,7 @@ def _run_start(args: argparse.Namespace) -> int:
                 "name": str(apply_summary["preset"]),
                 "copied_configs": list(apply_summary["copied_configs"]),  # type: ignore[arg-type]
                 "injected_env_keys": list(apply_summary["injected_env_keys"]),  # type: ignore[arg-type]
+                "no_env_hint": preset.no_env_hint,
             },
             "next": {
                 "ssh_command": f"smolvm ssh {vm.vm_id}",

--- a/src/smolvm/cli/main.py
+++ b/src/smolvm/cli/main.py
@@ -1794,7 +1794,6 @@ def _render_start_result(data: StartPayload) -> None:
         Text(str(vm_data["status"]), style=status_style(str(vm_data["status"]))),
     )
     details.add_row("OS", str(vm_data["os"]))
-    details.add_row("Backend", str(vm_data["backend"]))
     details.add_row("IP Address", str(vm_data["ip_address"] or "-"))
     details.add_row(
         "SSH Port",

--- a/src/smolvm/presets/__init__.py
+++ b/src/smolvm/presets/__init__.py
@@ -26,9 +26,17 @@ from smolvm.presets._install import apply_preset, collect_host_env
 from smolvm.presets._types import HostConfigCopy, HostKeychainSecret, Preset
 from smolvm.presets.claude_code import CLAUDE_CODE_PRESET
 from smolvm.presets.codex import CODEX_PRESET
+from smolvm.presets.hermes import HERMES_PRESET
+from smolvm.presets.openclaw import OPENCLAW_PRESET
 from smolvm.presets.pi import PI_PRESET
 
-_BUILTIN_PRESETS: tuple[Preset, ...] = (CODEX_PRESET, CLAUDE_CODE_PRESET, PI_PRESET)
+_BUILTIN_PRESETS: tuple[Preset, ...] = (
+    CODEX_PRESET,
+    CLAUDE_CODE_PRESET,
+    HERMES_PRESET,
+    OPENCLAW_PRESET,
+    PI_PRESET,
+)
 
 _REGISTRY: dict[str, Preset] = {p.name: p for p in _BUILTIN_PRESETS}
 
@@ -75,6 +83,8 @@ __all__ = [
     "CLAUDE_CODE_PRESET",
     "CODEX_PRESET",
     "GIT_HOST_CONFIGS",
+    "HERMES_PRESET",
+    "OPENCLAW_PRESET",
     "PI_PRESET",
     "HostConfigCopy",
     "HostKeychainSecret",

--- a/src/smolvm/presets/_install.py
+++ b/src/smolvm/presets/_install.py
@@ -133,7 +133,7 @@ def apply_preset(
     # the user sees two distinct progress steps instead of one opaque
     # "Installing..." line that stalls for the full duration.
     if preset.setup_script.strip():
-        notify("Installing system packages (apt + Node 20)...")
+        notify("Installing system packages...")
         _run_install_phase(ssh, preset, preset.setup_script, install_timeout, phase="setup")
 
     if preset.install_script.strip():

--- a/src/smolvm/presets/_scripts.py
+++ b/src/smolvm/presets/_scripts.py
@@ -21,9 +21,19 @@ import re
 # npm package names. ``@scope/name`` is the only multi-segment form allowed.
 _SAFE_NPM_NAME_RE = re.compile(r"^@?[a-zA-Z0-9._\-]+(/[a-zA-Z0-9._\-]+)?$")
 
-# Wait for cloud-init to release the apt lock, install Node.js 20 from
-# NodeSource if it's missing or older than 20. Idempotent.
-NODE20_BOOTSTRAP = r"""
+# PyPI package names — alphanumerics, hyphens, underscores, dots, optional extras.
+_SAFE_PYPI_NAME_RE = re.compile(r"^[a-zA-Z0-9._\-]+(\[[a-zA-Z0-9,._\-]+\])?$")
+
+
+def node_bootstrap(major: int = 20) -> str:
+    """Return a bash script that installs Node.js *major* via NodeSource.
+
+    Waits for cloud-init to release the apt lock, then installs Node
+    from NodeSource if it is missing or older than *major*. Idempotent.
+    """
+    if not isinstance(major, int) or major < 16:
+        raise ValueError(f"Unsupported Node major version: {major}")
+    return rf"""
 set -euo pipefail
 cloud-init status --wait >/dev/null 2>&1 || true
 export DEBIAN_FRONTEND=noninteractive
@@ -34,13 +44,32 @@ apt-get install -y -qq --no-install-recommends curl ca-certificates gnupg git
 needs_node=1
 if command -v node >/dev/null 2>&1; then
     major=$(node --version | sed 's/^v//' | cut -d. -f1)
-    if [ "${major:-0}" -ge 20 ]; then
+    if [ "${{major:-0}}" -ge {major} ]; then
         needs_node=0
     fi
 fi
 if [ "$needs_node" = "1" ]; then
-    curl -fsSL https://deb.nodesource.com/setup_20.x | bash -
+    curl -fsSL https://deb.nodesource.com/setup_{major}.x | bash -
     apt-get install -y -qq --no-install-recommends nodejs
+fi
+"""
+
+
+# Backward-compatible constant used by existing presets.
+NODE20_BOOTSTRAP = node_bootstrap(20)
+
+PYTHON_BOOTSTRAP = r"""
+set -euo pipefail
+cloud-init status --wait >/dev/null 2>&1 || true
+export DEBIAN_FRONTEND=noninteractive
+
+apt-get update -qq
+apt-get install -y -qq --no-install-recommends \
+    python3 python3-pip python3-venv curl ca-certificates git
+
+export PATH="$HOME/.local/bin:$PATH"
+if ! command -v uv >/dev/null 2>&1; then
+    curl -LsSf https://astral.sh/uv/install.sh | sh
 fi
 """
 
@@ -56,3 +85,19 @@ def npm_install_global(package: str) -> str:
     if not _SAFE_NPM_NAME_RE.match(package):
         raise ValueError(f"Refusing to install unsafe npm package name: {package!r}")
     return f"set -euo pipefail\nnpm install -g --silent {package}\n"
+
+
+def uv_install_global(package: str) -> str:
+    """Return a script that installs *package* system-wide via ``uv pip``.
+
+    Pair with :data:`PYTHON_BOOTSTRAP` as the preset's ``setup_script``
+    so that the apt/uv phase and the pip-install phase show up as two
+    separate progress steps in the CLI.
+    """
+    if not _SAFE_PYPI_NAME_RE.match(package):
+        raise ValueError(f"Refusing to install unsafe PyPI package name: {package!r}")
+    return (
+        "set -euo pipefail\n"
+        'export PATH="$HOME/.local/bin:$PATH"\n'
+        f"uv pip install --system {package}\n"
+    )

--- a/src/smolvm/presets/_types.py
+++ b/src/smolvm/presets/_types.py
@@ -131,3 +131,5 @@ class Preset:
     default_disk_mib: int = 8192
     launch_command: str | None = None
     """Guest command run when the user attaches after install — e.g. ``"codex"``."""
+    no_env_hint: str | None = None
+    """Shown after sandbox details when no ``host_env_vars`` were forwarded."""

--- a/src/smolvm/presets/hermes.py
+++ b/src/smolvm/presets/hermes.py
@@ -1,0 +1,50 @@
+# Copyright 2026 Celesto AI
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""NousResearch Hermes agent preset (https://hermes-agent.nousresearch.com/)."""
+
+from __future__ import annotations
+
+from smolvm.presets._scripts import PYTHON_BOOTSTRAP
+from smolvm.presets._types import HostConfigCopy, Preset
+
+_HERMES_REPO = "https://github.com/NousResearch/hermes-agent.git"
+_HERMES_INSTALL_DIR = "/opt/hermes-agent"
+
+HERMES_INSTALL_SCRIPT = rf"""
+set -euo pipefail
+export PATH="$HOME/.local/bin:$PATH"
+
+if [ ! -d {_HERMES_INSTALL_DIR} ]; then
+    git clone --depth 1 {_HERMES_REPO} {_HERMES_INSTALL_DIR}
+else
+    git -C {_HERMES_INSTALL_DIR} pull --ff-only || true
+fi
+
+cd {_HERMES_INSTALL_DIR}
+uv venv
+uv pip install -e ".[all]" || uv pip install -e .
+ln -sf {_HERMES_INSTALL_DIR}/.venv/bin/hermes /usr/local/bin/hermes
+"""
+
+HERMES_PRESET = Preset(
+    name="hermes",
+    summary="Start a sandbox with the Hermes agent preinstalled.",
+    setup_script=PYTHON_BOOTSTRAP,
+    install_script=HERMES_INSTALL_SCRIPT,
+    host_env_vars=("OPENROUTER_API_KEY", "OPENAI_API_KEY", "GOOGLE_API_KEY", "HF_TOKEN"),
+    host_configs=(HostConfigCopy(host_path="~/.hermes", guest_path="/root/.hermes"),),
+    default_disk_mib=10240,
+    launch_command="hermes",
+)

--- a/src/smolvm/presets/hermes.py
+++ b/src/smolvm/presets/hermes.py
@@ -47,4 +47,8 @@ HERMES_PRESET = Preset(
     host_configs=(HostConfigCopy(host_path="~/.hermes", guest_path="/root/.hermes"),),
     default_disk_mib=10240,
     launch_command="hermes",
+    no_env_hint=(
+        "No API key found. Set OPENROUTER_API_KEY on your machine,"
+        " or run 'hermes setup' inside the sandbox."
+    ),
 )

--- a/src/smolvm/presets/openclaw.py
+++ b/src/smolvm/presets/openclaw.py
@@ -28,4 +28,8 @@ OPENCLAW_PRESET = Preset(
     host_env_vars=("OPENROUTER_API_KEY", "OPENAI_API_KEY"),
     host_configs=(HostConfigCopy(host_path="~/.openclaw", guest_path="/root/.openclaw"),),
     launch_command="openclaw",
+    no_env_hint=(
+        "No API key found. Set OPENROUTER_API_KEY or OPENAI_API_KEY on your"
+        " machine, or run 'openclaw onboard' inside the sandbox."
+    ),
 )

--- a/src/smolvm/presets/openclaw.py
+++ b/src/smolvm/presets/openclaw.py
@@ -1,0 +1,31 @@
+# Copyright 2026 Celesto AI
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""OpenClaw CLI preset (https://github.com/openclaw/openclaw)."""
+
+from __future__ import annotations
+
+from smolvm.presets._scripts import node_bootstrap, npm_install_global
+from smolvm.presets._types import HostConfigCopy, Preset
+
+OPENCLAW_PRESET = Preset(
+    name="openclaw",
+    aliases=("claw",),
+    summary="Start a sandbox with the OpenClaw CLI preinstalled.",
+    setup_script=node_bootstrap(22),
+    install_script=npm_install_global("openclaw"),
+    host_env_vars=("OPENROUTER_API_KEY", "OPENAI_API_KEY"),
+    host_configs=(HostConfigCopy(host_path="~/.openclaw", guest_path="/root/.openclaw"),),
+    launch_command="openclaw",
+)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -2290,7 +2290,7 @@ class TestCliStart:
     def test_unknown_preset_errors(self, capsys: pytest.CaptureFixture) -> None:
         """An unknown preset name should fail at argparse-level."""
         with pytest.raises(SystemExit):
-            main(["hermes", "start"])
+            main(["nonexistent-agent", "start"])
         err = capsys.readouterr().err
         # argparse produces "invalid choice" for unknown subcommand
         assert "invalid choice" in err or "argument command" in err

--- a/tests/test_presets.py
+++ b/tests/test_presets.py
@@ -26,6 +26,8 @@ from smolvm.presets import (
     CLAUDE_CODE_PRESET,
     CODEX_PRESET,
     GIT_HOST_CONFIGS,
+    HERMES_PRESET,
+    OPENCLAW_PRESET,
     PI_PRESET,
     HostConfigCopy,
     HostKeychainSecret,
@@ -36,7 +38,7 @@ from smolvm.presets import (
     list_presets,
     preset_names,
 )
-from smolvm.presets._scripts import npm_install_global
+from smolvm.presets._scripts import npm_install_global, uv_install_global
 from smolvm.types import CommandResult
 
 
@@ -69,12 +71,18 @@ class TestRegistry:
     """Built-in preset registration."""
 
     def test_builtin_presets_registered(self) -> None:
-        assert preset_names() == ["claude-code", "codex", "pi"]
+        assert preset_names() == ["claude-code", "codex", "hermes", "openclaw", "pi"]
 
     def test_list_presets_sorted_by_name(self) -> None:
         names = [p.name for p in list_presets()]
         assert names == sorted(names)
-        assert {p.name for p in list_presets()} == {"codex", "claude-code", "pi"}
+        assert {p.name for p in list_presets()} == {
+            "codex",
+            "claude-code",
+            "hermes",
+            "openclaw",
+            "pi",
+        }
 
     def test_get_preset_returns_codex(self) -> None:
         assert get_preset("codex") is CODEX_PRESET
@@ -85,9 +93,15 @@ class TestRegistry:
     def test_get_preset_returns_pi(self) -> None:
         assert get_preset("pi") is PI_PRESET
 
+    def test_get_preset_returns_openclaw(self) -> None:
+        assert get_preset("openclaw") is OPENCLAW_PRESET
+
+    def test_get_preset_returns_hermes(self) -> None:
+        assert get_preset("hermes") is HERMES_PRESET
+
     def test_unknown_preset_lists_available(self) -> None:
-        with pytest.raises(KeyError, match="Available: claude-code, codex, pi"):
-            get_preset("hermes")
+        with pytest.raises(KeyError, match="Available: claude-code, codex, hermes, openclaw, pi"):
+            get_preset("nonexistent")
 
 
 class TestCodexPreset:
@@ -242,6 +256,66 @@ class TestPiPreset:
         assert PI_PRESET.setup_script == NODE20_BOOTSTRAP
 
 
+class TestOpenClawPreset:
+    """OpenClaw preset wires up the right keys, paths, and install command."""
+
+    def test_openclaw_preset_shape(self) -> None:
+        assert OPENCLAW_PRESET.name == "openclaw"
+        assert OPENCLAW_PRESET.aliases == ("claw",)
+        assert OPENCLAW_PRESET.launch_command == "openclaw"
+        assert OPENCLAW_PRESET.host_env_vars == ("OPENROUTER_API_KEY", "OPENAI_API_KEY")
+
+    def test_openclaw_copies_config_dir(self) -> None:
+        pairs = [(cfg.host_path, cfg.guest_path) for cfg in OPENCLAW_PRESET.host_configs]
+        assert pairs == [("~/.openclaw", "/root/.openclaw")]
+
+    def test_openclaw_install_runs_npm_install(self) -> None:
+        assert "openclaw" in OPENCLAW_PRESET.install_script
+        assert "npm install -g" in OPENCLAW_PRESET.install_script
+
+    def test_openclaw_setup_uses_node22(self) -> None:
+        assert "setup_22.x" in OPENCLAW_PRESET.setup_script
+        assert "-ge 22" in OPENCLAW_PRESET.setup_script
+
+    def test_openclaw_no_keychain_secrets(self) -> None:
+        assert OPENCLAW_PRESET.host_keychain_secrets == ()
+
+
+class TestHermesPreset:
+    """Hermes preset wires up the right keys, paths, and install command."""
+
+    def test_hermes_preset_shape(self) -> None:
+        assert HERMES_PRESET.name == "hermes"
+        assert HERMES_PRESET.aliases == ()
+        assert HERMES_PRESET.launch_command == "hermes"
+        assert HERMES_PRESET.host_env_vars == (
+            "OPENROUTER_API_KEY",
+            "OPENAI_API_KEY",
+            "GOOGLE_API_KEY",
+            "HF_TOKEN",
+        )
+
+    def test_hermes_copies_config_dir(self) -> None:
+        pairs = [(cfg.host_path, cfg.guest_path) for cfg in HERMES_PRESET.host_configs]
+        assert pairs == [("~/.hermes", "/root/.hermes")]
+
+    def test_hermes_install_clones_and_pip_installs(self) -> None:
+        assert "git clone" in HERMES_PRESET.install_script
+        assert "NousResearch/hermes-agent" in HERMES_PRESET.install_script
+        assert "uv venv" in HERMES_PRESET.install_script
+        assert "uv pip install" in HERMES_PRESET.install_script
+
+    def test_hermes_setup_installs_python(self) -> None:
+        assert "python3" in HERMES_PRESET.setup_script
+        assert "uv" in HERMES_PRESET.setup_script
+
+    def test_hermes_disk_bumped(self) -> None:
+        assert HERMES_PRESET.default_disk_mib == 10240
+
+    def test_hermes_no_keychain_secrets(self) -> None:
+        assert HERMES_PRESET.host_keychain_secrets == ()
+
+
 class TestNpmInstallGlobalSafety:
     """The npm install helper rejects unsafe package names."""
 
@@ -270,6 +344,56 @@ class TestNpmInstallGlobalSafety:
     def test_accepts_safe_names(self, name: str) -> None:
         script = npm_install_global(name)
         assert name in script
+
+
+class TestUvInstallGlobalSafety:
+    """The uv install helper rejects unsafe package names."""
+
+    @pytest.mark.parametrize(
+        "name",
+        [
+            "evil; rm -rf /",
+            "pkg && curl bad.example",
+            "name with spaces",
+        ],
+    )
+    def test_rejects_shell_metacharacters(self, name: str) -> None:
+        with pytest.raises(ValueError, match="unsafe PyPI package name"):
+            uv_install_global(name)
+
+    @pytest.mark.parametrize(
+        "name",
+        [
+            "hermes-agent",
+            "some-package.v2",
+            "package_name",
+        ],
+    )
+    def test_accepts_safe_names(self, name: str) -> None:
+        script = uv_install_global(name)
+        assert name in script
+
+
+class TestNodeBootstrapFunction:
+    """The parameterized node_bootstrap() helper."""
+
+    def test_node_bootstrap_20_matches_legacy_constant(self) -> None:
+        from smolvm.presets._scripts import NODE20_BOOTSTRAP, node_bootstrap
+
+        assert node_bootstrap(20) == NODE20_BOOTSTRAP
+
+    def test_node_bootstrap_22_uses_correct_version(self) -> None:
+        from smolvm.presets._scripts import node_bootstrap
+
+        script = node_bootstrap(22)
+        assert "setup_22.x" in script
+        assert "-ge 22" in script
+
+    def test_node_bootstrap_rejects_too_low(self) -> None:
+        from smolvm.presets._scripts import node_bootstrap
+
+        with pytest.raises(ValueError, match="Unsupported Node major version"):
+            node_bootstrap(10)
 
 
 class TestCollectHostEnv:
@@ -874,9 +998,7 @@ class TestGitCredentialInjection:
         apply_preset(ssh, self._stub_codex_preset())
 
         commands_run = [call.args[0] for call in ssh.run.call_args_list]
-        assert any(
-            "tar -xf" in cmd and "/root/.ssh" in cmd for cmd in commands_run
-        ), commands_run
+        assert any("tar -xf" in cmd and "/root/.ssh" in cmd for cmd in commands_run), commands_run
 
     def test_git_ssh_tar_owner_stripped_to_root(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
@@ -936,9 +1058,7 @@ class TestGitCredentialInjection:
         must chmod 0600 after upload so the file does not land
         world-readable inside the guest."""
         monkeypatch.setenv("HOME", str(tmp_path))
-        (tmp_path / ".git-credentials").write_text(
-            "https://user:token@github.com\n"
-        )
+        (tmp_path / ".git-credentials").write_text("https://user:token@github.com\n")
 
         ssh = MagicMock()
         ssh.run.return_value = _ok()
@@ -947,13 +1067,10 @@ class TestGitCredentialInjection:
 
         commands_run = [call.args[0] for call in ssh.run.call_args_list]
         assert any(
-            "chmod 600" in cmd and "/root/.git-credentials" in cmd
-            for cmd in commands_run
+            "chmod 600" in cmd and "/root/.git-credentials" in cmd for cmd in commands_run
         ), commands_run
 
-    def test_gitconfig_not_chmodded(
-        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
-    ) -> None:
+    def test_gitconfig_not_chmodded(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
         """``~/.gitconfig`` is conventionally world-readable; only
         credential files get the 0600 treatment. Guards against
         accidentally tightening every file_mode."""
@@ -966,7 +1083,8 @@ class TestGitCredentialInjection:
         apply_preset(ssh, self._stub_codex_preset())
 
         chmod_targets = [
-            cmd for cmd in (call.args[0] for call in ssh.run.call_args_list)
+            cmd
+            for cmd in (call.args[0] for call in ssh.run.call_args_list)
             if "chmod" in cmd and "/root/.gitconfig" in cmd
         ]
         assert chmod_targets == [], chmod_targets


### PR DESCRIPTION
## Summary

Add OpenClaw and Hermes as quick-start agent presets, similar to the existing codex/claude-code/pi presets. OpenClaw is npm-based (Node 22+), Hermes is the first Python-based preset (installed via uv into a venv from a git clone). Also refactors the Node bootstrap into a parameterized `node_bootstrap(major)` function, introduces `PYTHON_BOOTSTRAP` and `uv_install_global()` helpers, and removes the backend row from the sandbox details table.

## Related Issues

- N/A

## Testing

- `uv run pytest` — 792 passed, 13 skipped (all pre-existing), 0 regressions
- `uv run ruff check .` — all checks passed
- `smolvm openclaw start` — verified sandbox boots and OpenClaw CLI launches
- `smolvm hermes start` — verified sandbox boots and Hermes agent launches

## Checklist

- [x] Scope is focused and limited to this change
- [x] Tests added/updated for behavior changes
- [ ] Docs updated for user-visible changes
- [x] No secrets or sensitive data included

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Hermes agent preset for sandbox environments with API key support.
  * Added OpenClaw CLI preset for sandbox environments with Node.js integration.

* **Improvements**
  * Enhanced status display styling in sandbox details table.
  * Improved Node.js installation and version management for sandboxes.
  * Strengthened package installation validation.

* **Updates**
  * Simplified installation progress messaging.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->