### PR TITLE
feat(images): add openclaw QEMU manifest rows for amd64 + arm64

### DIFF
--- a/src/smolvm/images/published.py
+++ b/src/smolvm/images/published.py
@@ -98,6 +98,22 @@ def _release_asset_url(preset: Preset, arch: Arch, suffix: str, version: str) ->
     )
 
 
+def _release_kernel_url(arch: Arch, vmm: Vmm, version: str) -> str:
+    """URL for a preset-independent kernel artifact.
+
+    QEMU/libkrun kernels are built once per (arch, vmm) and shared across
+    all presets — the kernel doesn't depend on the userspace baked into
+    the rootfs. The asset name reflects that: ``vmlinux-<arch>-<vmm>.bin``,
+    no preset prefix. (The older Firecracker assets predate this convention
+    and use ``<preset>-<arch>-vmlinux.bin``; renaming them is a future
+    cleanup task.)
+    """
+    return (
+        f"https://github.com/CelestoAI/SmolVM/releases/download/"
+        f"{release_tag(version)}/vmlinux-{arch}-{vmm}.bin"
+    )
+
+
 # Version of the published images this CLI release was paired with.
 # Bumping this requires regenerating every MANIFEST entry below from a
 # fresh CI run (new artifacts → new SHAs → new URLs). The drift-detection
@@ -126,6 +142,28 @@ MANIFEST: dict[tuple[Preset, Arch, Vmm], PublishedImage] = {
         vmm="firecracker",
         kernel_url=_release_asset_url("openclaw", "arm64", "vmlinux.bin", _MANIFEST_VERSION),
         kernel_sha256="7d8dc0bce701037ea5ceccfc997c05b11f99aba215c73ed18a2269154837c497",
+        rootfs_url=_release_asset_url("openclaw", "arm64", "rootfs.ext4.zst", _MANIFEST_VERSION),
+        rootfs_sha256="48d86a4e4a75f8c101ebab3f76067cc2c92473ac0c30d5a2fd71a1dd2f43f6c7",
+    ),
+    # QEMU rows reuse the firecracker rootfs (same userspace; only the
+    # kernel differs). Kernels come from the SmolVM-built QEMU/libkrun
+    # kernel workflow (.github/workflows/build-qemu-kernel.yml) and use
+    # the preset-independent naming `vmlinux-<arch>-qemu.bin`.
+    ("openclaw", "amd64", "qemu"): PublishedImage(
+        preset="openclaw",
+        arch="amd64",
+        vmm="qemu",
+        kernel_url=_release_kernel_url("amd64", "qemu", _MANIFEST_VERSION),
+        kernel_sha256="db6ddc88e5b88941164df53f5f798d080b95a90c411df8d2b9f501eb18fb89aa",
+        rootfs_url=_release_asset_url("openclaw", "amd64", "rootfs.ext4.zst", _MANIFEST_VERSION),
+        rootfs_sha256="5d3fe222b017f350f5bb2f01c1fa28cd3425b5dddb32d6377d97bc0e3fea355b",
+    ),
+    ("openclaw", "arm64", "qemu"): PublishedImage(
+        preset="openclaw",
+        arch="arm64",
+        vmm="qemu",
+        kernel_url=_release_kernel_url("arm64", "qemu", _MANIFEST_VERSION),
+        kernel_sha256="6f4f42cfa1d3038bd06d99e09887119e4c7fdd2d1da02913e1b6b10359376752",
         rootfs_url=_release_asset_url("openclaw", "arm64", "rootfs.ext4.zst", _MANIFEST_VERSION),
         rootfs_sha256="48d86a4e4a75f8c101ebab3f76067cc2c92473ac0c30d5a2fd71a1dd2f43f6c7",
     ),


### PR DESCRIPTION
## Summary

Final piece of the QEMU-on-macOS rollout. Adds the two manifest rows that PR γ.a's `_vmm_for_host()` → `qemu` mapping was waiting on:

- `(openclaw, amd64, qemu)` → `vmlinux-amd64-qemu.bin` (sha256 `db6ddc88e5b88…`)
- `(openclaw, arm64, qemu)` → `vmlinux-arm64-qemu.bin` (sha256 `6f4f42cfa1d3…`)

Both reuse the existing **firecracker** rootfs URL + SHA — same userspace, only the kernel differs.

## What's new

- **`_release_kernel_url(arch, vmm, version)`** — preset-independent URL helper for `vmlinux-<arch>-<vmm>.bin` (the QEMU/libkrun kernel naming convention). The existing per-preset firecracker assets keep using `_release_asset_url`; rename is a future cleanup task per the kernel README.

## What this unlocks

Once the draft release at `images-v0.0.13` is published, macOS users running:

```sh
SMOLVM_USE_PUBLISHED=1 smolvm openclaw start
```

will pull the SmolVM-built QEMU kernel + the shared rootfs and boot end-to-end on Hypervisor.framework.

## Validated locally

The arm64 kernel from this exact CI run (sha256 `6f4f42cfa1d3…`) was smoke-booted via QEMU/HVF against the openclaw rootfs — `/init` runs through every stage, sshd binds port 22, openclaw device-approver up. Boot log lives in `/tmp/qemu-kernel-good-boot.log` from the earlier session.

## Test plan

- [x] `uv run pytest tests/test_published_images.py tests/test_cli.py` — 175 pass
- [x] `uv run ruff check src/smolvm/images/published.py` clean
- [ ] Manual: publish draft release `images-v0.0.13`, then `SMOLVM_USE_PUBLISHED=1 smolvm openclaw start` on macOS arm64

## Known follow-ups (separate)

- Rootfs uid 1001 bug — files in the current published rootfs are owned by uid 1001 instead of root, breaks setuid `mount`. The earlier `openclaw-ci-validation` rootfs has correct ownership; something regressed in the rootfs bake pipeline. Doesn't block QEMU work since this branch reuses the already-published rootfs URL/SHA, but worth filing as a separate issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Enhanced kernel asset URL generation for QEMU and libkrun virtual machines, enabling more flexible and independent kernel asset resolution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->