### PR TITLE
fix(images): shrink openclaw published image (closes #240)

### DIFF
--- a/src/smolvm/images/builder.py
+++ b/src/smolvm/images/builder.py
@@ -1022,7 +1022,19 @@ RUN npm init -y && \\
     npm --prefix /opt/openclaw install -g openclaw && \\
     ln -sf /opt/openclaw/bin/openclaw /usr/local/bin/openclaw && \\
     touch /var/log/openclaw.log && \\
-    chown node:node /var/log/openclaw.log
+    chown node:node /var/log/openclaw.log && \\
+    npm cache clean --force >/dev/null 2>&1 || true
+
+# Strip @node-llama-cpp GPU and non-host-arch backends. Inside Firecracker
+# there is no GPU passthrough, so the CUDA/Vulkan binaries are dead weight
+# (~600+ MiB on amd64). On arm64 only the matching arch package exists, so
+# the rm calls are no-ops there. The path reflects npm's `-g --prefix`
+# layout: /opt/openclaw/lib/node_modules/openclaw/node_modules/...
+RUN rm -rf \\
+    /opt/openclaw/lib/node_modules/openclaw/node_modules/@node-llama-cpp/linux-x64-cuda \\
+    /opt/openclaw/lib/node_modules/openclaw/node_modules/@node-llama-cpp/linux-x64-cuda-ext \\
+    /opt/openclaw/lib/node_modules/openclaw/node_modules/@node-llama-cpp/linux-x64-vulkan \\
+    /opt/openclaw/lib/node_modules/openclaw/node_modules/@node-llama-cpp/linux-armv7l
 
 # Sidecar and proxy scripts
 COPY device-approver.py /usr/local/bin/device-approver.py

--- a/src/smolvm/presets/_scripts.py
+++ b/src/smolvm/presets/_scripts.py
@@ -84,7 +84,13 @@ def npm_install_global(package: str) -> str:
     """
     if not _SAFE_NPM_NAME_RE.match(package):
         raise ValueError(f"Refusing to install unsafe npm package name: {package!r}")
-    return f"set -euo pipefail\nnpm install -g --silent {package}\n"
+    # Cleaning the cache after install removes ~350-700 MB of leftover
+    # tarballs from /root/.npm/_cacache; npm rebuilds it on demand.
+    return (
+        "set -euo pipefail\n"
+        f"npm install -g --silent {package}\n"
+        "npm cache clean --force >/dev/null 2>&1 || true\n"
+    )
 
 
 def uv_install_global(package: str) -> str:


### PR DESCRIPTION
## Summary

Two small changes that together drop the openclaw rootfs published to GitHub Releases from ~884 MB on amd64 to roughly arm64 parity (~150-200 MB). Both causes were identified in #240.

### Fix 1: clean npm cache after global installs

`src/smolvm/presets/_scripts.py` — the shared `npm_install_global` helper now appends `npm cache clean --force` after the install. This drops the leftover `/root/.npm/_cacache` (~691 MB amd64, ~354 MB arm64) from every node-based preset (codex, claude-code, openclaw, hermes). npm rebuilds the cache on demand, so this is safe.

### Fix 2: strip useless `@node-llama-cpp` GPU backends in openclaw bake

`src/smolvm/images/builder.py` — the openclaw Dockerfile now `rm -rf`s the four `@node-llama-cpp` packages that are unusable inside Firecracker (no GPU passthrough), saving ~673 MiB on amd64:

| package | size on amd64 |
|---|---|
| `linux-x64-cuda` | 151 MiB |
| `linux-x64-cuda-ext` | 443 MiB |
| `linux-x64-vulkan` | 74 MiB |
| `linux-armv7l` | 5.7 MiB |

The CPU backends actually used (`linux-x64`, `linux-arm64`) stay. Same Dockerfile also gets `npm cache clean --force` chained into the install RUN.

Verified package layout against `node:22.12.0-bookworm-slim` with `--platform linux/amd64`: openclaw installs into `/opt/openclaw/lib/node_modules/openclaw/node_modules/@node-llama-cpp/`. Verified package list against `npm view node-llama-cpp optionalDependencies`.

The Dockerfile fingerprint check picks up the change automatically, so users with cached images get the smaller rebuild on the next `smolvm openclaw start`.

## Test plan

- [x] `uv run ruff check src/smolvm/presets/_scripts.py src/smolvm/images/builder.py`
- [x] `uv run ruff format --check src/smolvm/presets/_scripts.py src/smolvm/images/builder.py`
- [x] `uv run pytest tests/test_images.py tests/test_build.py tests/test_published_images.py tests/test_presets.py` (167 passed)
- [ ] Next published-image bake (CI) confirms amd64 size drop

Closes #240

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Docker image build configuration to improve package management and cache handling.
  * Modified npm package installation process to include automatic cache cleanup, ensuring cleaner builds and optimized disk usage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->