### PR TITLE
feat(cli): pick published-image kernel variant from host OS

### DIFF
--- a/src/smolvm/cli/main.py
+++ b/src/smolvm/cli/main.py
@@ -51,7 +51,7 @@ from smolvm.host.doctor import run_doctor
 from smolvm.types import BrowserSessionState, GuestOS, VMState
 
 if TYPE_CHECKING:
-    from smolvm.images.published import Arch
+    from smolvm.images.published import Arch, Vmm
     from smolvm.types import BrowserSessionInfo, SnapshotInfo, VMInfo
 
 DASHBOARD_ALLOW_BETA_ENV = "SMOLVM_DASHBOARD_ALLOW_BETA"
@@ -1814,13 +1814,55 @@ def _render_start_result(data: StartPayload) -> None:
     console.print(f"Next: [bold]{next_step['ssh_command']}[/bold]")
 
 
-# Map preset name → boot args for the Firecracker published-image path. When
-# we add per-preset bake builders, the boot_args should move onto the Preset
-# itself; for now openclaw is the only published preset and this lookup
-# reflects that.
-_PUBLISHED_IMAGE_BOOT_ARGS = {
-    "openclaw": "reboot=k panic=1 pci=off init=/init 8250.nr_uarts=0",
+# Boot args for the published-image launch path, keyed by (preset, vmm).
+# Firecracker uses MMIO virtio + 8250 silenced (no PCI); QEMU/libkrun use
+# PCI virtio with an arch-specific console (added by _boot_args_for).
+# When we add per-preset bake builders, this can move onto the Preset
+# itself; for now openclaw is the only published preset.
+_PUBLISHED_IMAGE_BOOT_ARGS: dict[tuple[str, Vmm], str] = {
+    ("openclaw", "firecracker"): "reboot=k panic=1 pci=off init=/init 8250.nr_uarts=0",
+    ("openclaw", "qemu"): "reboot=k panic=1 init=/init",
+    ("openclaw", "libkrun"): "reboot=k panic=1 init=/init",
 }
+
+
+def _boot_args_for(preset_name: str, vmm: Vmm, arch: Arch) -> str:
+    """Resolve boot args for the published-image path.
+
+    For QEMU/libkrun, the console driver is arch-specific: arm64's QEMU
+    ``virt`` machine wires the console to a PL011 (ttyAMA0); x86's exposes
+    an 8250 (ttyS0). The Firecracker base string already disables 8250 and
+    relies on Firecracker's own console wiring, so no console= is needed
+    there.
+    """
+    base = _PUBLISHED_IMAGE_BOOT_ARGS[(preset_name, vmm)]
+    if vmm == "firecracker":
+        return base
+    console = "ttyAMA0" if arch == "arm64" else "ttyS0"
+    return f"console={console} {base}"
+
+
+def _vmm_for_host() -> Vmm:
+    """Pick the published-image kernel variant for this host's OS.
+
+    Linux runs Firecracker directly (KVM); macOS runs QEMU on top of
+    Hypervisor.framework. ``libkrun`` is reserved for a future spike and
+    intentionally not returned here yet — the CLI sticks to the two
+    runtimes we ship working kernels + backends for.
+
+    Deliberately doesn't read ``SMOLVM_BACKEND`` — the published path
+    pairs a specific kernel build with a specific runtime, so an env
+    override that swapped only one half would silently mismatch them.
+    """
+    system = platform.system()
+    if system == "Linux":
+        return "firecracker"
+    if system == "Darwin":
+        return "qemu"
+    raise RuntimeError(
+        f"Unsupported host OS for published images: {system!r}. "
+        f"Set SMOLVM_USE_PUBLISHED=0 (or unset) to fall back to the local build."
+    )
 
 
 def _published_path_enabled() -> bool:
@@ -1870,35 +1912,19 @@ def _run_start_with_published_image(args: argparse.Namespace, preset: object) ->
 
     _preset: Preset = preset  # type: ignore[assignment]
 
-    # Published images are built with a Firecracker-CI kernel (virtio-MMIO,
-    # no PCI drivers) and the launch path below uses backend="firecracker",
-    # which requires KVM and the Linux `ip` toolchain for TAP setup.
-    # Neither exists on macOS — the failure cascades through several
-    # confusing error messages (sudo, missing `ip`, network-cleanup also
-    # fails). Reject up-front with one clear message instead. Tracked as a
-    # follow-up to validate libkrun (Firecracker-API-compatible runtime
-    # backed by Hypervisor.framework) for macOS parity.
-    if platform.system() != "Linux":
-        return _emit_cli_error(
-            "start",
-            2,
-            ValueError(
-                f"Published images are Linux-only for now: the Firecracker "
-                f"runtime they use requires KVM, which is unavailable on "
-                f"{platform.system()}, so run `smolvm {_preset.name} start` "
-                f"without SMOLVM_USE_PUBLISHED to use the default flow."
-            ),
-            json_output=args.json,
-        )
+    try:
+        vmm = _vmm_for_host()
+    except RuntimeError as exc:
+        return _emit_cli_error("start", 2, exc, json_output=args.json)
 
-    if _preset.name not in _PUBLISHED_IMAGE_BOOT_ARGS:
+    if (_preset.name, vmm) not in _PUBLISHED_IMAGE_BOOT_ARGS:
         return _emit_cli_error(
             "start",
             2,
             ValueError(
                 f"Preset {_preset.name!r} has no boot_args configured for the "
-                f"published-image path. Unset SMOLVM_USE_PUBLISHED to use the "
-                f"default install-at-boot flow."
+                f"published-image path under vmm {vmm!r}. Unset "
+                f"SMOLVM_USE_PUBLISHED to use the default install-at-boot flow."
             ),
             json_output=args.json,
         )
@@ -1909,19 +1935,23 @@ def _run_start_with_published_image(args: argparse.Namespace, preset: object) ->
         public_key_value = public_key_path.read_text().strip()
 
         # Raises ImageError with a clear message if the (preset, arch, vmm)
-        # tuple has no manifest entry. ``vmm`` is hardcoded to firecracker
-        # here and reflects the only kernel variant we publish today; the
-        # CLI-side platform-to-vmm mapping (Linux→firecracker, Darwin→qemu)
-        # lands in a follow-up PR alongside the QEMU kernel rows.
-        local_image = ensure_published_image(_preset.name, arch, "firecracker")  # type: ignore[arg-type]
+        # tuple has no manifest entry — covers the gap where a host platform
+        # is supported in principle but no published kernel exists for it
+        # yet.
+        local_image = ensure_published_image(_preset.name, arch, vmm)
+
+        # vmm → backend: firecracker maps to the firecracker runtime; qemu
+        # and libkrun both run under the qemu backend on macOS today (libkrun
+        # support arrives in a separate spike).
+        backend = "firecracker" if vmm == "firecracker" else "qemu"
 
         config = VMConfig(
             vm_id=_resolve_vm_name(args.name, prefix=_preset.name),
             memory=args.memory_mib if args.memory_mib is not None else _preset.default_mem_mib,
             kernel_path=local_image.kernel_path,
             rootfs_path=local_image.rootfs_path,
-            boot_args=_PUBLISHED_IMAGE_BOOT_ARGS[_preset.name],
-            backend="firecracker",
+            boot_args=_boot_args_for(_preset.name, vmm, arch),
+            backend=backend,
             ssh_public_key=public_key_value,
         )
 
@@ -1946,7 +1976,7 @@ def _run_start_with_published_image(args: argparse.Namespace, preset: object) ->
                         else VMState.RUNNING.value
                     ),
                     "os": "debian-bookworm",
-                    "backend": "firecracker",
+                    "backend": backend,
                     "ip_address": network.guest_ip if network else None,
                     "ssh_port": network.ssh_host_port if network else None,
                 },

--- a/src/smolvm/cli/main.py
+++ b/src/smolvm/cli/main.py
@@ -1825,6 +1825,16 @@ _PUBLISHED_IMAGE_BOOT_ARGS: dict[tuple[str, Vmm], str] = {
     ("openclaw", "libkrun"): "reboot=k panic=1 init=/init",
 }
 
+# vmm → SmolVM runtime backend. libkrun ships a Firecracker-API-compatible
+# control plane; we route it through the qemu backend on macOS until the
+# libkrun spike lands its own runtime path. Explicit dict (vs ternary)
+# keeps that intentional aliasing visible at the call site.
+_VMM_TO_BACKEND: dict[Vmm, str] = {
+    "firecracker": "firecracker",
+    "qemu": "qemu",
+    "libkrun": "qemu",
+}
+
 
 def _boot_args_for(preset_name: str, vmm: Vmm, arch: Arch) -> str:
     """Resolve boot args for the published-image path.
@@ -1940,10 +1950,7 @@ def _run_start_with_published_image(args: argparse.Namespace, preset: object) ->
         # yet.
         local_image = ensure_published_image(_preset.name, arch, vmm)
 
-        # vmm → backend: firecracker maps to the firecracker runtime; qemu
-        # and libkrun both run under the qemu backend on macOS today (libkrun
-        # support arrives in a separate spike).
-        backend = "firecracker" if vmm == "firecracker" else "qemu"
+        backend = _VMM_TO_BACKEND[vmm]
 
         config = VMConfig(
             vm_id=_resolve_vm_name(args.name, prefix=_preset.name),

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -2827,53 +2827,99 @@ class TestPublishedImageLaunchPath:
         assert ret == 1
         mock_ensure.assert_called_once()
 
-    @patch.dict(os.environ, {"SMOLVM_USE_PUBLISHED": "1"})
-    @patch("smolvm.cli.main.platform.system", return_value="Darwin")
-    @patch("smolvm.images.published.ensure_published_image")
-    def test_published_path_rejects_macos_up_front(
+    @pytest.mark.parametrize(
+        "system,expected_vmm",
+        [
+            ("Linux", "firecracker"),
+            ("Darwin", "qemu"),
+        ],
+    )
+    @patch("smolvm.cli.main.platform.system")
+    def test_vmm_for_host_maps_os_to_kernel_variant(
         self,
-        mock_ensure: MagicMock,
-        _mock_system: MagicMock,
-        capsys: pytest.CaptureFixture[str],
+        mock_system: MagicMock,
+        system: str,
+        expected_vmm: str,
     ) -> None:
-        """macOS hits Firecracker's KVM/TAP requirements; reject before that.
+        from smolvm.cli.main import _vmm_for_host
 
-        The pre-fix failure cascade was confusing: sudo prompt → missing
-        ``ip`` binary → cleanup-also-fails. One clear error pointing at
-        the install-at-boot fallback is much friendlier.
-        """
-        ret = main(["openclaw", "start", "--json"])
+        mock_system.return_value = system
+        assert _vmm_for_host() == expected_vmm
 
-        captured = capsys.readouterr()
-        envelope = json.loads(captured.out)
+    @patch("smolvm.cli.main.platform.system", return_value="FreeBSD")
+    def test_vmm_for_host_rejects_unsupported_os(self, _mock_system: MagicMock) -> None:
+        from smolvm.cli.main import _vmm_for_host
 
-        assert ret == 2  # ValueError → exit 2 (matches existing CLI convention)
-        assert envelope["exit_code"] == 2
-        assert envelope["error"] is not None
-        assert "Linux-only" in envelope["error"]["message"]
-        # Most importantly, ensure_published_image must NOT have been called —
-        # we should error before trying to download anything.
-        mock_ensure.assert_not_called()
+        with pytest.raises(RuntimeError, match="Unsupported host OS"):
+            _vmm_for_host()
 
+    @pytest.mark.parametrize(
+        "vmm,arch,expected_console",
+        [
+            ("qemu", "arm64", "console=ttyAMA0"),
+            ("qemu", "amd64", "console=ttyS0"),
+            ("libkrun", "arm64", "console=ttyAMA0"),
+            ("libkrun", "amd64", "console=ttyS0"),
+        ],
+    )
+    def test_boot_args_for_qemu_picks_console_per_arch(
+        self,
+        vmm: str,
+        arch: str,
+        expected_console: str,
+    ) -> None:
+        from smolvm.cli.main import _boot_args_for
+
+        result = _boot_args_for("openclaw", vmm, arch)  # type: ignore[arg-type]
+        assert expected_console in result
+        assert "init=/init" in result
+
+    def test_boot_args_for_firecracker_omits_console_arg(self) -> None:
+        from smolvm.cli.main import _boot_args_for
+
+        # Firecracker's base string already disables 8250 and uses its own
+        # console wiring — no console= should be added by the helper.
+        for arch in ("amd64", "arm64"):
+            result = _boot_args_for("openclaw", "firecracker", arch)  # type: ignore[arg-type]
+            assert "console=" not in result
+            assert "8250.nr_uarts=0" in result
+
+    @pytest.mark.parametrize(
+        "system,machine,expected_arch,expected_vmm,expected_backend",
+        [
+            ("Linux", "x86_64", "amd64", "firecracker", "firecracker"),
+            ("Linux", "aarch64", "arm64", "firecracker", "firecracker"),
+            ("Darwin", "arm64", "arm64", "qemu", "qemu"),
+            ("Darwin", "x86_64", "amd64", "qemu", "qemu"),
+        ],
+    )
     @patch.dict(os.environ, {"SMOLVM_USE_PUBLISHED": "1"})
     @patch("smolvm.cli.main.subprocess.run")
     @patch("smolvm.facade.SmolVM")
     @patch("smolvm.utils.ensure_ssh_key")
     @patch("smolvm.images.published.ensure_published_image")
-    @patch("smolvm.cli.main.platform.machine", return_value="x86_64")
-    @patch("smolvm.cli.main.platform.system", return_value="Linux")
+    @patch("smolvm.cli.main.platform.machine")
+    @patch("smolvm.cli.main.platform.system")
     def test_published_path_happy_path_skips_apply_preset(
         self,
-        _mock_system: MagicMock,
-        _mock_machine: MagicMock,
+        mock_system: MagicMock,
+        mock_machine: MagicMock,
         mock_ensure_image: MagicMock,
         mock_ensure_ssh_key: MagicMock,
         mock_vm_cls: MagicMock,
         _mock_subprocess: MagicMock,
         tmp_path: Path,
+        system: str,
+        machine: str,
+        expected_arch: str,
+        expected_vmm: str,
+        expected_backend: str,
     ) -> None:
         """End-to-end: download → VMConfig → start, no apply_preset call."""
         from smolvm.images.manager import LocalImage
+
+        mock_system.return_value = system
+        mock_machine.return_value = machine
 
         kernel = tmp_path / "vmlinux.bin"
         rootfs = tmp_path / "rootfs.ext4"
@@ -2885,7 +2931,7 @@ class TestPublishedImageLaunchPath:
         pub.write_text("ssh-ed25519 AAAAExampleKey user@host\n")
 
         mock_ensure_image.return_value = LocalImage(
-            name="openclaw-v0.0.13-amd64",
+            name=f"openclaw-v0.0.13-{expected_arch}-{expected_vmm}",
             kernel_path=kernel,
             rootfs_path=rootfs,
         )
@@ -2893,7 +2939,7 @@ class TestPublishedImageLaunchPath:
         mock_vm = MagicMock()
         mock_vm.vm_id = "sbx-published-1"
         mock_vm.info.status = VMState.RUNNING
-        mock_vm.info.config.backend = "firecracker"
+        mock_vm.info.config.backend = expected_backend
         mock_vm.info.network = MagicMock(spec=NetworkConfig)
         mock_vm.info.network.guest_ip = "172.16.0.2"
         mock_vm.info.network.ssh_host_port = 2200
@@ -2906,12 +2952,15 @@ class TestPublishedImageLaunchPath:
             mock_apply.assert_not_called()
 
         assert ret == 0
-        mock_ensure_image.assert_called_once_with("openclaw", "amd64", "firecracker")
+        mock_ensure_image.assert_called_once_with("openclaw", expected_arch, expected_vmm)
 
         # Verify VMConfig was built with the right wiring.
         config_arg = mock_vm_cls.call_args[0][0]
         assert config_arg.kernel_path == kernel
         assert config_arg.rootfs_path == rootfs
-        assert config_arg.backend == "firecracker"
+        assert config_arg.backend == expected_backend
         assert config_arg.ssh_public_key == "ssh-ed25519 AAAAExampleKey user@host"
         assert "init=/init" in config_arg.boot_args
+        if expected_vmm == "qemu":
+            expected_console = "ttyAMA0" if expected_arch == "arm64" else "ttyS0"
+            assert f"console={expected_console}" in config_arg.boot_args

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -2884,6 +2884,27 @@ class TestPublishedImageLaunchPath:
             assert "console=" not in result
             assert "8250.nr_uarts=0" in result
 
+    @patch.dict(os.environ, {"SMOLVM_USE_PUBLISHED": "1"})
+    @patch("smolvm.cli.main.platform.system", return_value="Linux")
+    @patch(
+        "smolvm.cli.main._PUBLISHED_IMAGE_BOOT_ARGS",
+        new={},  # nothing registered → unconditional miss
+    )
+    def test_published_path_rejects_unconfigured_preset_vmm(
+        self,
+        _mock_system: MagicMock,
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        """A preset with no boot_args entry for the resolved vmm must
+        produce a clean exit-2 error, not a KeyError further down."""
+        ret = main(["openclaw", "start", "--json"])
+
+        envelope = json.loads(capsys.readouterr().out)
+        assert ret == 2
+        assert envelope["exit_code"] == 2
+        assert "no boot_args" in envelope["error"]["message"]
+        assert "SMOLVM_USE_PUBLISHED" in envelope["error"]["message"]
+
     @pytest.mark.parametrize(
         "system,machine,expected_arch,expected_vmm,expected_backend",
         [


### PR DESCRIPTION
## Summary

Replaces the macOS hard-reject from #246 with a real platform→vmm mapping:
- **Linux** → Firecracker (KVM, MMIO virtio, 8250 silenced — unchanged)
- **Darwin** → QEMU (Hypervisor.framework, PCI virtio, arch-specific console)

The CLI threads `vmm` through `ensure_published_image`, the boot-args lookup, and backend selection. Once the matching manifest rows land (PR γ.b, pending the QEMU kernel CI run), macOS users get the same one-command `smolvm openclaw start` flow Linux users already have under `SMOLVM_USE_PUBLISHED=1`.

### What changed

- **`_vmm_for_host()`** — `Linux→firecracker`, `Darwin→qemu`. Deliberately skips `SMOLVM_BACKEND` to avoid swapping only one half of the (kernel, runtime) pair.
- **`_PUBLISHED_IMAGE_BOOT_ARGS`** — re-keyed by `(preset, vmm)`. Firecracker entry unchanged; new QEMU + libkrun entries.
- **`_boot_args_for(preset, vmm, arch)`** — adds the arch-specific console to QEMU/libkrun (`ttyAMA0` on arm64, `ttyS0` on amd64). Firecracker pass-through.
- **`_run_start_with_published_image`** — uses `_vmm_for_host()` + maps to backend (`firecracker` for Firecracker, `qemu` for QEMU/libkrun) instead of hardcoding everything to Firecracker.

### What's deferred

- **PR γ.b**: manifest rows for `(openclaw, amd64, qemu)` and `(openclaw, arm64, qemu)`. Waiting on the QEMU kernel CI run for real SHAs. Until those rows exist, `_vmm_for_host()` returning `qemu` on macOS will surface a clean `ImageError` from `ensure_published_image` — no behavioral regression vs the old hard-reject.
- **libkrun row**: kept in the boot-args dict so the Linux→firecracker→libkrun migration is a one-line plumbing change later.

## Test plan

- [x] `uv run pytest tests/test_cli.py tests/test_published_images.py` — 174 pass
- [x] `uv run ruff check` clean (one pre-existing E501 unrelated)
- [ ] After PR γ.b lands: `SMOLVM_USE_PUBLISHED=1 smolvm openclaw start` on macOS arm64

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * CLI now selects the host-specific hypervisor and reports the actual backend when launching published VM images (including macOS).

* **Bug Fixes**
  * Improved validation and clearer errors for unsupported host OS / missing boot-argument configurations; boot arguments vary by hypervisor and architecture.

* **Tests**
  * Expanded tests covering host→hypervisor mapping, arch-specific boot-arg behavior, end-to-end published-image launches, and failure exit messaging.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->