### PR TITLE
fix(kernel): use real defconfig and drop x86-only paravirt symbols

### DIFF
--- a/kernel/qemu/build.sh
+++ b/kernel/qemu/build.sh
@@ -4,7 +4,7 @@
 # Inputs (alongside this script in kernel/qemu/):
 #   linux.version    Pinned tarball version (e.g. "6.12.10")
 #   linux.sha256     SHA-256 line for `sha256sum -c`
-#   config.fragment  Our deltas merged onto microvm_defconfig (x86) or
+#   config.fragment  Our deltas merged onto x86_64_defconfig (x86) or
 #                    defconfig (arm64)
 #
 # Output: vmlinux-<arch>-qemu.bin in $OUT_DIR (default: $PWD).
@@ -89,7 +89,7 @@ SMOLVM_ARCH="${SMOLVM_ARCH_OVERRIDE:-$SMOLVM_ARCH}"
 
 # SmolVM arch label → kernel ARCH= variable.
 case "$SMOLVM_ARCH" in
-    amd64)  KARCH=x86_64; KIMAGE_REL=arch/x86/boot/bzImage; DEFCONFIG=microvm_defconfig ;;
+    amd64)  KARCH=x86_64; KIMAGE_REL=arch/x86/boot/bzImage; DEFCONFIG=x86_64_defconfig ;;
     arm64)  KARCH=arm64;  KIMAGE_REL=arch/arm64/boot/Image; DEFCONFIG=defconfig ;;
     *) echo "internal error: unhandled SMOLVM_ARCH $SMOLVM_ARCH" >&2; exit 2 ;;
 esac

--- a/kernel/qemu/config.fragment
+++ b/kernel/qemu/config.fragment
@@ -14,7 +14,6 @@
 # - Built-in (`=y`), not modular (`=m`): we ship one vmlinux and no initrd.
 #   If a driver needed at boot is `=m`, the kernel can't mount the rootfs to
 #   load it — chicken-and-egg.
-# - KVM_GUEST/PARAVIRT: small perf wins under Hypervisor.framework + KVM.
 
 # ── Bus + virtio ─────────────────────────────────────────────────────
 CONFIG_PCI=y                    # why: QEMU virt + libkrun use virtio-PCI
@@ -44,10 +43,6 @@ CONFIG_DEVTMPFS_MOUNT=y         # why: auto-mount /dev at boot
 CONFIG_NET=y                    # why: required for virtio-net + sshd
 CONFIG_INET=y                   # why: TCP/IP for SSH
 CONFIG_PACKET=y                 # why: AF_PACKET for some userspace tools
-
-# ── Hypervisor paravirt (small wins) ─────────────────────────────────
-CONFIG_KVM_GUEST=y              # why: PV-clock, PV-spinlocks under KVM
-CONFIG_PARAVIRT=y               # why: enables KVM_GUEST machinery
 
 # ── No modules, ever ─────────────────────────────────────────────────
 # Forces every config above to be `=y` (built into vmlinux). Removes the


### PR DESCRIPTION
## Summary

Two real bugs surfaced from the first CI run of `build-qemu-kernel.yml` (introduced in #248):

- **amd64:** `*** Can't find default configuration "arch/x86/configs/microvm_defconfig"!` — `microvm_defconfig` is a QEMU machine name, not an upstream Linux defconfig. Switch to `x86_64_defconfig`.
- **arm64:** `MISSING: CONFIG_KVM_GUEST — wanted =y, .config has: <absent>` — `CONFIG_KVM_GUEST` and `CONFIG_PARAVIRT` are x86-only Kconfig symbols. The perf wins (PV-clock, PV-spinlocks) are minor and the upstream defconfig already turns on what's needed. Drop both from `config.fragment`.

## Test plan

- [ ] CI: `build-qemu-kernel.yml` runs cleanly on both archs
- [ ] Resulting `vmlinux-<arch>-qemu.bin` artifacts upload to draft release `images-v0.0.13`
- [ ] `.config` artifact (saved alongside) shows `CONFIG_PCI=y`, `CONFIG_VIRTIO_PCI=y`, `CONFIG_SERIAL_AMBA_PL011_CONSOLE=y` for arm64

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Adjusted x86_64 kernel build baseline configuration.
  * Removed hypervisor paravirt support settings from kernel configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->