### PR TITLE
feat(images): inject authorized_keys via kernel cmdline at first boot

### DIFF
--- a/src/smolvm/images/builder.py
+++ b/src/smolvm/images/builder.py
@@ -1218,6 +1218,27 @@ if ! ls /etc/ssh/ssh_host_*_key >/dev/null 2>&1; then
 fi
 log_ts "ssh-hostkey-check-done"
 
+# Pull authorized_keys from the kernel cmdline if the host injected one.
+# Format: smolvm.authorized_key_b64=<base64-of-the-pubkey-line>. Used for
+# published images that don't bake keys at build time, so each VM gets the
+# launching user's key without rebuilding the rootfs.
+log_ts "ssh-authkey-inject-start"
+AUTHKEY_B64=$(cat /proc/cmdline | tr ' ' '\n' \
+    | grep '^smolvm.authorized_key_b64=' | head -1 | cut -d= -f2-)
+if [ -n "$AUTHKEY_B64" ]; then
+    DECODED=$(echo "$AUTHKEY_B64" | base64 -d 2>/dev/null)
+    if [ -n "$DECODED" ]; then
+        mkdir -p /root/.ssh
+        chmod 700 /root/.ssh
+        echo "$DECODED" > /root/.ssh/authorized_keys
+        chmod 600 /root/.ssh/authorized_keys
+        echo "SmolVM init: installed authorized_keys from cmdline"
+    else
+        echo "SmolVM init: smolvm.authorized_key_b64 present but failed to decode"
+    fi
+fi
+log_ts "ssh-authkey-inject-done"
+
 log_ts "sshd-start"
 /usr/sbin/sshd -e
 log_ts "sshd-invoked"

--- a/src/smolvm/images/builder.py
+++ b/src/smolvm/images/builder.py
@@ -1224,7 +1224,7 @@ log_ts "ssh-hostkey-check-done"
 # launching user's key without rebuilding the rootfs.
 log_ts "ssh-authkey-inject-start"
 AUTHKEY_B64=$(cat /proc/cmdline | tr ' ' '\n' \
-    | grep '^smolvm.authorized_key_b64=' | head -1 | cut -d= -f2-)
+    | grep '^smolvm\\.authorized_key_b64=' | head -1 | cut -d= -f2-)
 if [ -n "$AUTHKEY_B64" ]; then
     DECODED=$(echo "$AUTHKEY_B64" | base64 -d 2>/dev/null)
     if [ -n "$DECODED" ]; then

--- a/src/smolvm/types.py
+++ b/src/smolvm/types.py
@@ -304,6 +304,12 @@ class VMConfig(BaseModel):
         env_vars: Environment variables to inject into the guest
             after boot via SSH. Keys must be valid shell identifiers.
         port_forwards: Optional host TCP forwards configured at VM launch.
+        ssh_public_key: Optional OpenSSH public key (one-line ``authorized_keys``
+            format) to install in the guest's ``/root/.ssh/authorized_keys`` at
+            first boot. Passed via the kernel command line as
+            ``smolvm.authorized_key_b64=<base64>`` and read by ``/init``. Use
+            this for published pre-built images that don't bake keys at build
+            time, so each VM gets the launching user's key without rebuilding.
     """
 
     vm_id: Annotated[
@@ -331,6 +337,7 @@ class VMConfig(BaseModel):
     vsock: VsockConfig | None = None
     internet_settings: InternetSettings | None = None
     workspace_mounts: list[WorkspaceMount] = []
+    ssh_public_key: str | None = None
 
     @field_validator("vm_id", mode="before")
     @classmethod

--- a/src/smolvm/vm.py
+++ b/src/smolvm/vm.py
@@ -20,6 +20,7 @@ Orchestrates VM lifecycle, networking, and state management across runtimes.
 from __future__ import annotations
 
 import asyncio
+import base64
 import logging
 import os
 import platform
@@ -1614,10 +1615,7 @@ class SmolVMManager:
             tag = ws.resolved_tag(index)
             fsdev_id = f"fsdev-{tag}"
             workspace_fsdev_ids.append((fsdev_id, tag))
-            fsdev_opts = (
-                f"local,id={fsdev_id},path={ws.host_path},"
-                f"security_model=mapped-xattr"
-            )
+            fsdev_opts = f"local,id={fsdev_id},path={ws.host_path},security_model=mapped-xattr"
             if not ws.writable:
                 fsdev_opts += ",readonly=on"
             cmd.extend(["-fsdev", fsdev_opts])
@@ -1926,7 +1924,7 @@ class SmolVMManager:
                     fh.close()
 
     def _resolve_boot_args(self, vm_info: VMInfo) -> str:
-        """Resolve final boot args, injecting static IP config when absent."""
+        """Resolve final boot args, injecting static IP config and SSH key when absent."""
         args = vm_info.config.boot_args.strip()
         parts = args.split()
 
@@ -1937,6 +1935,18 @@ class SmolVMManager:
             if not any(part.startswith("root=") for part in parts):
                 parts.extend(["root=/dev/vda", "rw"])
             args = " ".join(parts).strip()
+            parts = args.split()
+
+        ssh_public_key = vm_info.config.ssh_public_key
+        if ssh_public_key and not any(
+            part.startswith("smolvm.authorized_key_b64=") for part in parts
+        ):
+            # Base64-encode so the value is a single space-free token — SSH
+            # public keys contain spaces ("ssh-ed25519 AAAA... user@host") that
+            # would otherwise split into separate cmdline params.
+            encoded = base64.b64encode(ssh_public_key.strip().encode("utf-8")).decode("ascii")
+            args = f"{args} smolvm.authorized_key_b64={encoded}".strip()
+            parts = args.split()
 
         if vm_info.network is None:
             return args

--- a/tests/test_vm.py
+++ b/tests/test_vm.py
@@ -29,7 +29,7 @@ from smolvm.exceptions import (
     VMAlreadyExistsError,
     VMNotFoundError,
 )
-from smolvm.types import VMConfig, VMState
+from smolvm.types import VMConfig, VMInfo, VMState
 from smolvm.vm import SmolVMManager
 
 
@@ -864,3 +864,98 @@ class TestProcessLifecycle:
 
         assert process.poll() is not None
         assert process.pid not in smol_vm._process_handles
+
+
+class TestResolveBootArgs:
+    """Tests for boot-args resolution, including SSH-key cmdline injection.
+
+    Published images don't bake authorized_keys at build time. The launching
+    user's pubkey is injected via the kernel cmdline as a base64-encoded
+    ``smolvm.authorized_key_b64`` param, which the guest's ``/init`` decodes
+    and writes to ``/root/.ssh/authorized_keys`` before sshd starts.
+    """
+
+    _ED25519_KEY = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIBxampleKeyForTestingOnly user@host"
+
+    def _vm_info(
+        self,
+        smol_vm: SmolVMManager,
+        sample_config: VMConfig,
+        *,
+        ssh_public_key: str | None = None,
+        boot_args: str | None = None,
+    ) -> VMInfo:
+        config_updates: dict[str, object] = {}
+        if ssh_public_key is not None:
+            config_updates["ssh_public_key"] = ssh_public_key
+        if boot_args is not None:
+            config_updates["boot_args"] = boot_args
+        if config_updates:
+            config = sample_config.model_copy(update=config_updates)
+        else:
+            config = sample_config
+        return VMInfo(vm_id=config.vm_id, status=VMState.STOPPED, config=config)
+
+    def test_no_key_means_no_cmdline_injection(
+        self, smol_vm: SmolVMManager, sample_config: VMConfig
+    ) -> None:
+        info = self._vm_info(smol_vm, sample_config)
+        assert "smolvm.authorized_key_b64=" not in smol_vm._resolve_boot_args(info)
+
+    def test_key_is_base64_encoded_into_cmdline(
+        self, smol_vm: SmolVMManager, sample_config: VMConfig
+    ) -> None:
+        import base64
+
+        info = self._vm_info(smol_vm, sample_config, ssh_public_key=self._ED25519_KEY)
+        args = smol_vm._resolve_boot_args(info)
+
+        token = next(
+            (p for p in args.split() if p.startswith("smolvm.authorized_key_b64=")),
+            None,
+        )
+        assert token is not None, args
+        encoded = token.split("=", 1)[1]
+        # Base64 is space-free — that's the whole point. Round-trip must match.
+        assert " " not in encoded
+        decoded = base64.b64decode(encoded).decode("utf-8")
+        assert decoded == self._ED25519_KEY
+
+    def test_key_in_existing_boot_args_is_not_duplicated(
+        self, smol_vm: SmolVMManager, sample_config: VMConfig
+    ) -> None:
+        info = self._vm_info(
+            smol_vm,
+            sample_config,
+            ssh_public_key=self._ED25519_KEY,
+            boot_args="console=ttyS0 smolvm.authorized_key_b64=PRESET",
+        )
+        args = smol_vm._resolve_boot_args(info)
+        tokens = [p for p in args.split() if p.startswith("smolvm.authorized_key_b64=")]
+        assert tokens == ["smolvm.authorized_key_b64=PRESET"]
+
+    def test_key_strip_whitespace_before_encoding(
+        self, smol_vm: SmolVMManager, sample_config: VMConfig
+    ) -> None:
+        """Trailing newlines from key files shouldn't end up in the encoded token."""
+        import base64
+
+        info = self._vm_info(smol_vm, sample_config, ssh_public_key=f"  {self._ED25519_KEY}\n\n")
+        args = smol_vm._resolve_boot_args(info)
+
+        token = next(p for p in args.split() if p.startswith("smolvm.authorized_key_b64="))
+        decoded = base64.b64decode(token.split("=", 1)[1]).decode("utf-8")
+        assert decoded == self._ED25519_KEY
+
+    def test_init_script_parses_authorized_key_cmdline(self) -> None:
+        """The /init script must contain the parser block — keep host + guest in sync."""
+        from smolvm.images.builder import ImageBuilder
+
+        script = ImageBuilder()._default_init_script()
+        assert "smolvm.authorized_key_b64=" in script
+        assert "base64 -d" in script
+        assert "/root/.ssh/authorized_keys" in script
+        # Parser must run BEFORE sshd starts, otherwise the new key isn't picked up.
+        authkey_at = script.find("ssh-authkey-inject-start")
+        sshd_at = script.find("sshd-start")
+        assert 0 <= authkey_at < sshd_at, "key install must precede sshd start"


### PR DESCRIPTION
## Summary

Adds the host→guest plumbing to deliver per-VM \`authorized_keys\` without baking them into the rootfs at build time. Required for published pre-built images (foundation in #228) where the same image is shared across users — every user supplies their own key at launch instead of needing a per-user rebuild.

**Mechanism: kernel cmdline.** Reuses the same channel \`/init\` already parses for IP config. Works for both Firecracker and QEMU without backend-specific code, no new drives/sockets/services, no new host dependencies, no schema changes for serialization.

### Host side ([vm.py](src/smolvm/vm.py))

\`_resolve_boot_args\` reads \`vm_info.config.ssh_public_key\` and appends \`smolvm.authorized_key_b64=<base64>\` when set. Base64 encoding makes the value a single space-free token — raw SSH keys contain spaces (\`ssh-ed25519 AAAA... user@host\`) that would otherwise split into separate cmdline params. Skipped if \`boot_args\` already contains the param so callers can override.

### Guest side ([builder.py \_base_init_script](src/smolvm/images/builder.py))

A new block between the host-key check and the sshd start parses \`/proc/cmdline\`, decodes the base64 value, and writes \`/root/.ssh/authorized_keys\` with mode 0600. Failed decode is logged but doesn't abort boot — the failure surfaces as \"no SSH access\" rather than \"guest panics,\" which is the right shape for a recoverable misconfiguration.

### Schema change

[\`VMConfig\`](src/smolvm/types.py) gets a new optional \`ssh_public_key: str | None = None\` field. Existing callers and serialization paths are unaffected.

## Why this design

The earlier alternatives I considered (recapped from the planning conversation):

| Mechanism | Why rejected |
|---|---|
| Cloud-init NoCloud ISO | Existing SmolVM images don't run cloud-init/systemd; would need custom-format ISO + reader. Heavyweight for one ~80-byte string. |
| Firecracker MMDS | Firecracker-only. macOS users on QEMU would need a fallback anyway. |
| 9p workspace mount | QEMU-only. Blocks snapshots. |
| vsock | Most generic, most code to write. Reach for it later when we need bidirectional or KB-sized data. |
| Plain cmdline (no encoding) | SSH keys contain spaces — breaks naive parsing. |

Cmdline + base64 is the simplest mechanism that works on both backends with the channel that's already there.

## Phase 2 (separate PR)

Remove the existing \`COPY authorized_keys\` baking from the four key-using builders (\`build_alpine_ssh_key\`, \`build_debian_ssh_key\`, \`build_browser_rootfs\`, \`build_openclaw_rootfs\`), since cmdline injection makes it redundant. Keeping baking in **this** PR means the two paths coexist — cmdline takes precedence on first boot since \`/init\` runs after the rootfs is mounted — minimizing disruption to the current local-build flow while the publishing path comes online.

## Related Issues

- Closes #
- Pairs with #229 (host keys at first boot) to complete the \"published images are safe to share\" story

## Testing

- \`uv run pytest tests/test_vm.py tests/test_types.py tests/test_images.py tests/test_build.py tests/test_published_images.py tests/test_runtime_qemu.py\` — 164 passed (5 new + 159 existing, no regressions)
- \`uv run ruff check ...\` — clean
- \`uv run ruff format --check ...\` — clean

New tests in \`TestResolveBootArgs\`:
- No key set → no cmdline injection
- Key set → base64-encoded token round-trips back to the original
- Pre-existing cmdline param wins (caller override)
- Whitespace stripped before encoding (handles trailing newlines from key files)
- Generated \`/init\` script contains the parser block, and the parser runs **before** sshd starts (otherwise the new key wouldn't be picked up on the same boot)

Not yet tested end-to-end with a real VM — that comes when phase 2 lands and the publishing path actually exercises the cmdline path.

## Checklist

- [x] Scope is focused and limited to this change
- [x] Tests added/updated for behavior changes
- [ ] Docs updated for user-visible changes (no user-visible behavior yet — field is optional and unset by default)
- [x] No secrets or sensitive data included

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * SSH public keys can now be automatically installed in VMs at boot time.

* **Tests**
  * Added test coverage for SSH key injection functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->