### PR TITLE
ci: fix tomllib.loads() bytes/str confusion in workflow

### DIFF
--- a/.github/workflows/build-published-images.yml
+++ b/.github/workflows/build-published-images.yml
@@ -93,7 +93,9 @@ jobs:
           if [ -n "$INPUT_TAG" ]; then
             tag="$INPUT_TAG"
           else
-            version=$(uv run python -c "import tomllib; print(tomllib.loads(open('pyproject.toml','rb').read())['project']['version'])")
+            # tomllib.load() takes a binary file; tomllib.loads() takes a str
+            # (NOT bytes). The file-handle form is the simpler one to get right.
+            version=$(uv run python -c "import tomllib; print(tomllib.load(open('pyproject.toml','rb'))['project']['version'])")
             tag="images-v${version}"
           fi
           echo "tag=${tag}" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
## Summary

The matrix workflow from [#237](https://github.com/CelestoAI/SmolVM/pull/237) fails immediately at "Resolve release tag" with:

\`\`\`
TypeError: a bytes-like object is required, not 'str'
\`\`\`

[Failed run.](https://github.com/CelestoAI/SmolVM/actions/runs/25293381489) Both arch cells fail identically — this is pure Python, not arch-specific.

The bug: I used \`tomllib.loads(open(..., 'rb').read())\`, which passes **bytes** to a function that requires **str**. The two correct call shapes are:

| Function | Input |
|---|---|
| \`tomllib.load(fp)\` | binary file object |
| \`tomllib.loads(s)\` | \`str\` (NOT bytes) |

This PR switches to \`tomllib.load(open('pyproject.toml','rb'))\` — the simpler one to get right.

Verified locally:

\`\`\`bash
$ uv run python -c "import tomllib; print(tomllib.load(open('pyproject.toml','rb'))['project']['version'])"
0.0.13
\`\`\`

## Honest postmortem

Should have caught this before merging #237. The one-liner is short enough I could have run it locally before committing. I'll start running these inline-Python steps locally before pushing workflow changes.

## Plan after merge

Re-trigger the workflow. Expect the same successful build path as #235's last run, but now with both arch cells running in parallel and uploading to a draft GitHub Release at \`images-v0.0.13\`.

## Checklist

- [x] Scope is focused and limited to this change
- [x] Tested locally before pushing this time
- [x] No secrets or sensitive data included