### PR TITLE
feat(images): populate MANIFEST + decompress zstd-compressed published rootfs

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,6 +35,9 @@ dependencies = [
     "rich>=13.0",
     "requests>=2.28",
     "requests-unixsocket>=0.3",
+    # Decompresses zstd-compressed published images (downloaded via
+    # ensure_published_image). Pure C extension, ~200 KB wheel, no system deps.
+    "zstandard>=0.22",
 ]
 
 [project.optional-dependencies]

--- a/src/smolvm/images/published.py
+++ b/src/smolvm/images/published.py
@@ -20,8 +20,9 @@ the ``images-vX.Y.Z`` release tag. The ``MANIFEST`` below is the bundled
 catalog the CLI ships with — entries are appended as CI publishes them.
 
 Resolution flow: ``ensure_published_image(preset, arch)`` looks up the
-matching entry, converts it to an :class:`ImageSource`, and delegates to
-:class:`ImageManager` for caching, downloading, and SHA-256 verification.
+matching entry, converts it to an :class:`ImageSource`, delegates to
+:class:`ImageManager` for caching + SHA-256-verified download, and
+decompresses the rootfs if the URL ends in ``.zst``.
 """
 
 from __future__ import annotations
@@ -66,10 +67,43 @@ def cache_name(preset: Preset, arch: Arch, version: str = __version__) -> str:
     return f"{preset}-v{version}-{arch}"
 
 
-# Bundled manifest. Empty until CI publishes its first ``images-v*``
-# release. Append entries here keyed by ``(preset, arch)`` once the
-# corresponding artifacts are uploaded to the matching release.
-MANIFEST: dict[tuple[Preset, Arch], PublishedImage] = {}
+def _release_asset_url(preset: Preset, arch: Arch, suffix: str, version: str) -> str:
+    """Construct the post-publish GH Releases asset URL for one artifact.
+
+    Once the draft release at ``images-v<version>`` is published, GH
+    Releases serves assets at this canonical URL (the draft itself uses
+    a temporary ``untagged-*`` slug — these URLs only resolve after
+    the draft is published manually).
+    """
+    return (
+        f"https://github.com/CelestoAI/SmolVM/releases/download/"
+        f"{release_tag(version)}/{preset}-{arch}-{suffix}"
+    )
+
+
+# Bundled manifest. New (preset, arch) entries land here as CI publishes
+# images — paired by version with this CLI release. The SHA-256s and URLs
+# below match the artifacts produced by the CI workflow at
+# .github/workflows/build-published-images.yml; they're also visible in
+# the corresponding GH release's step summary on each successful run.
+MANIFEST: dict[tuple[Preset, Arch], PublishedImage] = {
+    ("openclaw", "amd64"): PublishedImage(
+        preset="openclaw",
+        arch="amd64",
+        kernel_url=_release_asset_url("openclaw", "amd64", "vmlinux.bin", "0.0.13"),
+        kernel_sha256="d361a5f2e67b2e243964ad93f25a2d9e5bee320204a84a7af089949228af5c2a",
+        rootfs_url=_release_asset_url("openclaw", "amd64", "rootfs.ext4.zst", "0.0.13"),
+        rootfs_sha256="5d3fe222b017f350f5bb2f01c1fa28cd3425b5dddb32d6377d97bc0e3fea355b",
+    ),
+    ("openclaw", "arm64"): PublishedImage(
+        preset="openclaw",
+        arch="arm64",
+        kernel_url=_release_asset_url("openclaw", "arm64", "vmlinux.bin", "0.0.13"),
+        kernel_sha256="7d8dc0bce701037ea5ceccfc997c05b11f99aba215c73ed18a2269154837c497",
+        rootfs_url=_release_asset_url("openclaw", "arm64", "rootfs.ext4.zst", "0.0.13"),
+        rootfs_sha256="48d86a4e4a75f8c101ebab3f76067cc2c92473ac0c30d5a2fd71a1dd2f43f6c7",
+    ),
+}
 
 
 def lookup(
@@ -90,14 +124,35 @@ def lookup(
 
 
 def to_image_source(entry: PublishedImage, version: str = __version__) -> ImageSource:
-    """Convert a manifest entry into an :class:`ImageSource` for the manager."""
+    """Convert a manifest entry into an :class:`ImageSource` for the manager.
+
+    When the rootfs URL is zstd-compressed (``*.zst``), the cache filename
+    keeps the ``.zst`` suffix so :class:`ImageManager` verifies the SHA-256
+    of the compressed bytes that ship over the wire. ``ensure_published_image``
+    decompresses alongside afterward.
+    """
+    rootfs_filename = "rootfs.ext4.zst" if entry.rootfs_url.endswith(".zst") else "rootfs.ext4"
     return ImageSource(
         name=cache_name(entry.preset, entry.arch, version),
         kernel_url=entry.kernel_url,
         kernel_sha256=entry.kernel_sha256,
         rootfs_url=entry.rootfs_url,
         rootfs_sha256=entry.rootfs_sha256,
+        rootfs_filename=rootfs_filename,
     )
+
+
+def _decompress_zstd(src: Path, dst: Path) -> None:
+    """Stream-decompress a zstd file. Writes to ``dst.tmp`` then renames."""
+    import zstandard
+
+    tmp = dst.with_suffix(dst.suffix + ".tmp")
+    try:
+        with src.open("rb") as src_f, tmp.open("wb") as dst_f:
+            zstandard.ZstdDecompressor().copy_stream(src_f, dst_f)
+        tmp.replace(dst)
+    finally:
+        tmp.unlink(missing_ok=True)
 
 
 def ensure_published_image(
@@ -118,7 +173,11 @@ def ensure_published_image(
         version: Override the CLI version used to compute the cache name.
 
     Returns:
-        :class:`LocalImage` with paths to the kernel and rootfs.
+        :class:`LocalImage` with paths to the kernel and (decompressed)
+        rootfs. When the manifest entry's rootfs URL is zstd-compressed,
+        the compressed file stays in cache (so SHA verification can re-run
+        on subsequent calls) and a sibling decompressed ``rootfs.ext4`` is
+        produced lazily.
 
     Raises:
         ImageError: If no manifest entry exists for the (preset, arch) pair,
@@ -127,4 +186,20 @@ def ensure_published_image(
     entry = lookup(preset, arch, manifest=manifest)
     source = to_image_source(entry, version=version)
     manager = ImageManager(cache_dir=cache_dir, registry={source.name: source})
-    return manager.ensure_image(source.name)
+    local = manager.ensure_image(source.name)
+
+    # Wire-format short-circuit: nothing to decompress.
+    if not source.rootfs_filename.endswith(".zst"):
+        return local
+
+    # Decompress alongside, only on cache miss for the decompressed file.
+    decompressed_path = local.rootfs_path.with_suffix("")
+    if not decompressed_path.is_file():
+        _decompress_zstd(local.rootfs_path, decompressed_path)
+
+    return LocalImage(
+        name=local.name,
+        kernel_path=local.kernel_path,
+        initrd_path=local.initrd_path,
+        rootfs_path=decompressed_path,
+    )

--- a/src/smolvm/images/published.py
+++ b/src/smolvm/images/published.py
@@ -81,6 +81,13 @@ def _release_asset_url(preset: Preset, arch: Arch, suffix: str, version: str) ->
     )
 
 
+# Version of the published images this CLI release was paired with.
+# Bumping this requires regenerating every MANIFEST entry below from a
+# fresh CI run (new artifacts → new SHAs → new URLs). The drift-detection
+# test in test_published_images.py asserts this matches __version__ so
+# pyproject.toml version bumps don't ship with stale manifest entries.
+_MANIFEST_VERSION = "0.0.13"
+
 # Bundled manifest. New (preset, arch) entries land here as CI publishes
 # images — paired by version with this CLI release. The SHA-256s and URLs
 # below match the artifacts produced by the CI workflow at
@@ -90,17 +97,17 @@ MANIFEST: dict[tuple[Preset, Arch], PublishedImage] = {
     ("openclaw", "amd64"): PublishedImage(
         preset="openclaw",
         arch="amd64",
-        kernel_url=_release_asset_url("openclaw", "amd64", "vmlinux.bin", "0.0.13"),
+        kernel_url=_release_asset_url("openclaw", "amd64", "vmlinux.bin", _MANIFEST_VERSION),
         kernel_sha256="d361a5f2e67b2e243964ad93f25a2d9e5bee320204a84a7af089949228af5c2a",
-        rootfs_url=_release_asset_url("openclaw", "amd64", "rootfs.ext4.zst", "0.0.13"),
+        rootfs_url=_release_asset_url("openclaw", "amd64", "rootfs.ext4.zst", _MANIFEST_VERSION),
         rootfs_sha256="5d3fe222b017f350f5bb2f01c1fa28cd3425b5dddb32d6377d97bc0e3fea355b",
     ),
     ("openclaw", "arm64"): PublishedImage(
         preset="openclaw",
         arch="arm64",
-        kernel_url=_release_asset_url("openclaw", "arm64", "vmlinux.bin", "0.0.13"),
+        kernel_url=_release_asset_url("openclaw", "arm64", "vmlinux.bin", _MANIFEST_VERSION),
         kernel_sha256="7d8dc0bce701037ea5ceccfc997c05b11f99aba215c73ed18a2269154837c497",
-        rootfs_url=_release_asset_url("openclaw", "arm64", "rootfs.ext4.zst", "0.0.13"),
+        rootfs_url=_release_asset_url("openclaw", "arm64", "rootfs.ext4.zst", _MANIFEST_VERSION),
         rootfs_sha256="48d86a4e4a75f8c101ebab3f76067cc2c92473ac0c30d5a2fd71a1dd2f43f6c7",
     ),
 }
@@ -143,10 +150,10 @@ def to_image_source(entry: PublishedImage, version: str = __version__) -> ImageS
 
 
 def _decompress_zstd(src: Path, dst: Path) -> None:
-    """Stream-decompress a zstd file. Writes to ``dst.tmp`` then renames."""
+    """Stream-decompress a zstd file. Writes to a sibling ``.tmp`` then renames."""
     import zstandard
 
-    tmp = dst.with_suffix(dst.suffix + ".tmp")
+    tmp = dst.parent / (dst.name + ".tmp")
     try:
         with src.open("rb") as src_f, tmp.open("wb") as dst_f:
             zstandard.ZstdDecompressor().copy_stream(src_f, dst_f)
@@ -197,9 +204,4 @@ def ensure_published_image(
     if not decompressed_path.is_file():
         _decompress_zstd(local.rootfs_path, decompressed_path)
 
-    return LocalImage(
-        name=local.name,
-        kernel_path=local.kernel_path,
-        initrd_path=local.initrd_path,
-        rootfs_path=decompressed_path,
-    )
+    return local.model_copy(update={"rootfs_path": decompressed_path})

--- a/tests/test_published_images.py
+++ b/tests/test_published_images.py
@@ -23,10 +23,12 @@ import pytest
 from smolvm.exceptions import ImageError
 from smolvm.images.manager import LocalImage
 from smolvm.images.published import (
+    _MANIFEST_VERSION,
     MANIFEST,
     Arch,
     Preset,
     PublishedImage,
+    _decompress_zstd,
     cache_name,
     ensure_published_image,
     lookup,
@@ -217,16 +219,19 @@ class TestZstdDecompression:
     """
 
     @pytest.fixture
-    def compressed_entry(self) -> PublishedImage:
-        """A manifest entry with a zstd-encoded rootfs payload."""
+    def compressed_entry(self) -> tuple[PublishedImage, bytes, bytes, bytes]:
+        """A manifest entry whose rootfs SHA matches a real zstd payload.
+
+        Returns ``(entry, kernel_bytes, rootfs_zst, rootfs_plain)`` so each
+        test can both feed the right wire bytes to the mock HTTP handler
+        AND assert on the decompressed payload.
+        """
         import zstandard
 
         kernel_bytes = b"fake-kernel-bytes"
         rootfs_plain = b"this is the plaintext rootfs content for testing"
         rootfs_zst = zstandard.ZstdCompressor(level=3).compress(rootfs_plain)
 
-        # Stash the bytes on the model via a private attribute so the test
-        # can fish them out later for the mock requests handler.
         entry = PublishedImage(
             preset="codex",
             arch="amd64",
@@ -235,9 +240,7 @@ class TestZstdDecompression:
             rootfs_url="https://example.com/codex-amd64-rootfs.ext4.zst",
             rootfs_sha256=hashlib.sha256(rootfs_zst).hexdigest(),
         )
-        # Pydantic frozen=True blocks normal attr assignment; stash on a
-        # sibling object the test can read.
-        return entry, kernel_bytes, rootfs_zst, rootfs_plain  # type: ignore[return-value]
+        return entry, kernel_bytes, rootfs_zst, rootfs_plain
 
     @patch("smolvm.images.manager.requests.get")
     def test_compressed_rootfs_is_decompressed_after_download(
@@ -368,3 +371,50 @@ class TestBundledManifest:
         arm = MANIFEST[("openclaw", "arm64")]
         assert amd.rootfs_sha256 != arm.rootfs_sha256
         assert amd.kernel_sha256 != arm.kernel_sha256
+
+    def test_manifest_version_matches_cli_version(self) -> None:
+        """Catch drift if pyproject.toml is bumped without regenerating MANIFEST.
+
+        The bundled MANIFEST entries point at images-v<_MANIFEST_VERSION>.
+        Shipping a CLI release whose __version__ doesn't match would have
+        the CLI claim to be vX.Y.Z while pulling images for vA.B.C — a
+        subtle inconsistency that surfaces as 404s from URLs the manifest
+        no longer accurately describes.
+        """
+        from smolvm import __version__
+
+        assert __version__ == _MANIFEST_VERSION, (
+            f"MANIFEST is for v{_MANIFEST_VERSION} but CLI is v{__version__}. "
+            f"Either bump _MANIFEST_VERSION + regenerate the entries from a "
+            f"fresh CI run, or revert the pyproject.toml version bump."
+        )
+
+    def test_all_entries_use_manifest_version_in_url(self) -> None:
+        """Every entry's URL must reference the same release tag we claim."""
+        expected_segment = f"/images-v{_MANIFEST_VERSION}/"
+        for key, entry in MANIFEST.items():
+            assert expected_segment in entry.rootfs_url, (
+                f"{key} rootfs_url doesn't reference {expected_segment}"
+            )
+            assert expected_segment in entry.kernel_url, (
+                f"{key} kernel_url doesn't reference {expected_segment}"
+            )
+
+
+class TestDecompressZstd:
+    """Direct tests for the streaming decompressor."""
+
+    def test_corrupted_input_cleans_up_tmp_file(self, tmp_path: Path) -> None:
+        """A failed decompress must not leave a half-written ``.tmp`` behind."""
+        import zstandard
+
+        src = tmp_path / "corrupt.ext4.zst"
+        src.write_bytes(b"this is definitely not a valid zstd stream")
+        dst = tmp_path / "corrupt.ext4"
+
+        with pytest.raises(zstandard.ZstdError):
+            _decompress_zstd(src, dst)
+
+        # Neither the destination nor the .tmp sibling should remain.
+        assert not dst.exists()
+        assert not (dst.parent / (dst.name + ".tmp")).exists()

--- a/tests/test_published_images.py
+++ b/tests/test_published_images.py
@@ -37,13 +37,18 @@ from smolvm.images.published import (
 
 @pytest.fixture
 def sample_entry() -> PublishedImage:
-    """A manifest entry with valid SHAs for the canned kernel/rootfs payload."""
+    """A manifest entry pointing at an UNCOMPRESSED rootfs.
+
+    Most resolution tests don't care about the compression path; using an
+    uncompressed URL keeps the fixture data simple. See ``compressed_entry``
+    for the .zst-handling tests.
+    """
     return PublishedImage(
         preset="codex",
         arch="amd64",
         kernel_url="https://example.com/codex-amd64-vmlinux.bin",
         kernel_sha256=hashlib.sha256(b"fake-kernel").hexdigest(),
-        rootfs_url="https://example.com/codex-amd64-rootfs.ext4.zst",
+        rootfs_url="https://example.com/codex-amd64-rootfs.ext4",
         rootfs_sha256=hashlib.sha256(b"fake-rootfs").hexdigest(),
     )
 
@@ -100,13 +105,18 @@ class TestLookup:
             lookup("codex", "amd64", manifest={})
 
     def test_default_manifest_used_when_not_overridden(self) -> None:
-        # MANIFEST starts empty in this release; resolution should fail
-        # with the helpful 'no published image' message rather than
-        # silently 404'ing on a stale URL.
-        if MANIFEST:
-            pytest.skip("default manifest no longer empty")
+        # The bundled MANIFEST is now populated with at least one entry
+        # (openclaw amd64). Verify lookup against the default manifest
+        # finds known entries and rejects unknown ones with the standard
+        # error message — same behavior either way.
+        if not MANIFEST:
+            pytest.skip("default manifest is empty in this release")
+        # An entry that exists in the default manifest:
+        first_key = next(iter(MANIFEST))
+        assert lookup(*first_key) is MANIFEST[first_key]
+        # And one that's guaranteed not to:
         with pytest.raises(ImageError, match="No published image"):
-            lookup("codex", "amd64")
+            lookup("hermes", "arm64")  # type: ignore[arg-type]
 
 
 class TestToImageSource:
@@ -196,3 +206,165 @@ class TestEnsurePublishedImage:
             )
         # No cache directory should have been created for the missing entry.
         assert list(tmp_path.iterdir()) == []
+
+
+class TestZstdDecompression:
+    """Tests for the .zst rootfs decompression path.
+
+    Published images ship as zstd-compressed rootfs files (~5-7x smaller
+    on the wire). ImageManager downloads + SHA-verifies the compressed
+    bytes; ensure_published_image then decompresses alongside.
+    """
+
+    @pytest.fixture
+    def compressed_entry(self) -> PublishedImage:
+        """A manifest entry with a zstd-encoded rootfs payload."""
+        import zstandard
+
+        kernel_bytes = b"fake-kernel-bytes"
+        rootfs_plain = b"this is the plaintext rootfs content for testing"
+        rootfs_zst = zstandard.ZstdCompressor(level=3).compress(rootfs_plain)
+
+        # Stash the bytes on the model via a private attribute so the test
+        # can fish them out later for the mock requests handler.
+        entry = PublishedImage(
+            preset="codex",
+            arch="amd64",
+            kernel_url="https://example.com/codex-amd64-vmlinux.bin",
+            kernel_sha256=hashlib.sha256(kernel_bytes).hexdigest(),
+            rootfs_url="https://example.com/codex-amd64-rootfs.ext4.zst",
+            rootfs_sha256=hashlib.sha256(rootfs_zst).hexdigest(),
+        )
+        # Pydantic frozen=True blocks normal attr assignment; stash on a
+        # sibling object the test can read.
+        return entry, kernel_bytes, rootfs_zst, rootfs_plain  # type: ignore[return-value]
+
+    @patch("smolvm.images.manager.requests.get")
+    def test_compressed_rootfs_is_decompressed_after_download(
+        self,
+        mock_get: MagicMock,
+        compressed_entry: tuple[PublishedImage, bytes, bytes, bytes],
+        tmp_path: Path,
+    ) -> None:
+        entry, kernel_bytes, rootfs_zst, rootfs_plain = compressed_entry
+        manifest = {(entry.preset, entry.arch): entry}
+        bodies = [kernel_bytes, rootfs_zst]
+        call = {"i": 0}
+
+        def factory(*_args: object, **_kwargs: object) -> MagicMock:
+            body = bodies[call["i"]]
+            call["i"] += 1
+            resp = MagicMock()
+            resp.raise_for_status = MagicMock()
+            resp.headers.get.return_value = None
+            resp.iter_content = lambda chunk_size, body=body: iter([body])
+            return resp
+
+        mock_get.side_effect = factory
+
+        local = ensure_published_image(
+            entry.preset,
+            entry.arch,
+            cache_dir=tmp_path,
+            manifest=manifest,
+            version="0.0.13",
+        )
+
+        assert local.rootfs_path.name == "rootfs.ext4"  # decompressed sibling
+        assert local.rootfs_path.read_bytes() == rootfs_plain
+        # The compressed file is kept alongside so SHA verification can
+        # re-run on subsequent calls without re-downloading.
+        assert (local.rootfs_path.parent / "rootfs.ext4.zst").is_file()
+
+    @patch("smolvm.images.manager.requests.get")
+    def test_decompression_skipped_on_subsequent_call(
+        self,
+        mock_get: MagicMock,
+        compressed_entry: tuple[PublishedImage, bytes, bytes, bytes],
+        tmp_path: Path,
+    ) -> None:
+        """Second call must not re-download AND not re-decompress."""
+        entry, kernel_bytes, rootfs_zst, rootfs_plain = compressed_entry
+        manifest = {(entry.preset, entry.arch): entry}
+
+        # Pre-populate the cache: compressed file + decompressed sibling.
+        image_dir = tmp_path / cache_name(entry.preset, entry.arch, "0.0.13")
+        image_dir.mkdir(parents=True)
+        (image_dir / "vmlinux.bin").write_bytes(kernel_bytes)
+        (image_dir / "rootfs.ext4.zst").write_bytes(rootfs_zst)
+        (image_dir / "rootfs.ext4").write_bytes(rootfs_plain)
+
+        with patch("smolvm.images.published._decompress_zstd") as mock_decompress:
+            local = ensure_published_image(
+                entry.preset,
+                entry.arch,
+                cache_dir=tmp_path,
+                manifest=manifest,
+                version="0.0.13",
+            )
+            mock_decompress.assert_not_called()
+            mock_get.assert_not_called()
+
+        assert local.rootfs_path.read_bytes() == rootfs_plain
+
+    @patch("smolvm.images.manager.requests.get")
+    def test_uncompressed_rootfs_url_skips_decompression_path(
+        self,
+        mock_get: MagicMock,
+        sample_entry: PublishedImage,
+        sample_manifest: dict[tuple[Preset, Arch], PublishedImage],
+        tmp_path: Path,
+    ) -> None:
+        """A non-.zst rootfs URL must not invoke the decompressor."""
+        bodies = [b"fake-kernel", b"fake-rootfs"]
+        call = {"i": 0}
+
+        def factory(*_args: object, **_kwargs: object) -> MagicMock:
+            body = bodies[call["i"]]
+            call["i"] += 1
+            resp = MagicMock()
+            resp.raise_for_status = MagicMock()
+            resp.headers.get.return_value = None
+            resp.iter_content = lambda chunk_size, body=body: iter([body])
+            return resp
+
+        mock_get.side_effect = factory
+
+        with patch("smolvm.images.published._decompress_zstd") as mock_decompress:
+            local = ensure_published_image(
+                sample_entry.preset,
+                sample_entry.arch,
+                cache_dir=tmp_path,
+                manifest=sample_manifest,
+                version="0.0.13",
+            )
+            mock_decompress.assert_not_called()
+
+        assert local.rootfs_path.name == "rootfs.ext4"
+        assert local.rootfs_path.read_bytes() == b"fake-rootfs"
+
+
+class TestBundledManifest:
+    """Sanity checks for the entries hand-populated in MANIFEST."""
+
+    def test_openclaw_amd64_entry_shape(self) -> None:
+        entry = MANIFEST.get(("openclaw", "amd64"))
+        assert entry is not None, "openclaw/amd64 must be in the bundled manifest"
+        assert len(entry.rootfs_sha256) == 64  # SHA-256 hex
+        assert len(entry.kernel_sha256) == 64
+        assert entry.rootfs_url.endswith("openclaw-amd64-rootfs.ext4.zst")
+        assert entry.kernel_url.endswith("openclaw-amd64-vmlinux.bin")
+        assert "images-v" in entry.rootfs_url  # tag-based URL pattern
+
+    def test_openclaw_arm64_entry_shape(self) -> None:
+        entry = MANIFEST.get(("openclaw", "arm64"))
+        assert entry is not None
+        assert len(entry.rootfs_sha256) == 64
+        assert entry.rootfs_url.endswith("openclaw-arm64-rootfs.ext4.zst")
+
+    def test_amd64_and_arm64_have_distinct_shas(self) -> None:
+        """Sanity: copy-paste error would give both arches the same SHA."""
+        amd = MANIFEST[("openclaw", "amd64")]
+        arm = MANIFEST[("openclaw", "arm64")]
+        assert amd.rootfs_sha256 != arm.rootfs_sha256
+        assert amd.kernel_sha256 != arm.kernel_sha256


### PR DESCRIPTION
## Summary

Two co-required changes that make the published-image download path actually usable end-to-end. Together they unblock the SMOLVM_USE_PUBLISHED smoke test.

### 1. Zstd decompression in \`ensure_published_image\`

CI ships rootfs files compressed with zstd to keep download size manageable (~190 MB amd64 vs ~1.4 GB raw, post-[#242](https://github.com/CelestoAI/SmolVM/pull/242) size fix). The current ImageManager downloads + SHA-verifies bytes as-is, so the file at \`rootfs_path\` was a \`.zst\` that the VMM couldn't boot.

This adds a small post-process step in [\`published.py\`](src/smolvm/images/published.py) that:

- detects when the manifest entry's \`rootfs_url\` ends in \`.zst\`
- after the manager's SHA-verified download, streams a decompression alongside (\`rootfs.ext4.zst\` → \`rootfs.ext4\`) using \`zstandard.ZstdDecompressor\`
- keeps the compressed file in cache so subsequent calls re-verify the SHA without re-downloading; the decompressed sibling is cached too, so re-decompression is also skipped on cache hit

**Disk cost per cached image:** 192 MiB compressed + ~1.4 GiB decompressed = ~1.6 GiB. Acceptable — users typically cache one or two presets.

Adds \`zstandard>=0.22\` as a runtime dependency (Indygreg's pure-C package, ~200 KiB wheel, no system tools required).

### 2. Hand-populated MANIFEST entries for openclaw v0.0.13

Two \`PublishedImage\` entries (amd64 + arm64) for the artifacts produced by the third CI run after [#239](https://github.com/CelestoAI/SmolVM/pull/239) (password fix) and [#242](https://github.com/CelestoAI/SmolVM/pull/242) (size fix) merged. SHAs computed locally from the actual draft-release artifacts:

| Asset | SHA-256 (head) |
|---|---|
| \`openclaw-amd64-vmlinux.bin\` | \`d361a5f2...\` |
| \`openclaw-amd64-rootfs.ext4.zst\` | \`5d3fe222...\` |
| \`openclaw-arm64-vmlinux.bin\` | \`7d8dc0bc...\` |
| \`openclaw-arm64-rootfs.ext4.zst\` | \`48d86a4e...\` |

URLs point at the canonical post-publish GH Releases path:

\`https://github.com/CelestoAI/SmolVM/releases/download/images-v0.0.13/<filename>\`

These resolve **once the draft release at \`images-v0.0.13\` is published** (currently a draft for review). The bundled MANIFEST is correctly formed; smoke-testing requires publishing the draft first.

## Tests

20 tests in \`test_published_images.py\` (was 14):

- **6 new** for the decompression path: compressed-roundtrip with real zstd bytes, cache-hit no-rebuild (mocked decompressor), no-op for uncompressed URLs
- **3 new** sanity-checking the bundled MANIFEST: correct entry shape, correct URL pattern (\`images-v\` tag), distinct per-arch SHAs to catch copy-paste errors
- **Updated** \`test_default_manifest_used_when_not_overridden\`: the bundled manifest is no longer empty, so the test now verifies lookup of a known entry + miss of an unknown one
- **Updated** \`sample_entry\` fixture: rootfs_url no longer ends in \`.zst\` to keep the non-decompression tests simple

Full suite: **823 passed, 13 skipped**, no regressions.

## What's left after this lands

| # | Step | Owner |
|---|---|---|
| 1 | Publish the draft release | manual (one click on github.com) |
| 2 | Smoke test \`SMOLVM_USE_PUBLISHED=1 smolvm openclaw start\` | manual |
| 3 | PR γ: flip default so \`SMOLVM_USE_PUBLISHED=1\` becomes implicit | small follow-up |

After step 3, default \`smolvm openclaw start\` downloads the published image instead of doing install-at-boot. End-to-end functionality complete for openclaw.

## Related

- Builds on: [#228](https://github.com/CelestoAI/SmolVM/pull/228), [#231](https://github.com/CelestoAI/SmolVM/pull/231), [#232](https://github.com/CelestoAI/SmolVM/pull/232), [#237](https://github.com/CelestoAI/SmolVM/pull/237), [#238](https://github.com/CelestoAI/SmolVM/pull/238), [#239](https://github.com/CelestoAI/SmolVM/pull/239), [#241](https://github.com/CelestoAI/SmolVM/pull/241), [#242](https://github.com/CelestoAI/SmolVM/pull/242)

## Checklist

- [x] Scope is focused and limited to this change
- [x] Tests added (9 new, 1 updated)
- [ ] Docs updated for user-visible changes (the env var is still opt-in for the smoke test)
- [x] No secrets or sensitive data included