### PR TITLE
feat(presets): forward OPENCLAW_GATEWAY_TOKEN/PASSWORD to openclaw guest

### DIFF
--- a/src/smolvm/cli/main.py
+++ b/src/smolvm/cli/main.py
@@ -1963,6 +1963,7 @@ def _run_start_with_published_image(args: argparse.Namespace, preset: object) ->
         )
 
         vm: SmolVM | None = None
+        success = False
         try:
             vm = SmolVM(
                 config,
@@ -2000,11 +2001,23 @@ def _run_start_with_published_image(args: argparse.Namespace, preset: object) ->
             else:
                 _render_start_result(data)
 
+            success = True
             if not args.json and _preset.launch_command:
                 return _maybe_attach_and_launch(vm, _preset, attach=getattr(args, "attach", None))
             return 0
         finally:
             if vm is not None:
+                # On failure (e.g. wait_for_ssh timeout) the VM is unusable
+                # to the caller, but the underlying QEMU/Firecracker process
+                # is still alive and burning CPU. close() only releases
+                # SDK handles, not the runtime — explicitly stop+delete to
+                # reap the process. On success we leave the VM running so
+                # the user can ssh into it.
+                if not success:
+                    with suppress(Exception):
+                        vm.stop()
+                    with suppress(Exception):
+                        vm.delete()
                 vm.close()
     except ImageError as exc:
         return _emit_cli_error("start", 1, exc, json_output=args.json)

--- a/src/smolvm/presets/openclaw.py
+++ b/src/smolvm/presets/openclaw.py
@@ -25,11 +25,17 @@ OPENCLAW_PRESET = Preset(
     summary="Start a sandbox with the OpenClaw CLI preinstalled.",
     setup_script=node_bootstrap(22),
     install_script=npm_install_global("openclaw"),
-    host_env_vars=("OPENROUTER_API_KEY", "OPENAI_API_KEY"),
+    host_env_vars=(
+        "OPENROUTER_API_KEY",
+        "OPENAI_API_KEY",
+        "OPENCLAW_GATEWAY_TOKEN",
+        "OPENCLAW_GATEWAY_PASSWORD",
+    ),
     host_configs=(HostConfigCopy(host_path="~/.openclaw", guest_path="/root/.openclaw"),),
     launch_command="openclaw",
     no_env_hint=(
-        "No API key found. Set OPENROUTER_API_KEY or OPENAI_API_KEY on your"
-        " machine, or run 'openclaw onboard' inside the sandbox."
+        "No API key found. Set OPENROUTER_API_KEY, OPENAI_API_KEY, or"
+        " OPENCLAW_GATEWAY_TOKEN on your machine, or run 'openclaw onboard'"
+        " inside the sandbox."
     ),
 )

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -2985,3 +2985,62 @@ class TestPublishedImageLaunchPath:
         if expected_vmm == "qemu":
             expected_console = "ttyAMA0" if expected_arch == "arm64" else "ttyS0"
             assert f"console={expected_console}" in config_arg.boot_args
+
+        # Success path: VM is left running so the user can ssh in. stop()
+        # and delete() must NOT have been called — only close() to release
+        # SDK handles.
+        mock_vm.stop.assert_not_called()
+        mock_vm.delete.assert_not_called()
+        mock_vm.close.assert_called_once()
+
+    @patch.dict(os.environ, {"SMOLVM_USE_PUBLISHED": "1"})
+    @patch("smolvm.cli.main.subprocess.run")
+    @patch("smolvm.facade.SmolVM")
+    @patch("smolvm.utils.ensure_ssh_key")
+    @patch("smolvm.images.published.ensure_published_image")
+    @patch("smolvm.cli.main.platform.machine", return_value="arm64")
+    @patch("smolvm.cli.main.platform.system", return_value="Darwin")
+    def test_published_path_reaps_vm_on_failure(
+        self,
+        _mock_system: MagicMock,
+        _mock_machine: MagicMock,
+        mock_ensure_image: MagicMock,
+        mock_ensure_ssh_key: MagicMock,
+        mock_vm_cls: MagicMock,
+        _mock_subprocess: MagicMock,
+        tmp_path: Path,
+    ) -> None:
+        """If wait_for_ssh fails, the VM (and its QEMU process) must be
+        stopped and deleted — not just close()d, which only releases SDK
+        handles and leaves the runtime burning CPU."""
+        from smolvm.exceptions import OperationTimeoutError
+        from smolvm.images.manager import LocalImage
+
+        kernel = tmp_path / "vmlinux.bin"
+        rootfs = tmp_path / "rootfs.ext4"
+        priv = tmp_path / "id_ed25519"
+        pub = tmp_path / "id_ed25519.pub"
+        for p in (kernel, rootfs, priv):
+            p.touch()
+        pub.write_text("ssh-ed25519 AAAAExampleKey user@host\n")
+
+        mock_ensure_image.return_value = LocalImage(
+            name="openclaw-v0.0.13-arm64-qemu",
+            kernel_path=kernel,
+            rootfs_path=rootfs,
+        )
+        mock_ensure_ssh_key.return_value = (priv, pub)
+        mock_vm = MagicMock()
+        mock_vm.vm_id = "sbx-published-leak"
+        mock_vm.wait_for_ssh.side_effect = OperationTimeoutError(
+            "wait_for_ssh: simulated timeout", 30.0
+        )
+        mock_vm_cls.return_value = mock_vm
+
+        ret = main(["openclaw", "start", "--json"])
+
+        assert ret == 1  # OperationTimeoutError → exit 1
+        mock_vm.start.assert_called_once()
+        mock_vm.stop.assert_called_once()
+        mock_vm.delete.assert_called_once()
+        mock_vm.close.assert_called_once()

--- a/tests/test_presets.py
+++ b/tests/test_presets.py
@@ -263,7 +263,12 @@ class TestOpenClawPreset:
         assert OPENCLAW_PRESET.name == "openclaw"
         assert OPENCLAW_PRESET.aliases == ("claw",)
         assert OPENCLAW_PRESET.launch_command == "openclaw"
-        assert OPENCLAW_PRESET.host_env_vars == ("OPENROUTER_API_KEY", "OPENAI_API_KEY")
+        assert OPENCLAW_PRESET.host_env_vars == (
+            "OPENROUTER_API_KEY",
+            "OPENAI_API_KEY",
+            "OPENCLAW_GATEWAY_TOKEN",
+            "OPENCLAW_GATEWAY_PASSWORD",
+        )
 
     def test_openclaw_copies_config_dir(self) -> None:
         pairs = [(cfg.host_path, cfg.guest_path) for cfg in OPENCLAW_PRESET.host_configs]


### PR DESCRIPTION
## Summary

Two fixes from the same E2E session:

### 1. Forward OPENCLAW_GATEWAY_TOKEN/PASSWORD to the openclaw guest

When openclaw boots inside the sandbox without a recognised credential it errors with `Missing gateway auth token. Fix: set OPENCLAW_GATEWAY_TOKEN/OPENCLAW_GATEWAY_PASSWORD ...` — but the SmolVM preset only forwarded `OPENROUTER_API_KEY` and `OPENAI_API_KEY` from host, so users with the gateway-token flow had no way to pass it through without SSHing in and running `openclaw onboard` interactively.

- Add `OPENCLAW_GATEWAY_TOKEN` and `OPENCLAW_GATEWAY_PASSWORD` to `host_env_vars`.
- Update `no_env_hint` to mention `OPENCLAW_GATEWAY_TOKEN`.

### 2. Reap VM on published-path failure (was leaking QEMU)

When `wait_for_ssh` times out, `_run_start_with_published_image` was calling only `vm.close()`. `close()` releases SDK handles but does NOT terminate the QEMU/Firecracker process, so a failed launch left an orphan process burning ~190% CPU on the host. Three failed launches in one session = three zombies eating ~564% combined CPU.

Fix: track `success` explicitly. On failure, call `stop()` + `delete()` before `close()` to terminate the runtime and clean up the VM record. On success the VM stays running so the user can ssh in.

## Test plan

- [x] `uv run pytest tests/test_presets.py tests/test_cli.py::TestPublishedImageLaunchPath` — 79 + 28 pass
- [x] `uv run ruff check` clean (two pre-existing E501s on unrelated lines)
- [ ] Manual: `OPENCLAW_GATEWAY_TOKEN=... SMOLVM_USE_PUBLISHED=1 smolvm openclaw start` reaches the openclaw prompt
- [ ] Manual: simulate a wait_for_ssh failure and verify `pgrep qemu-system` is empty afterward

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * OpenClaw preset now requires OPENCLAW_GATEWAY_TOKEN and OPENCLAW_GATEWAY_PASSWORD (in addition to existing keys); setup guidance updated.
* **Bug Fixes**
  * CLI start flow improved to ensure VMs are stopped and cleaned up on startup failures while leaving successful runs active.
* **Tests**
  * Updated tests to cover new env var requirements and startup/cleanup behaviors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->