### PR TITLE
ci: add proof-of-pipeline workflow for building published images

### DIFF
--- a/.github/workflows/build-published-images.yml
+++ b/.github/workflows/build-published-images.yml
@@ -1,0 +1,114 @@
+# Build a SmolVM preset image in CI and upload it as a GitHub Actions artifact.
+#
+# This is the proof-of-pipeline workflow — it validates that ImageBuilder can
+# run inside a GH Actions runner end-to-end (Docker available, ext4 build via
+# the docker fallback path since the loopfs helper isn't installed, no privileges
+# beyond what ubuntu-latest grants by default). Future PRs add: matrix expansion
+# (preset × arch), GH Releases upload (instead of artifacts), cosign keyless
+# signing, and an auto-generated PR that populates the bundled MANIFEST.
+#
+# Manual trigger only for now. Artifacts expire after 7 days so we don't burn
+# storage on experiments.
+
+name: Build Published Images
+
+on:
+  workflow_dispatch:
+    inputs:
+      preset:
+        description: "Preset to build"
+        type: choice
+        default: openclaw
+        options:
+          - openclaw
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+
+      - name: Set up Python 3.13
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.13"
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Cache Rust build
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: rust-${{ runner.os }}-${{ hashFiles('Cargo.toml', 'smolvm-core/Cargo.toml') }}
+          restore-keys: rust-${{ runner.os }}-
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@caf0cab7a618c569241d31dcd442f54681755d39 # v3.2.4
+
+      - name: Install dependencies
+        run: uv sync --extra dev
+
+      - name: Confirm Docker is available
+        run: |
+          docker --version
+          docker info >/dev/null
+
+      - name: Build image
+        id: build
+        env:
+          PRESET: ${{ inputs.preset }}
+        run: |
+          # Calls the existing builder method directly. No SSH key is provided —
+          # published images don't bake authorized_keys (see PR #232); the user's
+          # key is injected at boot via the kernel cmdline.
+          uv run python <<'PY'
+          import os
+          import sys
+          from pathlib import Path
+          from smolvm.images.builder import ImageBuilder
+
+          preset = os.environ["PRESET"]
+          builder = ImageBuilder()
+          if preset == "openclaw":
+              kernel, rootfs = builder.build_openclaw_rootfs(name=f"{preset}-amd64")
+          else:
+              sys.exit(f"unknown preset: {preset}")
+
+          # Emit the artifact paths so the next step can find them.
+          out = Path(os.environ["GITHUB_OUTPUT"])
+          out.write_text(
+              f"kernel_path={kernel}\nrootfs_path={rootfs}\n",
+              encoding="utf-8",
+          )
+          print(f"kernel: {kernel} ({kernel.stat().st_size:,} bytes)")
+          print(f"rootfs: {rootfs} ({rootfs.stat().st_size:,} bytes)")
+          PY
+
+      - name: Compress rootfs
+        run: |
+          # zstd is preinstalled on ubuntu-latest. Compresses the sparse ext4
+          # to ~30-50% of its used size, which matters once we ship via Releases.
+          zstd -19 -T0 --rm -o rootfs.ext4.zst "${{ steps.build.outputs.rootfs_path }}"
+          ls -lh rootfs.ext4.zst "${{ steps.build.outputs.kernel_path }}"
+
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ inputs.preset }}-amd64
+          path: |
+            ${{ steps.build.outputs.kernel_path }}
+            rootfs.ext4.zst
+          retention-days: 7
+          if-no-files-found: error


### PR DESCRIPTION
## Summary

First step toward the published-image pipeline. A manual-trigger GitHub Actions workflow that invokes [\`ImageBuilder.build_openclaw_rootfs\`](src/smolvm/images/builder.py) end-to-end inside a runner, compresses the result with zstd, and uploads kernel+rootfs as a GH Actions artifact.

**This PR ships nothing to users.** It validates the build works in CI. Releases, signing, and manifest population come in follow-up PRs.

### Scope (deliberately minimal)

| Concern | This PR | Future PR |
|---|---|---|
| Trigger | Manual (\`workflow_dispatch\`) | Tag-driven (\`images-v*\`) |
| Presets | openclaw only | All four |
| Arches | amd64 only | amd64 + arm64 matrix |
| Destination | GH Actions artifact (7-day retention) | GH Releases |
| Signing | None | Cosign keyless |
| Manifest update | None | Auto-PR populating \`MANIFEST\` |

### Why this minimal scope

The single biggest unknown is **whether \`ImageBuilder\` can actually run under GH Actions.** It needs Docker (available on \`ubuntu-latest\`) but the loopfs helper isn't installed (\`smolvm setup\` hasn't run), so the ext4 build will exercise the docker fallback path (\`_create_ext4_with_docker\`) instead of the loopfs path. That code path exists but isn't routinely exercised in CI; running it once tells us whether it works in this environment before we commit to the full publishing infrastructure.

If something breaks — privileges, Docker socket, build timeout, ext4 size on tmpfs — surfaces here cheaply with no impact on real users. If it succeeds, we expand.

### Notable choices

- **No SSH key passed to the builder.** Published images no longer bake \`authorized_keys\` ([#232](https://github.com/CelestoAI/SmolVM/pull/232)); the launching user's key arrives via the kernel cmdline at boot ([#231](https://github.com/CelestoAI/SmolVM/pull/231)). The build runs key-less and that's correct.
- **Compression with zstd at -19.** Slow but maximizes ratio; worth it for distribution. \`ubuntu-latest\` ships \`zstd\` preinstalled.
- **\`if-no-files-found: error\`** on the upload step. If anything in the chain produces nothing, we fail loudly rather than silently uploading an empty artifact.
- **Mirrors conventions from [pytest.yml](.github/workflows/pytest.yml)** — \`uv\`, Python 3.13, Rust toolchain + cache. Same setup steps so the runner profile matches.

### Known smell to address in a follow-up

OpenClaw builds with \`ssh_password='smolvm'\` by default. For a published image, every user would inherit that password. The cmdline-injected pubkey makes password auth redundant. A follow-up PR should disable password auth for the publishing path (\`PasswordAuthentication no\` + \`PermitRootLogin prohibit-password\`). Out of scope here.

## Related Issues

- Closes #
- Foundation work: [#228](https://github.com/CelestoAI/SmolVM/pull/228) (manifest), [#229](https://github.com/CelestoAI/SmolVM/pull/229), [#230](https://github.com/CelestoAI/SmolVM/pull/230), [#231](https://github.com/CelestoAI/SmolVM/pull/231), [#232](https://github.com/CelestoAI/SmolVM/pull/232)

## Testing

- YAML parses (\`python -c "import yaml; yaml.safe_load(...)"\`).
- **Cannot test the workflow itself without merging** — that's why this is a draft. Plan: merge → trigger manually via the Actions tab → watch what happens → iterate.

Expected first-run failure modes (in rough probability order):
1. ext4 build fails because the docker fallback path needs privileges we don't have.
2. Build succeeds but artifact is too large (openclaw rootfs ~2 GB; GH Actions allows 5 GB so should be fine).
3. \`uv sync --extra dev\` doesn't install something the builder needs at runtime.
4. The image build is slow enough that the 30-minute timeout fires.

If we hit (1), we either install the loopfs helper in the runner or accept that the docker fallback is the published-image build path.

## Checklist

- [x] Scope is focused and limited to this change
- [ ] Tests added/updated — no test file applies; the workflow itself is the test
- [ ] Docs updated — no user-visible behavior yet
- [x] No secrets or sensitive data included