### PR TITLE
fix(images): generate SSH host keys at first boot, not at image build

### DIFF
--- a/src/smolvm/images/builder.py
+++ b/src/smolvm/images/builder.py
@@ -234,9 +234,9 @@ RUN apk add --no-cache \\
     curl \\
     bash
 
-# Configure SSH
-RUN ssh-keygen -A && \\
-    sed -i 's/#PermitRootLogin.*/PermitRootLogin yes/' /etc/ssh/sshd_config && \\
+# Configure SSH (host keys are generated at first boot in /init, not here,
+# so each VM gets a unique SSH identity — required for safely sharing images.)
+RUN sed -i 's/#PermitRootLogin.*/PermitRootLogin yes/' /etc/ssh/sshd_config && \\
     sed -i 's/#PasswordAuthentication.*/PasswordAuthentication yes/' /etc/ssh/sshd_config && \\
     echo "root:${SSH_PASSWORD}" | chpasswd
 
@@ -336,8 +336,8 @@ RUN apk add --no-cache \
     curl \
     bash
 
-RUN ssh-keygen -A && \
-    mkdir -p /root/.ssh && chmod 700 /root/.ssh && \
+# Host keys generated at first boot in /init, not here, so each VM has unique identity.
+RUN mkdir -p /root/.ssh && chmod 700 /root/.ssh && \
     sed -i 's/#PermitRootLogin.*/PermitRootLogin prohibit-password/' /etc/ssh/sshd_config && \
     sed -i 's/#PasswordAuthentication.*/PasswordAuthentication no/' /etc/ssh/sshd_config && \
     sed -i 's/#PubkeyAuthentication.*/PubkeyAuthentication yes/' /etc/ssh/sshd_config
@@ -446,8 +446,8 @@ RUN apt-get update && apt-get install -y --no-install-recommends \\
     ca-certificates \\
     && rm -rf /var/lib/apt/lists/*
 
-RUN ssh-keygen -A && \\
-    mkdir -p /run/sshd /root/.ssh && chmod 700 /root/.ssh && \\
+# Host keys generated at first boot in /init, not here, so each VM has unique identity.
+RUN mkdir -p /run/sshd /root/.ssh && chmod 700 /root/.ssh && \\
     sed -ri 's/^#?PermitRootLogin .*/PermitRootLogin prohibit-password/' /etc/ssh/sshd_config && \\
     sed -ri 's/^#?PasswordAuthentication .*/PasswordAuthentication no/' /etc/ssh/sshd_config && \\
     sed -ri 's/^#?PubkeyAuthentication .*/PubkeyAuthentication yes/' /etc/ssh/sshd_config
@@ -791,8 +791,8 @@ RUN apt-get update && apt-get install -y --no-install-recommends \\
     tar \\
     && rm -rf /var/lib/apt/lists/*
 
-RUN ssh-keygen -A && \\
-    mkdir -p /run/sshd /root/.ssh && chmod 700 /root/.ssh && \\
+# Host keys generated at first boot in /init, not here, so each VM has unique identity.
+RUN mkdir -p /run/sshd /root/.ssh && chmod 700 /root/.ssh && \\
     sed -ri 's/^#?PermitRootLogin .*/PermitRootLogin prohibit-password/' /etc/ssh/sshd_config && \\
     sed -ri 's/^#?PasswordAuthentication .*/PasswordAuthentication no/' /etc/ssh/sshd_config && \\
     sed -ri 's/^#?PubkeyAuthentication .*/PubkeyAuthentication yes/' /etc/ssh/sshd_config
@@ -1009,8 +1009,8 @@ RUN apt-get update && apt-get install -y --no-install-recommends \\
     {packages_str} \\
     && rm -rf /var/lib/apt/lists/*
 
-RUN ssh-keygen -A && \\
-    mkdir -p /run/sshd /root/.ssh && chmod 700 /root/.ssh && \\
+# Host keys generated at first boot in /init, not here, so each VM has unique identity.
+RUN mkdir -p /run/sshd /root/.ssh && chmod 700 /root/.ssh && \\
     sed -ri 's/^#?PermitRootLogin .*/PermitRootLogin yes/' /etc/ssh/sshd_config && \\
     sed -ri 's/^#?PasswordAuthentication .*/PasswordAuthentication yes/' /etc/ssh/sshd_config && \\
     echo "root:${{SSH_PASSWORD}}" | chpasswd

--- a/src/smolvm/images/builder.py
+++ b/src/smolvm/images/builder.py
@@ -234,9 +234,12 @@ RUN apk add --no-cache \\
     curl \\
     bash
 
-# Configure SSH (host keys are generated at first boot in /init, not here,
-# so each VM gets a unique SSH identity — required for safely sharing images.)
-RUN sed -i 's/#PermitRootLogin.*/PermitRootLogin yes/' /etc/ssh/sshd_config && \\
+# Configure SSH. Host keys are generated at first boot in /init, not here,
+# so each VM gets a unique SSH identity — required for safely sharing images.
+# The 'rm -f' purges any keys planted by the openssh package install (e.g.
+# Debian's openssh-server postinst runs ssh-keygen -A automatically).
+RUN rm -f /etc/ssh/ssh_host_* && \\
+    sed -i 's/#PermitRootLogin.*/PermitRootLogin yes/' /etc/ssh/sshd_config && \\
     sed -i 's/#PasswordAuthentication.*/PasswordAuthentication yes/' /etc/ssh/sshd_config && \\
     echo "root:${SSH_PASSWORD}" | chpasswd
 
@@ -336,8 +339,10 @@ RUN apk add --no-cache \
     curl \
     bash
 
-# Host keys generated at first boot in /init, not here, so each VM has unique identity.
-RUN mkdir -p /root/.ssh && chmod 700 /root/.ssh && \
+# Host keys generated at first boot in /init so each VM has unique identity.
+# 'rm -f' purges keys planted by the openssh install postinst.
+RUN rm -f /etc/ssh/ssh_host_* && \
+    mkdir -p /root/.ssh && chmod 700 /root/.ssh && \
     sed -i 's/#PermitRootLogin.*/PermitRootLogin prohibit-password/' /etc/ssh/sshd_config && \
     sed -i 's/#PasswordAuthentication.*/PasswordAuthentication no/' /etc/ssh/sshd_config && \
     sed -i 's/#PubkeyAuthentication.*/PubkeyAuthentication yes/' /etc/ssh/sshd_config
@@ -446,8 +451,10 @@ RUN apt-get update && apt-get install -y --no-install-recommends \\
     ca-certificates \\
     && rm -rf /var/lib/apt/lists/*
 
-# Host keys generated at first boot in /init, not here, so each VM has unique identity.
-RUN mkdir -p /run/sshd /root/.ssh && chmod 700 /root/.ssh && \\
+# Host keys generated at first boot in /init so each VM has unique identity.
+# 'rm -f' purges keys planted by the openssh-server postinst on Debian.
+RUN rm -f /etc/ssh/ssh_host_* && \\
+    mkdir -p /run/sshd /root/.ssh && chmod 700 /root/.ssh && \\
     sed -ri 's/^#?PermitRootLogin .*/PermitRootLogin prohibit-password/' /etc/ssh/sshd_config && \\
     sed -ri 's/^#?PasswordAuthentication .*/PasswordAuthentication no/' /etc/ssh/sshd_config && \\
     sed -ri 's/^#?PubkeyAuthentication .*/PubkeyAuthentication yes/' /etc/ssh/sshd_config
@@ -791,8 +798,10 @@ RUN apt-get update && apt-get install -y --no-install-recommends \\
     tar \\
     && rm -rf /var/lib/apt/lists/*
 
-# Host keys generated at first boot in /init, not here, so each VM has unique identity.
-RUN mkdir -p /run/sshd /root/.ssh && chmod 700 /root/.ssh && \\
+# Host keys generated at first boot in /init so each VM has unique identity.
+# 'rm -f' purges keys planted by the openssh-server postinst on Debian.
+RUN rm -f /etc/ssh/ssh_host_* && \\
+    mkdir -p /run/sshd /root/.ssh && chmod 700 /root/.ssh && \\
     sed -ri 's/^#?PermitRootLogin .*/PermitRootLogin prohibit-password/' /etc/ssh/sshd_config && \\
     sed -ri 's/^#?PasswordAuthentication .*/PasswordAuthentication no/' /etc/ssh/sshd_config && \\
     sed -ri 's/^#?PubkeyAuthentication .*/PubkeyAuthentication yes/' /etc/ssh/sshd_config
@@ -1009,8 +1018,10 @@ RUN apt-get update && apt-get install -y --no-install-recommends \\
     {packages_str} \\
     && rm -rf /var/lib/apt/lists/*
 
-# Host keys generated at first boot in /init, not here, so each VM has unique identity.
-RUN mkdir -p /run/sshd /root/.ssh && chmod 700 /root/.ssh && \\
+# Host keys generated at first boot in /init so each VM has unique identity.
+# 'rm -f' purges keys planted by the openssh-server postinst on Debian.
+RUN rm -f /etc/ssh/ssh_host_* && \\
+    mkdir -p /run/sshd /root/.ssh && chmod 700 /root/.ssh && \\
     sed -ri 's/^#?PermitRootLogin .*/PermitRootLogin yes/' /etc/ssh/sshd_config && \\
     sed -ri 's/^#?PasswordAuthentication .*/PasswordAuthentication yes/' /etc/ssh/sshd_config && \\
     echo "root:${{SSH_PASSWORD}}" | chpasswd


### PR DESCRIPTION
## Summary

Removes \`ssh-keygen -A\` from all five Dockerfile build paths (\`build_alpine_ssh\`, \`build_alpine_ssh_key\`, the two desktop variants, and \`build_openclaw_rootfs\`). The \`/init\` script already has an idempotent fallback that generates host keys when missing — see [builder.py:1180-1183](https://github.com/CelestoAI/SmolVM/blob/main/src/smolvm/images/builder.py#L1180-L1183) — so this just promotes the fallback to the primary path.

### Why

Today every VM cloned from a cached image inherits the same baked-in \`/etc/ssh/ssh_host_*_key\` files. The risk is bounded to a single user's machine while images are local-only — \`vm.py:511\` copies/reflinks the rootfs per VM, but they all start from the same template. Any two VMs cloned from the same image share an SSH identity.

Once images are published (foundation landed in #228), every SmolVM user worldwide would share the same host keys. That makes guest impersonation on shared networks trivial and breaks SSH host-key pinning entirely. This PR is a prerequisite for safely flipping on the publishing path.

### Why this is safe to land independently

The change is a functional no-op for existing users:

- \`/init\` already runs \`ssh-keygen -A\` when \`/etc/ssh/ssh_host_*_key\` is missing — that branch just hasn't fired before because the keys were always baked.
- Each VM gets its own rootfs copy ([vm.py:511](https://github.com/CelestoAI/SmolVM/blob/main/src/smolvm/vm.py#L511) — reflink CoW or full copy). Per-VM key writes don't collide.
- Cost is ~100-200 ms one-time work at first boot per VM. Subsequent boots reuse the persisted keys.

### Why not do this in CI later

Even before publishing exists, this is the correct design — two VMs that are nominally separate sandboxes shouldn't share a cryptographic identity. The CI work is what made the bug user-visible-at-scale; the bug itself was always there.

## Related Issues

- Closes #
- Follow-up to #228 (published-image manifest foundation)

## Testing

- \`uv run pytest tests/test_images.py tests/test_build.py tests/test_published_images.py\` — 83 passed, no regressions
- \`uv run ruff check src/smolvm/images/builder.py\` — clean
- \`uv run ruff format --check src/smolvm/images/builder.py\` — clean
- Manual: not yet booted a sandbox locally to verify the first-boot path fires and SSH works on the resulting VM. Worth doing before un-drafting.

## Checklist

- [x] Scope is focused and limited to this change
- [x] Tests added/updated for behavior changes (existing tests cover the build path; \`/init\` host-key generation is shell logic outside Python's reach)
- [ ] Docs updated for user-visible changes (no user-visible behavior change)
- [x] No secrets or sensitive data included

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * SSH host key generation has been moved from Docker image build time to first VM instance boot, ensuring each VM instance receives unique SSH credentials rather than sharing build-time generated keys. SSH runtime directories are properly configured during image build.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->