### PR TITLE
fix(images): preserve file uid/gid in docker-built ext4 rootfs

### DIFF
--- a/src/smolvm/images/builder.py
+++ b/src/smolvm/images/builder.py
@@ -1465,9 +1465,13 @@ echo "Device-approver running with PID=${DEVICE_APPROVER_PID}"
         """
         logger.info("  [3/4] Creating ext4 filesystem via Docker helper (%dMB)...", rootfs_size_mb)
 
-        rootfs_dir = tmpdir / "rootfs-dir"
-        rootfs_dir.mkdir()
-
+        # Validate tar member paths up-front so a malicious docker export
+        # can't trick the in-container extraction either. Python's tarfile
+        # is the cheapest tool for the security check; the actual extract
+        # happens below as root inside the container so file uids/gids are
+        # preserved (extracting on the host as the unprivileged runner uid
+        # silently rewrites everything to that uid, then mke2fs -d bakes
+        # those bogus uids into the ext4 inodes — was a real bug).
         with tarfile.open(tar_path, "r") as tar:
             for member in tar.getmembers():
                 member_path = Path(member.name)
@@ -1476,21 +1480,14 @@ echo "Device-approver running with PID=${DEVICE_APPROVER_PID}"
                         f"Refusing to extract suspicious tar path from docker export: {member.name}"
                     )
 
-            # Python 3.14 defaults to a restrictive extraction filter that rejects
-            # absolute symlink targets commonly present in container rootfs archives.
-            # We already validated member names above, so trusted extraction is safe here.
-            try:
-                tar.extractall(path=rootfs_dir, filter="fully_trusted")
-            except TypeError:
-                # Python <3.12 does not support the 'filter' argument.
-                tar.extractall(path=rootfs_dir)
-
         rootfs_path.unlink(missing_ok=True)
         rootfs_name = shlex.quote(rootfs_path.name)
         shell_cmd = (
             "set -e; "
-            "apk add --no-cache e2fsprogs >/dev/null; "
-            f"mke2fs -d /work/rootfs -t ext4 -F /work/out/{rootfs_name} "
+            "apk add --no-cache e2fsprogs tar >/dev/null; "
+            "mkdir -p /work/rootfs-staging; "
+            "tar -xf /work/in/rootfs.tar -C /work/rootfs-staging; "
+            f"mke2fs -d /work/rootfs-staging -t ext4 -F /work/out/{rootfs_name} "
             f"{rootfs_size_mb}M >/dev/null"
         )
 
@@ -1501,7 +1498,7 @@ echo "Device-approver running with PID=${DEVICE_APPROVER_PID}"
                     "run",
                     "--rm",
                     "-v",
-                    f"{rootfs_dir.resolve()}:/work/rootfs:ro",
+                    f"{tar_path.resolve()}:/work/in/rootfs.tar:ro",
                     "-v",
                     f"{rootfs_path.parent.resolve()}:/work/out",
                     "alpine:3.19",
@@ -1518,7 +1515,7 @@ echo "Device-approver running with PID=${DEVICE_APPROVER_PID}"
             stderr = (e.stderr or "").strip()
             raise ImageError(
                 "Failed to create ext4 image via Docker helper.\n"
-                f"Command: docker run ... mke2fs\n"
+                f"Command: docker run ... tar | mke2fs\n"
                 f"stderr: {stderr}"
             ) from e
 


### PR DESCRIPTION
## Summary

The Docker path of [`_create_ext4_with_docker`](src/smolvm/images/builder.py) extracted the container-export tar **on the host** as the unprivileged build-process uid (501 on macOS, 1001 on GitHub-hosted runners), then handed the tree to `mke2fs -d` inside an Alpine container. `mke2fs -d` faithfully copies on-disk uid/gid from the source tree into ext4 inodes, so every file in the resulting rootfs ended up owned by the host runner uid instead of root.

## How this surfaced

While running `SMOLVM_USE_PUBLISHED=1 smolvm openclaw start` end-to-end on macOS to validate the QEMU-on-HVF rollout (#247–#254), the boot would reach `/init` cleanly but timeout at `wait_for_ssh`. Investigation showed `/bin/mount` in the published rootfs was owned by uid 1001:

```
$ debugfs -R 'stat /bin/mount' openclaw-arm64-rootfs.ext4
Inode: 48121   Type: regular    Mode:  04755
User:  1001   Group:  1001   ...
```

Setuid `mount` switched to uid 1001, failed its own root check, /init couldn't mount /proc, /sys, etc., and sshd never bound. Same bug affects firecracker on Linux — just rarely exercised because `SMOLVM_USE_PUBLISHED=1` was opt-in.

## Fix

Move the tar extraction inside the same container that runs `mke2fs`. Tar bind-mounted read-only; busybox `tar -xf` extracts as root; `mke2fs -d` reads root-owned files; ext4 inodes get uid 0 as intended. The pre-extract host-side member-name validation stays — it's a security check (refuses suspicious paths), not a perms check, and we want it to fail before spinning up Docker.

## Validation

- `uv run pytest tests/test_build.py` — 17/17 pass
- `uv run ruff check src/smolvm/images/builder.py` — clean
- **Smoke proof:** synthesized a tar with a uid-0 regular file + a uid-0 setuid binary, ran through the patched function, `debugfs` confirmed both inodes have `User: 0  Group: 0` in the resulting ext4 and the setuid bit survived.

## Risk

Low. The Docker path is the macOS path and the GitHub-runner path; both are exercised. The Linux loopfs path (`_create_ext4_with_loopfs`) is unchanged. The only behavioral difference is that the rootfs now has correct ownership — which was the documented intent all along.

## Follow-up

Once this lands, the next published rootfs build will have correct ownership, and macOS `SMOLVM_USE_PUBLISHED=1 smolvm openclaw start` should boot end-to-end through the QEMU/HVF path that landed in #251 + #254.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Introduced safety validation checks when processing container image archives to enhance security and ensure reliable extraction.

* **Refactor**
  * Optimized container image extraction and filesystem creation workflow for improved efficiency and resource utilization during the build process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->