### PR TITLE
refactor(images): stop baking authorized_keys into rootfs

### DIFF
--- a/src/smolvm/browser.py
+++ b/src/smolvm/browser.py
@@ -152,6 +152,7 @@ def _build_browser_vm_config(
         retain_disk_on_delete=browser_config.profile_mode == "persistent",
         env_vars=browser_config.env_vars,
         port_forwards=port_forwards,
+        ssh_public_key=public_key.read_text().strip(),
     )
     return config, resolved_ssh_key_path
 

--- a/src/smolvm/facade.py
+++ b/src/smolvm/facade.py
@@ -316,9 +316,7 @@ def _resolve_auto_config_public_key(ssh_key_path: str | None) -> tuple[str, Path
     return ssh_key_path, public_key
 
 
-def _parse_mount_specs(
-    specs: list[str], *, writable: bool = False
-) -> list[WorkspaceMount]:
+def _parse_mount_specs(specs: list[str], *, writable: bool = False) -> list[WorkspaceMount]:
     """Parse ``HOST_PATH[:GUEST_PATH]`` strings into WorkspaceMount objects.
 
     If no guest path is given, the mount defaults to ``/workspace``
@@ -336,9 +334,7 @@ def _parse_mount_specs(
             host_str = spec
             guest_path = "/workspace" if len(specs) == 1 else f"/workspace-{index}"
         mounts.append(
-            WorkspaceMount(
-                host_path=Path(host_str), guest_path=guest_path, writable=writable
-            )
+            WorkspaceMount(host_path=Path(host_str), guest_path=guest_path, writable=writable)
         )
     return mounts
 
@@ -676,6 +672,7 @@ def _build_auto_config(
         rootfs_path=rootfs,
         boot_args=boot_args,
         backend=resolved_backend,
+        ssh_public_key=public_key_value,
     )
     logger.info(
         "Auto-configured VM: %s (os=%s, backend=%s)",
@@ -1069,11 +1066,7 @@ class SmolVM:
                 )
                 self._ssh_ready = True
             count = len(workspace_mounts)
-            notify(
-                "Mounting workspace..."
-                if count == 1
-                else f"Mounting {count} workspaces..."
-            )
+            notify("Mounting workspace..." if count == 1 else f"Mounting {count} workspaces...")
             self._mount_workspaces()
 
         return self
@@ -1266,9 +1259,7 @@ class SmolVM:
         """
         source = Path(local_path).expanduser()
         if not source.exists():
-            raise ValueError(
-                f"Local file not found: {source}. Check the path and try again."
-            )
+            raise ValueError(f"Local file not found: {source}. Check the path and try again.")
         if not source.is_file():
             raise ValueError(
                 f"Not a file: {source}. Pass a path to a single file, not a directory."
@@ -1289,9 +1280,7 @@ class SmolVM:
         if make_dirs:
             parent = _guest_parent_dir(destination)
             if parent:
-                result = ssh.run(
-                    f"mkdir -p -- {shlex.quote(parent)}", timeout=30, shell="raw"
-                )
+                result = ssh.run(f"mkdir -p -- {shlex.quote(parent)}", timeout=30, shell="raw")
                 if result.exit_code != 0:
                     stderr = result.stderr.strip()
                     raise SmolVMError(
@@ -2020,9 +2009,7 @@ class SmolVM:
 
         overlay_probe = " && modprobe overlay 2>/dev/null" if need_overlay else ""
         probe_script = (
-            "modprobe 9p 2>/dev/null && "
-            "modprobe 9pnet_virtio 2>/dev/null"
-            f"{overlay_probe}"
+            f"modprobe 9p 2>/dev/null && modprobe 9pnet_virtio 2>/dev/null{overlay_probe}"
         )
         probe = self._ssh.run(probe_script, timeout=15)
         if probe.exit_code == 0:

--- a/src/smolvm/images/builder.py
+++ b/src/smolvm/images/builder.py
@@ -323,19 +323,20 @@ RUN rm -f /etc/ssh/ssh_host_* && \
     sed -i 's/#PasswordAuthentication.*/PasswordAuthentication no/' /etc/ssh/sshd_config && \
     sed -i 's/#PubkeyAuthentication.*/PubkeyAuthentication yes/' /etc/ssh/sshd_config
 
-COPY authorized_keys /root/.ssh/authorized_keys
-RUN chmod 600 /root/.ssh/authorized_keys && chown -R root:root /root/.ssh
-
 COPY init /init
 RUN chmod +x /init
 """
 
+        # ssh_public_key is intentionally not in the fingerprint and not baked
+        # into the rootfs. Per-VM keys are injected via the kernel cmdline at
+        # boot (see VMConfig.ssh_public_key + /init parser), so two users with
+        # different keys can share one cached image.
+        _ = key_value
         fingerprint_data = self._fingerprint_with_content(
             {
                 "rootfs_size_mb": rootfs_size_mb,
                 "kernel_url": resolved_kernel_url,
                 "kernel_profile": kernel_profile.value,
-                "ssh_public_key": key_value,
             },
             dockerfile_content,
             init_script,
@@ -351,7 +352,7 @@ RUN chmod +x /init
             if not self.check_docker():
                 raise self.docker_requirement_error()
 
-            logger.info("SSH key or config changed for image '%s'. Rebuilding...", name)
+            logger.info("Inputs changed for image '%s'. Rebuilding...", name)
             # Remove stale files
             kernel_path.unlink(missing_ok=True)
             rootfs_path.unlink(missing_ok=True)
@@ -370,7 +371,6 @@ RUN chmod +x /init
                 kernel_path,
                 rootfs_path,
                 rootfs_size_mb,
-                extra_files={"authorized_keys": f"{key_value}\n"},
                 kernel_url=resolved_kernel_url,
                 fingerprint_data=fingerprint_data,
             )
@@ -438,19 +438,18 @@ RUN rm -f /etc/ssh/ssh_host_* && \\
     sed -ri 's/^#?PasswordAuthentication .*/PasswordAuthentication no/' /etc/ssh/sshd_config && \\
     sed -ri 's/^#?PubkeyAuthentication .*/PubkeyAuthentication yes/' /etc/ssh/sshd_config
 
-COPY authorized_keys /root/.ssh/authorized_keys
-RUN chmod 600 /root/.ssh/authorized_keys && chown -R root:root /root/.ssh
-
 COPY init /init
 RUN chmod +x /init
 """
 
+        # ssh_public_key is intentionally not in the fingerprint and not baked
+        # into the rootfs — see VMConfig.ssh_public_key + /init parser.
+        _ = key_value
         fingerprint_data = self._fingerprint_with_content(
             {
                 "rootfs_size_mb": rootfs_size_mb,
                 "kernel_url": resolved_kernel_url,
                 "kernel_profile": kernel_profile.value,
-                "ssh_public_key": key_value,
                 "base_image": base_image,
             },
             dockerfile_content,
@@ -486,7 +485,6 @@ RUN chmod +x /init
                 kernel_path,
                 rootfs_path,
                 rootfs_size_mb,
-                extra_files={"authorized_keys": f"{key_value}\n"},
                 kernel_url=resolved_kernel_url,
                 fingerprint_data=fingerprint_data,
             )
@@ -794,9 +792,6 @@ RUN rm -f /etc/ssh/ssh_host_* && \\
     sed -ri 's/^#?PasswordAuthentication .*/PasswordAuthentication no/' /etc/ssh/sshd_config && \\
     sed -ri 's/^#?PubkeyAuthentication .*/PubkeyAuthentication yes/' /etc/ssh/sshd_config
 
-COPY authorized_keys /root/.ssh/authorized_keys
-RUN chmod 600 /root/.ssh/authorized_keys && chown -R root:root /root/.ssh
-
 RUN mkdir -p \\
     /opt/smolvm-browser/profiles \\
     /opt/smolvm-browser/downloads \\
@@ -810,12 +805,14 @@ COPY init /init
 RUN chmod +x /init
 """
 
+        # ssh_public_key is intentionally not in the fingerprint and not baked
+        # into the rootfs — see VMConfig.ssh_public_key + /init parser.
+        _ = key_value
         fingerprint_data = self._fingerprint_with_content(
             {
                 "rootfs_size_mb": rootfs_size_mb,
                 "kernel_url": resolved_kernel_url,
                 "kernel_profile": kernel_profile.value,
-                "ssh_public_key": key_value,
                 "base_image": base_image,
                 "image_type": "browser-chromium-v3",
                 "_browser_session_sha256": hashlib.sha256(browser_session_sh.encode()).hexdigest(),
@@ -849,7 +846,6 @@ RUN chmod +x /init
                 rootfs_path,
                 rootfs_size_mb,
                 extra_files={
-                    "authorized_keys": f"{key_value}\n",
                     "smolvm-browser-session": browser_session_sh,
                     "smolvm-browser-wait-port": wait_port_py,
                 },
@@ -1021,10 +1017,6 @@ RUN rm -f /etc/ssh/ssh_host_* && \\
     sed -ri 's/^#?PasswordAuthentication .*/PasswordAuthentication yes/' /etc/ssh/sshd_config && \\
     echo "root:${{SSH_PASSWORD}}" | chpasswd
 
-# Inject authorized_keys if provided
-COPY authorized_keys /root/.ssh/authorized_keys
-RUN chmod 600 /root/.ssh/authorized_keys 2>/dev/null || true
-
 # Prepare OpenClaw directories and workspace
 RUN useradd -m -s /bin/bash node 2>/dev/null || true && \\
     mkdir -p /opt/openclaw /home/node/.openclaw/devices /workspace && \\
@@ -1051,12 +1043,14 @@ COPY init /init
 RUN chmod +x /init
 """
 
+        # ssh_public_key is intentionally not in the fingerprint and not baked
+        # into the rootfs — see VMConfig.ssh_public_key + /init parser.
+        _ = key_value
         fingerprint_data = self._fingerprint_with_content(
             {
                 "rootfs_size_mb": rootfs_size_mb,
                 "kernel_url": kernel_url,
                 "ssh_password": ssh_password,
-                "ssh_public_key": key_value,
                 "extra_packages": extra_packages,
                 "_device_approver_sha256": hashlib.sha256(device_approver_py.encode()).hexdigest(),
                 "_watch_devices_sha256": hashlib.sha256(watch_devices_sh.encode()).hexdigest(),
@@ -1093,7 +1087,6 @@ RUN chmod +x /init
                     "device-approver.py": device_approver_py,
                     "watch-devices.sh": watch_devices_sh,
                     "systemctl": systemctl_proxy_sh,
-                    "authorized_keys": f"{key_value}\n" if key_value else "",
                 },
                 build_args={"SSH_PASSWORD": ssh_password},
                 kernel_url=kernel_url,

--- a/tests/test_browser.py
+++ b/tests/test_browser.py
@@ -153,6 +153,43 @@ def test_build_browser_vm_config_allocates_qemu_live_port_forwards(
     assert mock_allocate_host_port.call_count == 2
 
 
+@patch("smolvm.utils.ensure_ssh_key")
+@patch("smolvm.images.builder.ImageBuilder")
+def test_build_browser_vm_config_passes_pubkey_to_vmconfig(
+    mock_builder_cls: MagicMock,
+    mock_ensure_ssh_key: MagicMock,
+    tmp_path: Path,
+) -> None:
+    """Browser VMConfig must carry the user's pubkey so /init injects it at boot.
+
+    Browser images no longer bake authorized_keys at build time
+    (see src/smolvm/images/builder.py build_browser_rootfs); the key is
+    delivered via the kernel cmdline, which only fires when ssh_public_key
+    is set on VMConfig.
+    """
+    kernel = tmp_path / "kernel"
+    rootfs = tmp_path / "rootfs.ext4"
+    private_key = tmp_path / "id_ed25519"
+    public_key = tmp_path / "id_ed25519.pub"
+    kernel.touch()
+    rootfs.touch()
+    private_key.touch()
+    pubkey_value = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIMockKey user@test"
+    public_key.write_text(f"{pubkey_value}\n")
+
+    mock_ensure_ssh_key.return_value = (private_key, public_key)
+    mock_builder = MagicMock()
+    mock_builder.build_browser_rootfs.return_value = (kernel, rootfs)
+    mock_builder_cls.return_value = mock_builder
+
+    vm_config, _ = _build_browser_vm_config(
+        session_id="browser-key-test",
+        browser_config=BrowserSessionConfig(session_id="browser-key-test"),
+    )
+
+    assert vm_config.ssh_public_key == pubkey_value
+
+
 @patch("smolvm.browser.SmolVM")
 @patch("smolvm.browser._build_browser_vm_config")
 def test_browser_session_start_persists_ready_state(

--- a/tests/test_facade.py
+++ b/tests/test_facade.py
@@ -182,6 +182,48 @@ class TestVMInit:
     @patch("smolvm.facade.SmolVMManager")
     @patch("smolvm.images.builder.ImageBuilder")
     @patch("smolvm.utils.ensure_ssh_key")
+    @patch("smolvm.runtime.backends.platform.system", return_value="Linux")
+    def test_autoconfigure_passes_pubkey_to_vmconfig(
+        self,
+        _: MagicMock,
+        mock_ensure_ssh_key: MagicMock,
+        mock_builder_cls: MagicMock,
+        mock_sdk_cls: MagicMock,
+        tmp_path: Path,
+    ) -> None:
+        """Auto-config VMConfig must carry the user's pubkey for /init to inject at boot.
+
+        Alpine/Debian SSH-key images no longer bake authorized_keys at build
+        time (see src/smolvm/images/builder.py); the key is delivered via the
+        kernel cmdline, which only fires when ssh_public_key is set.
+        """
+        kernel = tmp_path / "auto-kernel"
+        rootfs = tmp_path / "auto-rootfs.ext4"
+        private_key = tmp_path / "id_ed25519"
+        public_key = tmp_path / "id_ed25519.pub"
+        kernel.touch()
+        rootfs.touch()
+        private_key.touch()
+        pubkey_value = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIMockKey user@test"
+        public_key.write_text(f"{pubkey_value}\n")
+
+        mock_ensure_ssh_key.return_value = (private_key, public_key)
+        mock_builder = MagicMock()
+        mock_builder.build_alpine_ssh_key.return_value = (kernel, rootfs)
+        mock_builder_cls.return_value = mock_builder
+
+        mock_sdk = MagicMock()
+        mock_sdk.create.return_value = MagicMock(vm_id="vm001", status=VMState.CREATED)
+        mock_sdk_cls.return_value = mock_sdk
+
+        SmolVM()
+
+        created_config = mock_sdk.create.call_args[0][0]
+        assert created_config.ssh_public_key == pubkey_value
+
+    @patch("smolvm.facade.SmolVMManager")
+    @patch("smolvm.images.builder.ImageBuilder")
+    @patch("smolvm.utils.ensure_ssh_key")
     def test_autoconfigure_with_debian_firecracker_uses_debian_builder(
         self,
         mock_ensure_ssh_key: MagicMock,


### PR DESCRIPTION
## Summary

Phase 2 follow-up to #231 — completes the move from build-time key baking to first-boot cmdline injection. The two changes are coupled and have to ship together: removing the bake without wiring \`ssh_public_key\` on VMConfig would break SSH for local users; wiring without removing the bake is a no-op (cmdline overwrites the same baked key).

### Builder side (4 methods that previously baked keys)

[\`build_alpine_ssh_key\`](src/smolvm/images/builder.py), [\`build_debian_ssh_key\`](src/smolvm/images/builder.py), [\`build_browser_rootfs\`](src/smolvm/images/builder.py), [\`build_openclaw_rootfs\`](src/smolvm/images/builder.py): drop the \`COPY authorized_keys /root/.ssh/...\` from each Dockerfile, drop the corresponding entry from the \`extra_files\` dict passed to \`_do_build\`, and drop \`ssh_public_key\` from the fingerprint inputs. The \`key_value\` variable is preserved (computed for input validation) but no longer used for baking — flagged inline with \`_ = key_value\` plus a comment so future readers know it's intentional.

The fingerprint change is a real efficiency win: two users with different keys can now share a single cached image, since the image content is key-independent.

### VMConfig wiring (2 sites that consume those builders)

- [\`facade.py:_build_auto_config\`](src/smolvm/facade.py): pass \`ssh_public_key=public_key_value\` when constructing VMConfig
- [\`browser.py:_build_browser_vm_config\`](src/smolvm/browser.py): same, reading from \`public_key.read_text().strip()\`

Both sites already have the pubkey in scope — they were passing it to the builder for baking. Now they pass it to VMConfig instead, which the existing \`/init\` parser (#231) reads from the kernel cmdline at boot.

### Sites NOT affected

Other VMConfig construction sites in facade.py (S3 image, Ubuntu cloud QEMU, Debian firmware) use cloud-init seed ISOs for SSH key injection and are unaffected.

## End-to-end behavior

**Local users (unchanged in practice):** Used to get a baked key from the build; now get the same key injected at boot via \`/init\` reading the cmdline. Functional outcome identical.

**Cache shape:** Now key-independent. Same image hash regardless of which user's key is in play.

**Publishing path (the whole point):** Published images can now be shipped without anyone's key in them. Each user's key arrives via the cmdline at their own VM's boot. Foundation for #228's manifest path becoming actually useful.

## Related Issues

- Closes #
- Phase 2 of #231 (the deferred half: wire + remove the bake)

## Testing

- \`uv run pytest tests/test_images.py tests/test_build.py tests/test_published_images.py tests/test_facade.py tests/test_browser.py tests/test_vm.py\` — 209 passed, 8 skipped (2 new + existing, no regressions)
- \`uv run ruff check ...\` — clean (modulo two pre-existing E501s in cli/main.py, untouched here)
- \`uv run ruff format --check ...\` — clean

New tests:
- \`test_facade.py::TestSmolVMSDK::test_autoconfigure_passes_pubkey_to_vmconfig\` — auto-config wiring
- \`test_browser.py::test_build_browser_vm_config_passes_pubkey_to_vmconfig\` — browser wiring

Both assert that \`VMConfig.ssh_public_key\` carries the launching user's pubkey, which is what the cmdline injection code from #231 needs to fire.

Note: the diff in \`facade.py\` includes a few unrelated formatter normalizations (multi-line → single-line collapses) — ruff format touched the file when I edited it. Style only, no behavior change.

## Checklist

- [x] Scope is focused and limited to this change
- [x] Tests added/updated for behavior changes
- [ ] Docs updated for user-visible changes (no user-visible behavior change — internal mechanism swap)
- [x] No secrets or sensitive data included