### PR TITLE
feat(cli): wire published-image launch path behind SMOLVM_USE_PUBLISHED

### DIFF
--- a/src/smolvm/cli/main.py
+++ b/src/smolvm/cli/main.py
@@ -161,8 +161,7 @@ def _create_progress_message(backend: str, guest_os: GuestOS) -> str:
             "(first run may download the kernel, initrd, and rootfs)..."
         )
     return (
-        f"Preparing {guest_os.value} operating system image "
-        "(first run may build or download it)..."
+        f"Preparing {guest_os.value} operating system image (first run may build or download it)..."
     )
 
 
@@ -449,8 +448,7 @@ def _add_preset_parsers(
                 action="store_true",
                 default=None,
                 help=(
-                    f"After install, ssh in and run `{preset.launch_command}` "
-                    "without prompting."
+                    f"After install, ssh in and run `{preset.launch_command}` without prompting."
                 ),
             )
             attach_group.add_argument(
@@ -668,9 +666,7 @@ def build_parser() -> argparse.ArgumentParser:
         "info",
         help="Show full details for a sandbox.",
     )
-    info_parser.add_argument(
-        "vm_id", metavar="sandbox", help="Name or ID of the sandbox."
-    )
+    info_parser.add_argument("vm_id", metavar="sandbox", help="Name or ID of the sandbox.")
     info_parser.add_argument(
         "--json",
         action="store_true",
@@ -832,7 +828,9 @@ def build_parser() -> argparse.ArgumentParser:
         "restore",
         help="Restore a snapshot back into its original sandbox.",
     )
-    snapshot_restore.add_argument("snapshot_id", metavar="snapshot", help="Name or ID of the snapshot.")
+    snapshot_restore.add_argument(
+        "snapshot_id", metavar="snapshot", help="Name or ID of the snapshot."
+    )
     snapshot_restore.add_argument(
         "--resume",
         action="store_true",
@@ -853,7 +851,9 @@ def build_parser() -> argparse.ArgumentParser:
         "delete",
         help="Delete a snapshot and its files.",
     )
-    snapshot_delete.add_argument("snapshot_id", metavar="snapshot", help="Name or ID of the snapshot.")
+    snapshot_delete.add_argument(
+        "snapshot_id", metavar="snapshot", help="Name or ID of the snapshot."
+    )
     snapshot_delete.add_argument(
         "--json",
         action="store_true",
@@ -1037,13 +1037,17 @@ def build_parser() -> argparse.ArgumentParser:
         "open",
         help="Open a live browser session in your default browser.",
     )
-    browser_open.add_argument("session_id", metavar="session", help="Session ID (printed by 'browser start').")
+    browser_open.add_argument(
+        "session_id", metavar="session", help="Session ID (printed by 'browser start')."
+    )
 
     browser_logs = browser_sub.add_parser(
         "logs",
         help="Print browser session logs.",
     )
-    browser_logs.add_argument("session_id", metavar="session", help="Session ID (printed by 'browser start').")
+    browser_logs.add_argument(
+        "session_id", metavar="session", help="Session ID (printed by 'browser start')."
+    )
     browser_logs.add_argument(
         "--tail",
         type=int,
@@ -1463,11 +1467,7 @@ def _render_info_result(data: InfoPayload) -> None:
     else:
         memory_str = f"{vm_data['memory']} MiB"
 
-    disk_str = (
-        f"{vm_data['disk_size']} MiB"
-        if vm_data["disk_size"] is not None
-        else "-"
-    )
+    disk_str = f"{vm_data['disk_size']} MiB" if vm_data["disk_size"] is not None else "-"
 
     details = Table(title="VM Details", show_header=False)
     details.add_column("Field")
@@ -1590,9 +1590,7 @@ def _build_and_boot_with_progress(
 
         def on_download(label: str, chunk: int, total: int | None) -> None:
             if label not in download_tasks:
-                download_tasks[label] = progress.add_task(
-                    f"Downloading {label}", total=total
-                )
+                download_tasks[label] = progress.add_task(f"Downloading {label}", total=total)
             progress.update(download_tasks[label], advance=chunk)
 
         config, ssh_key_path = _build_fn(on_download)
@@ -1815,12 +1813,153 @@ def _render_start_result(data: StartPayload) -> None:
     console.print(f"Next: [bold]{next_step['ssh_command']}[/bold]")
 
 
+# Map preset name → boot args for the Firecracker published-image path. When
+# we add per-preset bake builders, the boot_args should move onto the Preset
+# itself; for now openclaw is the only published preset and this lookup
+# reflects that.
+_PUBLISHED_IMAGE_BOOT_ARGS = {
+    "openclaw": "reboot=k panic=1 pci=off init=/init 8250.nr_uarts=0",
+}
+
+
+def _published_path_enabled() -> bool:
+    """Opt-in switch for the published-image launch path.
+
+    Set ``SMOLVM_USE_PUBLISHED=1`` to bypass the install-at-boot flow and
+    download a pre-built rootfs from GitHub Releases instead. Default is
+    off — flipped on once the published flow has been smoke-tested
+    end-to-end (separate PR).
+    """
+    return os.environ.get("SMOLVM_USE_PUBLISHED", "").strip().lower() in {"1", "true", "yes"}
+
+
+def _host_arch_for_published() -> str:
+    """Host CPU architecture in the form the manifest uses (``amd64``/``arm64``)."""
+    machine = platform.machine().lower()
+    if machine in {"arm64", "aarch64"}:
+        return "arm64"
+    if machine in {"x86_64", "amd64"}:
+        return "amd64"
+    raise RuntimeError(
+        f"Unsupported host architecture for published images: {machine!r}. "
+        f"Set SMOLVM_USE_PUBLISHED=0 (or unset) to fall back to the local build."
+    )
+
+
+def _run_start_with_published_image(args: argparse.Namespace, preset: object) -> int:
+    """Launch a sandbox using a pre-built published image.
+
+    Bypasses the default install-at-boot flow:
+    - downloads the kernel + rootfs from GitHub Releases (cached at
+      ``~/.smolvm/images/<preset>-v<version>-<arch>/``)
+    - boots Firecracker (matching how images are built in CI)
+    - skips ``apply_preset`` since the preset's tools are already baked in
+    - injects the user's pubkey via the kernel cmdline so SSH works on
+      first boot
+
+    Falls back to a clean error message when the preset has no published
+    image yet (e.g. presets without bake builders).
+    """
+    from smolvm.exceptions import ImageError
+    from smolvm.facade import SmolVM, _resolve_vm_name
+    from smolvm.images.published import ensure_published_image
+    from smolvm.presets._types import Preset
+    from smolvm.types import VMConfig
+    from smolvm.utils import ensure_ssh_key
+
+    _preset: Preset = preset  # type: ignore[assignment]
+
+    if _preset.name not in _PUBLISHED_IMAGE_BOOT_ARGS:
+        return _emit_cli_error(
+            "start",
+            2,
+            ValueError(
+                f"Preset {_preset.name!r} has no boot_args configured for the "
+                f"published-image path. Unset SMOLVM_USE_PUBLISHED to use the "
+                f"default install-at-boot flow."
+            ),
+            json_output=args.json,
+        )
+
+    try:
+        arch = _host_arch_for_published()
+        private_key, public_key_path = ensure_ssh_key()
+        public_key_value = public_key_path.read_text().strip()
+
+        # Raises ImageError with a clear message if the (preset, arch) pair
+        # has no manifest entry — the manifest is bundled in published.py
+        # and starts empty until the auto-update PR populates it.
+        local_image = ensure_published_image(_preset.name, arch)  # type: ignore[arg-type]
+
+        config = VMConfig(
+            vm_id=_resolve_vm_name(args.name, prefix=_preset.name),
+            memory=args.memory_mib if args.memory_mib is not None else _preset.default_mem_mib,
+            kernel_path=local_image.kernel_path,
+            rootfs_path=local_image.rootfs_path,
+            boot_args=_PUBLISHED_IMAGE_BOOT_ARGS[_preset.name],
+            backend="firecracker",
+            ssh_public_key=public_key_value,
+        )
+
+        vm: SmolVM | None = None
+        try:
+            vm = SmolVM(
+                config,
+                ssh_key_path=str(private_key),
+                mounts=args.mounts,
+                writable_mounts=args.writable_mounts,
+            )
+            vm.start(boot_timeout=args.boot_timeout)
+            vm.wait_for_ssh(timeout=args.boot_timeout)
+
+            network = vm.info.network
+            data: StartPayload = {
+                "vm": {
+                    "name": vm.vm_id,
+                    "status": (
+                        vm.info.status.value
+                        if isinstance(vm.info.status, VMState)
+                        else VMState.RUNNING.value
+                    ),
+                    "os": "debian-bookworm",
+                    "backend": "firecracker",
+                    "ip_address": network.guest_ip if network else None,
+                    "ssh_port": network.ssh_host_port if network else None,
+                },
+                "preset": {
+                    "name": _preset.name,
+                    "copied_configs": [],
+                    "injected_env_keys": [],
+                    "no_env_hint": _preset.no_env_hint,
+                },
+                "next": {"ssh_command": f"smolvm ssh {vm.vm_id}"},
+            }
+            if args.json:
+                emit_json("start", 0, data=data)
+            else:
+                _render_start_result(data)
+
+            if not args.json and _preset.launch_command:
+                return _maybe_attach_and_launch(vm, _preset, attach=getattr(args, "attach", None))
+            return 0
+        finally:
+            if vm is not None:
+                vm.close()
+    except ImageError as exc:
+        return _emit_cli_error("start", 1, exc, json_output=args.json)
+    except Exception as exc:
+        return _emit_cli_error("start", 1, exc, json_output=args.json)
+
+
 def _run_start(args: argparse.Namespace) -> int:
     """Handle ``smolvm <preset> start``."""
     from smolvm.facade import SmolVM, _build_auto_config
     from smolvm.presets import apply_preset, get_preset
 
     preset = get_preset(args.preset_name)
+
+    if _published_path_enabled():
+        return _run_start_with_published_image(args, preset)
 
     backend = args.backend or "qemu"
     if backend != "qemu":
@@ -1829,9 +1968,7 @@ def _run_start(args: argparse.Namespace) -> int:
         return _emit_cli_error(
             "start",
             2,
-            ValueError(
-                f"Preset {preset.name!r} requires --backend qemu (got {backend!r})."
-            ),
+            ValueError(f"Preset {preset.name!r} requires --backend qemu (got {backend!r})."),
             json_output=args.json,
         )
 
@@ -1958,10 +2095,7 @@ def _maybe_attach_and_launch(
     if attach is None:
         if not sys.stdin.isatty():
             return 0
-        prompt = (
-            f"\nLaunch [bold]{_preset.launch_command}[/bold] in "
-            f"'{_vm.vm_id}' now? \\[Y/n] "
-        )
+        prompt = f"\nLaunch [bold]{_preset.launch_command}[/bold] in '{_vm.vm_id}' now? \\[Y/n] "
         try:
             console.print(prompt, end="")
             answer = input("").strip().lower()
@@ -1997,7 +2131,7 @@ def _exec_launch_command(vm: object, launch_command: str) -> int:
     # warning. SSH non-login shells skip /etc/profile, and Ubuntu's
     # default root PATH does not include ~/.local/bin.
     cmd.append(
-        f'[ -r {ENV_FILE} ] && . {ENV_FILE}; '
+        f"[ -r {ENV_FILE} ] && . {ENV_FILE}; "
         f'export PATH="$HOME/.local/bin:$PATH"; '
         f"exec {launch_command}"
     )
@@ -2488,8 +2622,7 @@ def _run_env(args: argparse.Namespace) -> int:
                         title="Environment Updated",
                         border_style="yellow",
                         message=(
-                            f"No matching variables found on '{args.vm_id}': "
-                            f"{', '.join(args.keys)}"
+                            f"No matching variables found on '{args.vm_id}': {', '.join(args.keys)}"
                         ),
                         rows=[],
                         show_reload_hint=False,
@@ -2497,10 +2630,7 @@ def _run_env(args: argparse.Namespace) -> int:
             return 0
 
         current = vm.list_env_vars()
-        variables = {
-            key: current[key] if args.show_values else "****"
-            for key in sorted(current)
-        }
+        variables = {key: current[key] if args.show_values else "****" for key in sorted(current)}
         data = {
             "vm_id": args.vm_id,
             "masked": not args.show_values,
@@ -2523,10 +2653,7 @@ def _render_file_upload(data: FileUploadPayload) -> None:
     console = console_stdout()
     console.print(
         Panel.fit(
-            (
-                f"Uploaded '{data['local_path']}' to '{data['guest_path']}' "
-                f"on '{data['vm_id']}'."
-            ),
+            (f"Uploaded '{data['local_path']}' to '{data['guest_path']}' on '{data['vm_id']}'."),
             title="File Uploaded",
             border_style="green",
         )
@@ -2591,16 +2718,12 @@ def _run_ssh(args: argparse.Namespace) -> int:
 
         console = console_stdout()
         if vm.status in {VMState.CREATED, VMState.STOPPED}:
-            with console.status(
-                f"Starting sandbox '{args.vm_id}'...", spinner="dots"
-            ) as status:
+            with console.status(f"Starting sandbox '{args.vm_id}'...", spinner="dots") as status:
                 vm.start(boot_timeout=args.boot_timeout)
                 status.update("Waiting for SSH...")
                 vm.wait_for_ssh(timeout=args.boot_timeout)
         elif vm.status == VMState.PAUSED:
-            with console.status(
-                f"Resuming sandbox '{args.vm_id}'...", spinner="dots"
-            ) as status:
+            with console.status(f"Resuming sandbox '{args.vm_id}'...", spinner="dots") as status:
                 vm.resume()
                 status.update("Waiting for SSH...")
                 vm.wait_for_ssh(timeout=args.boot_timeout)
@@ -2868,9 +2991,7 @@ def _run_browser(args: argparse.Namespace) -> int:
         try:
             session = BrowserSession.from_id(args.session_id)
             if session.live_url is None:
-                raise RuntimeError(
-                    f"Browser session '{args.session_id}' does not have a live_url."
-                )
+                raise RuntimeError(f"Browser session '{args.session_id}' does not have a live_url.")
             opened = session.open_live_view()
             if not opened:
                 print(f"Open this URL manually: {session.live_url}")

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -427,9 +427,7 @@ class TestCliFile:
         vm.upload_file.return_value = "/tmp/note.txt"
         mock_vm_cls.from_id.return_value = vm
 
-        ret = main(
-            ["file", "upload", "vm001", str(source), "/tmp/note.txt", "--no-create-dirs"]
-        )
+        ret = main(["file", "upload", "vm001", str(source), "/tmp/note.txt", "--no-create-dirs"])
 
         assert ret == 0
         vm.upload_file.assert_called_once_with(
@@ -818,13 +816,19 @@ class TestCliCreateImage:
     def test_image_with_name_and_memory(self) -> None:
         """--image should work alongside --name, --memory, and --disk-size."""
         parser = build_parser()
-        args = parser.parse_args([
-            "create",
-            "--image", "s3://bucket/img/",
-            "--name", "my-vm",
-            "--memory", "1024",
-            "--disk-size", "2048",
-        ])
+        args = parser.parse_args(
+            [
+                "create",
+                "--image",
+                "s3://bucket/img/",
+                "--name",
+                "my-vm",
+                "--memory",
+                "1024",
+                "--disk-size",
+                "2048",
+            ]
+        )
         assert args.image == "s3://bucket/img/"
         assert args.name == "my-vm"
         assert args.memory_mib == 1024
@@ -835,11 +839,15 @@ class TestCliCreateImage:
         capsys: pytest.CaptureFixture[str],
     ) -> None:
         """--disk-size has no effect on prebuilt S3 images and must be rejected."""
-        ret = main([
-            "create",
-            "--image", "s3://bucket/img/",
-            "--disk-size", "8192",
-        ])
+        ret = main(
+            [
+                "create",
+                "--image",
+                "s3://bucket/img/",
+                "--disk-size",
+                "8192",
+            ]
+        )
 
         assert ret == 1
         err = capsys.readouterr().err
@@ -1515,9 +1523,7 @@ class TestCliBrowser:
         assert payload["data"]["cdp_url"] == "http://127.0.0.1:39222"
 
     @patch("smolvm.browser.BrowserSession")
-    def test_browser_start_live_shortcut(
-        self, mock_browser_cls: MagicMock
-    ) -> None:
+    def test_browser_start_live_shortcut(self, mock_browser_cls: MagicMock) -> None:
         """`smolvm browser start --live` should map to live mode."""
         session = MagicMock()
         session.session_id = "browser-abc123"
@@ -2268,9 +2274,7 @@ class TestCliStart:
         vm.info.network.ssh_host_port = 2200
         return vm
 
-    def test_top_level_help_lists_known_presets(
-        self, capsys: pytest.CaptureFixture
-    ) -> None:
+    def test_top_level_help_lists_known_presets(self, capsys: pytest.CaptureFixture) -> None:
         """`smolvm --help` should list every registered preset as a top-level command."""
         with pytest.raises(SystemExit):
             main(["--help"])
@@ -2278,9 +2282,7 @@ class TestCliStart:
         assert "codex" in out
         assert "claude-code" in out
 
-    def test_preset_help_lists_start_action(
-        self, capsys: pytest.CaptureFixture
-    ) -> None:
+    def test_preset_help_lists_start_action(self, capsys: pytest.CaptureFixture) -> None:
         """`smolvm codex --help` should list the `start` action."""
         with pytest.raises(SystemExit):
             main(["codex", "--help"])
@@ -2295,9 +2297,7 @@ class TestCliStart:
         # argparse produces "invalid choice" for unknown subcommand
         assert "invalid choice" in err or "argument command" in err
 
-    def test_launch_snippet_runs_when_env_file_missing(
-        self, tmp_path: Path
-    ) -> None:
+    def test_launch_snippet_runs_when_env_file_missing(self, tmp_path: Path) -> None:
         """The remote command built by `_exec_launch_command` must exec the
         harness even when /etc/profile.d/smolvm_env.sh does not exist —
         regression for claude-code with subscription auth where no
@@ -2332,9 +2332,7 @@ class TestCliStart:
         # The snippet calls `exec claude`; for the runtime check we
         # substitute a benign command we can verify ran.
         snippet = remote.replace("exec claude", "echo LAUNCHED")
-        snippet = snippet.replace(
-            "/etc/profile.d/smolvm_env.sh", str(missing_env_file)
-        )
+        snippet = snippet.replace("/etc/profile.d/smolvm_env.sh", str(missing_env_file))
         completed = subprocess.run(
             ["bash", "-c", snippet], capture_output=True, text=True, check=False
         )
@@ -2342,9 +2340,7 @@ class TestCliStart:
         assert "LAUNCHED" in completed.stdout
         assert "No such file" not in completed.stderr
 
-    def test_launch_snippet_prepends_local_bin_to_path(
-        self, tmp_path: Path
-    ) -> None:
+    def test_launch_snippet_prepends_local_bin_to_path(self, tmp_path: Path) -> None:
         """The launch snippet must prepend ``~/.local/bin`` to PATH so a
         harness that self-installed there (claude-code's npm postinstall
         migrates to ``~/.local/bin/claude``) is found by the non-login
@@ -2380,9 +2376,7 @@ class TestCliStart:
 
         missing_env_file = tmp_path / "missing.sh"
         snippet = remote.replace("exec claude", "command -v claude")
-        snippet = snippet.replace(
-            "/etc/profile.d/smolvm_env.sh", str(missing_env_file)
-        )
+        snippet = snippet.replace("/etc/profile.d/smolvm_env.sh", str(missing_env_file))
         completed = subprocess.run(
             ["bash", "-c", snippet],
             capture_output=True,
@@ -2406,9 +2400,7 @@ class TestCliStart:
         assert args.command == "claude"
         assert args.preset_name == "claude-code"
 
-    def test_top_level_help_lists_claude_alias(
-        self, capsys: pytest.CaptureFixture
-    ) -> None:
+    def test_top_level_help_lists_claude_alias(self, capsys: pytest.CaptureFixture) -> None:
         """The alias should appear in the top-level help so the
         shorthand is discoverable, not a hidden trick."""
         import re
@@ -2602,9 +2594,7 @@ class TestCliStart:
             "exec must chain with ';' not '&&' so a missing env file does "
             f"not abort the launch — got {remote!r}"
         )
-        assert "[ -r " in remote, (
-            "env file source must be guarded with a file-existence check"
-        )
+        assert "[ -r " in remote, "env file source must be guarded with a file-existence check"
 
     @patch("smolvm.cli.main.subprocess.run")
     @patch("smolvm.cli.main._apply_preset_with_progress")
@@ -2728,3 +2718,168 @@ class TestCliStart:
 
         assert ret == 0
         mock_subprocess_run.assert_not_called()
+
+
+class TestPublishedImageLaunchPath:
+    """Tests for the SMOLVM_USE_PUBLISHED opt-in launch path.
+
+    When set, ``smolvm <preset> start`` skips the install-at-boot flow
+    (build alpine_ssh_key + apply_preset) and instead downloads a
+    pre-built rootfs from GitHub Releases via ensure_published_image,
+    then boots Firecracker directly. Tooling assumed to be preinstalled
+    in the image.
+    """
+
+    def test_env_helper_default_off(self) -> None:
+        from smolvm.cli.main import _published_path_enabled
+
+        # Use monkeypatch-style explicit cleanup so this test is hermetic.
+        prev = os.environ.pop("SMOLVM_USE_PUBLISHED", None)
+        try:
+            assert _published_path_enabled() is False
+        finally:
+            if prev is not None:
+                os.environ["SMOLVM_USE_PUBLISHED"] = prev
+
+    @pytest.mark.parametrize(
+        "value,expected",
+        [
+            ("1", True),
+            ("true", True),
+            ("TRUE", True),
+            ("yes", True),
+            ("YES", True),
+            ("0", False),
+            ("false", False),
+            ("no", False),
+            ("", False),
+        ],
+    )
+    def test_env_helper_parses_truthy(self, value: str, expected: bool) -> None:
+        from smolvm.cli.main import _published_path_enabled
+
+        prev = os.environ.get("SMOLVM_USE_PUBLISHED")
+        try:
+            os.environ["SMOLVM_USE_PUBLISHED"] = value
+            assert _published_path_enabled() is expected
+        finally:
+            if prev is None:
+                os.environ.pop("SMOLVM_USE_PUBLISHED", None)
+            else:
+                os.environ["SMOLVM_USE_PUBLISHED"] = prev
+
+    @patch("smolvm.cli.main.platform.machine")
+    def test_arch_helper_normalizes(self, mock_machine: MagicMock) -> None:
+        from smolvm.cli.main import _host_arch_for_published
+
+        for raw, expected in [
+            ("x86_64", "amd64"),
+            ("amd64", "amd64"),
+            ("AMD64", "amd64"),
+            ("arm64", "arm64"),
+            ("aarch64", "arm64"),
+            ("ARM64", "arm64"),
+        ]:
+            mock_machine.return_value = raw
+            assert _host_arch_for_published() == expected, raw
+
+    @patch("smolvm.cli.main.platform.machine", return_value="riscv64")
+    def test_arch_helper_rejects_unsupported(self, _mock_machine: MagicMock) -> None:
+        from smolvm.cli.main import _host_arch_for_published
+
+        with pytest.raises(RuntimeError, match="Unsupported host architecture"):
+            _host_arch_for_published()
+
+    @patch.dict(os.environ, {"SMOLVM_USE_PUBLISHED": "1"})
+    @patch("smolvm.cli.main._run_start_with_published_image")
+    def test_start_routes_to_published_path_when_env_set(
+        self,
+        mock_published_path: MagicMock,
+    ) -> None:
+        """SMOLVM_USE_PUBLISHED=1 must short-circuit before the legacy path."""
+        mock_published_path.return_value = 0
+
+        ret = main(["openclaw", "start", "--json"])
+
+        assert ret == 0
+        mock_published_path.assert_called_once()
+        # First positional is args, second is the resolved preset.
+        called_args = mock_published_path.call_args[0]
+        assert called_args[1].name == "openclaw"
+
+    @patch.dict(os.environ, {"SMOLVM_USE_PUBLISHED": "1"})
+    @patch("smolvm.images.published.ensure_published_image")
+    def test_published_path_surfaces_missing_manifest_error(
+        self,
+        mock_ensure: MagicMock,
+    ) -> None:
+        """An empty manifest entry should produce a clean CLI error, not a crash."""
+        from smolvm.exceptions import ImageError
+
+        mock_ensure.side_effect = ImageError(
+            "No published image for preset 'openclaw' on arch 'amd64' (available: (none))."
+        )
+
+        ret = main(["openclaw", "start", "--json"])
+
+        assert ret == 1
+        mock_ensure.assert_called_once()
+
+    @patch.dict(os.environ, {"SMOLVM_USE_PUBLISHED": "1"})
+    @patch("smolvm.cli.main.subprocess.run")
+    @patch("smolvm.facade.SmolVM")
+    @patch("smolvm.utils.ensure_ssh_key")
+    @patch("smolvm.images.published.ensure_published_image")
+    @patch("smolvm.cli.main.platform.machine", return_value="x86_64")
+    def test_published_path_happy_path_skips_apply_preset(
+        self,
+        _mock_machine: MagicMock,
+        mock_ensure_image: MagicMock,
+        mock_ensure_ssh_key: MagicMock,
+        mock_vm_cls: MagicMock,
+        _mock_subprocess: MagicMock,
+        tmp_path: Path,
+    ) -> None:
+        """End-to-end: download → VMConfig → start, no apply_preset call."""
+        from smolvm.images.manager import LocalImage
+
+        kernel = tmp_path / "vmlinux.bin"
+        rootfs = tmp_path / "rootfs.ext4"
+        priv = tmp_path / "id_ed25519"
+        pub = tmp_path / "id_ed25519.pub"
+        kernel.touch()
+        rootfs.touch()
+        priv.touch()
+        pub.write_text("ssh-ed25519 AAAAExampleKey user@host\n")
+
+        mock_ensure_image.return_value = LocalImage(
+            name="openclaw-v0.0.13-amd64",
+            kernel_path=kernel,
+            rootfs_path=rootfs,
+        )
+        mock_ensure_ssh_key.return_value = (priv, pub)
+        mock_vm = MagicMock()
+        mock_vm.vm_id = "sbx-published-1"
+        mock_vm.info.status = VMState.RUNNING
+        mock_vm.info.config.backend = "firecracker"
+        mock_vm.info.network = MagicMock(spec=NetworkConfig)
+        mock_vm.info.network.guest_ip = "172.16.0.2"
+        mock_vm.info.network.ssh_host_port = 2200
+        mock_vm_cls.return_value = mock_vm
+
+        # If apply_preset gets called, this test should fail loudly.
+        with patch("smolvm.presets.apply_preset") as mock_apply:
+            ret = main(["openclaw", "start", "--json"])
+
+            mock_apply.assert_not_called()
+
+        assert ret == 0
+        mock_ensure_image.assert_called_once_with("openclaw", "amd64")
+
+        # Verify VMConfig was built with the right wiring.
+        config_arg = mock_vm_cls.call_args[0][0]
+        assert config_arg.kernel_path == kernel
+        assert config_arg.rootfs_path == rootfs
+        assert config_arg.backend == "firecracker"
+        assert config_arg.ssh_public_key == "ssh-ed25519 AAAAExampleKey user@host"
+        assert "init=/init" in config_arg.boot_args


### PR DESCRIPTION
## Summary

PR β in the publishing rollout. Adds an opt-in launch path that downloads a pre-built rootfs from GitHub Releases instead of doing the default install-at-boot (alpine_ssh_key + apply_preset) flow.

**Default is off; existing flow unchanged.** Will be flipped to default in a follow-up PR (G) once smoke-tested end-to-end.

## How the new path works

Set \`SMOLVM_USE_PUBLISHED=1\` and \`smolvm <preset> start\` will:

1. Resolve host arch (\`amd64\` / \`arm64\`)
2. Call [\`ensure_published_image(preset.name, arch)\`](src/smolvm/images/published.py) — downloads kernel + rootfs from URLs in the bundled \`MANIFEST\`, verifies SHA-256, caches at \`~/.smolvm/images/<preset>-v<version>-<arch>/\`
3. Build a Firecracker VMConfig pointing at the downloaded files, with \`ssh_public_key\` set so the cmdline-injection wiring from [#231](https://github.com/CelestoAI/SmolVM/pull/231) installs the user's key in \`/root/.ssh/authorized_keys\` at boot
4. Boot, wait for SSH
5. **Skip \`apply_preset\`** — the harness is already installed in the published image

## Why this lands now (with empty MANIFEST)

The wiring is the substantive piece. The MANIFEST currently has no entries (foundation in [#228](https://github.com/CelestoAI/SmolVM/pull/228)), so calls to \`ensure_published_image\` raise \`ImageError\` cleanly. Wiring + tests land independently of manifest population, which arrives in a small follow-up after PR α ([#239](https://github.com/CelestoAI/SmolVM/pull/239)) merges and CI re-runs to produce artifacts with the password-auth fix applied.

## Order of operations to a usable end-to-end flow

| # | Step | Status |
|---|---|---|
| 1 | This PR (wiring + opt-in) | This PR |
| 2 | [#239](https://github.com/CelestoAI/SmolVM/pull/239) (key-only auth in openclaw image) | open |
| 3 | CI re-run after #239 → new artifacts in draft release | manual trigger |
| 4 | Small PR populates MANIFEST with new SHAs | TBD |
| 5 | Smoke test: \`SMOLVM_USE_PUBLISHED=1 smolvm openclaw start\` boots cleanly | manual |
| 6 | PR γ: flip default | TBD |

Each step is small and reviewable. Total time from this PR to default-flipped published flow: ~1 day if nothing surprises.

## Architectural note

The default openclaw preset uses \`backend="qemu"\` + Ubuntu cloud image + install-at-boot. The published path uses \`backend="firecracker"\` + Debian Bookworm + preinstalled openclaw. Different stacks. Hardcoding this divergence is fine while openclaw is the only published preset — when other presets get bake builders, the boot_args + backend choice should lift onto the Preset class itself. Flagged inline with a comment on \`_PUBLISHED_IMAGE_BOOT_ARGS\`.

## Tests

15 new tests in \`TestPublishedImageLaunchPath\`:

- Env var parsing (truthy/falsy, including missing)
- Arch normalization (\`x86_64\`/\`amd64\` → \`amd64\`, \`arm64\`/\`aarch64\` → \`arm64\`, unsupported raises)
- Start command routes to the published path when env set
- Empty manifest produces a clean CLI error (not a crash)
- Happy-path end-to-end: \`ensure_published_image\` called → VMConfig built correctly → \`SmolVM.start\` invoked → \`apply_preset\` explicitly **not** called (asserted via mock)

Full suite: **344 passed, 8 skipped**, no regressions.

## Related Issues

- Closes #
- Builds on: [#228](https://github.com/CelestoAI/SmolVM/pull/228), [#231](https://github.com/CelestoAI/SmolVM/pull/231), [#232](https://github.com/CelestoAI/SmolVM/pull/232), [#233](https://github.com/CelestoAI/SmolVM/pull/233), [#235](https://github.com/CelestoAI/SmolVM/pull/235), [#237](https://github.com/CelestoAI/SmolVM/pull/237), [#238](https://github.com/CelestoAI/SmolVM/pull/238)
- Pairs with: [#239](https://github.com/CelestoAI/SmolVM/pull/239) (password-auth disable) and [#240](https://github.com/CelestoAI/SmolVM/issues/240) (size disparity investigation)

## Checklist

- [x] Scope is focused and limited to this change
- [x] Tests added for new behavior (15 new, all passing)
- [ ] Docs updated for user-visible changes (no user-visible behavior yet — env var is opt-in for testing)
- [x] No secrets or sensitive data included