### PR TITLE
ci: arch matrix + upload to draft GitHub Release

### DIFF
--- a/.github/workflows/build-published-images.yml
+++ b/.github/workflows/build-published-images.yml
@@ -1,14 +1,24 @@
-# Build a SmolVM preset image in CI and upload it as a GitHub Actions artifact.
+# Build SmolVM preset images and upload them to a draft GitHub Release.
 #
-# This is the proof-of-pipeline workflow — it validates that ImageBuilder can
-# run inside a GH Actions runner end-to-end (Docker available, ext4 build via
-# the docker fallback path since the loopfs helper isn't installed, no privileges
-# beyond what ubuntu-latest grants by default). Future PRs add: matrix expansion
-# (preset × arch), GH Releases upload (instead of artifacts), cosign keyless
-# signing, and an auto-generated PR that populates the bundled MANIFEST.
+# Matrix: arch ∈ {amd64, arm64}. Each cell builds the same preset for its arch
+# on a runner of the matching architecture, compresses the rootfs with zstd,
+# computes SHA-256, and uploads to a draft release tagged with the CLI version
+# (lock-step with the bundled MANIFEST in src/smolvm/images/published.py).
 #
-# Manual trigger only for now. Artifacts expire after 7 days so we don't burn
-# storage on experiments.
+# The release stays in DRAFT until a human reviews and publishes it. Drafts
+# are invisible to the public and freely deletable, so re-runs and experiments
+# are safe.
+#
+# Currently only the openclaw preset is wired — it's the only preset with a
+# dedicated bake builder (build_openclaw_rootfs). Codex/Claude Code/Hermes use
+# the runtime-install pattern (setup_script + install_script defined in
+# src/smolvm/presets/) and would need their own bake builders before they can
+# be added to this matrix.
+#
+# Manual trigger only for now. Future PRs add: cosign keyless signing of each
+# uploaded asset, an auto-generated PR that populates MANIFEST in published.py
+# with the new (URL, SHA, size) tuples, and possibly a tag-driven trigger so
+# CLI releases auto-build their image set.
 
 name: Build Published Images
 
@@ -21,13 +31,23 @@ on:
         default: openclaw
         options:
           - openclaw
+      release_tag:
+        description: >-
+          Release tag (e.g. images-v0.0.13). Created as draft if missing.
+          Leave empty to derive from the project version in pyproject.toml.
+        type: string
+        default: ""
 
 permissions:
-  contents: read
+  contents: write  # required to create/upload to GitHub Releases
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        arch: [amd64, arm64]
+    runs-on: ${{ matrix.arch == 'arm64' && 'ubuntu-24.04-arm' || 'ubuntu-latest' }}
     timeout-minutes: 30
 
     steps:
@@ -51,8 +71,8 @@ jobs:
             ~/.cargo/registry
             ~/.cargo/git
             target
-          key: rust-${{ runner.os }}-${{ hashFiles('Cargo.toml', 'smolvm-core/Cargo.toml') }}
-          restore-keys: rust-${{ runner.os }}-
+          key: rust-${{ runner.os }}-${{ matrix.arch }}-${{ hashFiles('Cargo.toml', 'smolvm-core/Cargo.toml') }}
+          restore-keys: rust-${{ runner.os }}-${{ matrix.arch }}-
 
       - name: Install uv
         uses: astral-sh/setup-uv@caf0cab7a618c569241d31dcd442f54681755d39 # v3.2.4
@@ -65,10 +85,25 @@ jobs:
           docker --version
           docker info >/dev/null
 
+      - name: Resolve release tag
+        id: release
+        env:
+          INPUT_TAG: ${{ inputs.release_tag }}
+        run: |
+          if [ -n "$INPUT_TAG" ]; then
+            tag="$INPUT_TAG"
+          else
+            version=$(uv run python -c "import tomllib; print(tomllib.loads(open('pyproject.toml','rb').read())['project']['version'])")
+            tag="images-v${version}"
+          fi
+          echo "tag=${tag}" >> "$GITHUB_OUTPUT"
+          echo "Release tag: ${tag}"
+
       - name: Build image
         id: build
         env:
           PRESET: ${{ inputs.preset }}
+          ARCH: ${{ matrix.arch }}
         run: |
           # Calls the existing builder method directly. No SSH key is provided —
           # published images don't bake authorized_keys (see PR #232); the user's
@@ -80,44 +115,104 @@ jobs:
           from smolvm.images.builder import ImageBuilder
 
           preset = os.environ["PRESET"]
+          arch = os.environ["ARCH"]
+          name = f"{preset}-{arch}"
+
           builder = ImageBuilder()
           if preset == "openclaw":
-              # Default rootfs_size_mb=2048 doesn't fit the openclaw image
-              # content today (Node 22 + npm globals + apt deps overflow).
-              # 4096 MiB gives comfortable headroom; the published artifact
-              # is sparse and zstd-compresses well, so the wire size is
-              # unaffected. Default in build_openclaw_rootfs should
-              # probably be bumped too — tracked separately.
+              # Default rootfs_size_mb=2048 doesn't fit current openclaw content
+              # (Node 22 + npm globals + apt deps overflow). 4 GiB gives
+              # headroom — the resulting file is sparse and zstd-compresses to
+              # roughly its used size, so wire size impact is minimal. Builder
+              # default should probably be bumped too — tracked in #234/#236.
               kernel, rootfs = builder.build_openclaw_rootfs(
-                  name=f"{preset}-amd64",
+                  name=name,
                   rootfs_size_mb=4096,
               )
           else:
               sys.exit(f"unknown preset: {preset}")
 
-          # Emit the artifact paths so the next step can find them.
-          out = Path(os.environ["GITHUB_OUTPUT"])
-          out.write_text(
-              f"kernel_path={kernel}\nrootfs_path={rootfs}\n",
-              encoding="utf-8",
-          )
+          # Append (don't overwrite) GITHUB_OUTPUT in case any prior step wrote to it.
+          with Path(os.environ["GITHUB_OUTPUT"]).open("a", encoding="utf-8") as fh:
+              fh.write(f"kernel_path={kernel}\n")
+              fh.write(f"rootfs_path={rootfs}\n")
+              fh.write(f"name={name}\n")
           print(f"kernel: {kernel} ({kernel.stat().st_size:,} bytes)")
           print(f"rootfs: {rootfs} ({rootfs.stat().st_size:,} bytes)")
           PY
 
-      - name: Compress rootfs
+      - name: Stage release assets
+        id: stage
+        env:
+          NAME: ${{ steps.build.outputs.name }}
+          KERNEL_PATH: ${{ steps.build.outputs.kernel_path }}
+          ROOTFS_PATH: ${{ steps.build.outputs.rootfs_path }}
         run: |
-          # zstd is preinstalled on ubuntu-latest. Compresses the sparse ext4
-          # to ~30-50% of its used size, which matters once we ship via Releases.
-          zstd -19 -T0 --rm -o rootfs.ext4.zst "${{ steps.build.outputs.rootfs_path }}"
-          ls -lh rootfs.ext4.zst "${{ steps.build.outputs.kernel_path }}"
+          # zstd is preinstalled on the GH-hosted runners. -19 maxes ratio.
+          # Already-compressed payloads (Node binaries, packed JS) limit the
+          # ratio in practice; openclaw lands ~62% of the source on disk.
+          zstd -19 -T0 --rm -o "${NAME}-rootfs.ext4.zst" "$ROOTFS_PATH"
+          cp "$KERNEL_PATH" "${NAME}-vmlinux.bin"
+          ls -lh "${NAME}-rootfs.ext4.zst" "${NAME}-vmlinux.bin"
 
-      - name: Upload artifacts
-        uses: actions/upload-artifact@v4
-        with:
-          name: ${{ inputs.preset }}-amd64
-          path: |
-            ${{ steps.build.outputs.kernel_path }}
-            rootfs.ext4.zst
-          retention-days: 7
-          if-no-files-found: error
+      - name: Compute SHA-256
+        id: sha
+        env:
+          NAME: ${{ steps.build.outputs.name }}
+        run: |
+          rootfs_sha=$(sha256sum "${NAME}-rootfs.ext4.zst" | cut -d' ' -f1)
+          kernel_sha=$(sha256sum "${NAME}-vmlinux.bin" | cut -d' ' -f1)
+          rootfs_size=$(stat -c '%s' "${NAME}-rootfs.ext4.zst")
+          kernel_size=$(stat -c '%s' "${NAME}-vmlinux.bin")
+          {
+            echo "rootfs_sha=${rootfs_sha}"
+            echo "kernel_sha=${kernel_sha}"
+            echo "rootfs_size=${rootfs_size}"
+            echo "kernel_size=${kernel_size}"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Upload to GitHub Releases (draft)
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG: ${{ steps.release.outputs.tag }}
+          NAME: ${{ steps.build.outputs.name }}
+        run: |
+          # Idempotent draft create. The matrix may race two cells trying to
+          # create the same draft; the second create fails with "already exists"
+          # which we swallow. Subsequent uploads proceed normally.
+          if ! gh release view "$TAG" --repo "$GITHUB_REPOSITORY" >/dev/null 2>&1; then
+            gh release create "$TAG" \
+              --repo "$GITHUB_REPOSITORY" \
+              --draft \
+              --title "Published images $TAG" \
+              --notes "Auto-generated draft release for SmolVM published images. Verify SHA-256 sums and content before publishing." \
+              || echo "Draft already exists (race with another matrix cell), continuing."
+          fi
+
+          # --clobber overwrites any prior asset with the same name, so re-runs
+          # of the workflow for the same tag replace existing artifacts cleanly.
+          gh release upload "$TAG" \
+            --repo "$GITHUB_REPOSITORY" \
+            --clobber \
+            "${NAME}-rootfs.ext4.zst" \
+            "${NAME}-vmlinux.bin"
+
+      - name: Step summary
+        env:
+          NAME: ${{ steps.build.outputs.name }}
+          TAG: ${{ steps.release.outputs.tag }}
+          ROOTFS_SHA: ${{ steps.sha.outputs.rootfs_sha }}
+          KERNEL_SHA: ${{ steps.sha.outputs.kernel_sha }}
+          ROOTFS_SIZE: ${{ steps.sha.outputs.rootfs_size }}
+          KERNEL_SIZE: ${{ steps.sha.outputs.kernel_size }}
+        run: |
+          {
+            echo "## Build summary: \`${NAME}\`"
+            echo ""
+            echo "Uploaded to draft release [\`${TAG}\`](https://github.com/${GITHUB_REPOSITORY}/releases/tag/${TAG})."
+            echo ""
+            echo "| File | Size | SHA-256 |"
+            echo "| --- | --- | --- |"
+            echo "| ${NAME}-vmlinux.bin | $(numfmt --to=iec-i --suffix=B ${KERNEL_SIZE}) | \`${KERNEL_SHA}\` |"
+            echo "| ${NAME}-rootfs.ext4.zst | $(numfmt --to=iec-i --suffix=B ${ROOTFS_SIZE}) | \`${ROOTFS_SHA}\` |"
+          } >> "$GITHUB_STEP_SUMMARY"


### PR DESCRIPTION
## Summary

PR B in the publishing pipeline rollout (after [#233](https://github.com/CelestoAI/SmolVM/pull/233) proof-of-pipeline and [#235](https://github.com/CelestoAI/SmolVM/pull/235) size bump). Two changes to the existing workflow:

### 1. arch matrix

| Cell | Runner |
|---|---|
| amd64 | \`ubuntu-latest\` |
| arm64 | \`ubuntu-24.04-arm\` (GH-provided arm64, free for public repos) |

\`fail-fast: false\` so an arm64 issue doesn't kill the amd64 build (or vice versa). Cache key gains the arch dimension so the cells don't fight over the Rust target dir.

### 2. Destination: draft GitHub Release (not Actions artifacts)

Tagged from the project version in \`pyproject.toml\` (\`images-vX.Y.Z\`), or from the workflow input if provided. **Stays in DRAFT until a human reviews and publishes** — drafts are invisible to the public and freely deletable, so re-runs are safe.

Per-cell upload format: \`<preset>-<arch>-vmlinux.bin\` and \`<preset>-<arch>-rootfs.ext4.zst\`. Each cell also computes SHA-256 sums and emits a step summary so the run page shows file sizes + hashes without needing to download anything.

\`--clobber\` on upload makes re-runs idempotent (re-running the workflow against the same tag replaces existing assets cleanly).

### Race handling

Matrix cells may try to create the same draft simultaneously. The \`gh release view\` check first + create-or-skip-on-conflict handles that benignly: whichever cell wins the create-race writes the draft; the other one logs "already exists" and proceeds with upload.

## Scope: still openclaw only

Codex/Claude Code/Hermes presets use the runtime-install pattern (\`setup_script\` + \`install_script\` in [\`src/smolvm/presets/\`](src/smolvm/presets/)) and have **no bake builder**, so they can't go through this pipeline yet. Adding them is its own multi-PR effort starting with \`build_codex_rootfs\`, \`build_claude_code_rootfs\`, \`build_hermes_rootfs\`. The workflow input is a \`choice\` restricted to \`openclaw\` to make this impossible to misuse.

## Permissions change

Bumped \`contents\` permission from \`read\` → \`write\` since we now create/upload to Releases. Uses the default \`GITHUB_TOKEN\`; no separate secret needed.

## Related Issues

- Closes #
- Builds on: [#233](https://github.com/CelestoAI/SmolVM/pull/233), [#235](https://github.com/CelestoAI/SmolVM/pull/235)

## Plan after merge

Trigger manually via Actions tab. Expected result: a draft release at \`images-v0.0.13\` (current pyproject version) with four assets:

- \`openclaw-amd64-vmlinux.bin\` (~16 MB)
- \`openclaw-amd64-rootfs.ext4.zst\` (~870 MB based on PR #235's measurement)
- \`openclaw-arm64-vmlinux.bin\` (similar)
- \`openclaw-arm64-rootfs.ext4.zst\` (similar)

Total release size ~1.7 GB. Stays as a draft. We can delete it after verifying.

If arm64 fails — most likely cause: a Docker image variant unavailable, or build time exceeding 30-min timeout on slower arm64 runners. We adjust from there.

## Future PRs

- **PR C** — cosign keyless signing of each uploaded asset
- **PR D** — auto-PR populating \`MANIFEST\` in [published.py](src/smolvm/images/published.py) with the new (URL, SHA, size) tuples after a release is published

## Testing

- YAML parses (\`python -c "import yaml; yaml.safe_load(...)"\`).
- Cannot pre-test the workflow change without merging — that's why this is a draft. Plan: merge → trigger manually → watch what happens → iterate.

## Checklist

- [x] Scope is focused and limited to this change
- [ ] Tests added/updated — workflow IS the test
- [ ] Docs updated — no user-visible behavior yet (the draft release is invisible until published)
- [x] No secrets or sensitive data included

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Pre-built preset images now available for multiple processor architectures (amd64 and arm64) as published release assets.
  * Images are compressed for optimized download size.
  * SHA-256 checksums and file sizes provided for integrity verification.
  * Workflow now supports manual release tag specification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->