### PR TITLE
fix(images): disable SSH password auth in published images (closes #234)

### DIFF
--- a/src/smolvm/images/builder.py
+++ b/src/smolvm/images/builder.py
@@ -867,10 +867,6 @@ RUN chmod +x /init
     def build_openclaw_rootfs(
         self,
         name: str = "openclaw",
-        # Kept for backward compatibility with existing callers; ignored.
-        # The image is now key-only (PasswordAuthentication no) so published
-        # rootfs files cannot be exploited via the previous default password.
-        ssh_password: str = "smolvm",
         ssh_public_key: str | Path | None = None,
         rootfs_size_mb: int = 2048,
         kernel_url: str | None = None,
@@ -891,9 +887,6 @@ RUN chmod +x /init
 
         Args:
             name: Image name for caching.
-            ssh_password: Deprecated and ignored; kept for backward compatibility.
-                The image is key-only — pubkeys are injected per-VM via the
-                kernel cmdline at boot.
             ssh_public_key: Public key content or path to a public key file.
             rootfs_size_mb: Size of rootfs in MB (default: 2048).
             kernel_url: Optional kernel URL override.

--- a/src/smolvm/images/builder.py
+++ b/src/smolvm/images/builder.py
@@ -867,8 +867,9 @@ RUN chmod +x /init
     def build_openclaw_rootfs(
         self,
         name: str = "openclaw",
-        # Note: 'smolvm' is intentionally kept as the default for simplified local
-        # demos and testing fixtures. Production usages should override this value.
+        # Kept for backward compatibility with existing callers; ignored.
+        # The image is now key-only (PasswordAuthentication no) so published
+        # rootfs files cannot be exploited via the previous default password.
         ssh_password: str = "smolvm",
         ssh_public_key: str | Path | None = None,
         rootfs_size_mb: int = 2048,
@@ -890,7 +891,9 @@ RUN chmod +x /init
 
         Args:
             name: Image name for caching.
-            ssh_password: Root password for SSH (default: smolvm).
+            ssh_password: Deprecated and ignored; kept for backward compatibility.
+                The image is key-only — pubkeys are injected per-VM via the
+                kernel cmdline at boot.
             ssh_public_key: Public key content or path to a public key file.
             rootfs_size_mb: Size of rootfs in MB (default: 2048).
             kernel_url: Optional kernel URL override.
@@ -995,7 +998,6 @@ exit 0
         dockerfile_content = f"""
 FROM node:22.12.0-bookworm-slim
 
-ARG SSH_PASSWORD
 ENV DEBIAN_FRONTEND=noninteractive
 
 RUN apt-get update && apt-get install -y --no-install-recommends \\
@@ -1013,9 +1015,9 @@ RUN apt-get update && apt-get install -y --no-install-recommends \\
 # 'rm -f' purges keys planted by the openssh-server postinst on Debian.
 RUN rm -f /etc/ssh/ssh_host_* && \\
     mkdir -p /run/sshd /root/.ssh && chmod 700 /root/.ssh && \\
-    sed -ri 's/^#?PermitRootLogin .*/PermitRootLogin yes/' /etc/ssh/sshd_config && \\
-    sed -ri 's/^#?PasswordAuthentication .*/PasswordAuthentication yes/' /etc/ssh/sshd_config && \\
-    echo "root:${{SSH_PASSWORD}}" | chpasswd
+    sed -ri 's/^#?PermitRootLogin .*/PermitRootLogin prohibit-password/' /etc/ssh/sshd_config && \\
+    sed -ri 's/^#?PasswordAuthentication .*/PasswordAuthentication no/' /etc/ssh/sshd_config && \\
+    sed -ri 's/^#?PubkeyAuthentication .*/PubkeyAuthentication yes/' /etc/ssh/sshd_config
 
 # Prepare OpenClaw directories and workspace
 RUN useradd -m -s /bin/bash node 2>/dev/null || true && \\
@@ -1050,7 +1052,6 @@ RUN chmod +x /init
             {
                 "rootfs_size_mb": rootfs_size_mb,
                 "kernel_url": kernel_url,
-                "ssh_password": ssh_password,
                 "extra_packages": extra_packages,
                 "_device_approver_sha256": hashlib.sha256(device_approver_py.encode()).hexdigest(),
                 "_watch_devices_sha256": hashlib.sha256(watch_devices_sh.encode()).hexdigest(),
@@ -1088,7 +1089,6 @@ RUN chmod +x /init
                     "watch-devices.sh": watch_devices_sh,
                     "systemctl": systemctl_proxy_sh,
                 },
-                build_args={"SSH_PASSWORD": ssh_password},
                 kernel_url=kernel_url,
                 fingerprint_data=fingerprint_data,
             )


### PR DESCRIPTION
## Summary

Closes #234.

The openclaw image-builder configured the guest's `sshd` with `PasswordAuthentication yes` and a default root password of `smolvm`. For local dev that's fine, but published rootfs files ship the same image to many users — every sandbox would accept `root:smolvm` over SSH, which is trivially exploitable on a shared network.

PR #231/#232 already wired up kernel-cmdline injection of `authorized_keys` at first boot, so per-VM SSH key delivery works for shared images and pubkey auth is sufficient on its own.

## Changes

In `build_openclaw_rootfs` (src/smolvm/images/builder.py):

- `PermitRootLogin yes` -> `PermitRootLogin prohibit-password`
- `PasswordAuthentication yes` -> `PasswordAuthentication no`
- Added `PubkeyAuthentication yes`
- Dropped `ARG SSH_PASSWORD`, the `echo \"root:${SSH_PASSWORD}\" | chpasswd` line, the `build_args={\"SSH_PASSWORD\": ssh_password}` kwarg on `_do_build`, and `ssh_password` from the cache fingerprint.
- Kept the `ssh_password` parameter on `build_openclaw_rootfs` itself for backward compatibility (now ignored). Comment + docstring updated to call this out.

## Audit of other builders

Confirmed the other key-using builders are already correct — no action needed:

- `build_alpine_ssh_key` (line 309-328): `PasswordAuthentication no`, `PermitRootLogin prohibit-password`. Good.
- `build_debian_ssh_key` (line 425-440): `PasswordAuthentication no`, `PermitRootLogin prohibit-password`. Good.
- `build_browser_rootfs` (line 778-794): `PasswordAuthentication no`, `PermitRootLogin prohibit-password`. Good.

The legacy `build_alpine_ssh` (password-based) is a demo/example builder and is not called from any caller in `src/` — left alone since it's out of scope for this issue.

## Test plan

- [x] `uv run ruff check src/smolvm/images/builder.py` — clean
- [x] `uv run ruff format --check src/smolvm/images/builder.py` — clean
- [x] `uv run pytest tests/test_images.py tests/test_build.py tests/test_published_images.py` — 88 passed
- [x] `grep -n \"ssh_password\\|SSH_PASSWORD\\|chpasswd\\|PasswordAuthentication\" src/smolvm/images/builder.py` — every remaining hit is intentional (legacy `build_alpine_ssh` unchanged; `PasswordAuthentication no` lines in key-only builders; the kept-for-compat `ssh_password` parameter and comment in `build_openclaw_rootfs`)

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>