### PR TITLE
refactor(images): add vmm dimension to PublishedImage manifest schema

### DIFF
--- a/src/smolvm/cli/main.py
+++ b/src/smolvm/cli/main.py
@@ -51,6 +51,7 @@ from smolvm.host.doctor import run_doctor
 from smolvm.types import BrowserSessionState, GuestOS, VMState
 
 if TYPE_CHECKING:
+    from smolvm.images.published import Arch
     from smolvm.types import BrowserSessionInfo, SnapshotInfo, VMInfo
 
 DASHBOARD_ALLOW_BETA_ENV = "SMOLVM_DASHBOARD_ALLOW_BETA"
@@ -1833,7 +1834,7 @@ def _published_path_enabled() -> bool:
     return os.environ.get("SMOLVM_USE_PUBLISHED", "").strip().lower() in {"1", "true", "yes"}
 
 
-def _host_arch_for_published() -> str:
+def _host_arch_for_published() -> Arch:
     """Host CPU architecture in the form the manifest uses (``amd64``/``arm64``)."""
     machine = platform.machine().lower()
     if machine in {"arm64", "aarch64"}:

--- a/src/smolvm/cli/main.py
+++ b/src/smolvm/cli/main.py
@@ -1886,10 +1886,12 @@ def _run_start_with_published_image(args: argparse.Namespace, preset: object) ->
         private_key, public_key_path = ensure_ssh_key()
         public_key_value = public_key_path.read_text().strip()
 
-        # Raises ImageError with a clear message if the (preset, arch) pair
-        # has no manifest entry — the manifest is bundled in published.py
-        # and starts empty until the auto-update PR populates it.
-        local_image = ensure_published_image(_preset.name, arch)  # type: ignore[arg-type]
+        # Raises ImageError with a clear message if the (preset, arch, vmm)
+        # tuple has no manifest entry. ``vmm`` is hardcoded to firecracker
+        # here and reflects the only kernel variant we publish today; the
+        # CLI-side platform-to-vmm mapping (Linux→firecracker, Darwin→qemu)
+        # lands in a follow-up PR alongside the QEMU kernel rows.
+        local_image = ensure_published_image(_preset.name, arch, "firecracker")  # type: ignore[arg-type]
 
         config = VMConfig(
             vm_id=_resolve_vm_name(args.name, prefix=_preset.name),

--- a/src/smolvm/images/published.py
+++ b/src/smolvm/images/published.py
@@ -27,9 +27,9 @@ decompresses the rootfs if the URL ends in ``.zst``.
 Why ``vmm`` is a separate dimension: the kernel must be tuned for the
 hypervisor it runs under (Firecracker uses MMIO virtio + 8250 UART; QEMU
 uses PCI virtio + PL011 UART on aarch64). The same rootfs works for both
-since it's just a filesystem, but different kernels are required. The CLI
-auto-derives ``vmm`` from ``platform.system()`` — that policy lives at the
-CLI layer, not here.
+since it's just a filesystem, but different kernels are required. The
+caller (typically the CLI) decides which ``vmm`` to request — this module
+is policy-free.
 """
 
 from __future__ import annotations

--- a/src/smolvm/images/published.py
+++ b/src/smolvm/images/published.py
@@ -19,10 +19,17 @@ lock-step to the CLI version: SmolVM ``X.Y.Z`` always pulls images from
 the ``images-vX.Y.Z`` release tag. The ``MANIFEST`` below is the bundled
 catalog the CLI ships with — entries are appended as CI publishes them.
 
-Resolution flow: ``ensure_published_image(preset, arch)`` looks up the
+Resolution flow: ``ensure_published_image(preset, arch, vmm)`` looks up the
 matching entry, converts it to an :class:`ImageSource`, delegates to
 :class:`ImageManager` for caching + SHA-256-verified download, and
 decompresses the rootfs if the URL ends in ``.zst``.
+
+Why ``vmm`` is a separate dimension: the kernel must be tuned for the
+hypervisor it runs under (Firecracker uses MMIO virtio + 8250 UART; QEMU
+uses PCI virtio + PL011 UART on aarch64). The same rootfs works for both
+since it's just a filesystem, but different kernels are required. The CLI
+auto-derives ``vmm`` from ``platform.system()`` — that policy lives at the
+CLI layer, not here.
 """
 
 from __future__ import annotations
@@ -38,6 +45,9 @@ from smolvm.images.manager import ImageManager, ImageSource, LocalImage
 
 Arch = Literal["amd64", "arm64"]
 Preset = Literal["codex", "claude-code", "openclaw", "hermes"]
+# ``libkrun`` is reserved here for a future spike — manifest accepts the type
+# but the CLI never resolves a host to it until libkrun support is wired.
+Vmm = Literal["firecracker", "qemu", "libkrun"]
 
 
 class PublishedImage(BaseModel):
@@ -45,6 +55,7 @@ class PublishedImage(BaseModel):
 
     preset: Preset
     arch: Arch
+    vmm: Vmm
     kernel_url: str
     kernel_sha256: str
     rootfs_url: str
@@ -58,13 +69,19 @@ def release_tag(version: str = __version__) -> str:
     return f"images-v{version}"
 
 
-def cache_name(preset: Preset, arch: Arch, version: str = __version__) -> str:
+def cache_name(preset: Preset, arch: Arch, vmm: Vmm, version: str = __version__) -> str:
     """Cache directory name under ``~/.smolvm/images/``.
 
-    Versioned + arch-suffixed so multiple installs and architectures
-    coexist on the same machine without overwriting each other.
+    Versioned + arch- + vmm-suffixed so multiple installs, architectures,
+    and hypervisors coexist on the same machine without overwriting each
+    other. A user switching backends mid-session gets a fresh cache dir
+    per vmm rather than fighting over one.
+
+    Note: caches from before the vmm dimension landed (no ``-<vmm>``
+    suffix) become orphaned and ignored. They stay on disk untouched
+    until the user clears them.
     """
-    return f"{preset}-v{version}-{arch}"
+    return f"{preset}-v{version}-{arch}-{vmm}"
 
 
 def _release_asset_url(preset: Preset, arch: Arch, suffix: str, version: str) -> str:
@@ -88,23 +105,25 @@ def _release_asset_url(preset: Preset, arch: Arch, suffix: str, version: str) ->
 # pyproject.toml version bumps don't ship with stale manifest entries.
 _MANIFEST_VERSION = "0.0.13"
 
-# Bundled manifest. New (preset, arch) entries land here as CI publishes
+# Bundled manifest. New (preset, arch, vmm) entries land here as CI publishes
 # images — paired by version with this CLI release. The SHA-256s and URLs
 # below match the artifacts produced by the CI workflow at
 # .github/workflows/build-published-images.yml; they're also visible in
 # the corresponding GH release's step summary on each successful run.
-MANIFEST: dict[tuple[Preset, Arch], PublishedImage] = {
-    ("openclaw", "amd64"): PublishedImage(
+MANIFEST: dict[tuple[Preset, Arch, Vmm], PublishedImage] = {
+    ("openclaw", "amd64", "firecracker"): PublishedImage(
         preset="openclaw",
         arch="amd64",
+        vmm="firecracker",
         kernel_url=_release_asset_url("openclaw", "amd64", "vmlinux.bin", _MANIFEST_VERSION),
         kernel_sha256="d361a5f2e67b2e243964ad93f25a2d9e5bee320204a84a7af089949228af5c2a",
         rootfs_url=_release_asset_url("openclaw", "amd64", "rootfs.ext4.zst", _MANIFEST_VERSION),
         rootfs_sha256="5d3fe222b017f350f5bb2f01c1fa28cd3425b5dddb32d6377d97bc0e3fea355b",
     ),
-    ("openclaw", "arm64"): PublishedImage(
+    ("openclaw", "arm64", "firecracker"): PublishedImage(
         preset="openclaw",
         arch="arm64",
+        vmm="firecracker",
         kernel_url=_release_asset_url("openclaw", "arm64", "vmlinux.bin", _MANIFEST_VERSION),
         kernel_sha256="7d8dc0bce701037ea5ceccfc997c05b11f99aba215c73ed18a2269154837c497",
         rootfs_url=_release_asset_url("openclaw", "arm64", "rootfs.ext4.zst", _MANIFEST_VERSION),
@@ -116,16 +135,18 @@ MANIFEST: dict[tuple[Preset, Arch], PublishedImage] = {
 def lookup(
     preset: Preset,
     arch: Arch,
+    vmm: Vmm,
     *,
-    manifest: dict[tuple[Preset, Arch], PublishedImage] | None = None,
+    manifest: dict[tuple[Preset, Arch, Vmm], PublishedImage] | None = None,
 ) -> PublishedImage:
     """Look up a manifest entry, raising :class:`ImageError` if missing."""
     catalog = MANIFEST if manifest is None else manifest
-    entry = catalog.get((preset, arch))
+    entry = catalog.get((preset, arch, vmm))
     if entry is None:
-        available = ", ".join(sorted(f"{p}/{a}" for (p, a) in catalog)) or "(none)"
+        available = ", ".join(sorted(f"{p}/{a}/{v}" for (p, a, v) in catalog)) or "(none)"
         raise ImageError(
-            f"No published image for preset '{preset}' on arch '{arch}' (available: {available})."
+            f"No published image for preset '{preset}' on arch '{arch}' under "
+            f"vmm '{vmm}' (available: {available})."
         )
     return entry
 
@@ -140,7 +161,7 @@ def to_image_source(entry: PublishedImage, version: str = __version__) -> ImageS
     """
     rootfs_filename = "rootfs.ext4.zst" if entry.rootfs_url.endswith(".zst") else "rootfs.ext4"
     return ImageSource(
-        name=cache_name(entry.preset, entry.arch, version),
+        name=cache_name(entry.preset, entry.arch, entry.vmm, version),
         kernel_url=entry.kernel_url,
         kernel_sha256=entry.kernel_sha256,
         rootfs_url=entry.rootfs_url,
@@ -165,9 +186,10 @@ def _decompress_zstd(src: Path, dst: Path) -> None:
 def ensure_published_image(
     preset: Preset,
     arch: Arch,
+    vmm: Vmm,
     *,
     cache_dir: Path | None = None,
-    manifest: dict[tuple[Preset, Arch], PublishedImage] | None = None,
+    manifest: dict[tuple[Preset, Arch, Vmm], PublishedImage] | None = None,
     version: str = __version__,
 ) -> LocalImage:
     """Download (if needed) and return paths to a published preset image.
@@ -175,6 +197,9 @@ def ensure_published_image(
     Args:
         preset: Preset name (e.g. ``"codex"``).
         arch: Guest CPU architecture (``"amd64"`` or ``"arm64"``).
+        vmm: Hypervisor variant the image was built for (``"firecracker"``,
+            ``"qemu"``, or ``"libkrun"``). Caller must pre-resolve this from
+            host platform — this module is policy-free.
         cache_dir: Override the default cache directory (mainly for tests).
         manifest: Override the bundled manifest (mainly for tests).
         version: Override the CLI version used to compute the cache name.
@@ -187,10 +212,10 @@ def ensure_published_image(
         produced lazily.
 
     Raises:
-        ImageError: If no manifest entry exists for the (preset, arch) pair,
-            or if download / SHA-256 verification fails.
+        ImageError: If no manifest entry exists for the (preset, arch, vmm)
+            tuple, or if download / SHA-256 verification fails.
     """
-    entry = lookup(preset, arch, manifest=manifest)
+    entry = lookup(preset, arch, vmm, manifest=manifest)
     source = to_image_source(entry, version=version)
     manager = ImageManager(cache_dir=cache_dir, registry={source.name: source})
     local = manager.ensure_image(source.name)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -2874,7 +2874,7 @@ class TestPublishedImageLaunchPath:
             mock_apply.assert_not_called()
 
         assert ret == 0
-        mock_ensure_image.assert_called_once_with("openclaw", "amd64")
+        mock_ensure_image.assert_called_once_with("openclaw", "amd64", "firecracker")
 
         # Verify VMConfig was built with the right wiring.
         config_arg = mock_vm_cls.call_args[0][0]

--- a/tests/test_published_images.py
+++ b/tests/test_published_images.py
@@ -15,6 +15,7 @@
 """Tests for the published-image manifest and resolution path."""
 
 import hashlib
+from collections import defaultdict
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
@@ -28,6 +29,7 @@ from smolvm.images.published import (
     Arch,
     Preset,
     PublishedImage,
+    Vmm,
     _decompress_zstd,
     cache_name,
     ensure_published_image,
@@ -48,6 +50,7 @@ def sample_entry() -> PublishedImage:
     return PublishedImage(
         preset="codex",
         arch="amd64",
+        vmm="firecracker",
         kernel_url="https://example.com/codex-amd64-vmlinux.bin",
         kernel_sha256=hashlib.sha256(b"fake-kernel").hexdigest(),
         rootfs_url="https://example.com/codex-amd64-rootfs.ext4",
@@ -58,67 +61,81 @@ def sample_entry() -> PublishedImage:
 @pytest.fixture
 def sample_manifest(
     sample_entry: PublishedImage,
-) -> dict[tuple[Preset, Arch], PublishedImage]:
-    return {(sample_entry.preset, sample_entry.arch): sample_entry}
+) -> dict[tuple[Preset, Arch, Vmm], PublishedImage]:
+    return {(sample_entry.preset, sample_entry.arch, sample_entry.vmm): sample_entry}
 
 
 class TestNaming:
     def test_release_tag_uses_version(self) -> None:
         assert release_tag("0.0.13") == "images-v0.0.13"
 
-    def test_cache_name_includes_preset_version_arch(self) -> None:
-        assert cache_name("codex", "amd64", version="0.0.13") == "codex-v0.0.13-amd64"
+    def test_cache_name_includes_preset_version_arch_vmm(self) -> None:
+        assert (
+            cache_name("codex", "amd64", "firecracker", version="0.0.13")
+            == "codex-v0.0.13-amd64-firecracker"
+        )
 
     def test_cache_name_distinguishes_arches(self) -> None:
-        amd = cache_name("codex", "amd64", version="0.0.13")
-        arm = cache_name("codex", "arm64", version="0.0.13")
+        amd = cache_name("codex", "amd64", "firecracker", version="0.0.13")
+        arm = cache_name("codex", "arm64", "firecracker", version="0.0.13")
         assert amd != arm
 
     def test_cache_name_distinguishes_versions(self) -> None:
-        v1 = cache_name("codex", "amd64", version="0.0.13")
-        v2 = cache_name("codex", "amd64", version="0.0.14")
+        v1 = cache_name("codex", "amd64", "firecracker", version="0.0.13")
+        v2 = cache_name("codex", "amd64", "firecracker", version="0.0.14")
         assert v1 != v2
+
+    def test_cache_name_distinguishes_vmms(self) -> None:
+        """A user with both firecracker and qemu caches must not share a path."""
+        fc = cache_name("openclaw", "amd64", "firecracker", version="0.0.13")
+        qe = cache_name("openclaw", "amd64", "qemu", version="0.0.13")
+        assert fc != qe
 
 
 class TestLookup:
     def test_returns_matching_entry(
         self,
         sample_entry: PublishedImage,
-        sample_manifest: dict[tuple[Preset, Arch], PublishedImage],
+        sample_manifest: dict[tuple[Preset, Arch, Vmm], PublishedImage],
     ) -> None:
-        assert lookup("codex", "amd64", manifest=sample_manifest) is sample_entry
+        assert lookup("codex", "amd64", "firecracker", manifest=sample_manifest) is sample_entry
 
     def test_missing_pair_raises_image_error(
         self,
-        sample_manifest: dict[tuple[Preset, Arch], PublishedImage],
+        sample_manifest: dict[tuple[Preset, Arch, Vmm], PublishedImage],
     ) -> None:
         with pytest.raises(ImageError, match="No published image for preset 'codex'"):
-            lookup("codex", "arm64", manifest=sample_manifest)
+            lookup("codex", "arm64", "firecracker", manifest=sample_manifest)
 
-    def test_error_lists_available_pairs(
+    def test_error_lists_available_tuples(
         self,
-        sample_manifest: dict[tuple[Preset, Arch], PublishedImage],
+        sample_manifest: dict[tuple[Preset, Arch, Vmm], PublishedImage],
     ) -> None:
-        with pytest.raises(ImageError, match="codex/amd64"):
-            lookup("openclaw", "amd64", manifest=sample_manifest)
+        with pytest.raises(ImageError, match="codex/amd64/firecracker"):
+            lookup("openclaw", "amd64", "firecracker", manifest=sample_manifest)
 
     def test_error_when_manifest_empty(self) -> None:
         with pytest.raises(ImageError, match=r"available: \(none\)"):
-            lookup("codex", "amd64", manifest={})
+            lookup("codex", "amd64", "firecracker", manifest={})
+
+    def test_error_mentions_vmm_dimension(
+        self,
+        sample_manifest: dict[tuple[Preset, Arch, Vmm], PublishedImage],
+    ) -> None:
+        """Looking up a vmm that doesn't exist names it explicitly."""
+        with pytest.raises(ImageError, match=r"vmm 'qemu'"):
+            lookup("codex", "amd64", "qemu", manifest=sample_manifest)
 
     def test_default_manifest_used_when_not_overridden(self) -> None:
-        # The bundled MANIFEST is now populated with at least one entry
-        # (openclaw amd64). Verify lookup against the default manifest
-        # finds known entries and rejects unknown ones with the standard
-        # error message — same behavior either way.
+        # Verify lookup against the default (bundled) manifest finds known
+        # entries and rejects unknown ones with the standard error.
         if not MANIFEST:
             pytest.skip("default manifest is empty in this release")
-        # An entry that exists in the default manifest:
         first_key = next(iter(MANIFEST))
         assert lookup(*first_key) is MANIFEST[first_key]
         # And one that's guaranteed not to:
         with pytest.raises(ImageError, match="No published image"):
-            lookup("hermes", "arm64")  # type: ignore[arg-type]
+            lookup("hermes", "arm64", "firecracker")  # type: ignore[arg-type]
 
 
 class TestToImageSource:
@@ -131,17 +148,22 @@ class TestToImageSource:
 
     def test_name_uses_cache_name(self, sample_entry: PublishedImage) -> None:
         source = to_image_source(sample_entry, version="0.0.13")
-        assert source.name == cache_name(sample_entry.preset, sample_entry.arch, version="0.0.13")
+        assert source.name == cache_name(
+            sample_entry.preset,
+            sample_entry.arch,
+            sample_entry.vmm,
+            version="0.0.13",
+        )
 
 
 class TestEnsurePublishedImage:
     def test_returns_cached_without_download(
         self,
         tmp_path: Path,
-        sample_manifest: dict[tuple[Preset, Arch], PublishedImage],
+        sample_manifest: dict[tuple[Preset, Arch, Vmm], PublishedImage],
     ) -> None:
         version = "0.0.13"
-        image_dir = tmp_path / cache_name("codex", "amd64", version=version)
+        image_dir = tmp_path / cache_name("codex", "amd64", "firecracker", version=version)
         image_dir.mkdir(parents=True)
         (image_dir / "vmlinux.bin").write_bytes(b"fake-kernel")
         (image_dir / "rootfs.ext4").write_bytes(b"fake-rootfs")
@@ -150,6 +172,7 @@ class TestEnsurePublishedImage:
             local = ensure_published_image(
                 "codex",
                 "amd64",
+                "firecracker",
                 cache_dir=tmp_path,
                 manifest=sample_manifest,
                 version=version,
@@ -165,7 +188,7 @@ class TestEnsurePublishedImage:
         self,
         mock_get: MagicMock,
         tmp_path: Path,
-        sample_manifest: dict[tuple[Preset, Arch], PublishedImage],
+        sample_manifest: dict[tuple[Preset, Arch, Vmm], PublishedImage],
     ) -> None:
         version = "0.0.13"
         bodies = [b"fake-kernel", b"fake-rootfs"]
@@ -185,6 +208,7 @@ class TestEnsurePublishedImage:
         local = ensure_published_image(
             "codex",
             "amd64",
+            "firecracker",
             cache_dir=tmp_path,
             manifest=sample_manifest,
             version=version,
@@ -194,20 +218,77 @@ class TestEnsurePublishedImage:
         assert local.rootfs_path.read_bytes() == b"fake-rootfs"
         assert mock_get.call_count == 2
 
-    def test_unknown_pair_raises_before_touching_filesystem(
+    def test_unknown_tuple_raises_before_touching_filesystem(
         self,
         tmp_path: Path,
-        sample_manifest: dict[tuple[Preset, Arch], PublishedImage],
+        sample_manifest: dict[tuple[Preset, Arch, Vmm], PublishedImage],
     ) -> None:
         with pytest.raises(ImageError, match="No published image"):
             ensure_published_image(
                 "codex",
                 "arm64",
+                "firecracker",
                 cache_dir=tmp_path,
                 manifest=sample_manifest,
             )
         # No cache directory should have been created for the missing entry.
         assert list(tmp_path.iterdir()) == []
+
+    def test_different_vmms_get_different_cache_dirs(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        """Same (preset, arch) but different vmms must NOT share cache state.
+
+        A user who runs both firecracker and qemu variants gets two cache
+        directories. They share nothing — different kernels, possibly
+        different rootfs URLs. Even if the rootfs is identical bytes, the
+        cache layout keeps them isolated to avoid cross-vmm cache poisoning.
+        """
+        version = "0.0.13"
+        # Pre-populate two distinct caches at the expected paths.
+        for vmm in ("firecracker", "qemu"):
+            image_dir = tmp_path / cache_name("codex", "amd64", vmm, version=version)  # type: ignore[arg-type]
+            image_dir.mkdir(parents=True)
+            (image_dir / "vmlinux.bin").write_bytes(f"kernel-{vmm}".encode())
+            (image_dir / "rootfs.ext4").write_bytes(b"shared-rootfs")
+
+        # Build a manifest with both vmm rows pointing at distinct kernel URLs.
+        manifest: dict[tuple[Preset, Arch, Vmm], PublishedImage] = {}
+        for vmm in ("firecracker", "qemu"):
+            manifest[("codex", "amd64", vmm)] = PublishedImage(  # type: ignore[index]
+                preset="codex",
+                arch="amd64",
+                vmm=vmm,  # type: ignore[arg-type]
+                kernel_url=f"https://example.com/codex-{vmm}-kernel",
+                kernel_sha256=hashlib.sha256(f"kernel-{vmm}".encode()).hexdigest(),
+                rootfs_url="https://example.com/codex-rootfs.ext4",
+                rootfs_sha256=hashlib.sha256(b"shared-rootfs").hexdigest(),
+            )
+
+        with patch("smolvm.images.manager.requests.get") as mock_get:
+            fc_local = ensure_published_image(
+                "codex",
+                "amd64",
+                "firecracker",
+                cache_dir=tmp_path,
+                manifest=manifest,
+                version=version,
+            )
+            qe_local = ensure_published_image(
+                "codex",
+                "amd64",
+                "qemu",
+                cache_dir=tmp_path,
+                manifest=manifest,
+                version=version,
+            )
+            mock_get.assert_not_called()
+
+        # Distinct paths, distinct kernel bytes.
+        assert fc_local.kernel_path != qe_local.kernel_path
+        assert fc_local.kernel_path.read_bytes() == b"kernel-firecracker"
+        assert qe_local.kernel_path.read_bytes() == b"kernel-qemu"
 
 
 class TestZstdDecompression:
@@ -235,6 +316,7 @@ class TestZstdDecompression:
         entry = PublishedImage(
             preset="codex",
             arch="amd64",
+            vmm="firecracker",
             kernel_url="https://example.com/codex-amd64-vmlinux.bin",
             kernel_sha256=hashlib.sha256(kernel_bytes).hexdigest(),
             rootfs_url="https://example.com/codex-amd64-rootfs.ext4.zst",
@@ -250,7 +332,7 @@ class TestZstdDecompression:
         tmp_path: Path,
     ) -> None:
         entry, kernel_bytes, rootfs_zst, rootfs_plain = compressed_entry
-        manifest = {(entry.preset, entry.arch): entry}
+        manifest = {(entry.preset, entry.arch, entry.vmm): entry}
         bodies = [kernel_bytes, rootfs_zst]
         call = {"i": 0}
 
@@ -268,6 +350,7 @@ class TestZstdDecompression:
         local = ensure_published_image(
             entry.preset,
             entry.arch,
+            entry.vmm,
             cache_dir=tmp_path,
             manifest=manifest,
             version="0.0.13",
@@ -288,10 +371,10 @@ class TestZstdDecompression:
     ) -> None:
         """Second call must not re-download AND not re-decompress."""
         entry, kernel_bytes, rootfs_zst, rootfs_plain = compressed_entry
-        manifest = {(entry.preset, entry.arch): entry}
+        manifest = {(entry.preset, entry.arch, entry.vmm): entry}
 
         # Pre-populate the cache: compressed file + decompressed sibling.
-        image_dir = tmp_path / cache_name(entry.preset, entry.arch, "0.0.13")
+        image_dir = tmp_path / cache_name(entry.preset, entry.arch, entry.vmm, "0.0.13")
         image_dir.mkdir(parents=True)
         (image_dir / "vmlinux.bin").write_bytes(kernel_bytes)
         (image_dir / "rootfs.ext4.zst").write_bytes(rootfs_zst)
@@ -301,6 +384,7 @@ class TestZstdDecompression:
             local = ensure_published_image(
                 entry.preset,
                 entry.arch,
+                entry.vmm,
                 cache_dir=tmp_path,
                 manifest=manifest,
                 version="0.0.13",
@@ -315,7 +399,7 @@ class TestZstdDecompression:
         self,
         mock_get: MagicMock,
         sample_entry: PublishedImage,
-        sample_manifest: dict[tuple[Preset, Arch], PublishedImage],
+        sample_manifest: dict[tuple[Preset, Arch, Vmm], PublishedImage],
         tmp_path: Path,
     ) -> None:
         """A non-.zst rootfs URL must not invoke the decompressor."""
@@ -337,6 +421,7 @@ class TestZstdDecompression:
             local = ensure_published_image(
                 sample_entry.preset,
                 sample_entry.arch,
+                sample_entry.vmm,
                 cache_dir=tmp_path,
                 manifest=sample_manifest,
                 version="0.0.13",
@@ -350,25 +435,25 @@ class TestZstdDecompression:
 class TestBundledManifest:
     """Sanity checks for the entries hand-populated in MANIFEST."""
 
-    def test_openclaw_amd64_entry_shape(self) -> None:
-        entry = MANIFEST.get(("openclaw", "amd64"))
-        assert entry is not None, "openclaw/amd64 must be in the bundled manifest"
+    def test_openclaw_amd64_firecracker_entry_shape(self) -> None:
+        entry = MANIFEST.get(("openclaw", "amd64", "firecracker"))
+        assert entry is not None, "openclaw/amd64/firecracker must be in the bundled manifest"
         assert len(entry.rootfs_sha256) == 64  # SHA-256 hex
         assert len(entry.kernel_sha256) == 64
         assert entry.rootfs_url.endswith("openclaw-amd64-rootfs.ext4.zst")
         assert entry.kernel_url.endswith("openclaw-amd64-vmlinux.bin")
         assert "images-v" in entry.rootfs_url  # tag-based URL pattern
 
-    def test_openclaw_arm64_entry_shape(self) -> None:
-        entry = MANIFEST.get(("openclaw", "arm64"))
+    def test_openclaw_arm64_firecracker_entry_shape(self) -> None:
+        entry = MANIFEST.get(("openclaw", "arm64", "firecracker"))
         assert entry is not None
         assert len(entry.rootfs_sha256) == 64
         assert entry.rootfs_url.endswith("openclaw-arm64-rootfs.ext4.zst")
 
     def test_amd64_and_arm64_have_distinct_shas(self) -> None:
         """Sanity: copy-paste error would give both arches the same SHA."""
-        amd = MANIFEST[("openclaw", "amd64")]
-        arm = MANIFEST[("openclaw", "arm64")]
+        amd = MANIFEST[("openclaw", "amd64", "firecracker")]
+        arm = MANIFEST[("openclaw", "arm64", "firecracker")]
         assert amd.rootfs_sha256 != arm.rootfs_sha256
         assert amd.kernel_sha256 != arm.kernel_sha256
 
@@ -398,6 +483,45 @@ class TestBundledManifest:
             )
             assert expected_segment in entry.kernel_url, (
                 f"{key} kernel_url doesn't reference {expected_segment}"
+            )
+
+    def test_entry_field_matches_manifest_key(self) -> None:
+        """The fields on each row must match the (preset, arch, vmm) tuple it lives under."""
+        for (preset, arch, vmm), entry in MANIFEST.items():
+            key = (preset, arch, vmm)
+            assert entry.preset == preset, f"row at {key} has preset={entry.preset!r}"
+            assert entry.arch == arch, f"row at {key} has arch={entry.arch!r}"
+            assert entry.vmm == vmm, f"row at {key} has vmm={entry.vmm!r}"
+
+    def test_rootfs_sha_is_consistent_across_vmm_variants(self) -> None:
+        """For any (preset, arch), all vmm rows must share the same rootfs SHA.
+
+        Rationale: the rootfs is filesystem-format only — VMM-agnostic. Different
+        vmm rows for the same (preset, arch) point at the SAME rootfs file. If
+        someone updates only the firecracker row's SHA after a rootfs rebuild
+        and forgets the qemu row, downloads silently 404 (or worse, mismatch).
+        This test catches that.
+
+        The check is conservative: if a future need actually requires
+        per-vmm rootfs differences (unlikely — the rootfs doesn't see the
+        VMM), this assertion needs revisiting along with the "shared rootfs"
+        design assumption.
+        """
+        by_preset_arch: dict[tuple[Preset, Arch], list[PublishedImage]] = defaultdict(list)
+        for (preset, arch, _vmm), entry in MANIFEST.items():
+            by_preset_arch[(preset, arch)].append(entry)
+
+        for (preset, arch), entries in by_preset_arch.items():
+            if len(entries) < 2:
+                continue  # nothing to compare
+            shas = {e.rootfs_sha256 for e in entries}
+            urls = {e.rootfs_url for e in entries}
+            assert len(shas) == 1, (
+                f"{preset}/{arch}: rootfs SHAs differ across vmm rows: {sorted(shas)}. "
+                f"Likely one row was updated after a rootfs rebuild and another wasn't."
+            )
+            assert len(urls) == 1, (
+                f"{preset}/{arch}: rootfs URLs differ across vmm rows: {sorted(urls)}."
             )
 
 


### PR DESCRIPTION
## Summary

**PR α** of the custom-QEMU-kernel rollout. Schema-only — preserves all existing behavior. Lays groundwork for shipping a second specialized kernel per arch (Firecracker for Linux today, QEMU for macOS in subsequent PRs).

## What changes

- New literal: \`Vmm = Literal["firecracker", "qemu", "libkrun"]\`. \`libkrun\` is reserved from day one — saves a forced second migration when the libkrun spike lands; CLI never resolves to it yet.
- New field on [\`PublishedImage\`](src/smolvm/images/published.py): \`vmm: Vmm\`.
- \`MANIFEST\` re-keyed to \`dict[tuple[Preset, Arch, Vmm], PublishedImage]\`. The existing two openclaw entries are annotated \`vmm=\"firecracker\"\`. **No QEMU rows yet** — those land alongside the kernel artifacts in PR β.
- \`cache_name\` returns \`<preset>-v<version>-<arch>-<vmm>/\` so caches are isolated per VMM. Old layout (without \`-<vmm>\`) becomes orphaned on disk; users clear with \`rm -rf ~/.smolvm/images/<preset>-v<version>-<arch>\`.
- \`lookup\`, \`ensure_published_image\` take \`vmm\` as a required arg. Error message lists \`preset/arch/vmm\` tuples.
- The single CLI caller ([\`_run_start_with_published_image\`](src/smolvm/cli/main.py)) hardcodes \`vmm=\"firecracker\"\` to preserve current behavior. Platform→vmm mapping lands in PR γ.

## What stays the same

- Behavior at \`smolvm openclaw start\` (with or without \`SMOLVM_USE_PUBLISHED\`) is **byte-identical**. Same kernel, same rootfs, same cache contents at a path that's just one segment longer.
- \`_MANIFEST_VERSION\` not bumped — same artifacts, additional rows once PR γ lands.
- The macOS hard-reject from [#246](https://github.com/CelestoAI/SmolVM/pull/246) (still open) is untouched.

## Why \`vmm\` is a separate dimension

The kernel must be tuned for the hypervisor it runs under: Firecracker uses MMIO virtio + 8250 UART; QEMU uses PCI virtio + PL011 UART (arm64). The same rootfs works for both since it's just a filesystem, but different kernels are required. We verified empirically that the Firecracker-CI kernel produces zero serial output under QEMU on macOS arm64 — see #246 thread.

## Rollout sequence (this is PR α)

1. **PR α (this PR)** — schema, no behavior change
2. **PR β** — custom kernel build infrastructure (new \`build-qemu-kernel.yml\` workflow, \`kernel/qemu/{config.fragment,build.sh,...}\`)
3. **PR ε** — boot smoke gate (CI workflow that boots both Fc and QEMU artifacts on Linux runners)
4. **PR γ** — manifest QEMU rows + CLI \`_vmm_for_host()\` (Linux→firecracker, Darwin→qemu); replaces the macOS hard-reject from #246
5. **PR δ** — libkrun stub rows (optional)

## Tests

**28 in \`test_published_images.py\`** (was 23):

- \`cache_name\` distinguishes vmms (firecracker vs qemu paths differ).
- \`lookup\` error mentions the vmm dimension explicitly.
- \`ensure_published_image\` with same (preset, arch) but different vmm gets distinct cache directories — guards the design assumption that VMMs are isolated.
- \`test_entry_field_matches_manifest_key\`: every row's fields match its tuple key (catches future copy-paste mistakes).
- \`test_rootfs_sha_is_consistent_across_vmm_variants\`: for any (preset, arch), all vmm rows must share the same \`rootfs_sha256\`. Doesn't fire yet (only firecracker rows), but in place to catch the \"we updated only the firecracker row\" bug when PR γ adds qemu rows.

Plus one CLI test updated to assert the new 3-arg \`ensure_published_image\` call shape.

**Full suite:** 831 passed, 13 skipped, **no regressions**.

## Checklist

- [x] Scope is focused and limited to schema migration
- [x] Tests added/updated (5 new, 1 updated, 23 carried over)
- [x] No user-visible behavior change
- [x] No secrets or sensitive data included

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Published images are now hypervisor-aware: manifests and caches include a vmm dimension (firecracker, qemu, libkrun) so downloads and caches are isolated per hypervisor.

* **Bug Fixes / Reliability**
  * Startup now selects and validates the Firecracker-specific published-image entry for the Firecracker path, preventing incorrect image selection.

* **Tests**
  * Test suite updated to cover vmm-keyed manifests, cache isolation, and lookup/error cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->