### PR TITLE
fix(cli): reject SMOLVM_USE_PUBLISHED on macOS with a clear error

### DIFF
--- a/src/smolvm/cli/main.py
+++ b/src/smolvm/cli/main.py
@@ -1884,7 +1884,7 @@ def _run_start_with_published_image(args: argparse.Namespace, preset: object) ->
             ValueError(
                 f"Published images are Linux-only for now: the Firecracker "
                 f"runtime they use requires KVM, which is unavailable on "
-                f"{platform.system()}. Run `smolvm {_preset.name} start` "
+                f"{platform.system()}, so run `smolvm {_preset.name} start` "
                 f"without SMOLVM_USE_PUBLISHED to use the default flow."
             ),
             json_output=args.json,

--- a/src/smolvm/cli/main.py
+++ b/src/smolvm/cli/main.py
@@ -1869,6 +1869,27 @@ def _run_start_with_published_image(args: argparse.Namespace, preset: object) ->
 
     _preset: Preset = preset  # type: ignore[assignment]
 
+    # Published images are built with a Firecracker-CI kernel (virtio-MMIO,
+    # no PCI drivers) and the launch path below uses backend="firecracker",
+    # which requires KVM and the Linux `ip` toolchain for TAP setup.
+    # Neither exists on macOS — the failure cascades through several
+    # confusing error messages (sudo, missing `ip`, network-cleanup also
+    # fails). Reject up-front with one clear message instead. Tracked as a
+    # follow-up to validate libkrun (Firecracker-API-compatible runtime
+    # backed by Hypervisor.framework) for macOS parity.
+    if platform.system() != "Linux":
+        return _emit_cli_error(
+            "start",
+            2,
+            ValueError(
+                f"Published images are Linux-only for now: the Firecracker "
+                f"runtime they use requires KVM, which is unavailable on "
+                f"{platform.system()}. Run `smolvm {_preset.name} start` "
+                f"without SMOLVM_USE_PUBLISHED to use the default flow."
+            ),
+            json_output=args.json,
+        )
+
     if _preset.name not in _PUBLISHED_IMAGE_BOOT_ARGS:
         return _emit_cli_error(
             "start",

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -2808,10 +2808,12 @@ class TestPublishedImageLaunchPath:
         assert called_args[1].name == "openclaw"
 
     @patch.dict(os.environ, {"SMOLVM_USE_PUBLISHED": "1"})
+    @patch("smolvm.cli.main.platform.system", return_value="Linux")
     @patch("smolvm.images.published.ensure_published_image")
     def test_published_path_surfaces_missing_manifest_error(
         self,
         mock_ensure: MagicMock,
+        _mock_system: MagicMock,
     ) -> None:
         """An empty manifest entry should produce a clean CLI error, not a crash."""
         from smolvm.exceptions import ImageError
@@ -2826,13 +2828,36 @@ class TestPublishedImageLaunchPath:
         mock_ensure.assert_called_once()
 
     @patch.dict(os.environ, {"SMOLVM_USE_PUBLISHED": "1"})
+    @patch("smolvm.cli.main.platform.system", return_value="Darwin")
+    @patch("smolvm.images.published.ensure_published_image")
+    def test_published_path_rejects_macos_up_front(
+        self,
+        mock_ensure: MagicMock,
+        _mock_system: MagicMock,
+    ) -> None:
+        """macOS hits Firecracker's KVM/TAP requirements; reject before that.
+
+        The pre-fix failure cascade was confusing: sudo prompt → missing
+        ``ip`` binary → cleanup-also-fails. One clear error pointing at
+        the install-at-boot fallback is much friendlier.
+        """
+        ret = main(["openclaw", "start", "--json"])
+
+        assert ret == 2  # ValueError → exit 2 (matches existing CLI convention)
+        # Most importantly, ensure_published_image must NOT have been called —
+        # we should error before trying to download anything.
+        mock_ensure.assert_not_called()
+
+    @patch.dict(os.environ, {"SMOLVM_USE_PUBLISHED": "1"})
     @patch("smolvm.cli.main.subprocess.run")
     @patch("smolvm.facade.SmolVM")
     @patch("smolvm.utils.ensure_ssh_key")
     @patch("smolvm.images.published.ensure_published_image")
     @patch("smolvm.cli.main.platform.machine", return_value="x86_64")
+    @patch("smolvm.cli.main.platform.system", return_value="Linux")
     def test_published_path_happy_path_skips_apply_preset(
         self,
+        _mock_system: MagicMock,
         _mock_machine: MagicMock,
         mock_ensure_image: MagicMock,
         mock_ensure_ssh_key: MagicMock,

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -2834,6 +2834,7 @@ class TestPublishedImageLaunchPath:
         self,
         mock_ensure: MagicMock,
         _mock_system: MagicMock,
+        capsys: pytest.CaptureFixture[str],
     ) -> None:
         """macOS hits Firecracker's KVM/TAP requirements; reject before that.
 
@@ -2843,7 +2844,13 @@ class TestPublishedImageLaunchPath:
         """
         ret = main(["openclaw", "start", "--json"])
 
+        captured = capsys.readouterr()
+        envelope = json.loads(captured.out)
+
         assert ret == 2  # ValueError → exit 2 (matches existing CLI convention)
+        assert envelope["exit_code"] == 2
+        assert envelope["error"] is not None
+        assert "Linux-only" in envelope["error"]["message"]
         # Most importantly, ensure_published_image must NOT have been called —
         # we should error before trying to download anything.
         mock_ensure.assert_not_called()


### PR DESCRIPTION
## Summary

Field report from a macOS user opting in via \`SMOLVM_USE_PUBLISHED=1\`:

\`\`\`
Failed to create VM openclaw-crick: Missing non-interactive sudo privileges
for SmolVM runtime command.
Command: sudo -n ip tuntap add tap2 mode tap user aniket
...
Failed to detect outbound interface: [Errno 2] No such file or directory: 'ip'
\`\`\`

The published-image launch path I added in [#241](https://github.com/CelestoAI/SmolVM/pull/241) hardcodes \`backend="firecracker"\`, which only runs on Linux: the CI images ship with a Firecracker-CI kernel (virtio-MMIO, no PCI), and Firecracker itself needs \`/dev/kvm\` + the Linux \`ip\` toolchain for TAP setup. On macOS the failure cascades through three confusing errors (\`sudo\` prompt → missing \`ip\` → cleanup-also-fails) before exiting non-zero.

This PR rejects up front with one clear message pointing back to the install-at-boot path, which still works on macOS:

\`\`\`
$ SMOLVM_USE_PUBLISHED=1 smolvm openclaw start
Error: Published images are Linux-only for now: the Firecracker runtime
they use requires KVM, which is unavailable on Darwin. Run \`smolvm openclaw
start\` without SMOLVM_USE_PUBLISHED to use the default flow.
\`\`\`

## Why this matters now

Without it, the rollout question \"flip the default in PR γ?\" carried a hidden risk: macOS users who set the env var (or get the env var set on their machine for testing) would see this confusing failure. With this fix in place, the macOS path is fail-fast with one clear message; flipping the default later won't regress macOS so long as the default-flip code also picks an appropriate backend per platform (or just leaves macOS on the install-at-boot path).

## Why a hard reject rather than auto-fallback

Two reasons:

1. **The user explicitly opted in via the env var.** Silently falling back to a different code path would surprise them. Fail-loud is more honest.
2. **We haven't validated libkrun yet.** SmolVM has \`BACKEND_LIBKRUN\` (Firecracker-API-compatible runtime backed by macOS Hypervisor.framework). Our images *might* boot under it — same virtio-MMIO model, same kernel ABI — but until that's tested, auto-falling-back to libkrun on macOS would risk shipping a different mysterious failure.

## Follow-up worth doing

Validate that our published Firecracker image actually boots under libkrun. If yes, the right next change swaps this hard reject for a backend swap (firecracker on Linux, libkrun on macOS) and macOS gets parity. Worth a separate spike PR.

## Testing

- \`uv run pytest tests/test_cli.py::TestPublishedImageLaunchPath\` — 16 passed (1 new + 15 existing, no regressions)
- \`uv run pytest tests/\` — 827 passed, 13 skipped, no regressions
- \`uv run ruff check src/smolvm/cli/main.py tests/test_cli.py\` — clean (modulo pre-existing E501 long-lines elsewhere in cli/main.py, untouched here)

New test \`test_published_path_rejects_macos_up_front\`:
- patches \`platform.system\` to \"Darwin\"
- runs \`smolvm openclaw start --json\` with \`SMOLVM_USE_PUBLISHED=1\`
- asserts exit code 2 (the existing CLI convention for ValueError)
- asserts \`ensure_published_image\` was **not** called — we cut the chain before any download attempt

Existing tests that exercise the published path got \`platform.system=\"Linux\"\` patches added so they don't hit the new rejection when the dev machine is macOS.

## Related

- Caused by: [#241](https://github.com/CelestoAI/SmolVM/pull/241) (hardcoded \`backend=\"firecracker\"\`)
- Unblocks: PR γ (default flip)
- Follow-up worth tracking: validate libkrun for macOS parity

## Checklist

- [x] Scope is focused
- [x] Test added for the new rejection (and existing tests updated to not regress)
- [x] No secrets or sensitive data included

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * The published-image launch mode now immediately rejects running on non‑Linux platforms (macOS, Windows, etc.), exits with code 2, and returns a clear error (also in JSON output when requested) to prevent later, misleading failures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->