### PR TITLE
docs: add coding agents video tutorial to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ With a single command you get a claude/codex pre-installed sandbox ready with gi
 
 Video tutorial:
 
-[![Coding agents in a sandbox](https://img.youtube.com/vi/j1qyrTsI0Jw/maxresdefault.jpg)](https://youtu.be/j1qyrTsI0Jw)
+<a href="https://youtu.be/j1qyrTsI0Jw"><img src="https://img.youtube.com/vi/j1qyrTsI0Jw/maxresdefault.jpg" alt="Coding agents in a sandbox" width="480"></a>
 
 ```bash
 smolvm codex start  # start a new environment with codex preinstalled

--- a/README.md
+++ b/README.md
@@ -108,6 +108,10 @@ It sucks to “press enter and accept changes” every few seconds while using c
 
 With a single command you get a claude/codex pre-installed sandbox ready with git credential to make you build a billion dollar business without making any mistake ;)
 
+Video tutorial:
+
+[![Coding agents in a sandbox](https://img.youtube.com/vi/j1qyrTsI0Jw/maxresdefault.jpg)](https://youtu.be/j1qyrTsI0Jw)
+
 ```bash
 smolvm codex start  # start a new environment with codex preinstalled
 


### PR DESCRIPTION
## Summary
- Add a clickable YouTube thumbnail to the **Coding agents** section in `README.md` linking to the tutorial at https://youtu.be/j1qyrTsI0Jw

## Test plan
- [ ] Confirm the thumbnail renders inline on GitHub and clicks through to the video

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a "Video tutorial" entry in the Coding agents section with an embedded YouTube thumbnail/link to a coding-agents-in-a-sandbox walkthrough to help users learn the feature. No other documentation or functional changes were made.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->