### PR TITLE
fix(images): hash Dockerfile and init script into build cache fingerprint

### DIFF
--- a/src/smolvm/images/builder.py
+++ b/src/smolvm/images/builder.py
@@ -196,28 +196,7 @@ class ImageBuilder:
         kernel_path = image_dir / "vmlinux.bin"
         rootfs_path = image_dir / "rootfs.ext4"
 
-        # Check fingerprint cache
         resolved_kernel_url = self._resolve_kernel_url(kernel_profile, kernel_url)
-
-        fingerprint_data = {
-            "rootfs_size_mb": rootfs_size_mb,
-            "kernel_url": resolved_kernel_url,
-            "kernel_profile": kernel_profile.value,
-            "ssh_password": ssh_password,
-        }
-        if (
-            kernel_path.exists()
-            and rootfs_path.exists()
-            and self._check_fingerprint(image_dir, fingerprint_data)
-        ):
-            logger.info("Image '%s' already exists and fingerprint matches at %s", name, image_dir)
-            return (kernel_path, rootfs_path)
-
-        if not self.check_docker():
-            raise self.docker_requirement_error()
-
-        logger.info("Building Alpine SSH image '%s'...", name)
-        image_dir.mkdir(parents=True, exist_ok=True)
 
         # The /init script runs as PID 1 inside the VM and brings up SSH.
         init_script = self._default_init_script()
@@ -247,6 +226,30 @@ RUN rm -f /etc/ssh/ssh_host_* && \\
 COPY init /init
 RUN chmod +x /init
 """
+
+        fingerprint_data = self._fingerprint_with_content(
+            {
+                "rootfs_size_mb": rootfs_size_mb,
+                "kernel_url": resolved_kernel_url,
+                "kernel_profile": kernel_profile.value,
+                "ssh_password": ssh_password,
+            },
+            dockerfile_content,
+            init_script,
+        )
+        if (
+            kernel_path.exists()
+            and rootfs_path.exists()
+            and self._check_fingerprint(image_dir, fingerprint_data)
+        ):
+            logger.info("Image '%s' already exists and fingerprint matches at %s", name, image_dir)
+            return (kernel_path, rootfs_path)
+
+        if not self.check_docker():
+            raise self.docker_requirement_error()
+
+        logger.info("Building Alpine SSH image '%s'...", name)
+        image_dir.mkdir(parents=True, exist_ok=True)
 
         try:
             self._do_build(
@@ -301,33 +304,6 @@ RUN chmod +x /init
 
         resolved_kernel_url = self._resolve_kernel_url(kernel_profile, kernel_url)
 
-        fingerprint_data = {
-            "rootfs_size_mb": rootfs_size_mb,
-            "kernel_url": resolved_kernel_url,
-            "kernel_profile": kernel_profile.value,
-            "ssh_public_key": key_value,
-        }
-
-        if kernel_path.exists() and rootfs_path.exists():
-            if self._check_fingerprint(image_dir, fingerprint_data):
-                logger.info(
-                    "Image '%s' already exists and fingerprint matches at %s", name, image_dir
-                )
-                return (kernel_path, rootfs_path)
-
-            if not self.check_docker():
-                raise self.docker_requirement_error()
-
-            logger.info("SSH key or config changed for image '%s'. Rebuilding...", name)
-            # Remove stale files
-            kernel_path.unlink(missing_ok=True)
-            rootfs_path.unlink(missing_ok=True)
-        elif not self.check_docker():
-            raise self.docker_requirement_error()
-
-        logger.info("Building Alpine key-only SSH image '%s'...", name)
-        image_dir.mkdir(parents=True, exist_ok=True)
-
         init_script = self._default_init_script()
 
         dockerfile_content = """
@@ -353,6 +329,37 @@ RUN chmod 600 /root/.ssh/authorized_keys && chown -R root:root /root/.ssh
 COPY init /init
 RUN chmod +x /init
 """
+
+        fingerprint_data = self._fingerprint_with_content(
+            {
+                "rootfs_size_mb": rootfs_size_mb,
+                "kernel_url": resolved_kernel_url,
+                "kernel_profile": kernel_profile.value,
+                "ssh_public_key": key_value,
+            },
+            dockerfile_content,
+            init_script,
+        )
+
+        if kernel_path.exists() and rootfs_path.exists():
+            if self._check_fingerprint(image_dir, fingerprint_data):
+                logger.info(
+                    "Image '%s' already exists and fingerprint matches at %s", name, image_dir
+                )
+                return (kernel_path, rootfs_path)
+
+            if not self.check_docker():
+                raise self.docker_requirement_error()
+
+            logger.info("SSH key or config changed for image '%s'. Rebuilding...", name)
+            # Remove stale files
+            kernel_path.unlink(missing_ok=True)
+            rootfs_path.unlink(missing_ok=True)
+        elif not self.check_docker():
+            raise self.docker_requirement_error()
+
+        logger.info("Building Alpine key-only SSH image '%s'...", name)
+        image_dir.mkdir(parents=True, exist_ok=True)
 
         try:
             self._do_build(
@@ -408,34 +415,6 @@ RUN chmod +x /init
 
         resolved_kernel_url = self._resolve_kernel_url(kernel_profile, kernel_url)
 
-        fingerprint_data = {
-            "rootfs_size_mb": rootfs_size_mb,
-            "kernel_url": resolved_kernel_url,
-            "kernel_profile": kernel_profile.value,
-            "ssh_public_key": key_value,
-            "base_image": base_image,
-        }
-
-        if kernel_path.exists() and rootfs_path.exists():
-            if self._check_fingerprint(image_dir, fingerprint_data):
-                logger.info(
-                    "Image '%s' already exists and fingerprint matches at %s", name, image_dir
-                )
-                return (kernel_path, rootfs_path)
-
-            if not self.check_docker():
-                raise self.docker_requirement_error()
-
-            logger.info("Inputs changed for image '%s'. Rebuilding...", name)
-            # Remove stale files
-            kernel_path.unlink(missing_ok=True)
-            rootfs_path.unlink(missing_ok=True)
-        elif not self.check_docker():
-            raise self.docker_requirement_error()
-
-        logger.info("Building Debian key-only SSH image '%s'...", name)
-        image_dir.mkdir(parents=True, exist_ok=True)
-
         init_script = self._default_init_script()
 
         dockerfile_content = f"""
@@ -465,6 +444,38 @@ RUN chmod 600 /root/.ssh/authorized_keys && chown -R root:root /root/.ssh
 COPY init /init
 RUN chmod +x /init
 """
+
+        fingerprint_data = self._fingerprint_with_content(
+            {
+                "rootfs_size_mb": rootfs_size_mb,
+                "kernel_url": resolved_kernel_url,
+                "kernel_profile": kernel_profile.value,
+                "ssh_public_key": key_value,
+                "base_image": base_image,
+            },
+            dockerfile_content,
+            init_script,
+        )
+
+        if kernel_path.exists() and rootfs_path.exists():
+            if self._check_fingerprint(image_dir, fingerprint_data):
+                logger.info(
+                    "Image '%s' already exists and fingerprint matches at %s", name, image_dir
+                )
+                return (kernel_path, rootfs_path)
+
+            if not self.check_docker():
+                raise self.docker_requirement_error()
+
+            logger.info("Inputs changed for image '%s'. Rebuilding...", name)
+            # Remove stale files
+            kernel_path.unlink(missing_ok=True)
+            rootfs_path.unlink(missing_ok=True)
+        elif not self.check_docker():
+            raise self.docker_requirement_error()
+
+        logger.info("Building Debian key-only SSH image '%s'...", name)
+        image_dir.mkdir(parents=True, exist_ok=True)
 
         try:
             self._do_build(
@@ -519,29 +530,6 @@ RUN chmod +x /init
         rootfs_path = image_dir / "rootfs.ext4"
 
         resolved_kernel_url = self._resolve_kernel_url(kernel_profile, kernel_url)
-
-        fingerprint_data = {
-            "rootfs_size_mb": rootfs_size_mb,
-            "kernel_url": resolved_kernel_url,
-            "kernel_profile": kernel_profile.value,
-            "ssh_public_key": key_value,
-            "base_image": base_image,
-            "image_type": "browser-chromium-v3",
-        }
-
-        if kernel_path.exists() and rootfs_path.exists():
-            if self._check_fingerprint(image_dir, fingerprint_data):
-                logger.info(
-                    "Image '%s' already exists and fingerprint matches at %s", name, image_dir
-                )
-                return (kernel_path, rootfs_path)
-
-            logger.info("Inputs changed for browser image '%s'. Rebuilding...", name)
-            kernel_path.unlink(missing_ok=True)
-            rootfs_path.unlink(missing_ok=True)
-
-        logger.info("Building browser image '%s'...", name)
-        image_dir.mkdir(parents=True, exist_ok=True)
 
         init_script = self._default_init_script()
 
@@ -822,6 +810,35 @@ COPY init /init
 RUN chmod +x /init
 """
 
+        fingerprint_data = self._fingerprint_with_content(
+            {
+                "rootfs_size_mb": rootfs_size_mb,
+                "kernel_url": resolved_kernel_url,
+                "kernel_profile": kernel_profile.value,
+                "ssh_public_key": key_value,
+                "base_image": base_image,
+                "image_type": "browser-chromium-v3",
+                "_browser_session_sha256": hashlib.sha256(browser_session_sh.encode()).hexdigest(),
+                "_wait_port_sha256": hashlib.sha256(wait_port_py.encode()).hexdigest(),
+            },
+            dockerfile_content,
+            init_script,
+        )
+
+        if kernel_path.exists() and rootfs_path.exists():
+            if self._check_fingerprint(image_dir, fingerprint_data):
+                logger.info(
+                    "Image '%s' already exists and fingerprint matches at %s", name, image_dir
+                )
+                return (kernel_path, rootfs_path)
+
+            logger.info("Inputs changed for browser image '%s'. Rebuilding...", name)
+            kernel_path.unlink(missing_ok=True)
+            rootfs_path.unlink(missing_ok=True)
+
+        logger.info("Building browser image '%s'...", name)
+        image_dir.mkdir(parents=True, exist_ok=True)
+
         try:
             self._do_build(
                 name,
@@ -914,29 +931,7 @@ RUN chmod +x /init
         kernel_path = image_dir / "vmlinux.bin"
         rootfs_path = image_dir / "rootfs.ext4"
 
-        fingerprint_data = {
-            "rootfs_size_mb": rootfs_size_mb,
-            "kernel_url": kernel_url,
-            "ssh_password": ssh_password,
-            "ssh_public_key": key_value,
-            "extra_packages": extra_packages,
-        }
-
-        if kernel_path.exists() and rootfs_path.exists():
-            if self._check_fingerprint(image_dir, fingerprint_data):
-                logger.info(
-                    "Image '%s' already exists and fingerprint matches at %s", name, image_dir
-                )
-                return (kernel_path, rootfs_path)
-
-            logger.info("Inputs changed for OpenClaw image '%s'. Rebuilding...", name)
-            kernel_path.unlink(missing_ok=True)
-            rootfs_path.unlink(missing_ok=True)
-
         packages_str = " ".join(extra_packages)
-
-        logger.info("Building OpenClaw image '%s' with extra packages: %s...", name, packages_str)
-        image_dir.mkdir(parents=True, exist_ok=True)
 
         init_script = self._openclaw_init_script()
 
@@ -1055,6 +1050,35 @@ RUN chmod +x \\
 COPY init /init
 RUN chmod +x /init
 """
+
+        fingerprint_data = self._fingerprint_with_content(
+            {
+                "rootfs_size_mb": rootfs_size_mb,
+                "kernel_url": kernel_url,
+                "ssh_password": ssh_password,
+                "ssh_public_key": key_value,
+                "extra_packages": extra_packages,
+                "_device_approver_sha256": hashlib.sha256(device_approver_py.encode()).hexdigest(),
+                "_watch_devices_sha256": hashlib.sha256(watch_devices_sh.encode()).hexdigest(),
+                "_systemctl_proxy_sha256": hashlib.sha256(systemctl_proxy_sh.encode()).hexdigest(),
+            },
+            dockerfile_content,
+            init_script,
+        )
+
+        if kernel_path.exists() and rootfs_path.exists():
+            if self._check_fingerprint(image_dir, fingerprint_data):
+                logger.info(
+                    "Image '%s' already exists and fingerprint matches at %s", name, image_dir
+                )
+                return (kernel_path, rootfs_path)
+
+            logger.info("Inputs changed for OpenClaw image '%s'. Rebuilding...", name)
+            kernel_path.unlink(missing_ok=True)
+            rootfs_path.unlink(missing_ok=True)
+
+        logger.info("Building OpenClaw image '%s' with extra packages: %s...", name, packages_str)
+        image_dir.mkdir(parents=True, exist_ok=True)
 
         try:
             self._do_build(
@@ -1303,6 +1327,24 @@ echo "Device-approver running with PID=${DEVICE_APPROVER_PID}"
         if kernel_url is not None:
             return kernel_url
         return resolve_kernel_url(kernel_profile, self._host_arch_key())
+
+    def _fingerprint_with_content(
+        self,
+        fingerprint_data: dict[str, typing.Any],
+        dockerfile_content: str,
+        init_script: str,
+    ) -> dict[str, typing.Any]:
+        """Augment the input-only fingerprint with Dockerfile and init-script hashes.
+
+        Without this, edits to the Dockerfile or /init script are invisible to
+        the fingerprint check — the cache keeps serving the old image even
+        though the build recipe has changed.
+        """
+        return {
+            **fingerprint_data,
+            "_dockerfile_sha256": hashlib.sha256(dockerfile_content.encode()).hexdigest(),
+            "_init_script_sha256": hashlib.sha256(init_script.encode()).hexdigest(),
+        }
 
     def _check_fingerprint(self, image_dir: Path, data: dict[str, typing.Any]) -> bool:
         """Check if the cached image fingerprint matches the current build inputs."""

--- a/tests/test_build.py
+++ b/tests/test_build.py
@@ -410,3 +410,63 @@ def test_rebuild_preserves_cached_artifacts_when_docker_is_unavailable(
 
     assert kernel_path.exists()
     assert rootfs_path.exists()
+
+
+class TestFingerprintWithContent:
+    """Tests for the cache-key augmentation that includes Dockerfile/init hashes.
+
+    Without this, edits to the Dockerfile or init script don't invalidate the
+    local cache — the user keeps getting the old image even though the recipe
+    changed.
+    """
+
+    def test_same_inputs_and_content_produce_stable_key(self, tmp_path: Path) -> None:
+        builder = ImageBuilder(cache_dir=tmp_path)
+        inputs = {"size_mb": 512, "ssh_password": "smolvm"}
+        a = builder._fingerprint_with_content(inputs, "FROM alpine:3.19", "#!/bin/sh\nexec /init")
+        b = builder._fingerprint_with_content(inputs, "FROM alpine:3.19", "#!/bin/sh\nexec /init")
+        assert a == b
+
+    def test_dockerfile_change_invalidates_key(self, tmp_path: Path) -> None:
+        builder = ImageBuilder(cache_dir=tmp_path)
+        inputs = {"size_mb": 512}
+        before = builder._fingerprint_with_content(inputs, "FROM alpine:3.19", "init")
+        after = builder._fingerprint_with_content(inputs, "FROM alpine:3.20", "init")
+        assert before["_dockerfile_sha256"] != after["_dockerfile_sha256"]
+
+    def test_init_script_change_invalidates_key(self, tmp_path: Path) -> None:
+        builder = ImageBuilder(cache_dir=tmp_path)
+        inputs = {"size_mb": 512}
+        before = builder._fingerprint_with_content(inputs, "FROM alpine", "echo old")
+        after = builder._fingerprint_with_content(inputs, "FROM alpine", "echo new")
+        assert before["_init_script_sha256"] != after["_init_script_sha256"]
+
+    def test_inputs_passthrough(self, tmp_path: Path) -> None:
+        """Augmentation must keep the original inputs alongside the content hashes."""
+        builder = ImageBuilder(cache_dir=tmp_path)
+        inputs = {"size_mb": 512, "ssh_password": "smolvm", "extra_packages": ["git"]}
+        result = builder._fingerprint_with_content(inputs, "df", "init")
+        for key, value in inputs.items():
+            assert result[key] == value
+
+    def test_old_fingerprint_files_invalidate_after_dockerfile_change(self, tmp_path: Path) -> None:
+        """End-to-end: a stored fingerprint becomes stale when the Dockerfile changes.
+
+        This is the bug that motivated the helper — without it, a fingerprint
+        written before a Dockerfile edit would still match after the edit.
+        """
+        builder = ImageBuilder(cache_dir=tmp_path)
+        image_dir = tmp_path / "preset"
+        image_dir.mkdir()
+
+        original = builder._fingerprint_with_content(
+            {"ssh_password": "smolvm"}, "FROM alpine:3.19", "init"
+        )
+        builder._write_fingerprint(image_dir, original)
+        assert builder._check_fingerprint(image_dir, original)
+
+        # Dockerfile changes — same inputs, but the cache key shifts.
+        edited = builder._fingerprint_with_content(
+            {"ssh_password": "smolvm"}, "FROM alpine:3.20", "init"
+        )
+        assert not builder._check_fingerprint(image_dir, edited)


### PR DESCRIPTION
## Summary

Closes the cache-invalidation gap deferred from #229. The build fingerprint previously captured only user-supplied inputs (\`rootfs_size_mb\`, \`ssh_password\`, etc.), so changes to Dockerfile content or the \`/init\` script were invisible to the cache check — \`~/.smolvm/images/<name>/.fingerprint\` kept matching after the build recipe changed, and users kept getting the old image until they manually wiped the cache.

Adds a small \`_fingerprint_with_content\` helper that augments the input dict with SHA-256 hashes of the Dockerfile content and init script. Each of the five builders now computes its Dockerfile + init early, then passes both through the helper before the cache check. The same augmented dict ends up in the \`.fingerprint\` file via \`_do_build\`'s existing write path.

For the two builders with extra script payloads (\`build_browser_rootfs\` ships session + wait-port helpers; \`build_openclaw_rootfs\` ships device-approver, watch-devices, and systemctl-shim sidecars) the script content hashes are also included — those are \`extra_files\` written into the build context, so their SHAs belong in the cache key too.

### Why this matters

Without this, any Dockerfile or init-script change requires every user to manually \`rm -rf ~/.smolvm/images/<preset>/\` to pick it up. Future contributors editing build recipes have no way to make their fix actually reach existing users, and bug reports become unreliable (\"works on my machine, but their cache is stale\").

### Useful side effect

The new fingerprint dict has additional keys that the old \`.fingerprint\` file never recorded, so the SHA comparison fails and a rebuild is triggered the next time any builder runs. Among other things, this picks up the host-key first-boot fix from #229 for users whose images were already cached when that PR landed.

## Related Issues

- Closes #
- Follow-up to #229 (deferred cache-invalidation concern)

## Testing

- \`uv run pytest tests/test_images.py tests/test_build.py tests/test_published_images.py\` — 88 passed (5 new + 83 existing, no regressions)
- \`uv run ruff check src/smolvm/images/builder.py tests/test_build.py\` — clean
- \`uv run ruff format --check ...\` — clean

New tests in \`TestFingerprintWithContent\`:
- Same inputs + content → stable key
- Dockerfile change → key invalidates
- Init-script change → key invalidates
- Original inputs survive augmentation
- End-to-end: a written fingerprint becomes stale after a Dockerfile edit

## Checklist

- [x] Scope is focused and limited to this change
- [x] Tests added/updated for behavior changes
- [ ] Docs updated for user-visible changes (no user-visible behavior change beyond \"caches now invalidate when they should\")
- [x] No secrets or sensitive data included