### PR TITLE
feat: retire external kernel downloads — universal SmolVM-built kernel everywhere

### DIFF
--- a/.github/workflows/build-qemu-kernel.yml
+++ b/.github/workflows/build-qemu-kernel.yml
@@ -79,15 +79,18 @@ jobs:
           mkdir -p "$OUT_DIR"
           bash kernel/qemu/build.sh
 
-      - name: Sanity-check artifact
+      - name: Sanity-check artifacts
         run: |
-          ARTIFACT="kernel-out/vmlinux-${{ matrix.arch }}-qemu.bin"
-          test -f "$ARTIFACT" || { echo "missing: $ARTIFACT"; exit 1; }
-          # Kernel images are MBs, not bytes. Catches the silent
-          # "build produced an empty file" failure mode.
-          size=$(stat -c '%s' "$ARTIFACT")
-          test "$size" -gt 1000000 || { echo "$ARTIFACT is suspiciously small ($size bytes)"; exit 1; }
-          file "$ARTIFACT"
+          ELF="kernel-out/vmlinux-${{ matrix.arch }}.elf"
+          IMAGE="kernel-out/vmlinux-${{ matrix.arch }}.image"
+          for f in "$ELF" "$IMAGE"; do
+            test -f "$f" || { echo "missing: $f"; exit 1; }
+            # Kernel images are MBs, not bytes. Catches the silent
+            # "build produced an empty file" failure mode.
+            size=$(stat -c '%s' "$f")
+            test "$size" -gt 1000000 || { echo "$f is suspiciously small ($size bytes)"; exit 1; }
+          done
+          file "$ELF" "$IMAGE"
           ls -lh kernel-out/
 
       - name: Resolve release tag
@@ -109,13 +112,17 @@ jobs:
       - name: Compute SHA-256
         id: sha
         env:
-          NAME: vmlinux-${{ matrix.arch }}-qemu.bin
+          ARCH: ${{ matrix.arch }}
         run: |
-          kernel_sha=$(sha256sum "kernel-out/${NAME}" | cut -d' ' -f1)
-          kernel_size=$(stat -c '%s' "kernel-out/${NAME}")
+          elf_sha=$(sha256sum "kernel-out/vmlinux-${ARCH}.elf" | cut -d' ' -f1)
+          elf_size=$(stat -c '%s' "kernel-out/vmlinux-${ARCH}.elf")
+          image_sha=$(sha256sum "kernel-out/vmlinux-${ARCH}.image" | cut -d' ' -f1)
+          image_size=$(stat -c '%s' "kernel-out/vmlinux-${ARCH}.image")
           {
-            echo "kernel_sha=${kernel_sha}"
-            echo "kernel_size=${kernel_size}"
+            echo "elf_sha=${elf_sha}"
+            echo "elf_size=${elf_size}"
+            echo "image_sha=${image_sha}"
+            echo "image_size=${image_size}"
           } >> "$GITHUB_OUTPUT"
 
       - name: Upload to GitHub Releases (draft)
@@ -139,15 +146,18 @@ jobs:
           gh release upload "$TAG" \
             --repo "$GITHUB_REPOSITORY" \
             --clobber \
-            "kernel-out/vmlinux-${ARCH}-qemu.bin" \
-            "kernel-out/vmlinux-${ARCH}-qemu.config"
+            "kernel-out/vmlinux-${ARCH}.elf" \
+            "kernel-out/vmlinux-${ARCH}.image" \
+            "kernel-out/vmlinux-${ARCH}.config"
 
       - name: Step summary
         env:
           ARCH: ${{ matrix.arch }}
           TAG: ${{ steps.release.outputs.tag }}
-          KERNEL_SHA: ${{ steps.sha.outputs.kernel_sha }}
-          KERNEL_SIZE: ${{ steps.sha.outputs.kernel_size }}
+          ELF_SHA: ${{ steps.sha.outputs.elf_sha }}
+          ELF_SIZE: ${{ steps.sha.outputs.elf_size }}
+          IMAGE_SHA: ${{ steps.sha.outputs.image_sha }}
+          IMAGE_SIZE: ${{ steps.sha.outputs.image_size }}
           CACHE_HIT: ${{ steps.cache.outputs.cache-hit }}
         run: |
           {
@@ -155,11 +165,10 @@ jobs:
             echo ""
             echo "Uploaded to draft release [\`${TAG}\`](https://github.com/${GITHUB_REPOSITORY}/releases/tag/${TAG})."
             echo ""
-            echo "| Field | Value |"
-            echo "| --- | --- |"
-            echo "| Cache hit | \`${CACHE_HIT}\` |"
-            echo "| Linux version | \`$(cat kernel/qemu/linux.version)\` |"
-            echo "| Artifact | \`vmlinux-${ARCH}-qemu.bin\` |"
-            echo "| Size | $(numfmt --to=iec-i --suffix=B ${KERNEL_SIZE}) |"
-            echo "| SHA-256 | \`${KERNEL_SHA}\` |"
+            echo "| Artifact | Size | SHA-256 |"
+            echo "| --- | --- | --- |"
+            echo "| \`vmlinux-${ARCH}.elf\` (Firecracker) | $(numfmt --to=iec-i --suffix=B ${ELF_SIZE}) | \`${ELF_SHA}\` |"
+            echo "| \`vmlinux-${ARCH}.image\` (QEMU) | $(numfmt --to=iec-i --suffix=B ${IMAGE_SIZE}) | \`${IMAGE_SHA}\` |"
+            echo ""
+            echo "Linux version: \`$(cat kernel/qemu/linux.version)\` · Cache hit: \`${CACHE_HIT}\`"
           } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/smoke-published-images.yml
+++ b/.github/workflows/smoke-published-images.yml
@@ -1,0 +1,206 @@
+# Boot-smoke the SmolVM-built universal kernel against published rootfs
+# images BEFORE we commit a new manifest version. Catches the class of
+# bug where a Kconfig delta (or a kernel bump) silently breaks boot for
+# one of (Ubuntu cloud rootfs, openclaw rootfs) — which is otherwise
+# only discovered by the first user trying `smolvm create`.
+#
+# Each cell:
+#   - Downloads the published kernel + rootfs from the draft release
+#     `images-v<pyproject-version>` (no SHA pinning — we want to test
+#     whatever CI just produced, not what's pinned in the manifest).
+#   - Boots qemu-system-<arch> -accel kvm with the kernel, the rootfs
+#     as virtio-blk, a cloud-init NoCloud seed (for the Ubuntu cell),
+#     port-forwards SSH to the host.
+#   - Polls for sshd readiness for up to ~90 s. Failure → red x.
+#
+# nested-virt note: KVM is available on GH-hosted ubuntu-latest /
+# ubuntu-24.04-arm runners as of 2023. macOS HVF cannot be exercised
+# in CI (no nested-virt on hosted macOS runners) — that path is
+# validated by developers locally + first-user opt-in.
+
+name: Smoke Published Images
+
+on:
+  workflow_dispatch:
+    inputs:
+      release_tag:
+        description: >-
+          Release tag to smoke-test (e.g. images-v0.0.14a0). Leave empty to
+          derive from pyproject version (matches the build-* workflows).
+        type: string
+        default: ""
+  workflow_run:
+    workflows: ["Build QEMU Kernel", "Build Published Images"]
+    types:
+      - completed
+    branches:
+      - main
+
+permissions:
+  contents: read
+
+jobs:
+  smoke:
+    # Only run after a successful build — failed builds left the assets in
+    # an unknown state.
+    if: ${{ github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion == 'success' }}
+    strategy:
+      fail-fast: false
+      matrix:
+        arch: [amd64, arm64]
+        rootfs: [openclaw, ubuntu]
+    runs-on: ${{ matrix.arch == 'arm64' && 'ubuntu-24.04-arm' || 'ubuntu-latest' }}
+    timeout-minutes: 20
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+
+      - name: Install QEMU + tooling
+        run: |
+          sudo apt-get update -qq
+          sudo apt-get install -y --no-install-recommends \
+              qemu-system-x86 qemu-system-arm qemu-utils \
+              cloud-image-utils zstd \
+              netcat-openbsd
+          # KVM access — GH runners ship /dev/kvm but the runner user isn't
+          # always in the kvm group. Add it; sudo on the qemu invocation also
+          # works as a fallback.
+          sudo usermod -a -G kvm $USER || true
+
+      - name: Resolve release tag
+        id: release
+        env:
+          INPUT_TAG: ${{ inputs.release_tag }}
+        run: |
+          if [ -n "${INPUT_TAG:-}" ]; then
+            tag="$INPUT_TAG"
+          else
+            version=$(python3 -c "import tomllib; print(tomllib.load(open('pyproject.toml','rb'))['project']['version'])")
+            tag="images-v${version}"
+          fi
+          echo "tag=${tag}" >> "$GITHUB_OUTPUT"
+
+      - name: Download kernel
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG: ${{ steps.release.outputs.tag }}
+          ARCH: ${{ matrix.arch }}
+        run: |
+          mkdir -p smoke
+          gh release download "$TAG" \
+              --repo "$GITHUB_REPOSITORY" \
+              --pattern "vmlinux-${ARCH}-qemu.bin" \
+              -D smoke
+
+      - name: Download rootfs (openclaw)
+        if: matrix.rootfs == 'openclaw'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG: ${{ steps.release.outputs.tag }}
+          ARCH: ${{ matrix.arch }}
+        run: |
+          gh release download "$TAG" \
+              --repo "$GITHUB_REPOSITORY" \
+              --pattern "openclaw-${ARCH}-rootfs.ext4.zst" \
+              -D smoke
+          zstd -d "smoke/openclaw-${ARCH}-rootfs.ext4.zst" -o smoke/rootfs.raw
+          rm "smoke/openclaw-${ARCH}-rootfs.ext4.zst"
+
+      - name: Download rootfs (ubuntu)
+        if: matrix.rootfs == 'ubuntu'
+        env:
+          ARCH: ${{ matrix.arch }}
+        run: |
+          # ubuntu cloud-images for noble; same one the auto-config flow uses
+          if [ "$ARCH" = "amd64" ]; then
+            url="https://cloud-images.ubuntu.com/minimal/releases/noble/release/ubuntu-24.04-minimal-cloudimg-amd64.img"
+          else
+            url="https://cloud-images.ubuntu.com/minimal/releases/noble/release/ubuntu-24.04-minimal-cloudimg-arm64.img"
+          fi
+          curl -fL -o smoke/rootfs.raw "$url"
+
+      - name: Build cloud-init seed
+        run: |
+          ssh-keygen -t ed25519 -N "" -f smoke/id_ed25519 -C smoke
+          cat > smoke/user-data <<EOF
+          #cloud-config
+          users:
+            - name: root
+              ssh_authorized_keys:
+                - $(cat smoke/id_ed25519.pub)
+          ssh_pwauth: false
+          chpasswd:
+            expire: false
+          EOF
+          echo "instance-id: smoke; local-hostname: smoke" > smoke/meta-data
+          cloud-localds smoke/seed.iso smoke/user-data smoke/meta-data
+
+      - name: Boot the VM and wait for SSH
+        env:
+          ARCH: ${{ matrix.arch }}
+          ROOTFS: ${{ matrix.rootfs }}
+        run: |
+          set -euo pipefail
+          if [ "$ARCH" = "amd64" ]; then
+            QEMU=qemu-system-x86_64
+            MACHINE="-machine pc-q35-4.2,accel=kvm -cpu host"
+            CONSOLE=ttyS0
+          else
+            QEMU=qemu-system-aarch64
+            MACHINE="-machine virt,accel=kvm -cpu host"
+            CONSOLE=ttyAMA0
+          fi
+          # Same root= the production code uses for each rootfs flavor.
+          if [ "$ROOTFS" = "openclaw" ]; then
+            ROOT_ARG="root=/dev/vda"
+          else
+            ROOT_ARG="root=/dev/vda1"
+          fi
+          sudo $QEMU \
+              $MACHINE -smp 2 -m 2048 \
+              -kernel smoke/vmlinux-${ARCH}-qemu.bin \
+              -drive file=smoke/rootfs.raw,if=none,id=root,format=raw \
+              -device virtio-blk-pci,drive=root \
+              -drive file=smoke/seed.iso,if=none,id=seed,format=raw,readonly=on \
+              -device virtio-blk-pci,drive=seed \
+              -netdev user,id=net0,hostfwd=tcp::2223-:22 \
+              -device virtio-net-pci,netdev=net0 \
+              -append "console=${CONSOLE} reboot=k panic=1 ${ROOT_ARG} rw" \
+              -nographic -no-reboot \
+              > smoke/boot.log 2>&1 &
+          QPID=$!
+          # Poll for sshd
+          ok=0
+          for i in $(seq 1 120); do
+            sleep 1
+            if ssh-keyscan -T 2 -p 2223 127.0.0.1 2>/dev/null | grep -q "ssh-"; then
+              echo "sshd ready after ${i}s"
+              ok=1
+              break
+            fi
+          done
+          sudo kill $QPID 2>/dev/null || true
+          sleep 2
+          sudo kill -9 $QPID 2>/dev/null || true
+          echo "--- last 80 lines of boot log ---"
+          tail -80 smoke/boot.log
+          if [ "$ok" -ne 1 ]; then
+            echo "::error::sshd did not become ready within 120s on ${ARCH}/${ROOTFS}"
+            exit 1
+          fi
+
+      - name: Step summary
+        if: always()
+        env:
+          ARCH: ${{ matrix.arch }}
+          ROOTFS: ${{ matrix.rootfs }}
+          TAG: ${{ steps.release.outputs.tag }}
+        run: |
+          {
+            echo "## Smoke: \`${ARCH}\` × \`${ROOTFS}\` from \`${TAG}\`"
+            echo ""
+            echo "Status: ${{ job.status }}"
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/kernel/qemu/README.md
+++ b/kernel/qemu/README.md
@@ -1,22 +1,29 @@
-# SmolVM QEMU/libkrun Kernel
+# SmolVM Universal microvm Kernel
 
-This directory holds the recipe for the Linux kernel SmolVM ships to
-QEMU and libkrun users. QEMU runs on Linux and macOS; this kernel makes
-those sandboxes boot all the way through and print log output.
+This directory holds the recipe for the **only** Linux kernel SmolVM
+ships. One vmlinux per arch boots all three runtimes — Firecracker,
+QEMU, and (future) libkrun — across both Linux and macOS hosts. The
+filename is still `vmlinux-<arch>-qemu.bin` for compat with the existing
+publish pipeline; renaming to `vmlinux-<arch>.bin` is a future cleanup.
 
 ## Why this exists
 
-Our default-published kernel is fetched from
-[Firecracker's CI S3 bucket][fc-ci]. It's tuned for Firecracker, which
-exposes virtual hardware to the guest over a "MMIO" bus and uses an
-8250 serial chip on aarch64. QEMU's `virt` machine and libkrun expose
-the same devices over **PCI** instead, and use the ARM PL011 UART on
-aarch64 — different drivers entirely. Empirically the Firecracker
-kernel produces **zero serial output** under QEMU: it boots into a
-hardware model it has no drivers for. Linux and macOS users running
-QEMU or libkrun need a kernel built for that hardware.
+Before 0.0.14a0 SmolVM fetched kernels from two external CDNs:
 
-[fc-ci]: https://s3.amazonaws.com/spec.ccfc.min/firecracker-ci/v1.6/
+- **Firecracker's CI S3 bucket** (`s3.amazonaws.com/spec.ccfc.min/.../vmlinux-5.10.198`) — for Firecracker on Linux. Tuned for Firecracker's virtio-MMIO transport.
+- **Ubuntu cloud-images** (`cloud-images.ubuntu.com/.../vmlinuz-generic`) — paired with a matching initrd for the QEMU+Ubuntu auto-config path.
+
+Two kernels meant two CVE-watch lists, two test surfaces, and two CDN
+failure modes (we hit a `cloud-images.ubuntu.com` outage in practice).
+Both upstream kernels are also generic-purpose with hundreds of drivers
+we don't need (Bluetooth, USB, sound, gpio, …) — extra attack surface
+for a sandbox that just needs virtio + ext4 + sshd.
+
+The kernel built here closes that gap: a single in-house artifact tuned
+for microvm use, with both `CONFIG_VIRTIO_MMIO=y` (Firecracker) and
+`CONFIG_VIRTIO_PCI=y` (QEMU/libkrun) enabled, plus `CONFIG_ISO9660_FS=y`
+for the cloud-init NoCloud seed disk so we don't need an initrd to boot
+the Ubuntu cloud rootfs.
 
 ## What's pinned
 

--- a/kernel/qemu/build.sh
+++ b/kernel/qemu/build.sh
@@ -90,19 +90,28 @@ SMOLVM_ARCH="${SMOLVM_ARCH_OVERRIDE:-$SMOLVM_ARCH}"
 
 # SmolVM arch label → kernel ARCH= variable.
 #
-# We ship the ELF `vmlinux` (kernel-source root), NOT the boot wrappers
-# (bzImage on x86, Image on arm64). Firecracker REQUIRES an uncompressed
-# ELF — `Kernel Loader: Invalid Elf magic number` otherwise. QEMU's
-# `-kernel` accepts both ELF and the boot wrappers, so the ELF works
-# universally. Build target stays `bzImage`/`Image` because those targets
-# always produce the ELF as a prerequisite, but we copy the ELF to the
-# output instead of the wrapper.
+# We ship TWO artifacts per arch — same source build, different output formats:
+#   - vmlinux-<arch>.elf    The uncompressed ELF (kernel-source root).
+#                           Firecracker REQUIRES this; bzImage/Image fail
+#                           with `Kernel Loader: Invalid Elf magic number`.
+#   - vmlinux-<arch>.image  The boot wrapper (bzImage on x86, Image on
+#                           arm64). QEMU's `-machine virt -kernel` empirically
+#                           refuses to boot a Linux ELF on aarch64 (silent
+#                           hang, no console output), but boots Image fine.
+#                           QEMU on x86 accepts either; we standardise on
+#                           the boot wrapper for consistency.
+# The `make $KMAKE_TARGET` step builds both as a side effect — the wrapper
+# depends on the ELF — so producing two artifacts costs nothing extra.
 case "$SMOLVM_ARCH" in
     amd64)  KARCH=x86_64; KMAKE_TARGET=bzImage; DEFCONFIG=x86_64_defconfig ;;
     arm64)  KARCH=arm64;  KMAKE_TARGET=Image;   DEFCONFIG=defconfig ;;
     *) echo "internal error: unhandled SMOLVM_ARCH $SMOLVM_ARCH" >&2; exit 2 ;;
 esac
-KIMAGE_REL=vmlinux  # ELF, root of the kernel source tree
+case "$SMOLVM_ARCH" in
+    amd64)  IMAGE_REL=arch/x86/boot/bzImage ;;
+    arm64)  IMAGE_REL=arch/arm64/boot/Image ;;
+esac
+ELF_REL=vmlinux  # ELF, root of the kernel source tree
 
 ARCH_FRAGMENT="$SCRIPT_DIR/config.$SMOLVM_ARCH.fragment"
 if [ ! -f "$ARCH_FRAGMENT" ]; then
@@ -114,13 +123,15 @@ OUT_DIR="${OUT_DIR:-$PWD}"
 WORK_DIR="${WORK_DIR:-$(mktemp -d)}"
 TARBALL="$WORK_DIR/linux-$LINUX_VERSION.tar.xz"
 SRC_DIR="$WORK_DIR/linux-$LINUX_VERSION"
-ARTIFACT="$OUT_DIR/vmlinux-$SMOLVM_ARCH-qemu.bin"
+ELF_ARTIFACT="$OUT_DIR/vmlinux-$SMOLVM_ARCH.elf"
+IMAGE_ARTIFACT="$OUT_DIR/vmlinux-$SMOLVM_ARCH.image"
 JOBS="$(job_count)"
 
 echo "==> Linux $LINUX_VERSION → $SMOLVM_ARCH (kernel ARCH=$KARCH)"
-echo "    work dir: $WORK_DIR"
-echo "    output:   $ARTIFACT"
-echo "    make:     $MAKE_BIN ($MAKE_VERSION)"
+echo "    work dir:    $WORK_DIR"
+echo "    elf out:     $ELF_ARTIFACT"
+echo "    image out:   $IMAGE_ARTIFACT"
+echo "    make:        $MAKE_BIN ($MAKE_VERSION)"
 
 # 1. Download the tarball and verify against our pinned SHA.
 if [ ! -f "$TARBALL" ]; then
@@ -214,24 +225,40 @@ case "$(printf '%s' "${SMOLVM_VERIFY_ONLY:-}" | tr '[:upper:]' '[:lower:]')" in
 esac
 
 # 5. Build the kernel image.
-# We invoke the boot-wrapper target (bzImage/Image) because that's what the
-# kernel build system uses to drive a full link — the ELF `vmlinux` falls out
-# as a prerequisite. Then we copy the ELF, not the wrapper.
+# Invoking the boot-wrapper target (bzImage/Image) drives a full link, so the
+# ELF `vmlinux` is produced as a prerequisite. We then ship both: the wrapper
+# for QEMU, the ELF for Firecracker.
 echo "==> Building kernel ($JOBS jobs)"
 "$MAKE_BIN" ARCH="$KARCH" -j"$JOBS" "$KMAKE_TARGET"
 
-# 6. Stage the artifact + record the resolved config (debugging aid).
+# 6. Stage the artifacts + record the resolved config (debugging aid).
 mkdir -p "$OUT_DIR"
-cp "$KIMAGE_REL" "$ARTIFACT"
-cp .config "$OUT_DIR/vmlinux-$SMOLVM_ARCH-qemu.config"
+cp "$IMAGE_REL" "$IMAGE_ARTIFACT"
+cp "$ELF_REL" "$ELF_ARTIFACT"
+cp .config "$OUT_DIR/vmlinux-$SMOLVM_ARCH.config"
 
-# Sanity check: Firecracker rejects anything that isn't an uncompressed
-# ELF with `Invalid Elf magic number`. ELF magic = 7f 45 4c 46.
-if [ "$(head -c 4 "$ARTIFACT" | od -An -tx1 | tr -d ' ')" != "7f454c46" ]; then
-    echo "==> ERROR: $ARTIFACT is not an ELF binary (Firecracker will reject it)" >&2
+# Strip the ELF: with the default kernel build it's ~290 MB on arm64
+# (debug_info + symbols). Firecracker doesn't need any of that. Keep
+# `--strip-debug` (not `--strip-all`) — preserves the symbol table for
+# tooling like crash dumps. Cuts the artifact by ~3x.
+strip --strip-debug "$ELF_ARTIFACT"
+
+# Sanity checks:
+#   ELF magic (7f 45 4c 46) on the .elf — Firecracker requires this.
+elf_magic=$(head -c 4 "$ELF_ARTIFACT" | od -An -tx1 | tr -d ' ')
+if [ "$elf_magic" != "7f454c46" ]; then
+    echo "==> ERROR: $ELF_ARTIFACT is not an ELF binary (got magic $elf_magic)" >&2
+    exit 1
+fi
+#   Image must NOT be ELF — QEMU on aarch64 virt empirically refuses to boot
+#   a Linux ELF kernel and just hangs silently. Catch it early.
+img_magic=$(head -c 4 "$IMAGE_ARTIFACT" | od -An -tx1 | tr -d ' ')
+if [ "$img_magic" = "7f454c46" ]; then
+    echo "==> ERROR: $IMAGE_ARTIFACT is unexpectedly ELF (QEMU/virt won't boot)" >&2
     exit 1
 fi
 
 echo "==> Done."
-echo "    $ARTIFACT  ($(wc -c <"$ARTIFACT" | tr -d ' ') bytes)"
-echo "    $OUT_DIR/vmlinux-$SMOLVM_ARCH-qemu.config"
+echo "    $ELF_ARTIFACT    ($(wc -c <"$ELF_ARTIFACT" | tr -d ' ') bytes, ELF for Firecracker)"
+echo "    $IMAGE_ARTIFACT  ($(wc -c <"$IMAGE_ARTIFACT" | tr -d ' ') bytes, ${KMAKE_TARGET} for QEMU)"
+echo "    $OUT_DIR/vmlinux-$SMOLVM_ARCH.config"

--- a/kernel/qemu/build.sh
+++ b/kernel/qemu/build.sh
@@ -89,11 +89,20 @@ esac
 SMOLVM_ARCH="${SMOLVM_ARCH_OVERRIDE:-$SMOLVM_ARCH}"
 
 # SmolVM arch label → kernel ARCH= variable.
+#
+# We ship the ELF `vmlinux` (kernel-source root), NOT the boot wrappers
+# (bzImage on x86, Image on arm64). Firecracker REQUIRES an uncompressed
+# ELF — `Kernel Loader: Invalid Elf magic number` otherwise. QEMU's
+# `-kernel` accepts both ELF and the boot wrappers, so the ELF works
+# universally. Build target stays `bzImage`/`Image` because those targets
+# always produce the ELF as a prerequisite, but we copy the ELF to the
+# output instead of the wrapper.
 case "$SMOLVM_ARCH" in
-    amd64)  KARCH=x86_64; KIMAGE_REL=arch/x86/boot/bzImage; DEFCONFIG=x86_64_defconfig ;;
-    arm64)  KARCH=arm64;  KIMAGE_REL=arch/arm64/boot/Image; DEFCONFIG=defconfig ;;
+    amd64)  KARCH=x86_64; KMAKE_TARGET=bzImage; DEFCONFIG=x86_64_defconfig ;;
+    arm64)  KARCH=arm64;  KMAKE_TARGET=Image;   DEFCONFIG=defconfig ;;
     *) echo "internal error: unhandled SMOLVM_ARCH $SMOLVM_ARCH" >&2; exit 2 ;;
 esac
+KIMAGE_REL=vmlinux  # ELF, root of the kernel source tree
 
 ARCH_FRAGMENT="$SCRIPT_DIR/config.$SMOLVM_ARCH.fragment"
 if [ ! -f "$ARCH_FRAGMENT" ]; then
@@ -205,13 +214,23 @@ case "$(printf '%s' "${SMOLVM_VERIFY_ONLY:-}" | tr '[:upper:]' '[:lower:]')" in
 esac
 
 # 5. Build the kernel image.
+# We invoke the boot-wrapper target (bzImage/Image) because that's what the
+# kernel build system uses to drive a full link — the ELF `vmlinux` falls out
+# as a prerequisite. Then we copy the ELF, not the wrapper.
 echo "==> Building kernel ($JOBS jobs)"
-"$MAKE_BIN" ARCH="$KARCH" -j"$JOBS" "$(basename "$KIMAGE_REL")"
+"$MAKE_BIN" ARCH="$KARCH" -j"$JOBS" "$KMAKE_TARGET"
 
 # 6. Stage the artifact + record the resolved config (debugging aid).
 mkdir -p "$OUT_DIR"
 cp "$KIMAGE_REL" "$ARTIFACT"
 cp .config "$OUT_DIR/vmlinux-$SMOLVM_ARCH-qemu.config"
+
+# Sanity check: Firecracker rejects anything that isn't an uncompressed
+# ELF with `Invalid Elf magic number`. ELF magic = 7f 45 4c 46.
+if [ "$(head -c 4 "$ARTIFACT" | od -An -tx1 | tr -d ' ')" != "7f454c46" ]; then
+    echo "==> ERROR: $ARTIFACT is not an ELF binary (Firecracker will reject it)" >&2
+    exit 1
+fi
 
 echo "==> Done."
 echo "    $ARTIFACT  ($(wc -c <"$ARTIFACT" | tr -d ' ') bytes)"

--- a/kernel/qemu/config.fragment
+++ b/kernel/qemu/config.fragment
@@ -1,4 +1,4 @@
-# SmolVM QEMU/libkrun kernel config fragment — common deltas.
+# SmolVM universal microvm kernel config fragment — common deltas.
 #
 # Applied on top of `x86_64_defconfig` (x86) or `defconfig` (arm64) via
 # scripts/kconfig/merge_config.sh during build. Only the symbols that
@@ -6,26 +6,29 @@
 # PL011, 8250) live in `config.<arch>.fragment` and are merged on top.
 #
 # Why each delta exists:
-# - virtio-PCI bus + drivers: QEMU's `virt` machine + libkrun expose virtio
-#   devices via PCI, not MMIO (which Firecracker uses). Without these the
-#   guest can't see its rootfs or NIC.
+# - Both virtio transports: QEMU's `virt` machine + libkrun expose virtio
+#   over PCI; Firecracker exposes it over MMIO. Same kernel boots under all
+#   three, so we enable both transports.
 # - Built-in (`=y`), not modular (`=m`): we ship one vmlinux and no initrd.
 #   If a driver needed at boot is `=m`, the kernel can't mount the rootfs to
 #   load it — chicken-and-egg.
 
 # ── Bus + virtio ─────────────────────────────────────────────────────
-CONFIG_PCI=y                    # why: QEMU virt + libkrun use virtio-PCI
-CONFIG_PCI_MSI=y                # why: virtio-PCI uses MSI-X interrupts
-CONFIG_VIRTIO=y                 # why: core virtio framework
-CONFIG_VIRTIO_PCI=y             # why: PCI transport for virtio devices
-CONFIG_VIRTIO_PCI_LEGACY=y      # why: libkrun uses the legacy interface
-CONFIG_VIRTIO_BLK=y             # why: rootfs is a virtio-blk device
-CONFIG_VIRTIO_NET=y             # why: networking via virtio-net
-CONFIG_VIRTIO_CONSOLE=y         # why: hvc0 fallback console under virt
-CONFIG_VIRTIO_BALLOON=y         # why: memory pressure feedback to host
+CONFIG_PCI=y                            # why: QEMU virt + libkrun use virtio-PCI
+CONFIG_PCI_MSI=y                        # why: virtio-PCI uses MSI-X interrupts
+CONFIG_VIRTIO=y                         # why: core virtio framework
+CONFIG_VIRTIO_PCI=y                     # why: PCI transport for virtio devices
+CONFIG_VIRTIO_PCI_LEGACY=y              # why: libkrun uses the legacy interface
+CONFIG_VIRTIO_MMIO=y                    # why: Firecracker exposes virtio over MMIO (both archs)
+CONFIG_VIRTIO_MMIO_CMDLINE_DEVICES=y    # why: discover MMIO devices via cmdline (Firecracker uses this)
+CONFIG_VIRTIO_BLK=y                     # why: rootfs is a virtio-blk device
+CONFIG_VIRTIO_NET=y                     # why: networking via virtio-net
+CONFIG_VIRTIO_CONSOLE=y                 # why: hvc0 fallback console under virt
+CONFIG_VIRTIO_BALLOON=y                 # why: memory pressure feedback to host
 
 # ── Filesystems built in (no initrd) ─────────────────────────────────
 CONFIG_EXT4_FS=y                # why: rootfs is ext4
+CONFIG_ISO9660_FS=y             # why: cloud-init NoCloud seed disk is an iso9660 image
 CONFIG_TMPFS=y                  # why: /tmp + tmpfs root for /init bootstrap
 CONFIG_DEVTMPFS=y               # why: /dev populated by kernel at mount
 CONFIG_DEVTMPFS_MOUNT=y         # why: auto-mount /dev at boot

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "smolvm"
-version = "0.0.13"
+version = "0.0.14a0"
 description = "Secure, isolated computers that AI agents can use to browse, run code, and get real work done. Free and open-source from Celesto AI"
 readme = "README.md"
 license = "Apache-2.0"

--- a/src/smolvm/facade.py
+++ b/src/smolvm/facade.py
@@ -492,11 +492,12 @@ def _build_auto_config(
             filename="rootfs.qcow2",
             on_download=on_download,
         )
-        # Pull the SmolVM-built base kernel (universal across Firecracker/QEMU/
-        # libkrun, no initrd needed — see kernel/qemu/README.md).
+        # Pull the SmolVM-built base kernel — Image format for QEMU
+        # (Firecracker would use the ELF; this branch is QEMU-only).
         host_arch = platform.machine()
         kernel_path = ensure_base_kernel(
             to_published_arch(host_arch),
+            "image",
             cache_dir=image_manager.cache_dir,
         )
 
@@ -650,12 +651,20 @@ def _build_auto_config(
         disk_size_mib=resolved_disk_size_mib,
     )
 
+    # Pick the kernel format the runtime backend requires. Same kernel source,
+    # different container: ``elf`` for Firecracker / libkrun, ``image`` for QEMU.
+    from smolvm.images.published import BASE_KERNELS, _kernel_format_for_vmm
+
+    kernel_fmt = _kernel_format_for_vmm(resolved_backend)  # type: ignore[arg-type]
+    base_kernel_url = BASE_KERNELS[to_published_arch(platform.machine())].url_for(kernel_fmt)
+
     if resolved_os is GuestOS.DEBIAN:
         kernel, rootfs = builder.build_debian_ssh_key(
             public_key_path,
             name=image_name,
             rootfs_size_mb=resolved_disk_size_mib,
             kernel_profile=kernel_profile,
+            kernel_url=base_kernel_url,
         )
     else:
         kernel, rootfs = builder.build_alpine_ssh_key(
@@ -663,6 +672,7 @@ def _build_auto_config(
             name=image_name,
             rootfs_size_mb=resolved_disk_size_mib,
             kernel_profile=kernel_profile,
+            kernel_url=base_kernel_url,
         )
 
     resolved_vm_name = _resolve_vm_name(vm_name, prefix=name_prefix)

--- a/src/smolvm/facade.py
+++ b/src/smolvm/facade.py
@@ -56,7 +56,7 @@ from smolvm.images.cloud_init import (
     default_user_data,
     seed_cache_key,
 )
-from smolvm.images.manager import ImageManager, ImageSource
+from smolvm.images.manager import ImageManager
 from smolvm.runtime.backends import BACKEND_LIBKRUN, BACKEND_QEMU, resolve_backend
 from smolvm.runtime.boot_profiles import KernelBootProfile, get_boot_profile_spec
 from smolvm.ssh import SSHClient
@@ -90,42 +90,18 @@ _AUTO_CONFIG_DEFAULT_DISK_SIZE_MIB = {
     GuestOS.UBUNTU: 2048,
 }
 _UBUNTU_CURRENT_RELEASE_DATE = "20260406"
-_QEMU_UBUNTU_AUTO_IMAGES: dict[str, ImageSource] = {
-    "ubuntu-noble-minimal-qemu-x86_64": ImageSource(
-        name="ubuntu-noble-minimal-qemu-x86_64",
-        kernel_url=(
-            "https://cloud-images.ubuntu.com/noble/current/unpacked/"
-            "noble-server-cloudimg-amd64-vmlinuz-generic"
-        ),
-        kernel_filename="vmlinuz",
-        initrd_url=(
-            "https://cloud-images.ubuntu.com/noble/current/unpacked/"
-            "noble-server-cloudimg-amd64-initrd-generic"
-        ),
-        initrd_filename="initrd",
-        rootfs_url=(
-            "https://cloud-images.ubuntu.com/minimal/releases/noble/release/"
-            "ubuntu-24.04-minimal-cloudimg-amd64.img"
-        ),
-        rootfs_filename="rootfs.qcow2",
+# Ubuntu cloud-images rootfs URLs. Post-0.0.14a0 we no longer fetch Ubuntu's
+# vmlinuz/initrd alongside — the SmolVM-built base kernel boots the rootfs
+# directly (CONFIG_ISO9660_FS=y enables the cloud-init NoCloud seed). Only
+# the qcow2 rootfs is fetched from cloud-images.ubuntu.com.
+_QEMU_UBUNTU_AUTO_IMAGES: dict[str, str] = {
+    "ubuntu-noble-minimal-qemu-x86_64": (
+        "https://cloud-images.ubuntu.com/minimal/releases/noble/release/"
+        "ubuntu-24.04-minimal-cloudimg-amd64.img"
     ),
-    "ubuntu-noble-minimal-qemu-aarch64": ImageSource(
-        name="ubuntu-noble-minimal-qemu-aarch64",
-        kernel_url=(
-            "https://cloud-images.ubuntu.com/noble/current/unpacked/"
-            "noble-server-cloudimg-arm64-vmlinuz-generic"
-        ),
-        kernel_filename="vmlinuz",
-        initrd_url=(
-            "https://cloud-images.ubuntu.com/noble/current/unpacked/"
-            "noble-server-cloudimg-arm64-initrd-generic"
-        ),
-        initrd_filename="initrd",
-        rootfs_url=(
-            "https://cloud-images.ubuntu.com/minimal/releases/noble/release/"
-            "ubuntu-24.04-minimal-cloudimg-arm64.img"
-        ),
-        rootfs_filename="rootfs.qcow2",
+    "ubuntu-noble-minimal-qemu-aarch64": (
+        "https://cloud-images.ubuntu.com/minimal/releases/noble/release/"
+        "ubuntu-24.04-minimal-cloudimg-arm64.img"
     ),
 }
 
@@ -495,31 +471,52 @@ def _build_auto_config(
                 f"ubuntu auto-config requires disk_size_mib >= {default_disk_size_mib} "
                 f"(got {resolved_disk_size_mib})"
             )
+        from smolvm.images.published import ensure_base_kernel
+
         image_name = _qemu_auto_config_image_name(GuestOS.UBUNTU)
-        image_manager = ImageManager(registry=_QEMU_UBUNTU_AUTO_IMAGES)
-        image = image_manager.ensure_image(image_name, on_download=on_download)
-        if image.initrd_path is None:
+        rootfs_url = _QEMU_UBUNTU_AUTO_IMAGES.get(image_name)
+        if rootfs_url is None:
             raise SmolVMError(
-                "Prebuilt QEMU auto-config image is missing an initrd",
+                "No prebuilt Ubuntu rootfs registered for this host architecture",
                 {"image_name": image_name},
             )
+        image_manager = ImageManager()
+        pristine_rootfs = image_manager.ensure_rootfs_only(
+            image_name,
+            url=rootfs_url,
+            filename="rootfs.qcow2",
+            on_download=on_download,
+        )
+        # Pull the SmolVM-built base kernel (universal across Firecracker/QEMU/
+        # libkrun, no initrd needed — see kernel/qemu/README.md).
+        host_arch = platform.machine().lower()
+        smolvm_arch = "amd64" if host_arch in {"x86_64", "amd64"} else "arm64"
+        kernel_path = ensure_base_kernel(smolvm_arch, cache_dir=image_manager.cache_dir)
 
         if resolved_disk_size_mib > default_disk_size_mib:
             rootfs_path, _resolved_size = _prepare_sized_qcow2(
                 cache_dir=image_manager.cache_dir,
                 base_image_name=image_name,
-                source_qcow2=image.rootfs_path,
+                source_qcow2=pristine_rootfs,
                 target_mib=resolved_disk_size_mib,
             )
         else:
-            rootfs_path = image.rootfs_path
+            rootfs_path = pristine_rootfs
 
-        boot_profile = KernelBootProfile.QEMU_DESKTOP_INITRAMFS
-        boot_args = get_boot_profile_spec(boot_profile).base_boot_args_for_backend(
-            resolved_backend,
-            platform.machine(),
-        )
-        boot_args = f"{boot_args} root=LABEL=cloudimg-rootfs rw"
+        # Direct kernel boot, no initrd. Ubuntu's cloud qcow2 has a 3-partition
+        # GPT layout (vda1=rootfs, vda15=ESP, vda16=/boot); without an initrd
+        # to resolve `LABEL=cloudimg-rootfs` we point at the partition directly.
+        # cloud-init userspace then reads the seed ISO at /dev/vdb
+        # (CONFIG_ISO9660_FS=y) and provisions sshd.
+        #
+        # We deliberately don't use the MICROVM_DIRECT boot-profile string here
+        # because it bakes in `init=/init` (the SmolVM-built Alpine/Debian images
+        # ship a custom /init shell script). Ubuntu's rootfs has no /init —
+        # init lives at /sbin/init (systemd). Letting the kernel pick its
+        # default search path lands on systemd, which kicks cloud-init.
+        normalized_arch = "aarch64" if platform.machine().lower() in {"arm64", "aarch64"} else "x86_64"
+        console = "ttyAMA0" if normalized_arch == "aarch64" else "ttyS0"
+        boot_args = f"console={console} reboot=k panic=1 root=/dev/vda1 rw"
 
         user_data = default_user_data(public_key_value)
         seed_key = seed_cache_key(
@@ -545,8 +542,7 @@ def _build_auto_config(
             vm_id=resolved_vm_name,
             vcpu_count=1,
             memory=resolved_memory,
-            kernel_path=image.kernel_path,
-            initrd_path=image.initrd_path,
+            kernel_path=kernel_path,
             rootfs_path=rootfs_path,
             extra_drives=[seed_path],
             boot_args=boot_args,

--- a/src/smolvm/facade.py
+++ b/src/smolvm/facade.py
@@ -58,7 +58,12 @@ from smolvm.images.cloud_init import (
 )
 from smolvm.images.manager import ImageManager
 from smolvm.runtime.backends import BACKEND_LIBKRUN, BACKEND_QEMU, resolve_backend
-from smolvm.runtime.boot_profiles import KernelBootProfile, get_boot_profile_spec
+from smolvm.runtime.boot_profiles import (
+    KernelBootProfile,
+    get_boot_profile_spec,
+    normalize_arch,
+    to_published_arch,
+)
 from smolvm.ssh import SSHClient
 from smolvm.types import (
     CommandResult,
@@ -489,9 +494,11 @@ def _build_auto_config(
         )
         # Pull the SmolVM-built base kernel (universal across Firecracker/QEMU/
         # libkrun, no initrd needed — see kernel/qemu/README.md).
-        host_arch = platform.machine().lower()
-        smolvm_arch = "amd64" if host_arch in {"x86_64", "amd64"} else "arm64"
-        kernel_path = ensure_base_kernel(smolvm_arch, cache_dir=image_manager.cache_dir)
+        host_arch = platform.machine()
+        kernel_path = ensure_base_kernel(
+            to_published_arch(host_arch),
+            cache_dir=image_manager.cache_dir,
+        )
 
         if resolved_disk_size_mib > default_disk_size_mib:
             rootfs_path, _resolved_size = _prepare_sized_qcow2(
@@ -514,8 +521,7 @@ def _build_auto_config(
         # ship a custom /init shell script). Ubuntu's rootfs has no /init —
         # init lives at /sbin/init (systemd). Letting the kernel pick its
         # default search path lands on systemd, which kicks cloud-init.
-        normalized_arch = "aarch64" if platform.machine().lower() in {"arm64", "aarch64"} else "x86_64"
-        console = "ttyAMA0" if normalized_arch == "aarch64" else "ttyS0"
+        console = "ttyAMA0" if normalize_arch(host_arch) == "aarch64" else "ttyS0"
         boot_args = f"console={console} reboot=k panic=1 root=/dev/vda1 rw"
 
         user_data = default_user_data(public_key_value)

--- a/src/smolvm/images/builder.py
+++ b/src/smolvm/images/builder.py
@@ -34,10 +34,8 @@ from pathlib import Path
 
 from smolvm.exceptions import ImageError, SmolVMError
 from smolvm.runtime.boot_profiles import (
-    QEMU_DESKTOP_KERNEL_URLS,
     KernelBootProfile,
     normalize_arch,
-    resolve_kernel_url,
 )
 from smolvm.utils import RUNTIME_PRIVILEGE_SETUP_HINT, run_command
 
@@ -50,8 +48,6 @@ SSH_BOOT_ARGS = "console=ttyS0 reboot=k panic=1 pci=off root=/dev/vda rw init=/i
 # vCPU exits on /dev/ttyS0 writes, which become a measurable host CPU tax at
 # 200+ VMs.  No console= since we don't need serial output in production.
 OPENCLAW_BOOT_ARGS = "reboot=k panic=1 pci=off init=/init 8250.nr_uarts=0"
-
-QEMU_KERNEL_URLS = QEMU_DESKTOP_KERNEL_URLS
 
 LOOPFS_HELPER_PATH = Path("/usr/local/libexec/smolvm-loopfs-helper")
 
@@ -1330,22 +1326,35 @@ echo "Device-approver running with PID=${DEVICE_APPROVER_PID}"
             raise ImageError(str(exc)) from exc
 
     def _kernel_url_for_host(self) -> str:
-        """Return a Firecracker-compatible kernel URL for the current host arch."""
+        """Return the SmolVM-built base kernel URL for the current host arch."""
         return self._resolve_kernel_url(KernelBootProfile.MICROVM_DIRECT)
 
     def qemu_kernel_url_for_host(self) -> str:
-        """Return the future desktop/initramfs QEMU kernel URL for the host arch."""
+        """Return the SmolVM-built base kernel URL for the current host arch.
+
+        Retained for back-compat with callers that branched on boot profile;
+        post-0.0.14a0 the QEMU and Firecracker paths use the same kernel.
+        """
         return self._resolve_kernel_url(KernelBootProfile.QEMU_DESKTOP_INITRAMFS)
 
     def _resolve_kernel_url(
         self,
-        kernel_profile: KernelBootProfile,
+        kernel_profile: KernelBootProfile,  # noqa: ARG002 (kept for back-compat)
         kernel_url: str | None = None,
     ) -> str:
-        """Return the effective kernel URL for an image build."""
+        """Return the effective kernel URL for an image build.
+
+        Both ``MICROVM_DIRECT`` and ``QEMU_DESKTOP_INITRAMFS`` resolve to the
+        same SmolVM-built artifact ([BASE_KERNELS](smolvm.images.published)) —
+        the per-profile URL split is gone after the kernel-source migration.
+        Callers passing an explicit ``kernel_url`` override that as before.
+        """
         if kernel_url is not None:
             return kernel_url
-        return resolve_kernel_url(kernel_profile, self._host_arch_key())
+        from smolvm.images.published import BASE_KERNELS
+
+        smolvm_arch = "amd64" if self._host_arch_key() == "x86_64" else "arm64"
+        return BASE_KERNELS[smolvm_arch].kernel_url
 
     def _fingerprint_with_content(
         self,
@@ -1392,7 +1401,23 @@ echo "Device-approver running with PID=${DEVICE_APPROVER_PID}"
         return hashlib.sha256(json_str.encode("utf-8")).hexdigest()
 
     def _download_kernel(self, url: str, dest: Path) -> None:
-        """Download kernel image to *dest* without external wget dependency."""
+        """Download kernel image to *dest*.
+
+        For SmolVM's published base kernel (the default path) we route through
+        :func:`smolvm.images.published.ensure_base_kernel`, which downloads to
+        a shared cache and SHA-256-verifies the artifact. Custom override URLs
+        fall back to a direct urllib fetch (no SHA — the override is the
+        caller's responsibility).
+        """
+        from smolvm.images.published import BASE_KERNELS, ensure_base_kernel
+
+        # Recognise our own published kernel URLs and use the verified path.
+        for arch, entry in BASE_KERNELS.items():
+            if entry.kernel_url == url:
+                cached = ensure_base_kernel(arch)
+                shutil.copy2(cached, dest)
+                return
+
         try:
             with (
                 urllib.request.urlopen(url, timeout=180) as response,

--- a/src/smolvm/images/builder.py
+++ b/src/smolvm/images/builder.py
@@ -1326,16 +1326,23 @@ echo "Device-approver running with PID=${DEVICE_APPROVER_PID}"
             raise ImageError(str(exc)) from exc
 
     def _kernel_url_for_host(self) -> str:
-        """Return the SmolVM-built base kernel URL for the current host arch."""
+        """Return the SmolVM-built base kernel URL for the current host arch.
+
+        Defaults to the ELF format (Firecracker-compatible). Callers that
+        need the Image format must pass an explicit ``kernel_url`` override.
+        """
         return self._resolve_kernel_url(KernelBootProfile.MICROVM_DIRECT)
 
     def qemu_kernel_url_for_host(self) -> str:
-        """Return the SmolVM-built base kernel URL for the current host arch.
+        """Return the SmolVM-built Image-format base kernel URL.
 
         Retained for back-compat with callers that branched on boot profile;
-        post-0.0.14a0 the QEMU and Firecracker paths use the same kernel.
+        returns the ``.image`` artifact (QEMU-compatible).
         """
-        return self._resolve_kernel_url(KernelBootProfile.QEMU_DESKTOP_INITRAMFS)
+        from smolvm.images.published import BASE_KERNELS
+
+        smolvm_arch = "amd64" if self._host_arch_key() == "x86_64" else "arm64"
+        return BASE_KERNELS[smolvm_arch].image_url
 
     def _resolve_kernel_url(
         self,
@@ -1344,17 +1351,17 @@ echo "Device-approver running with PID=${DEVICE_APPROVER_PID}"
     ) -> str:
         """Return the effective kernel URL for an image build.
 
-        Both ``MICROVM_DIRECT`` and ``QEMU_DESKTOP_INITRAMFS`` resolve to the
-        same SmolVM-built artifact ([BASE_KERNELS](smolvm.images.published)) —
-        the per-profile URL split is gone after the kernel-source migration.
-        Callers passing an explicit ``kernel_url`` override that as before.
+        Defaults to the ELF artifact (Firecracker-compatible). Callers wanting
+        the Image format pass it explicitly via ``kernel_url`` — typically
+        derived in ``_build_auto_config`` from ``BASE_KERNELS[arch].url_for(fmt)``
+        based on the resolved backend.
         """
         if kernel_url is not None:
             return kernel_url
         from smolvm.images.published import BASE_KERNELS
 
         smolvm_arch = "amd64" if self._host_arch_key() == "x86_64" else "arm64"
-        return BASE_KERNELS[smolvm_arch].kernel_url
+        return BASE_KERNELS[smolvm_arch].elf_url
 
     def _fingerprint_with_content(
         self,
@@ -1411,10 +1418,15 @@ echo "Device-approver running with PID=${DEVICE_APPROVER_PID}"
         """
         from smolvm.images.published import BASE_KERNELS, ensure_base_kernel
 
-        # Recognise our own published kernel URLs and use the verified path.
+        # Recognise our own published kernel URLs (either format) and use the
+        # SHA-verified cached path.
         for arch, entry in BASE_KERNELS.items():
-            if entry.kernel_url == url:
-                cached = ensure_base_kernel(arch)
+            if url == entry.elf_url:
+                cached = ensure_base_kernel(arch, "elf")
+                shutil.copy2(cached, dest)
+                return
+            if url == entry.image_url:
+                cached = ensure_base_kernel(arch, "image")
                 shutil.copy2(cached, dest)
                 return
 

--- a/src/smolvm/images/manager.py
+++ b/src/smolvm/images/manager.py
@@ -296,26 +296,12 @@ def _require_boto3() -> S3Client:
 # ---------------------------------------------------------------------------
 # Built-in image registry
 #
-# Version-pinned URLs from Firecracker's official CI/quickstart assets.
-# To add a new image, append an ImageSource entry here.
+# Empty by default — SmolVM ships its kernel via :data:`BASE_KERNELS` in
+# `smolvm.images.published` and rootfs images via :data:`MANIFEST` there.
+# This registry remains for tests and SDK callers that want a custom
+# (kernel_url, rootfs_url) pair without going through the published path.
 # ---------------------------------------------------------------------------
-BUILTIN_IMAGES: dict[str, ImageSource] = {
-    "hello": ImageSource(
-        name="hello",
-        kernel_url=("https://s3.amazonaws.com/spec.ccfc.min/img/hello/kernel/hello-vmlinux.bin"),
-        rootfs_url=("https://s3.amazonaws.com/spec.ccfc.min/img/hello/fsfiles/hello-rootfs.ext4"),
-    ),
-    "quickstart-x86_64": ImageSource(
-        name="quickstart-x86_64",
-        kernel_url=(
-            "https://s3.amazonaws.com/spec.ccfc.min/img/quickstart_guide/x86_64/kernels/vmlinux.bin"
-        ),
-        rootfs_url=(
-            "https://s3.amazonaws.com/spec.ccfc.min/img/quickstart_guide"
-            "/x86_64/rootfs/bionic.rootfs.ext4"
-        ),
-    ),
-}
+BUILTIN_IMAGES: dict[str, ImageSource] = {}
 
 
 class ImageManager:

--- a/src/smolvm/images/published.py
+++ b/src/smolvm/images/published.py
@@ -169,21 +169,20 @@ _MANIFEST_VERSION = "0.0.14a0"
 # Placeholder zeros are filled in by the next CI run after build.sh changes
 # the artifact split. Until then, downloads will fail SHA verification —
 # which is the right failure mode (we don't want to ship stale SHAs).
-_PLACEHOLDER_SHA = "0000000000000000000000000000000000000000000000000000000000000000"
 BASE_KERNELS: dict[Arch, BaseKernel] = {
     "amd64": BaseKernel(
         arch="amd64",
         elf_url=_release_kernel_url("amd64", "elf", _MANIFEST_VERSION),
-        elf_sha256=_PLACEHOLDER_SHA,
+        elf_sha256="f652d798efb2b19c4923e5e7ff4e7b2e9db31ec8347cec2a5e6a27b813b2d5a1",
         image_url=_release_kernel_url("amd64", "image", _MANIFEST_VERSION),
-        image_sha256=_PLACEHOLDER_SHA,
+        image_sha256="55061bc45706eca229afdad31451d63e0695ce990fb1d46301194b4771e607f0",
     ),
     "arm64": BaseKernel(
         arch="arm64",
         elf_url=_release_kernel_url("arm64", "elf", _MANIFEST_VERSION),
-        elf_sha256=_PLACEHOLDER_SHA,
+        elf_sha256="d837ec0f6c12d6dd9b96885464db876699e3984c9c8b0c3699569e2000221fc2",
         image_url=_release_kernel_url("arm64", "image", _MANIFEST_VERSION),
-        image_sha256=_PLACEHOLDER_SHA,
+        image_sha256="200862461ac269baf56c636a76a96db204e216fc8d16a983b910cd22bf72469b",
     ),
 }
 

--- a/src/smolvm/images/published.py
+++ b/src/smolvm/images/published.py
@@ -48,6 +48,11 @@ Preset = Literal["codex", "claude-code", "openclaw", "hermes"]
 # ``libkrun`` is reserved here for a future spike — manifest accepts the type
 # but the CLI never resolves a host to it until libkrun support is wired.
 Vmm = Literal["firecracker", "qemu", "libkrun"]
+# Kernel binary format. Firecracker requires "elf" (uncompressed ELF
+# vmlinux); QEMU on aarch64 virt only boots "image" (the Linux ARM64 boot
+# protocol — bzImage on x86, Image on arm64). Same kernel source build
+# produces both as a side effect, so we ship both per arch.
+KernelFormat = Literal["elf", "image"]
 
 
 class PublishedImage(BaseModel):
@@ -65,20 +70,36 @@ class PublishedImage(BaseModel):
 
 
 class BaseKernel(BaseModel):
-    """Per-arch SmolVM-built universal microvm kernel.
+    """Per-arch SmolVM-built microvm kernels — two formats from one build.
 
-    Single artifact that boots under Firecracker (virtio-MMIO transport) AND
-    QEMU/libkrun (virtio-PCI transport) — the ``kernel/qemu/build.sh`` recipe
-    enables both transports + ISO9660 (cloud-init NoCloud seed disk). Used
-    by the auto-config and preset-bake paths; replaces the previously-fetched
-    Firecracker-CI kernel and the Ubuntu cloud-image kernel.
+    The ``kernel/qemu/build.sh`` recipe produces both an ELF and a boot-wrapper
+    artifact in a single make invocation. We ship both because:
+
+    - Firecracker requires the ELF (``elf_url``) — its kernel loader rejects
+      bzImage/Image with ``Invalid Elf magic number``.
+    - QEMU on aarch64 ``virt`` empirically refuses to boot a Linux ELF
+      vmlinux (silent hang, no console output). It boots Image fine.
+      We standardise on the boot-wrapper format (``image_url``) for QEMU
+      on both archs.
+
+    Same kernel sources, same Kconfig, same boot behavior — just different
+    container format on the wire. Replaces the previously-fetched
+    Firecracker-CI kernel (S3) and Ubuntu cloud-image kernel.
     """
 
     arch: Arch
-    kernel_url: str
-    kernel_sha256: str
+    elf_url: str
+    elf_sha256: str
+    image_url: str
+    image_sha256: str
 
     model_config = {"frozen": True}
+
+    def url_for(self, fmt: KernelFormat) -> str:
+        return self.elf_url if fmt == "elf" else self.image_url
+
+    def sha256_for(self, fmt: KernelFormat) -> str:
+        return self.elf_sha256 if fmt == "elf" else self.image_sha256
 
 
 def release_tag(version: str = __version__) -> str:
@@ -115,19 +136,16 @@ def _release_asset_url(preset: Preset, arch: Arch, suffix: str, version: str) ->
     )
 
 
-def _release_kernel_url(arch: Arch, vmm: Vmm, version: str) -> str:
+def _release_kernel_url(arch: Arch, fmt: KernelFormat, version: str) -> str:
     """URL for a preset-independent kernel artifact.
 
-    QEMU/libkrun kernels are built once per (arch, vmm) and shared across
-    all presets — the kernel doesn't depend on the userspace baked into
-    the rootfs. The asset name reflects that: ``vmlinux-<arch>-<vmm>.bin``,
-    no preset prefix. (The older Firecracker assets predate this convention
-    and use ``<preset>-<arch>-vmlinux.bin``; renaming them is a future
-    cleanup task.)
+    Asset naming: ``vmlinux-<arch>.{elf|image}``. Same Linux source build
+    produces both formats (see ``kernel/qemu/build.sh``); the runtime picks
+    by backend (Firecracker→elf, QEMU→image).
     """
     return (
         f"https://github.com/CelestoAI/SmolVM/releases/download/"
-        f"{release_tag(version)}/vmlinux-{arch}-{vmm}.bin"
+        f"{release_tag(version)}/vmlinux-{arch}.{fmt}"
     )
 
 
@@ -138,69 +156,80 @@ def _release_kernel_url(arch: Arch, vmm: Vmm, version: str) -> str:
 # pyproject.toml version bumps don't ship with stale manifest entries.
 _MANIFEST_VERSION = "0.0.14a0"
 
-# Per-arch SmolVM-built universal kernels. Replaces the previously-fetched
-# Firecracker-CI vmlinux from S3 and the Ubuntu cloud kernel — same artifact
-# now boots all three runtimes (Firecracker / QEMU / libkrun). Source of
-# truth for kernel URL+SHA: the MANIFEST rows below reference these entries
-# so adding a future preset can't drift kernel SHAs across rows.
+# Per-arch SmolVM-built kernels. Each :class:`BaseKernel` carries BOTH the
+# ELF (Firecracker) and Image (QEMU) URLs+SHAs from the same source build.
+# Source of truth for kernel URL+SHA: the MANIFEST rows below reference
+# these entries via ``url_for(format)`` / ``sha256_for(format)``, so adding
+# a future preset can't drift kernel SHAs across rows.
 #
 # SHAs come from the build-qemu-kernel.yml CI run that publishes
-# `vmlinux-<arch>-qemu.bin` to release tag `images-v<_MANIFEST_VERSION>`;
+# ``vmlinux-<arch>.{elf,image}`` to release tag ``images-v<_MANIFEST_VERSION>``;
 # they're also visible in that workflow's step summary.
+#
+# Placeholder zeros are filled in by the next CI run after build.sh changes
+# the artifact split. Until then, downloads will fail SHA verification —
+# which is the right failure mode (we don't want to ship stale SHAs).
+_PLACEHOLDER_SHA = "0000000000000000000000000000000000000000000000000000000000000000"
 BASE_KERNELS: dict[Arch, BaseKernel] = {
     "amd64": BaseKernel(
         arch="amd64",
-        kernel_url=_release_kernel_url("amd64", "qemu", _MANIFEST_VERSION),
-        kernel_sha256="fa657a2c30e680ebdbc13c433cfa3b32fa30f6b59d2865ea31637d82cae7f0c5",
+        elf_url=_release_kernel_url("amd64", "elf", _MANIFEST_VERSION),
+        elf_sha256=_PLACEHOLDER_SHA,
+        image_url=_release_kernel_url("amd64", "image", _MANIFEST_VERSION),
+        image_sha256=_PLACEHOLDER_SHA,
     ),
     "arm64": BaseKernel(
         arch="arm64",
-        kernel_url=_release_kernel_url("arm64", "qemu", _MANIFEST_VERSION),
-        kernel_sha256="f937f2990b89ec55049cda69de729d4acc0d0fa9b2c86fbc457438ceed6ffff6",
+        elf_url=_release_kernel_url("arm64", "elf", _MANIFEST_VERSION),
+        elf_sha256=_PLACEHOLDER_SHA,
+        image_url=_release_kernel_url("arm64", "image", _MANIFEST_VERSION),
+        image_sha256=_PLACEHOLDER_SHA,
     ),
 }
 
-# Bundled preset manifest. The kernel URL/SHA on each row mirrors BASE_KERNELS
-# above (same artifact across firecracker/qemu rows) — the kernel is shared
-# but rows are kept distinct because consumers look up the full
-# (preset, arch, vmm) tuple, and boot args differ between firecracker and qemu.
-# Rootfs SHAs come from build-published-images.yml CI for the matching tag.
+
+def _kernel_format_for_vmm(vmm: Vmm) -> KernelFormat:
+    """Map runtime vmm to the kernel binary format it accepts.
+
+    Firecracker requires an uncompressed ELF; QEMU on aarch64 ``virt`` only
+    boots the Linux ARM64 boot-protocol Image (silent hang on ELF). libkrun
+    is Firecracker-API-compatible and uses the same ELF.
+    """
+    return "elf" if vmm in {"firecracker", "libkrun"} else "image"
+
+
+# Bundled preset manifest. The kernel URL/SHA on each row mirrors the matching
+# BASE_KERNELS entry's format-for-vmm so a single CI run is the source of
+# truth for every kernel SHA. Rootfs SHAs come from build-published-images.yml
+# CI for the matching tag.
+def _manifest_row(preset: Preset, arch: Arch, vmm: Vmm, rootfs_sha256: str) -> PublishedImage:
+    base = BASE_KERNELS[arch]
+    fmt = _kernel_format_for_vmm(vmm)
+    return PublishedImage(
+        preset=preset,
+        arch=arch,
+        vmm=vmm,
+        kernel_url=base.url_for(fmt),
+        kernel_sha256=base.sha256_for(fmt),
+        rootfs_url=_release_asset_url(preset, arch, "rootfs.ext4.zst", _MANIFEST_VERSION),
+        rootfs_sha256=rootfs_sha256,
+    )
+
+
+_OPENCLAW_AMD64_ROOTFS_SHA = "a332941df1dfe3d29c849072267148d84919e6b13fa810870049a0a3567be8f9"
+_OPENCLAW_ARM64_ROOTFS_SHA = "87a8d855801a1dc89bafa4ac9596767a5de221536a5f6a43bc57e308059af937"
 MANIFEST: dict[tuple[Preset, Arch, Vmm], PublishedImage] = {
-    ("openclaw", "amd64", "firecracker"): PublishedImage(
-        preset="openclaw",
-        arch="amd64",
-        vmm="firecracker",
-        kernel_url=BASE_KERNELS["amd64"].kernel_url,
-        kernel_sha256=BASE_KERNELS["amd64"].kernel_sha256,
-        rootfs_url=_release_asset_url("openclaw", "amd64", "rootfs.ext4.zst", _MANIFEST_VERSION),
-        rootfs_sha256="a332941df1dfe3d29c849072267148d84919e6b13fa810870049a0a3567be8f9",
+    ("openclaw", "amd64", "firecracker"): _manifest_row(
+        "openclaw", "amd64", "firecracker", _OPENCLAW_AMD64_ROOTFS_SHA
     ),
-    ("openclaw", "arm64", "firecracker"): PublishedImage(
-        preset="openclaw",
-        arch="arm64",
-        vmm="firecracker",
-        kernel_url=BASE_KERNELS["arm64"].kernel_url,
-        kernel_sha256=BASE_KERNELS["arm64"].kernel_sha256,
-        rootfs_url=_release_asset_url("openclaw", "arm64", "rootfs.ext4.zst", _MANIFEST_VERSION),
-        rootfs_sha256="87a8d855801a1dc89bafa4ac9596767a5de221536a5f6a43bc57e308059af937",
+    ("openclaw", "arm64", "firecracker"): _manifest_row(
+        "openclaw", "arm64", "firecracker", _OPENCLAW_ARM64_ROOTFS_SHA
     ),
-    ("openclaw", "amd64", "qemu"): PublishedImage(
-        preset="openclaw",
-        arch="amd64",
-        vmm="qemu",
-        kernel_url=BASE_KERNELS["amd64"].kernel_url,
-        kernel_sha256=BASE_KERNELS["amd64"].kernel_sha256,
-        rootfs_url=_release_asset_url("openclaw", "amd64", "rootfs.ext4.zst", _MANIFEST_VERSION),
-        rootfs_sha256="a332941df1dfe3d29c849072267148d84919e6b13fa810870049a0a3567be8f9",
+    ("openclaw", "amd64", "qemu"): _manifest_row(
+        "openclaw", "amd64", "qemu", _OPENCLAW_AMD64_ROOTFS_SHA
     ),
-    ("openclaw", "arm64", "qemu"): PublishedImage(
-        preset="openclaw",
-        arch="arm64",
-        vmm="qemu",
-        kernel_url=BASE_KERNELS["arm64"].kernel_url,
-        kernel_sha256=BASE_KERNELS["arm64"].kernel_sha256,
-        rootfs_url=_release_asset_url("openclaw", "arm64", "rootfs.ext4.zst", _MANIFEST_VERSION),
-        rootfs_sha256="87a8d855801a1dc89bafa4ac9596767a5de221536a5f6a43bc57e308059af937",
+    ("openclaw", "arm64", "qemu"): _manifest_row(
+        "openclaw", "arm64", "qemu", _OPENCLAW_ARM64_ROOTFS_SHA
     ),
 }
 
@@ -307,6 +336,7 @@ def ensure_published_image(
 
 def ensure_base_kernel(
     arch: Arch,
+    fmt: KernelFormat,
     *,
     cache_dir: Path | None = None,
     registry: dict[Arch, BaseKernel] | None = None,
@@ -314,15 +344,17 @@ def ensure_base_kernel(
 ) -> Path:
     """Download (if needed) and return the local path to the base kernel.
 
-    The base kernel is a single SmolVM-built artifact per arch that boots
-    under Firecracker, QEMU, and libkrun (see :class:`BaseKernel`). Replaces
-    every external kernel SmolVM previously fetched (Firecracker-CI on S3,
-    Ubuntu cloud-images vmlinuz). All consumers — the auto-config flow,
-    the preset image builder, the published-image launcher — funnel through
-    this function so there is exactly one kernel binary on disk per arch.
+    The base kernel exists in two formats per arch (see :class:`BaseKernel`):
+    ``elf`` for Firecracker (and libkrun), ``image`` for QEMU. Same source
+    build, different container formats. All consumers — the auto-config
+    flow, the preset image builder, the published-image launcher — funnel
+    through this function so there is exactly one kernel binary cached on
+    disk per ``(arch, fmt)``.
 
     Args:
         arch: Guest CPU architecture.
+        fmt: Binary format the runtime expects (``"elf"`` for Firecracker,
+            ``"image"`` for QEMU).
         cache_dir: Override the default cache directory (mainly for tests).
         registry: Override :data:`BASE_KERNELS` (mainly for tests).
         version: Override the CLI version used to compute the cache name.
@@ -342,9 +374,12 @@ def ensure_base_kernel(
             f"No base kernel registered for arch '{arch}' (available: {available})."
         )
     manager = ImageManager(cache_dir=cache_dir)
+    # Cache filename keeps the format suffix so the elf and image artifacts
+    # don't collide for the same (version, arch). Same dir is fine — both
+    # files coexist when a user runs both backends.
     return manager.ensure_rootfs_only(
         name=f"base-kernel-v{version}-{arch}",
-        url=entry.kernel_url,
-        filename="vmlinux.bin",
-        sha256=entry.kernel_sha256,
+        url=entry.url_for(fmt),
+        filename=f"vmlinux.{fmt}",
+        sha256=entry.sha256_for(fmt),
     )

--- a/src/smolvm/images/published.py
+++ b/src/smolvm/images/published.py
@@ -64,6 +64,23 @@ class PublishedImage(BaseModel):
     model_config = {"frozen": True}
 
 
+class BaseKernel(BaseModel):
+    """Per-arch SmolVM-built universal microvm kernel.
+
+    Single artifact that boots under Firecracker (virtio-MMIO transport) AND
+    QEMU/libkrun (virtio-PCI transport) — the ``kernel/qemu/build.sh`` recipe
+    enables both transports + ISO9660 (cloud-init NoCloud seed disk). Used
+    by the auto-config and preset-bake paths; replaces the previously-fetched
+    Firecracker-CI kernel and the Ubuntu cloud-image kernel.
+    """
+
+    arch: Arch
+    kernel_url: str
+    kernel_sha256: str
+
+    model_config = {"frozen": True}
+
+
 def release_tag(version: str = __version__) -> str:
     """GitHub Releases tag images for ``version`` are published under."""
     return f"images-v{version}"
@@ -121,51 +138,70 @@ def _release_kernel_url(arch: Arch, vmm: Vmm, version: str) -> str:
 # pyproject.toml version bumps don't ship with stale manifest entries.
 _MANIFEST_VERSION = "0.0.14a0"
 
-# Bundled manifest. New (preset, arch, vmm) entries land here as CI publishes
-# images — paired by version with this CLI release. The SHA-256s and URLs
-# below match the artifacts produced by the CI workflow at
-# .github/workflows/build-published-images.yml; they're also visible in
-# the corresponding GH release's step summary on each successful run.
+# Per-arch SmolVM-built universal kernels. Replaces the previously-fetched
+# Firecracker-CI vmlinux from S3 and the Ubuntu cloud kernel — same artifact
+# now boots all three runtimes (Firecracker / QEMU / libkrun). Same URL is
+# used by every MANIFEST row below; this registry is the source of truth so
+# adding a future preset doesn't drift kernel SHAs across rows.
+#
+# SHA-256 placeholders ("0" * 64) are filled in once build-qemu-kernel.yml
+# CI completes for the matching tag (images-v<_MANIFEST_VERSION>). The
+# drift-detection test in test_published_images.py refuses to load with
+# placeholder SHAs in a published manifest version.
+BASE_KERNELS: dict[Arch, BaseKernel] = {
+    "amd64": BaseKernel(
+        arch="amd64",
+        kernel_url=_release_kernel_url("amd64", "qemu", _MANIFEST_VERSION),
+        kernel_sha256="fa657a2c30e680ebdbc13c433cfa3b32fa30f6b59d2865ea31637d82cae7f0c5",
+    ),
+    "arm64": BaseKernel(
+        arch="arm64",
+        kernel_url=_release_kernel_url("arm64", "qemu", _MANIFEST_VERSION),
+        kernel_sha256="f937f2990b89ec55049cda69de729d4acc0d0fa9b2c86fbc457438ceed6ffff6",
+    ),
+}
+
+# Bundled preset manifest. The kernel URL/SHA on each row mirrors BASE_KERNELS
+# above (same artifact across firecracker/qemu rows) — kept duplicated on the
+# rows because consumers look up the full (preset, arch, vmm) tuple. Boot args
+# are what actually differ between firecracker and qemu rows. Rootfs SHAs
+# are placeholders until build-published-images.yml CI completes.
 MANIFEST: dict[tuple[Preset, Arch, Vmm], PublishedImage] = {
     ("openclaw", "amd64", "firecracker"): PublishedImage(
         preset="openclaw",
         arch="amd64",
         vmm="firecracker",
-        kernel_url=_release_asset_url("openclaw", "amd64", "vmlinux.bin", _MANIFEST_VERSION),
-        kernel_sha256="d361a5f2e67b2e243964ad93f25a2d9e5bee320204a84a7af089949228af5c2a",
+        kernel_url=BASE_KERNELS["amd64"].kernel_url,
+        kernel_sha256=BASE_KERNELS["amd64"].kernel_sha256,
         rootfs_url=_release_asset_url("openclaw", "amd64", "rootfs.ext4.zst", _MANIFEST_VERSION),
-        rootfs_sha256="919eea4fdaae8674c6749cb6acd9a1b51235369e412a08d38c5062519eaf8875",
+        rootfs_sha256="a332941df1dfe3d29c849072267148d84919e6b13fa810870049a0a3567be8f9",
     ),
     ("openclaw", "arm64", "firecracker"): PublishedImage(
         preset="openclaw",
         arch="arm64",
         vmm="firecracker",
-        kernel_url=_release_asset_url("openclaw", "arm64", "vmlinux.bin", _MANIFEST_VERSION),
-        kernel_sha256="7d8dc0bce701037ea5ceccfc997c05b11f99aba215c73ed18a2269154837c497",
+        kernel_url=BASE_KERNELS["arm64"].kernel_url,
+        kernel_sha256=BASE_KERNELS["arm64"].kernel_sha256,
         rootfs_url=_release_asset_url("openclaw", "arm64", "rootfs.ext4.zst", _MANIFEST_VERSION),
-        rootfs_sha256="bb5c42ffdd757ffb48c62f9d841230ff4e345a75fc40df210722d0a598626f29",
+        rootfs_sha256="87a8d855801a1dc89bafa4ac9596767a5de221536a5f6a43bc57e308059af937",
     ),
-    # QEMU rows reuse the firecracker rootfs (same userspace; only the
-    # kernel differs). Kernels come from the SmolVM-built QEMU/libkrun
-    # kernel workflow (.github/workflows/build-qemu-kernel.yml) and use
-    # the preset-independent naming `vmlinux-<arch>-qemu.bin`.
     ("openclaw", "amd64", "qemu"): PublishedImage(
         preset="openclaw",
         arch="amd64",
         vmm="qemu",
-        kernel_url=_release_kernel_url("amd64", "qemu", _MANIFEST_VERSION),
-        kernel_sha256="db6ddc88e5b88941164df53f5f798d080b95a90c411df8d2b9f501eb18fb89aa",
+        kernel_url=BASE_KERNELS["amd64"].kernel_url,
+        kernel_sha256=BASE_KERNELS["amd64"].kernel_sha256,
         rootfs_url=_release_asset_url("openclaw", "amd64", "rootfs.ext4.zst", _MANIFEST_VERSION),
-        rootfs_sha256="919eea4fdaae8674c6749cb6acd9a1b51235369e412a08d38c5062519eaf8875",
+        rootfs_sha256="a332941df1dfe3d29c849072267148d84919e6b13fa810870049a0a3567be8f9",
     ),
     ("openclaw", "arm64", "qemu"): PublishedImage(
         preset="openclaw",
         arch="arm64",
         vmm="qemu",
-        kernel_url=_release_kernel_url("arm64", "qemu", _MANIFEST_VERSION),
-        kernel_sha256="6f4f42cfa1d3038bd06d99e09887119e4c7fdd2d1da02913e1b6b10359376752",
+        kernel_url=BASE_KERNELS["arm64"].kernel_url,
+        kernel_sha256=BASE_KERNELS["arm64"].kernel_sha256,
         rootfs_url=_release_asset_url("openclaw", "arm64", "rootfs.ext4.zst", _MANIFEST_VERSION),
-        rootfs_sha256="bb5c42ffdd757ffb48c62f9d841230ff4e345a75fc40df210722d0a598626f29",
+        rootfs_sha256="87a8d855801a1dc89bafa4ac9596767a5de221536a5f6a43bc57e308059af937",
     ),
 }
 
@@ -268,3 +304,48 @@ def ensure_published_image(
         _decompress_zstd(local.rootfs_path, decompressed_path)
 
     return local.model_copy(update={"rootfs_path": decompressed_path})
+
+
+def ensure_base_kernel(
+    arch: Arch,
+    *,
+    cache_dir: Path | None = None,
+    registry: dict[Arch, BaseKernel] | None = None,
+    version: str = __version__,
+) -> Path:
+    """Download (if needed) and return the local path to the base kernel.
+
+    The base kernel is a single SmolVM-built artifact per arch that boots
+    under Firecracker, QEMU, and libkrun (see :class:`BaseKernel`). Replaces
+    every external kernel SmolVM previously fetched (Firecracker-CI on S3,
+    Ubuntu cloud-images vmlinuz). All consumers — the auto-config flow,
+    the preset image builder, the published-image launcher — funnel through
+    this function so there is exactly one kernel binary on disk per arch.
+
+    Args:
+        arch: Guest CPU architecture.
+        cache_dir: Override the default cache directory (mainly for tests).
+        registry: Override :data:`BASE_KERNELS` (mainly for tests).
+        version: Override the CLI version used to compute the cache name.
+
+    Returns:
+        Absolute path to the cached, SHA-256-verified vmlinux file.
+
+    Raises:
+        ImageError: If no base kernel is registered for ``arch``, or if
+            download / SHA verification fails.
+    """
+    catalog = BASE_KERNELS if registry is None else registry
+    entry = catalog.get(arch)
+    if entry is None:
+        available = ", ".join(sorted(catalog)) or "(none)"
+        raise ImageError(
+            f"No base kernel registered for arch '{arch}' (available: {available})."
+        )
+    manager = ImageManager(cache_dir=cache_dir)
+    return manager.ensure_rootfs_only(
+        name=f"base-kernel-v{version}-{arch}",
+        url=entry.kernel_url,
+        filename="vmlinux.bin",
+        sha256=entry.kernel_sha256,
+    )

--- a/src/smolvm/images/published.py
+++ b/src/smolvm/images/published.py
@@ -119,7 +119,7 @@ def _release_kernel_url(arch: Arch, vmm: Vmm, version: str) -> str:
 # fresh CI run (new artifacts → new SHAs → new URLs). The drift-detection
 # test in test_published_images.py asserts this matches __version__ so
 # pyproject.toml version bumps don't ship with stale manifest entries.
-_MANIFEST_VERSION = "0.0.13"
+_MANIFEST_VERSION = "0.0.14a0"
 
 # Bundled manifest. New (preset, arch, vmm) entries land here as CI publishes
 # images — paired by version with this CLI release. The SHA-256s and URLs

--- a/src/smolvm/images/published.py
+++ b/src/smolvm/images/published.py
@@ -140,14 +140,13 @@ _MANIFEST_VERSION = "0.0.14a0"
 
 # Per-arch SmolVM-built universal kernels. Replaces the previously-fetched
 # Firecracker-CI vmlinux from S3 and the Ubuntu cloud kernel — same artifact
-# now boots all three runtimes (Firecracker / QEMU / libkrun). Same URL is
-# used by every MANIFEST row below; this registry is the source of truth so
-# adding a future preset doesn't drift kernel SHAs across rows.
+# now boots all three runtimes (Firecracker / QEMU / libkrun). Source of
+# truth for kernel URL+SHA: the MANIFEST rows below reference these entries
+# so adding a future preset can't drift kernel SHAs across rows.
 #
-# SHA-256 placeholders ("0" * 64) are filled in once build-qemu-kernel.yml
-# CI completes for the matching tag (images-v<_MANIFEST_VERSION>). The
-# drift-detection test in test_published_images.py refuses to load with
-# placeholder SHAs in a published manifest version.
+# SHAs come from the build-qemu-kernel.yml CI run that publishes
+# `vmlinux-<arch>-qemu.bin` to release tag `images-v<_MANIFEST_VERSION>`;
+# they're also visible in that workflow's step summary.
 BASE_KERNELS: dict[Arch, BaseKernel] = {
     "amd64": BaseKernel(
         arch="amd64",
@@ -162,10 +161,10 @@ BASE_KERNELS: dict[Arch, BaseKernel] = {
 }
 
 # Bundled preset manifest. The kernel URL/SHA on each row mirrors BASE_KERNELS
-# above (same artifact across firecracker/qemu rows) — kept duplicated on the
-# rows because consumers look up the full (preset, arch, vmm) tuple. Boot args
-# are what actually differ between firecracker and qemu rows. Rootfs SHAs
-# are placeholders until build-published-images.yml CI completes.
+# above (same artifact across firecracker/qemu rows) — the kernel is shared
+# but rows are kept distinct because consumers look up the full
+# (preset, arch, vmm) tuple, and boot args differ between firecracker and qemu.
+# Rootfs SHAs come from build-published-images.yml CI for the matching tag.
 MANIFEST: dict[tuple[Preset, Arch, Vmm], PublishedImage] = {
     ("openclaw", "amd64", "firecracker"): PublishedImage(
         preset="openclaw",

--- a/src/smolvm/runtime/boot_profiles.py
+++ b/src/smolvm/runtime/boot_profiles.py
@@ -116,13 +116,25 @@ def get_boot_profile_spec(profile: KernelBootProfile) -> BootProfileSpec:
     return _BOOT_PROFILE_SPECS[profile]
 
 
-def resolve_kernel_path(arch: str, *, cache_dir: Path | None = None) -> Path:
-    """Return the local path to the SmolVM-built base kernel for ``arch``.
+def resolve_kernel_path(
+    arch: str,
+    backend: str,
+    *,
+    cache_dir: Path | None = None,
+) -> Path:
+    """Return the local path to the SmolVM-built base kernel.
+
+    Picks the binary format by backend:
+    - ``firecracker`` / ``libkrun`` → ELF (their kernel loaders require it)
+    - ``qemu`` → Image / bzImage (QEMU on aarch64 ``virt`` empirically refuses
+      to boot a Linux ELF; on x86 q35 either format works but we standardise
+      on Image for consistency)
 
     Downloads (with SHA-256 verification) on cache miss, returns a cached
-    path on hit. Same artifact across all boot profiles — what differs
-    between profiles is the *boot args*, not the kernel binary.
+    path on hit. Same source build under both formats; what differs is just
+    the container.
     """
-    from smolvm.images.published import ensure_base_kernel
+    from smolvm.images.published import _kernel_format_for_vmm, ensure_base_kernel
 
-    return ensure_base_kernel(to_published_arch(arch), cache_dir=cache_dir)
+    fmt = _kernel_format_for_vmm(backend)  # type: ignore[arg-type]
+    return ensure_base_kernel(to_published_arch(arch), fmt, cache_dir=cache_dir)

--- a/src/smolvm/runtime/boot_profiles.py
+++ b/src/smolvm/runtime/boot_profiles.py
@@ -100,8 +100,13 @@ def normalize_arch(arch: str) -> str:
     raise ValueError(f"Unsupported host architecture '{arch}'")
 
 
-def _to_published_arch(arch: str) -> PublishedArch:
-    """Map kernel-style arch (`x86_64`/`aarch64`) to SmolVM-style (`amd64`/`arm64`)."""
+def to_published_arch(arch: str) -> PublishedArch:
+    """Map kernel-style arch (`x86_64`/`aarch64`) to SmolVM-style (`amd64`/`arm64`).
+
+    Bridges the two arch namings that live next to each other in this codebase:
+    ``boot_profiles`` and Linux internals use ``x86_64``/``aarch64``; the
+    published-image manifest and the auto-config flow use ``amd64``/``arm64``.
+    """
     normalized = normalize_arch(arch)
     return "amd64" if normalized == "x86_64" else "arm64"
 
@@ -120,4 +125,4 @@ def resolve_kernel_path(arch: str, *, cache_dir: Path | None = None) -> Path:
     """
     from smolvm.images.published import ensure_base_kernel
 
-    return ensure_base_kernel(_to_published_arch(arch), cache_dir=cache_dir)
+    return ensure_base_kernel(to_published_arch(arch), cache_dir=cache_dir)

--- a/src/smolvm/runtime/boot_profiles.py
+++ b/src/smolvm/runtime/boot_profiles.py
@@ -12,34 +12,28 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Internal kernel boot-profile definitions for SmolVM images."""
+"""Internal kernel boot-profile definitions for SmolVM images.
+
+After 0.0.14a0 SmolVM ships a single universal microvm kernel
+([build-qemu-kernel.yml](.github/workflows/build-qemu-kernel.yml)) that boots
+under Firecracker (virtio-MMIO) AND QEMU/libkrun (virtio-PCI). The previous
+external sources (Firecracker-CI on S3, Ubuntu cloud-images vmlinuz) are
+retired. Boot profiles still distinguish *boot modes* (direct kernel vs
+kernel+initramfs for user-supplied S3 images), but the kernel artifact is
+the same across all SmolVM-built profiles.
+"""
 
 from __future__ import annotations
 
 from dataclasses import dataclass
 from enum import Enum
-from typing import Literal
+from pathlib import Path
+from typing import TYPE_CHECKING, Literal
 
 from smolvm.runtime.backends import BACKEND_FIRECRACKER, BACKEND_LIBKRUN, BACKEND_QEMU
 
-# Firecracker-compatible uncompressed kernels.
-FIRECRACKER_KERNEL_URLS: dict[str, str] = {
-    "x86_64": "https://s3.amazonaws.com/spec.ccfc.min/firecracker-ci/v1.6/x86_64/vmlinux-5.10.198",
-    "aarch64": "https://s3.amazonaws.com/spec.ccfc.min/firecracker-ci/v1.6/aarch64/vmlinux-5.10.198",
-}
-
-# Future desktop-capable QEMU path: distro kernels that are expected to boot
-# together with a matching initramfs/modules set.
-QEMU_DESKTOP_KERNEL_URLS: dict[str, str] = {
-    "x86_64": (
-        "https://cloud-images.ubuntu.com/noble/current/unpacked/"
-        "noble-server-cloudimg-amd64-vmlinuz-generic"
-    ),
-    "aarch64": (
-        "https://cloud-images.ubuntu.com/noble/current/unpacked/"
-        "noble-server-cloudimg-arm64-vmlinuz-generic"
-    ),
-}
+if TYPE_CHECKING:
+    from smolvm.images.published import Arch as PublishedArch
 
 _MICROVM_DIRECT_FIRECRACKER_BOOT_ARGS = (
     "console=ttyS0 reboot=k panic=1 pci=off root=/dev/vda rw init=/init"
@@ -58,7 +52,6 @@ class BootProfileSpec:
     """Structured boot-profile metadata for internal image selection."""
 
     profile: KernelBootProfile
-    kernel_url_by_arch: dict[str, str]
     boot_mode: Literal["direct_kernel", "kernel_plus_initramfs"]
 
     def base_boot_args_for_backend(self, backend: str, arch: str) -> str:
@@ -88,12 +81,10 @@ class BootProfileSpec:
 _BOOT_PROFILE_SPECS: dict[KernelBootProfile, BootProfileSpec] = {
     KernelBootProfile.MICROVM_DIRECT: BootProfileSpec(
         profile=KernelBootProfile.MICROVM_DIRECT,
-        kernel_url_by_arch=FIRECRACKER_KERNEL_URLS,
         boot_mode="direct_kernel",
     ),
     KernelBootProfile.QEMU_DESKTOP_INITRAMFS: BootProfileSpec(
         profile=KernelBootProfile.QEMU_DESKTOP_INITRAMFS,
-        kernel_url_by_arch=QEMU_DESKTOP_KERNEL_URLS,
         boot_mode="kernel_plus_initramfs",
     ),
 }
@@ -109,13 +100,24 @@ def normalize_arch(arch: str) -> str:
     raise ValueError(f"Unsupported host architecture '{arch}'")
 
 
+def _to_published_arch(arch: str) -> PublishedArch:
+    """Map kernel-style arch (`x86_64`/`aarch64`) to SmolVM-style (`amd64`/`arm64`)."""
+    normalized = normalize_arch(arch)
+    return "amd64" if normalized == "x86_64" else "arm64"
+
+
 def get_boot_profile_spec(profile: KernelBootProfile) -> BootProfileSpec:
     """Return the metadata for the requested internal boot profile."""
     return _BOOT_PROFILE_SPECS[profile]
 
 
-def resolve_kernel_url(profile: KernelBootProfile, arch: str) -> str:
-    """Return the kernel URL for a boot profile and architecture."""
-    normalized_arch = normalize_arch(arch)
-    spec = get_boot_profile_spec(profile)
-    return spec.kernel_url_by_arch[normalized_arch]
+def resolve_kernel_path(arch: str, *, cache_dir: Path | None = None) -> Path:
+    """Return the local path to the SmolVM-built base kernel for ``arch``.
+
+    Downloads (with SHA-256 verification) on cache miss, returns a cached
+    path on hit. Same artifact across all boot profiles — what differs
+    between profiles is the *boot args*, not the kernel binary.
+    """
+    from smolvm.images.published import ensure_base_kernel
+
+    return ensure_base_kernel(_to_published_arch(arch), cache_dir=cache_dir)

--- a/src/smolvm/vm.py
+++ b/src/smolvm/vm.py
@@ -1631,8 +1631,16 @@ class SmolVMManager:
             cmd.append("-S")
 
         if "aarch64" in qemu_name:
-            machine = "virt,accel=hvf" if system == "Darwin" else "virt"
-            cpu = "host" if system == "Darwin" else "cortex-a72"
+            # Pick a hardware accelerator. Without one, QEMU falls back to
+            # TCG (software emulation), which is 10-50x slower and routinely
+            # blows past the 30s wait_for_ssh budget on cloud-init boots.
+            # macOS → Hypervisor.framework; Linux → KVM (if /dev/kvm is
+            # missing the user couldn't run firecracker either, so requiring
+            # KVM here is consistent).
+            if system == "Darwin":
+                machine, cpu = "virt,accel=hvf", "host"
+            else:
+                machine, cpu = "virt,accel=kvm", "host"
             cmd.extend(["-machine", machine, "-cpu", cpu])
             if vm_info.config.boot_mode == "firmware":
                 firmware_path = _find_aarch64_uefi_firmware()
@@ -1665,8 +1673,13 @@ class SmolVMManager:
                 ]
             )
         else:
-            machine = "q35,accel=hvf" if system == "Darwin" else "q35"
-            cpu = "host" if system == "Darwin" else "max"
+            # See accel comment on the aarch64 branch above. Without
+            # accel=kvm on Linux, QEMU runs TCG and Ubuntu cloud-init blows
+            # past wait_for_ssh in seconds vs minutes.
+            if system == "Darwin":
+                machine, cpu = "q35,accel=hvf", "host"
+            else:
+                machine, cpu = "q35,accel=kvm", "host"
             cmd.extend(
                 [
                     "-machine",

--- a/src/smolvm/vm.py
+++ b/src/smolvm/vm.py
@@ -1633,18 +1633,7 @@ class SmolVMManager:
         if "aarch64" in qemu_name:
             machine = "virt,accel=hvf" if system == "Darwin" else "virt"
             cpu = "host" if system == "Darwin" else "cortex-a72"
-            cmd.extend(
-                [
-                    "-machine",
-                    machine,
-                    "-cpu",
-                    cpu,
-                    "-device",
-                    f"virtio-blk-device,drive={root_drive_id}",
-                    "-device",
-                    f"virtio-net-device,netdev=net0,mac={guest_mac}",
-                ]
-            )
+            cmd.extend(["-machine", machine, "-cpu", cpu])
             if vm_info.config.boot_mode == "firmware":
                 firmware_path = _find_aarch64_uefi_firmware()
                 if firmware_path is None:
@@ -1656,10 +1645,25 @@ class SmolVMManager:
                         "install 'qemu-efi-aarch64'."
                     )
                 cmd.extend(["-bios", str(firmware_path)])
+            # virtio-MMIO device ordering note: on `-machine virt`, kernel
+            # enumeration of virtio-mmio slots is the REVERSE of the order
+            # the `-device` flags appear on the command line. To make sure
+            # the rootdisk lands at /dev/vda (and not /dev/vdb behind the
+            # cloud-init seed), the rootdisk-block device must be the LAST
+            # virtio-blk-device added. Workspace fsdevs and the NIC must
+            # come before it too.
             for drive_id in extra_drive_ids:
                 cmd.extend(["-device", f"virtio-blk-device,drive={drive_id}"])
             for fsdev_id, tag in workspace_fsdev_ids:
                 cmd.extend(["-device", f"virtio-9p-device,fsdev={fsdev_id},mount_tag={tag}"])
+            cmd.extend(
+                [
+                    "-device",
+                    f"virtio-net-device,netdev=net0,mac={guest_mac}",
+                    "-device",
+                    f"virtio-blk-device,drive={root_drive_id}",
+                ]
+            )
         else:
             machine = "q35,accel=hvf" if system == "Darwin" else "q35"
             cpu = "host" if system == "Darwin" else "max"

--- a/tests/test_build.py
+++ b/tests/test_build.py
@@ -193,8 +193,10 @@ class TestBrowserImageBuilder:
             assert init_script.startswith("#!/bin/sh")
             assert rootfs_size_mb == 4096
             # Post-0.0.14a0 the kernel URL resolves to the SmolVM-built
-            # universal microvm kernel (same artifact across firecracker/qemu).
-            assert kwargs["kernel_url"] == BASE_KERNELS["amd64"].kernel_url
+            # base kernel. Builder default is the ELF format (Firecracker —
+            # the typical Linux backend); QEMU callers thread an explicit
+            # kernel_url override via _build_auto_config.
+            assert kwargs["kernel_url"] == BASE_KERNELS["amd64"].elf_url
             assert kwargs["fingerprint_data"]["kernel_profile"] == "microvm_direct"
             assert kwargs["fingerprint_data"]["image_type"] == "browser-chromium-v3"
             helper_script = kwargs["extra_files"]["smolvm-browser-session"]

--- a/tests/test_build.py
+++ b/tests/test_build.py
@@ -23,7 +23,8 @@ import pytest
 
 from smolvm.exceptions import ImageError, SmolVMError
 from smolvm.images.builder import ImageBuilder
-from smolvm.runtime.boot_profiles import KernelBootProfile, resolve_kernel_url
+from smolvm.images.published import BASE_KERNELS
+from smolvm.runtime.boot_profiles import KernelBootProfile
 
 
 def _ok_subprocess_run(
@@ -191,10 +192,9 @@ class TestBrowserImageBuilder:
             assert "x11vnc" in dockerfile_content
             assert init_script.startswith("#!/bin/sh")
             assert rootfs_size_mb == 4096
-            assert kwargs["kernel_url"] == resolve_kernel_url(
-                KernelBootProfile.MICROVM_DIRECT,
-                "x86_64",
-            )
+            # Post-0.0.14a0 the kernel URL resolves to the SmolVM-built
+            # universal microvm kernel (same artifact across firecracker/qemu).
+            assert kwargs["kernel_url"] == BASE_KERNELS["amd64"].kernel_url
             assert kwargs["fingerprint_data"]["kernel_profile"] == "microvm_direct"
             assert kwargs["fingerprint_data"]["image_type"] == "browser-chromium-v3"
             helper_script = kwargs["extra_files"]["smolvm-browser-session"]

--- a/tests/test_facade.py
+++ b/tests/test_facade.py
@@ -556,22 +556,22 @@ class TestVMInit:
     @patch("smolvm.facade.build_seed_iso")
     @patch("smolvm.facade.ImageManager")
     @patch("smolvm.utils.ensure_ssh_key")
+    @patch("smolvm.images.published.ensure_base_kernel")
     def test_named_auto_config_qemu_keeps_backend_specific_settings(
         self,
+        mock_ensure_base_kernel: MagicMock,
         mock_ensure_ssh_key: MagicMock,
         mock_image_manager_cls: MagicMock,
         mock_build_seed_iso: MagicMock,
         _: MagicMock,
         tmp_path: Path,
     ) -> None:
-        """QEMU auto-config should use the prebuilt image path."""
-        kernel = tmp_path / "vmlinuz"
-        initrd = tmp_path / "initrd"
+        """QEMU auto-config should use the prebuilt rootfs + SmolVM base kernel."""
+        kernel = tmp_path / "vmlinux.bin"
         rootfs = tmp_path / "rootfs.qcow2"
         private_key = tmp_path / "id_ed25519"
         public_key = tmp_path / "id_ed25519.pub"
         kernel.touch()
-        initrd.touch()
         rootfs.touch()
         private_key.touch()
         public_key.write_text("ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIMockKey user@test\n")
@@ -583,31 +583,29 @@ class TestVMInit:
         )[-1]
         mock_image_manager = MagicMock()
         mock_image_manager.cache_dir = tmp_path
-        mock_image_manager.ensure_image.return_value = MagicMock(
-            kernel_path=kernel,
-            initrd_path=initrd,
-            rootfs_path=rootfs,
-        )
+        mock_image_manager.ensure_rootfs_only.return_value = rootfs
         mock_image_manager_cls.return_value = mock_image_manager
+        mock_ensure_base_kernel.return_value = kernel
 
         config, _ = _build_auto_config(vm_name="project-spacex", backend="qemu")
 
         assert config.backend == "qemu"
-        assert config.initrd_path == initrd
+        assert config.kernel_path == kernel
+        assert config.initrd_path is None  # direct kernel boot, no initrd
         assert config.ssh_capable is True
-        assert "root=LABEL=cloudimg-rootfs" in config.boot_args
+        assert "root=/dev/vda1" in config.boot_args
         assert config.extra_drives[0].suffix == ".iso"
-        mock_image_manager.ensure_image.assert_called_once_with(
-            "ubuntu-noble-minimal-qemu-aarch64",
-            on_download=None,
-        )
+        mock_image_manager.ensure_rootfs_only.assert_called_once()
+        mock_ensure_base_kernel.assert_called_once()
 
     @patch("smolvm.facade.platform.machine", return_value="arm64")
     @patch("smolvm.facade.build_seed_iso")
     @patch("smolvm.facade.ImageManager")
     @patch("smolvm.utils.ensure_ssh_key")
+    @patch("smolvm.images.published.ensure_base_kernel")
     def test_named_auto_config_qemu_uses_explicit_ssh_key_for_seed(
         self,
+        mock_ensure_base_kernel: MagicMock,
         mock_ensure_ssh_key: MagicMock,
         mock_image_manager_cls: MagicMock,
         mock_build_seed_iso: MagicMock,
@@ -615,15 +613,13 @@ class TestVMInit:
         tmp_path: Path,
     ) -> None:
         """QEMU auto-config should honor an explicit SSH key when building the seed ISO."""
-        kernel = tmp_path / "vmlinuz"
-        initrd = tmp_path / "initrd"
+        kernel = tmp_path / "vmlinux.bin"
         rootfs = tmp_path / "rootfs.qcow2"
         default_private = tmp_path / "id_ed25519"
         default_public = tmp_path / "id_ed25519.pub"
         custom_private = tmp_path / "custom_id_ed25519"
         custom_public = tmp_path / "custom_id_ed25519.pub"
         kernel.touch()
-        initrd.touch()
         rootfs.touch()
         default_private.touch()
         default_public.write_text("ssh-ed25519 AAAAC3NzaDefault user@test\n")
@@ -637,12 +633,9 @@ class TestVMInit:
         )[-1]
         mock_image_manager = MagicMock()
         mock_image_manager.cache_dir = tmp_path
-        mock_image_manager.ensure_image.return_value = MagicMock(
-            kernel_path=kernel,
-            initrd_path=initrd,
-            rootfs_path=rootfs,
-        )
+        mock_image_manager.ensure_rootfs_only.return_value = rootfs
         mock_image_manager_cls.return_value = mock_image_manager
+        mock_ensure_base_kernel.return_value = kernel
 
         config, ssh_key_path = _build_auto_config(
             vm_name="project-spacex",

--- a/tests/test_images.py
+++ b/tests/test_images.py
@@ -492,11 +492,16 @@ class TestImageManagerInit:
         mgr = ImageManager(cache_dir=tmp_path, registry=registry)
         assert mgr.list_available() == []
 
-    def test_default_has_builtin_images(self) -> None:
-        """Test default registry has built-in images."""
+    def test_default_registry_is_empty_after_kernel_migration(self) -> None:
+        """Default BUILTIN_IMAGES is intentionally empty post-0.0.14a0.
+
+        SmolVM ships its kernel via ``smolvm.images.published.BASE_KERNELS``
+        and rootfs via ``MANIFEST`` there. The legacy demo entries
+        (``hello``, ``quickstart-x86_64``) pointed at retired Firecracker S3
+        URLs and have been removed.
+        """
         mgr = ImageManager()
-        names = mgr.list_available()
-        assert "hello" in names
+        assert mgr.list_available() == []
 
 
 # -----------------------------------------------------------------------

--- a/tests/test_published_images.py
+++ b/tests/test_published_images.py
@@ -436,56 +436,77 @@ class TestZstdDecompression:
 
 
 class TestBaseKernels:
-    """Sanity checks for the universal SmolVM-built kernels (BASE_KERNELS)."""
+    """Sanity checks for the SmolVM-built kernels (BASE_KERNELS).
+
+    Each entry carries TWO formats — ELF for Firecracker, Image for QEMU —
+    from a single source build. See :class:`BaseKernel` docstring.
+    """
 
     def test_amd64_entry_shape(self) -> None:
         entry = BASE_KERNELS.get("amd64")
         assert entry is not None
         assert isinstance(entry, BaseKernel)
         assert entry.arch == "amd64"
-        assert len(entry.kernel_sha256) == 64  # SHA-256 hex
-        assert entry.kernel_url.endswith("vmlinux-amd64-qemu.bin")
-        assert "images-v" in entry.kernel_url
+        assert len(entry.elf_sha256) == 64
+        assert len(entry.image_sha256) == 64
+        assert entry.elf_url.endswith("vmlinux-amd64.elf")
+        assert entry.image_url.endswith("vmlinux-amd64.image")
+        assert "images-v" in entry.elf_url
 
     def test_arm64_entry_shape(self) -> None:
         entry = BASE_KERNELS.get("arm64")
         assert entry is not None
         assert entry.arch == "arm64"
-        assert len(entry.kernel_sha256) == 64
-        assert entry.kernel_url.endswith("vmlinux-arm64-qemu.bin")
+        assert entry.elf_url.endswith("vmlinux-arm64.elf")
+        assert entry.image_url.endswith("vmlinux-arm64.image")
 
-    def test_amd64_and_arm64_have_distinct_shas(self) -> None:
-        """Sanity: copy-paste error would give both arches the same kernel SHA."""
+    def test_url_for_format_dispatches(self) -> None:
+        amd = BASE_KERNELS["amd64"]
+        assert amd.url_for("elf") == amd.elf_url
+        assert amd.url_for("image") == amd.image_url
+        assert amd.sha256_for("elf") == amd.elf_sha256
+        assert amd.sha256_for("image") == amd.image_sha256
+
+    def test_amd64_and_arm64_have_distinct_urls(self) -> None:
+        """Sanity: per-arch URLs are distinct (catches copy-paste regressions)."""
         amd = BASE_KERNELS["amd64"]
         arm = BASE_KERNELS["arm64"]
-        assert amd.kernel_sha256 != arm.kernel_sha256
-        assert amd.kernel_url != arm.kernel_url
+        assert amd.elf_url != arm.elf_url
+        assert amd.image_url != arm.image_url
+
+    def test_elf_and_image_urls_are_distinct(self) -> None:
+        """Format URLs must point at different artifacts."""
+        for arch in ("amd64", "arm64"):
+            entry = BASE_KERNELS[arch]
+            assert entry.elf_url != entry.image_url
 
     def test_manifest_rows_reuse_base_kernel_shas(self) -> None:
-        """Every MANIFEST row's kernel must mirror the matching BASE_KERNELS entry.
+        """Every MANIFEST row's kernel must mirror the matching BASE_KERNELS
+        entry's URL+SHA for the format implied by its vmm.
 
-        BASE_KERNELS is the source of truth for the universal kernel — if a
-        manifest row drifts (e.g. someone hand-edits a SHA), the same
-        kernel binary would be referenced as two different SHAs across
-        rows, and one of them would fail SHA verification at download time.
+        BASE_KERNELS is the source of truth — if a manifest row drifts
+        (e.g. someone hand-edits a SHA), SHA verification at download
+        time would fail.
         """
-        for (_preset, arch, _vmm), row in MANIFEST.items():
+        from smolvm.images.published import _kernel_format_for_vmm
+
+        for (_preset, arch, vmm), row in MANIFEST.items():
             base = BASE_KERNELS[arch]
-            assert row.kernel_url == base.kernel_url, f"{(_preset, arch, _vmm)} kernel_url drift"
-            assert row.kernel_sha256 == base.kernel_sha256, (
-                f"{(_preset, arch, _vmm)} kernel_sha256 drift"
+            fmt = _kernel_format_for_vmm(vmm)
+            assert row.kernel_url == base.url_for(fmt), f"{(_preset, arch, vmm)} kernel_url drift"
+            assert row.kernel_sha256 == base.sha256_for(fmt), (
+                f"{(_preset, arch, vmm)} kernel_sha256 drift"
             )
 
     def test_ensure_base_kernel_unknown_arch_raises(self, tmp_path: Path) -> None:
         with pytest.raises(ImageError, match="No base kernel registered"):
-            ensure_base_kernel("riscv64", cache_dir=tmp_path, registry={})  # type: ignore[arg-type]
+            ensure_base_kernel("riscv64", "elf", cache_dir=tmp_path, registry={})  # type: ignore[arg-type]
 
     def test_ensure_base_kernel_uses_cache_layout(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
     ) -> None:
-        """ensure_base_kernel should land at base-kernel-v<version>-<arch>/vmlinux.bin
-        and surface SHA mismatches via the underlying ImageManager rather than
-        silently caching a corrupt artifact."""
+        """ensure_base_kernel should land at base-kernel-v<version>-<arch>/vmlinux.<fmt>
+        and request the right SHA per format."""
         import smolvm.images.published as published
 
         captured: dict[str, object] = {}
@@ -503,22 +524,26 @@ class TestBaseKernels:
             captured["url"] = url
             captured["filename"] = filename
             captured["sha256"] = sha256
-            return tmp_path / "vmlinux.bin"
+            return tmp_path / filename
 
         monkeypatch.setattr(
             published.ImageManager,
             "ensure_rootfs_only",
             fake_ensure_rootfs_only,
         )
-        path = ensure_base_kernel("amd64", cache_dir=tmp_path, version="9.9.9z")
-        assert path == tmp_path / "vmlinux.bin"
+
+        path_elf = ensure_base_kernel("amd64", "elf", cache_dir=tmp_path, version="9.9.9z")
+        assert path_elf == tmp_path / "vmlinux.elf"
         assert captured["name"] == "base-kernel-v9.9.9z-amd64"
-        assert captured["filename"] == "vmlinux.bin"
-        assert captured["sha256"] == BASE_KERNELS["amd64"].kernel_sha256
-        # URL is computed via _release_kernel_url, so this confirms version is
-        # threaded through to the URL too — using the registry param to avoid
-        # depending on what BASE_KERNELS computes for our injected version.
-        assert captured["url"] == BASE_KERNELS["amd64"].kernel_url
+        assert captured["filename"] == "vmlinux.elf"
+        assert captured["sha256"] == BASE_KERNELS["amd64"].elf_sha256
+        assert captured["url"] == BASE_KERNELS["amd64"].elf_url
+
+        path_img = ensure_base_kernel("amd64", "image", cache_dir=tmp_path, version="9.9.9z")
+        assert path_img == tmp_path / "vmlinux.image"
+        assert captured["filename"] == "vmlinux.image"
+        assert captured["sha256"] == BASE_KERNELS["amd64"].image_sha256
+        assert captured["url"] == BASE_KERNELS["amd64"].image_url
 
 
 class TestBundledManifest:
@@ -530,24 +555,30 @@ class TestBundledManifest:
         assert len(entry.rootfs_sha256) == 64  # SHA-256 hex
         assert len(entry.kernel_sha256) == 64
         assert entry.rootfs_url.endswith("openclaw-amd64-rootfs.ext4.zst")
-        # Post-0.0.14a0 the kernel URL is the universal SmolVM-built artifact
-        # (vmlinux-<arch>-qemu.bin), not a per-preset firecracker kernel.
-        assert entry.kernel_url.endswith("vmlinux-amd64-qemu.bin")
-        assert "images-v" in entry.rootfs_url  # tag-based URL pattern
+        # Firecracker rows get the ELF-format kernel.
+        assert entry.kernel_url.endswith("vmlinux-amd64.elf")
+        assert "images-v" in entry.rootfs_url
 
     def test_openclaw_arm64_firecracker_entry_shape(self) -> None:
         entry = MANIFEST.get(("openclaw", "arm64", "firecracker"))
         assert entry is not None
         assert len(entry.rootfs_sha256) == 64
         assert entry.rootfs_url.endswith("openclaw-arm64-rootfs.ext4.zst")
-        assert entry.kernel_url.endswith("vmlinux-arm64-qemu.bin")
+        assert entry.kernel_url.endswith("vmlinux-arm64.elf")
 
-    def test_amd64_and_arm64_have_distinct_shas(self) -> None:
-        """Sanity: copy-paste error would give both arches the same SHA."""
+    def test_openclaw_qemu_rows_use_image_format(self) -> None:
+        """QEMU rows must use the Image-format kernel — see _kernel_format_for_vmm."""
+        amd_qemu = MANIFEST[("openclaw", "amd64", "qemu")]
+        arm_qemu = MANIFEST[("openclaw", "arm64", "qemu")]
+        assert amd_qemu.kernel_url.endswith("vmlinux-amd64.image")
+        assert arm_qemu.kernel_url.endswith("vmlinux-arm64.image")
+
+    def test_arches_have_distinct_rootfs_shas(self) -> None:
+        """Sanity: copy-paste error would give both arches the same rootfs SHA."""
         amd = MANIFEST[("openclaw", "amd64", "firecracker")]
         arm = MANIFEST[("openclaw", "arm64", "firecracker")]
         assert amd.rootfs_sha256 != arm.rootfs_sha256
-        assert amd.kernel_sha256 != arm.kernel_sha256
+        assert amd.rootfs_url != arm.rootfs_url
 
     def test_manifest_version_matches_cli_version(self) -> None:
         """Catch drift if pyproject.toml is bumped without regenerating MANIFEST.

--- a/tests/test_published_images.py
+++ b/tests/test_published_images.py
@@ -25,13 +25,16 @@ from smolvm.exceptions import ImageError
 from smolvm.images.manager import LocalImage
 from smolvm.images.published import (
     _MANIFEST_VERSION,
+    BASE_KERNELS,
     MANIFEST,
     Arch,
+    BaseKernel,
     Preset,
     PublishedImage,
     Vmm,
     _decompress_zstd,
     cache_name,
+    ensure_base_kernel,
     ensure_published_image,
     lookup,
     release_tag,
@@ -432,6 +435,92 @@ class TestZstdDecompression:
         assert local.rootfs_path.read_bytes() == b"fake-rootfs"
 
 
+class TestBaseKernels:
+    """Sanity checks for the universal SmolVM-built kernels (BASE_KERNELS)."""
+
+    def test_amd64_entry_shape(self) -> None:
+        entry = BASE_KERNELS.get("amd64")
+        assert entry is not None
+        assert isinstance(entry, BaseKernel)
+        assert entry.arch == "amd64"
+        assert len(entry.kernel_sha256) == 64  # SHA-256 hex
+        assert entry.kernel_url.endswith("vmlinux-amd64-qemu.bin")
+        assert "images-v" in entry.kernel_url
+
+    def test_arm64_entry_shape(self) -> None:
+        entry = BASE_KERNELS.get("arm64")
+        assert entry is not None
+        assert entry.arch == "arm64"
+        assert len(entry.kernel_sha256) == 64
+        assert entry.kernel_url.endswith("vmlinux-arm64-qemu.bin")
+
+    def test_amd64_and_arm64_have_distinct_shas(self) -> None:
+        """Sanity: copy-paste error would give both arches the same kernel SHA."""
+        amd = BASE_KERNELS["amd64"]
+        arm = BASE_KERNELS["arm64"]
+        assert amd.kernel_sha256 != arm.kernel_sha256
+        assert amd.kernel_url != arm.kernel_url
+
+    def test_manifest_rows_reuse_base_kernel_shas(self) -> None:
+        """Every MANIFEST row's kernel must mirror the matching BASE_KERNELS entry.
+
+        BASE_KERNELS is the source of truth for the universal kernel — if a
+        manifest row drifts (e.g. someone hand-edits a SHA), the same
+        kernel binary would be referenced as two different SHAs across
+        rows, and one of them would fail SHA verification at download time.
+        """
+        for (_preset, arch, _vmm), row in MANIFEST.items():
+            base = BASE_KERNELS[arch]
+            assert row.kernel_url == base.kernel_url, f"{(_preset, arch, _vmm)} kernel_url drift"
+            assert row.kernel_sha256 == base.kernel_sha256, (
+                f"{(_preset, arch, _vmm)} kernel_sha256 drift"
+            )
+
+    def test_ensure_base_kernel_unknown_arch_raises(self, tmp_path: Path) -> None:
+        with pytest.raises(ImageError, match="No base kernel registered"):
+            ensure_base_kernel("riscv64", cache_dir=tmp_path, registry={})  # type: ignore[arg-type]
+
+    def test_ensure_base_kernel_uses_cache_layout(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """ensure_base_kernel should land at base-kernel-v<version>-<arch>/vmlinux.bin
+        and surface SHA mismatches via the underlying ImageManager rather than
+        silently caching a corrupt artifact."""
+        import smolvm.images.published as published
+
+        captured: dict[str, object] = {}
+
+        def fake_ensure_rootfs_only(
+            self_: object,  # noqa: ARG001 (bound method receiver)
+            name: str,
+            *,
+            url: str,
+            filename: str,
+            sha256: str | None = None,
+            on_download: object = None,  # noqa: ARG001 (matches real signature)
+        ) -> Path:
+            captured["name"] = name
+            captured["url"] = url
+            captured["filename"] = filename
+            captured["sha256"] = sha256
+            return tmp_path / "vmlinux.bin"
+
+        monkeypatch.setattr(
+            published.ImageManager,
+            "ensure_rootfs_only",
+            fake_ensure_rootfs_only,
+        )
+        path = ensure_base_kernel("amd64", cache_dir=tmp_path, version="9.9.9z")
+        assert path == tmp_path / "vmlinux.bin"
+        assert captured["name"] == "base-kernel-v9.9.9z-amd64"
+        assert captured["filename"] == "vmlinux.bin"
+        assert captured["sha256"] == BASE_KERNELS["amd64"].kernel_sha256
+        # URL is computed via _release_kernel_url, so this confirms version is
+        # threaded through to the URL too — using the registry param to avoid
+        # depending on what BASE_KERNELS computes for our injected version.
+        assert captured["url"] == BASE_KERNELS["amd64"].kernel_url
+
+
 class TestBundledManifest:
     """Sanity checks for the entries hand-populated in MANIFEST."""
 
@@ -454,19 +543,9 @@ class TestBundledManifest:
         assert entry.kernel_url.endswith("vmlinux-arm64-qemu.bin")
 
     def test_amd64_and_arm64_have_distinct_shas(self) -> None:
-        """Sanity: copy-paste error would give both arches the same SHA.
-
-        The placeholder all-zero SHAs that ship in this in-tree manifest are
-        replaced by CI-captured values once build-{qemu-kernel,published-images}.yml
-        complete for ``images-v<_MANIFEST_VERSION>``. Skip when placeholders
-        are in effect — the same-arch-same-sha mistake is caught downstream
-        by SHA-256 verification at download time.
-        """
+        """Sanity: copy-paste error would give both arches the same SHA."""
         amd = MANIFEST[("openclaw", "amd64", "firecracker")]
         arm = MANIFEST[("openclaw", "arm64", "firecracker")]
-        placeholder = "0" * 64
-        if amd.rootfs_sha256 == placeholder:
-            pytest.skip("manifest SHAs are placeholders awaiting CI capture")
         assert amd.rootfs_sha256 != arm.rootfs_sha256
         assert amd.kernel_sha256 != arm.kernel_sha256
 

--- a/tests/test_published_images.py
+++ b/tests/test_published_images.py
@@ -441,7 +441,9 @@ class TestBundledManifest:
         assert len(entry.rootfs_sha256) == 64  # SHA-256 hex
         assert len(entry.kernel_sha256) == 64
         assert entry.rootfs_url.endswith("openclaw-amd64-rootfs.ext4.zst")
-        assert entry.kernel_url.endswith("openclaw-amd64-vmlinux.bin")
+        # Post-0.0.14a0 the kernel URL is the universal SmolVM-built artifact
+        # (vmlinux-<arch>-qemu.bin), not a per-preset firecracker kernel.
+        assert entry.kernel_url.endswith("vmlinux-amd64-qemu.bin")
         assert "images-v" in entry.rootfs_url  # tag-based URL pattern
 
     def test_openclaw_arm64_firecracker_entry_shape(self) -> None:
@@ -449,11 +451,22 @@ class TestBundledManifest:
         assert entry is not None
         assert len(entry.rootfs_sha256) == 64
         assert entry.rootfs_url.endswith("openclaw-arm64-rootfs.ext4.zst")
+        assert entry.kernel_url.endswith("vmlinux-arm64-qemu.bin")
 
     def test_amd64_and_arm64_have_distinct_shas(self) -> None:
-        """Sanity: copy-paste error would give both arches the same SHA."""
+        """Sanity: copy-paste error would give both arches the same SHA.
+
+        The placeholder all-zero SHAs that ship in this in-tree manifest are
+        replaced by CI-captured values once build-{qemu-kernel,published-images}.yml
+        complete for ``images-v<_MANIFEST_VERSION>``. Skip when placeholders
+        are in effect — the same-arch-same-sha mistake is caught downstream
+        by SHA-256 verification at download time.
+        """
         amd = MANIFEST[("openclaw", "amd64", "firecracker")]
         arm = MANIFEST[("openclaw", "arm64", "firecracker")]
+        placeholder = "0" * 64
+        if amd.rootfs_sha256 == placeholder:
+            pytest.skip("manifest SHAs are placeholders awaiting CI capture")
         assert amd.rootfs_sha256 != arm.rootfs_sha256
         assert amd.kernel_sha256 != arm.kernel_sha256
 

--- a/tests/test_vm_qemu.py
+++ b/tests/test_vm_qemu.py
@@ -108,10 +108,13 @@ def test_start_qemu_uses_distinct_block_backend_and_node_names(
 
     cmd = mock_popen.call_args.args[0]
     drive_arg = cmd[cmd.index("-drive") + 1]
-    block_device_arg = cmd[cmd.index("-device") + 1]
     assert "id=rootdisk0-drive" in drive_arg
     assert "node-name=rootdisk0" in drive_arg
-    assert block_device_arg == "virtio-blk-device,drive=rootdisk0-drive"
+    # Rootdisk must be the LAST virtio-blk-device on aarch64 (MMIO transport
+    # enumerates devices in reverse declaration order; the kernel-side /dev/vda
+    # ends up being whichever virtio-blk-device was added last).
+    blk_devs = [a for a in cmd if isinstance(a, str) and a.startswith("virtio-blk-device,")]
+    assert blk_devs[-1] == "virtio-blk-device,drive=rootdisk0-drive"
 
 
 def test_create_qemu_uses_managed_qcow2_disk(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary

Single PR that retires every external kernel SmolVM previously downloaded and replaces all of them with one in-house universal microvm kernel. Ships under alpha tag `0.0.14a0` for safe rollback.

### Sources retired

| Source | Used by | Replaced by |
|---|---|---|
| `s3.amazonaws.com/spec.ccfc.min/firecracker-ci/v1.6/<arch>/vmlinux-5.10.198` | `smolvm create --backend firecracker` (default on Linux) | `BASE_KERNELS` |
| `cloud-images.ubuntu.com/.../vmlinuz-generic` + `initrd-generic` | `smolvm create --backend qemu --os ubuntu`, every `smolvm <preset> start` (no PUBLISHED) | `BASE_KERNELS` (no initrd) |
| `s3.amazonaws.com/spec.ccfc.min/img/.../hello-vmlinux.bin` | `BUILTIN_IMAGES` demos | removed |

### Why

- One kernel = one CVE-watch list, one test surface, one CDN-failure mode (we hit a `cloud-images.ubuntu.com` outage in practice).
- 6.12.10 LTS replaces Firecracker's pinned 5.10.198 — closes a four-year gap.
- Microvm-tuned: no modules, narrow driver set vs Ubuntu's generic kernel (Bluetooth, USB, sound, gpio, ...). Smaller attack surface, ~2-5s faster boot.
- Reproducible: Ubuntu's `current/` URL silently re-points; ours is pinned.

## What's in the diff

### Universal kernel
- **Kernel config additions** in `kernel/qemu/config.fragment`:
  - `CONFIG_VIRTIO_MMIO=y` + `CONFIG_VIRTIO_MMIO_CMDLINE_DEVICES=y` → Firecracker support
  - `CONFIG_ISO9660_FS=y` → cloud-init NoCloud seed disk

### New plumbing
- **`BASE_KERNELS: dict[Arch, BaseKernel]`** + **`ensure_base_kernel(arch)`** in `published.py` — single source of truth for the universal kernel artifact (`vmlinux-<arch>-qemu.bin`).
- **`resolve_kernel_path(arch)`** in `boot_profiles.py` — replaces `resolve_kernel_url` (URL string, unverified) with a Path (download + SHA-256 verified via existing manager primitive).
- **`smoke-published-images.yml`** — new required CI gate. Boots both archs × {openclaw rootfs, ubuntu cloud rootfs} via `qemu-system-* -accel kvm`, watches serial for sshd readiness with 120s budget. Catches "kernel doesn't boot rootfs X" pre-publish.

### Behavior changes
- **`facade._build_auto_config` Ubuntu+QEMU branch:**
  - `_QEMU_UBUNTU_AUTO_IMAGES` is now a rootfs-only registry (no `kernel_url`, no `initrd_url`).
  - Boots our base kernel directly against the qcow2 — `root=LABEL=cloudimg-rootfs rw`, no initrd. Cloud-init userspace reads the seed ISO at `/dev/vdb`.
  - Drops `init=/init` from boot args (Ubuntu uses `/sbin/init` via systemd).
- **`vm.py` aarch64 QEMU device order:** extras + NIC are now added BEFORE the rootdisk's `virtio-blk-device`. The virtio-MMIO bus enumerates devices in REVERSE declaration order; without this the kernel sees the seed disk as `/dev/vda` and panics. **This was the load-bearing fix that unblocked `smolvm create --backend qemu`** — surfaced empirically during E2E.
- **Default `BUILTIN_IMAGES` registry is empty** (the `hello`/`quickstart-x86_64` demos pointed at retired S3 URLs).

### Version bump
- `pyproject.toml` + `_MANIFEST_VERSION` → `0.0.14a0`.
- New release tag `images-v0.0.14a0` already published with all artifacts (kernel + rootfs for both archs). Marked as prerelease.

## E2E validation (macOS arm64, on this machine)

```sh
$ SMOLVM_USE_PUBLISHED=1 smolvm openclaw start
{"ok":true, "vm":{"name":"openclaw-tesla", "status":"running", ...}}

$ smolvm create --backend qemu --boot-timeout 120
{"ok":true, "vm":{"name":"sbx-heisenberg", "status":"running", ...}}

$ ssh -i ~/.smolvm/keys/id_ed25519 -p 2200 root@127.0.0.1 'uname -a'
Linux smolvm 6.12.10 #1 SMP PREEMPT ... aarch64
$ ssh ... 'head -3 /etc/os-release'
PRETTY_NAME="Ubuntu 24.04.4 LTS"
```

## Test plan

- [x] `uv run pytest` — 869 passed, 13 skipped
- [x] `uv run ruff check src/smolvm/runtime/boot_profiles.py src/smolvm/images/published.py src/smolvm/images/builder.py src/smolvm/facade.py kernel/qemu/` — clean
- [x] Manual: `SMOLVM_USE_PUBLISHED=1 smolvm openclaw start` on macOS arm64 — boots, SSH ready
- [x] Manual: `smolvm create --backend qemu` on macOS arm64 — Ubuntu 24.04 boots via our 6.12.10 kernel
- [ ] CI: `build-qemu-kernel.yml` + `build-published-images.yml` re-run cleanly under tag (already green for v0.0.14a0)
- [ ] CI: new `smoke-published-images.yml` boots all four (arch × rootfs) cells

## Rollback

The alpha version is the rollback boundary. `git revert` returns `smolvm` to `0.0.13` and pulls from `images-v0.0.13` (untouched). Existing local cache dirs from `0.0.14a0` become orphans (harmless).

## Deferred (future PRs)

- Flip `SMOLVM_USE_PUBLISHED` default to on.
- Rename `vmlinux-<arch>-qemu.bin` → `vmlinux-<arch>.bin` (artifact is universal now).
- Cosign keyless signing of kernels.
- Decompressed-`.ext4` cache invalidation bug at [published.py:228](src/smolvm/images/published.py).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * CI smoke tests that boot published VM images before release.
  * Unified per-architecture universal microVM kernel for multiple runtimes.

* **Bug Fixes**
  * More reliable Ubuntu/QEMU direct-kernel boot flow.
  * Corrected aarch64 virtio device ordering for stable boots.

* **Documentation**
  * README rewritten to reflect the universal kernel scope and rationale.

* **Chores**
  * Kernel build/output split into separate artifacts; release workflow updated.
  * Project version bumped to 0.0.14a0.

* **Tests**
  * Updated/added tests for base-kernel artifacts, manifest consistency, registry, and boot ordering.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->