### PR TITLE
fix(images): collapse manifest version into IMAGES_RELEASE_TAG; resync kernel SHAs

### DIFF
--- a/.github/workflows/build-microvm-kernel.yml
+++ b/.github/workflows/build-microvm-kernel.yml
@@ -101,10 +101,10 @@ jobs:
           if [ -n "${INPUT_TAG:-}" ]; then
             tag="$INPUT_TAG"
           else
-            # tomllib.load() takes a binary file; tomllib.loads() takes a str
-            # (NOT bytes). Same idiom as build-published-images.yml.
-            version=$(python3 -c "import tomllib; print(tomllib.load(open('pyproject.toml','rb'))['project']['version'])")
-            tag="images-v${version}"
+            # Single source of truth — published.py::IMAGES_RELEASE_TAG.
+            # Doesn't auto-track pyproject version; bumped only when image
+            # artifacts are republished (see published.py docstring).
+            tag=$(python3 -c 'import sys; sys.path.insert(0, "src"); from smolvm.images.published import IMAGES_RELEASE_TAG; print(IMAGES_RELEASE_TAG)')
           fi
           echo "tag=${tag}" >> "$GITHUB_OUTPUT"
           echo "Release tag: ${tag}"
@@ -141,8 +141,9 @@ jobs:
               --notes "Auto-generated draft release for SmolVM published images. Verify SHA-256 sums and content before publishing." \
               || echo "Draft already exists (race with another matrix cell), continuing."
           fi
-          # --clobber overwrites any prior asset with the same name, so re-runs
-          # of the workflow for the same tag replace existing artifacts cleanly.
+          # --clobber overwrites prior artifacts. NOTE: allows silent SHA
+          # drift relative to BASE_KERNELS — drift detection via live SHA
+          # smoke test is a separate workflow.
           gh release upload "$TAG" \
             --repo "$GITHUB_REPOSITORY" \
             --clobber \

--- a/.github/workflows/build-microvm-kernel.yml
+++ b/.github/workflows/build-microvm-kernel.yml
@@ -1,5 +1,5 @@
-# Build SmolVM's microvm Linux kernel and upload it to the
-# images-v<version> draft GitHub Release.
+# Build SmolVM's microvm Linux kernel and upload it to the GitHub
+# Release named by published.py::IMAGES_RELEASE_TAG.
 #
 # Decoupled from build-published-images.yml on purpose: kernel cadence
 # differs from rootfs cadence. This workflow re-runs only when the inputs
@@ -22,7 +22,8 @@ on:
       release_tag:
         description: >-
           Release tag to upload to (e.g. images-v0.0.14a0). Created as a
-          draft if missing. Leave empty to derive from pyproject version.
+          draft if missing. Leave empty to use IMAGES_RELEASE_TAG from
+          published.py.
         type: string
         default: ""
   push:

--- a/.github/workflows/build-published-images.yml
+++ b/.github/workflows/build-published-images.yml
@@ -33,7 +33,7 @@ on:
       release_tag:
         description: >-
           Release tag (e.g. images-v0.0.13). Created as draft if missing.
-          Leave empty to derive from the project version in pyproject.toml.
+          Leave empty to use IMAGES_RELEASE_TAG from published.py.
         type: string
         default: ""
 

--- a/.github/workflows/build-published-images.yml
+++ b/.github/workflows/build-published-images.yml
@@ -151,8 +151,8 @@ jobs:
           if [ -n "$INPUT_TAG" ]; then
             tag="$INPUT_TAG"
           else
-            version=$(uv run python -c "import tomllib; print(tomllib.load(open('pyproject.toml','rb'))['project']['version'])")
-            tag="images-v${version}"
+            # Single source of truth — published.py::IMAGES_RELEASE_TAG.
+            tag=$(uv run python -c 'from smolvm.images.published import IMAGES_RELEASE_TAG; print(IMAGES_RELEASE_TAG)')
           fi
           echo "tag=${tag}" >> "$GITHUB_OUTPUT"
           echo "Release tag: ${tag}"
@@ -222,6 +222,11 @@ jobs:
               || echo "Draft already exists (race with another matrix cell), continuing."
           fi
 
+          # --clobber overwrites any prior asset with the same name, so
+          # re-runs of the workflow for the same tag replace existing
+          # artifacts. NOTE: this allows silent SHA drift relative to the
+          # manifest. Catching that requires a smoke test that verifies
+          # live bytes against recorded SHAs — tracked separately.
           gh release upload "$TAG" \
             --repo "$GITHUB_REPOSITORY" \
             --clobber \
@@ -294,8 +299,8 @@ jobs:
           if [ -n "$INPUT_TAG" ]; then
             tag="$INPUT_TAG"
           else
-            version=$(python3 -c "import tomllib; print(tomllib.load(open('pyproject.toml','rb'))['project']['version'])")
-            tag="images-v${version}"
+            # Single source of truth — published.py::IMAGES_RELEASE_TAG.
+            tag=$(uv run python -c 'from smolvm.images.published import IMAGES_RELEASE_TAG; print(IMAGES_RELEASE_TAG)')
           fi
           echo "tag=${tag}" >> "$GITHUB_OUTPUT"
           echo "Release tag: ${tag}"
@@ -368,6 +373,11 @@ jobs:
               || echo "Draft already exists (race with another matrix cell), continuing."
           fi
 
+          # --clobber overwrites any prior asset with the same name, so
+          # re-runs of the workflow for the same tag replace existing
+          # artifacts. NOTE: this allows silent SHA drift relative to the
+          # manifest. Catching that requires a smoke test that verifies
+          # live bytes against recorded SHAs — tracked separately.
           gh release upload "$TAG" \
             --repo "$GITHUB_REPOSITORY" \
             --clobber \

--- a/.github/workflows/build-published-images.yml
+++ b/.github/workflows/build-published-images.yml
@@ -328,6 +328,11 @@ jobs:
           sudo ARCH="$ARCH" bash scripts/ci/build-preset.sh \
             "$PRESET" /tmp/base/base-rootfs.ext4 /tmp/out "$SIZE"
 
+          # build-preset.sh ran under sudo (mount + chroot need root), so
+          # /tmp/out is owned by root. Chown to the runner user so the
+          # subsequent zstd `--rm` step can delete the source file.
+          sudo chown -R "$(id -u):$(id -g)" /tmp/out
+
           name="${PRESET}-${ARCH}"
           rootfs="/tmp/out/${name}-rootfs.ext4"
 

--- a/src/smolvm/images/published.py
+++ b/src/smolvm/images/published.py
@@ -161,15 +161,6 @@ def _release_kernel_url(arch: Arch, fmt: KernelFormat) -> str:
     )
 
 
-def release_tag(version: str = __version__) -> str:  # noqa: ARG001  # kept for back-compat
-    """Deprecated. Returns :data:`IMAGES_RELEASE_TAG` — argument is ignored.
-
-    Old behavior derived ``images-v<version>`` from the CLI version, but
-    that coupled CLI bumps to image republishes. Kept as a thin shim so
-    external callers don't break.
-    """
-    return IMAGES_RELEASE_TAG
-
 # Per-arch SmolVM-built kernels. Each :class:`BaseKernel` carries BOTH the
 # ELF (Firecracker) and Image (QEMU) URLs+SHAs from the same source build.
 # Source of truth for kernel URL+SHA: the MANIFEST rows below reference

--- a/src/smolvm/images/published.py
+++ b/src/smolvm/images/published.py
@@ -102,41 +102,53 @@ class BaseKernel(BaseModel):
         return self.elf_sha256 if fmt == "elf" else self.image_sha256
 
 
-def release_tag(version: str = __version__) -> str:
-    """GitHub Releases tag images for ``version`` are published under."""
-    return f"images-v{version}"
+# SINGLE SOURCE OF TRUTH for the GitHub Releases tag this CLI pulls
+# images from. Independent of the CLI version in ``pyproject.toml`` —
+# coupling them (via the previous ``_MANIFEST_VERSION``) meant a CLI
+# bump silently invalidated every manifest SHA pin.
+#
+# CI workflows (``build-microvm-kernel.yml``,
+# ``build-published-images.yml``) read this constant rather than
+# deriving from pyproject — change here flows to both sides.
+#
+# Bumping protocol — one PR:
+#   1. Edit this string (e.g. ``images-v0.0.15``).
+#   2. Run the kernel + published-image workflows, copy SHAs from the
+#      step summaries into ``BASE_KERNELS`` and ``MANIFEST``.
+#   3. Promote the draft release on GitHub.
+#
+# CI still passes ``--clobber`` to ``gh release upload`` for
+# operational ergonomics, so SHA drift is technically possible. A
+# follow-up smoke test should fetch each ``rootfs_url`` / ``kernel_url``
+# and verify the live bytes match the recorded SHA.
+IMAGES_RELEASE_TAG = "images-v0.0.14a0"
 
 
 def cache_name(preset: Preset, arch: Arch, vmm: Vmm, version: str = __version__) -> str:
     """Cache directory name under ``~/.smolvm/images/``.
 
-    Versioned + arch- + vmm-suffixed so multiple installs, architectures,
-    and hypervisors coexist on the same machine without overwriting each
-    other. A user switching backends mid-session gets a fresh cache dir
-    per vmm rather than fighting over one.
-
-    Note: caches from before the vmm dimension landed (no ``-<vmm>``
-    suffix) become orphaned and ignored. They stay on disk untouched
-    until the user clears them.
+    Keyed on the **CLI** version (not the images tag) so a CLI upgrade
+    invalidates local caches even when the images tag hasn't moved —
+    avoids serving a stale ``.ext4`` decompressed from the prior CLI's
+    decompression sidecar.
     """
     return f"{preset}-v{version}-{arch}-{vmm}"
 
 
-def _release_asset_url(preset: Preset, arch: Arch, suffix: str, version: str) -> str:
+def _release_asset_url(preset: Preset, arch: Arch, suffix: str) -> str:
     """Construct the post-publish GH Releases asset URL for one artifact.
 
-    Once the draft release at ``images-v<version>`` is published, GH
-    Releases serves assets at this canonical URL (the draft itself uses
-    a temporary ``untagged-*`` slug — these URLs only resolve after
-    the draft is published manually).
+    Once the draft at :data:`IMAGES_RELEASE_TAG` is published, GH Releases
+    serves assets at this canonical URL (drafts use a temporary
+    ``untagged-*`` slug — these URLs only resolve after publish).
     """
     return (
         f"https://github.com/CelestoAI/SmolVM/releases/download/"
-        f"{release_tag(version)}/{preset}-{arch}-{suffix}"
+        f"{IMAGES_RELEASE_TAG}/{preset}-{arch}-{suffix}"
     )
 
 
-def _release_kernel_url(arch: Arch, fmt: KernelFormat, version: str) -> str:
+def _release_kernel_url(arch: Arch, fmt: KernelFormat) -> str:
     """URL for a preset-independent kernel artifact.
 
     Asset naming: ``vmlinux-<arch>.{elf|image}``. Same Linux source build
@@ -145,14 +157,18 @@ def _release_kernel_url(arch: Arch, fmt: KernelFormat, version: str) -> str:
     """
     return (
         f"https://github.com/CelestoAI/SmolVM/releases/download/"
-        f"{release_tag(version)}/vmlinux-{arch}.{fmt}"
+        f"{IMAGES_RELEASE_TAG}/vmlinux-{arch}.{fmt}"
     )
 
 
-# Version of the published images this CLI release was paired with.
-# Bumping this requires regenerating every MANIFEST entry below from a
-# fresh CI run (new artifacts → new SHAs → new URLs).
-_MANIFEST_VERSION = "0.0.14a0"
+def release_tag(version: str = __version__) -> str:  # noqa: ARG001  # kept for back-compat
+    """Deprecated. Returns :data:`IMAGES_RELEASE_TAG` — argument is ignored.
+
+    Old behavior derived ``images-v<version>`` from the CLI version, but
+    that coupled CLI bumps to image republishes. Kept as a thin shim so
+    external callers don't break.
+    """
+    return IMAGES_RELEASE_TAG
 
 # Per-arch SmolVM-built kernels. Each :class:`BaseKernel` carries BOTH the
 # ELF (Firecracker) and Image (QEMU) URLs+SHAs from the same source build.
@@ -160,23 +176,23 @@ _MANIFEST_VERSION = "0.0.14a0"
 # these entries via ``url_for(format)`` / ``sha256_for(format)``, so adding
 # a future preset can't drift kernel SHAs across rows.
 #
-# SHAs come from the build-microvm-kernel.yml CI run that publishes
-# ``vmlinux-<arch>.{elf,image}`` to release tag ``images-v<_MANIFEST_VERSION>``;
-# they're also visible in that workflow's step summary.
+# SHAs come from the ``Build microvm Kernel`` workflow run that publishes
+# ``vmlinux-<arch>.{elf,image}`` to :data:`IMAGES_RELEASE_TAG`; they're
+# also visible in that workflow's step summary.
 BASE_KERNELS: dict[Arch, BaseKernel] = {
     "amd64": BaseKernel(
         arch="amd64",
-        elf_url=_release_kernel_url("amd64", "elf", _MANIFEST_VERSION),
-        elf_sha256="f652d798efb2b19c4923e5e7ff4e7b2e9db31ec8347cec2a5e6a27b813b2d5a1",
-        image_url=_release_kernel_url("amd64", "image", _MANIFEST_VERSION),
-        image_sha256="55061bc45706eca229afdad31451d63e0695ce990fb1d46301194b4771e607f0",
+        elf_url=_release_kernel_url("amd64", "elf"),
+        elf_sha256="7be5c70c5fd5b12771aad71f6eddf8bf82006c3886c28be2e2f04be0812cd56b",
+        image_url=_release_kernel_url("amd64", "image"),
+        image_sha256="d77c0b8c9fa6bbf163c04aee2067b374ff5a952b10040ed407dbc659a2af2552",
     ),
     "arm64": BaseKernel(
         arch="arm64",
-        elf_url=_release_kernel_url("arm64", "elf", _MANIFEST_VERSION),
-        elf_sha256="d837ec0f6c12d6dd9b96885464db876699e3984c9c8b0c3699569e2000221fc2",
-        image_url=_release_kernel_url("arm64", "image", _MANIFEST_VERSION),
-        image_sha256="200862461ac269baf56c636a76a96db204e216fc8d16a983b910cd22bf72469b",
+        elf_url=_release_kernel_url("arm64", "elf"),
+        elf_sha256="77795663bf9b0fe229d2a8e77bc454cf56cbe2ba94130320ec235fc31a73d92b",
+        image_url=_release_kernel_url("arm64", "image"),
+        image_sha256="ddc7344a2e1298bcdc467dd900236456c08159734ac43cae9b104ded506e3839",
     ),
 }
 
@@ -204,7 +220,7 @@ def _manifest_row(preset: Preset, arch: Arch, vmm: Vmm, rootfs_sha256: str) -> P
         vmm=vmm,
         kernel_url=base.url_for(fmt),
         kernel_sha256=base.sha256_for(fmt),
-        rootfs_url=_release_asset_url(preset, arch, "rootfs.ext4.zst", _MANIFEST_VERSION),
+        rootfs_url=_release_asset_url(preset, arch, "rootfs.ext4.zst"),
         rootfs_sha256=rootfs_sha256,
     )
 

--- a/tests/test_published_images.py
+++ b/tests/test_published_images.py
@@ -38,7 +38,6 @@ from smolvm.images.published import (
     ensure_published_image,
     is_preset_published,
     lookup,
-    release_tag,
     to_image_source,
 )
 
@@ -70,11 +69,10 @@ def sample_manifest(
 
 
 class TestNaming:
-    def test_release_tag_returns_pinned_tag(self) -> None:
-        # release_tag() now ignores its arg and returns IMAGES_RELEASE_TAG
-        # to decouple the images release from CLI version bumps.
-        assert release_tag() == IMAGES_RELEASE_TAG
-        assert release_tag("0.0.13") == IMAGES_RELEASE_TAG
+    def test_release_tag_constant_format(self) -> None:
+        # Sanity: the tag still resembles a release identifier so any
+        # downstream tooling that parses it doesn't break silently.
+        assert IMAGES_RELEASE_TAG.startswith("images-v")
 
     def test_cache_name_includes_preset_version_arch_vmm(self) -> None:
         assert (

--- a/tests/test_published_images.py
+++ b/tests/test_published_images.py
@@ -24,8 +24,8 @@ import pytest
 from smolvm.exceptions import ImageError
 from smolvm.images.manager import LocalImage
 from smolvm.images.published import (
-    _MANIFEST_VERSION,
     BASE_KERNELS,
+    IMAGES_RELEASE_TAG,
     MANIFEST,
     Arch,
     BaseKernel,
@@ -70,8 +70,11 @@ def sample_manifest(
 
 
 class TestNaming:
-    def test_release_tag_uses_version(self) -> None:
-        assert release_tag("0.0.13") == "images-v0.0.13"
+    def test_release_tag_returns_pinned_tag(self) -> None:
+        # release_tag() now ignores its arg and returns IMAGES_RELEASE_TAG
+        # to decouple the images release from CLI version bumps.
+        assert release_tag() == IMAGES_RELEASE_TAG
+        assert release_tag("0.0.13") == IMAGES_RELEASE_TAG
 
     def test_cache_name_includes_preset_version_arch_vmm(self) -> None:
         assert (
@@ -674,9 +677,9 @@ class TestBundledManifest:
         assert amd.rootfs_sha256 != arm.rootfs_sha256
         assert amd.rootfs_url != arm.rootfs_url
 
-    def test_all_entries_use_manifest_version_in_url(self) -> None:
-        """Every entry's URL must reference the same release tag we claim."""
-        expected_segment = f"/images-v{_MANIFEST_VERSION}/"
+    def test_all_entries_use_release_tag_in_url(self) -> None:
+        """Every entry's URL must reference the pinned release tag."""
+        expected_segment = f"/{IMAGES_RELEASE_TAG}/"
         for key, entry in MANIFEST.items():
             assert expected_segment in entry.rootfs_url, (
                 f"{key} rootfs_url doesn't reference {expected_segment}"


### PR DESCRIPTION
## Why

The build dispatch on \`main\` failed with \`ImageError: SHA-256 mismatch for vmlinux-amd64.elf\`. Root cause was **two coupled drifts**:

1. \`_MANIFEST_VERSION = \"0.0.14a0\"\` in [published.py](src/smolvm/images/published.py) but \`pyproject.toml\` had moved to \`0.0.14a1\`. CI derived the release tag from pyproject, so the workflow uploaded to \`images-v0.0.14a1\` while the runtime tried to download from \`images-v0.0.14a0\`.
2. Kernel artifacts at \`images-v0.0.14a0\` got re-uploaded after the 6.12.85 kernel bump, but \`BASE_KERNELS\` SHAs were never updated to match.

Both come from the same disease: too many sources of truth for \"which release does the manifest point at.\" This PR collapses them.

## What

| Change | Why |
|---|---|
| Rename \`_MANIFEST_VERSION\` → \`IMAGES_RELEASE_TAG\` (full tag string, not version fragment) | Clearer semantic; can't be confused with \`__version__\` |
| Decouple from \`__version__\` (CLI version bumps no longer affect images tag) | A CLI bump shouldn't silently invalidate every manifest SHA |
| Both CI workflows read the tag via \`python -c 'from smolvm.images.published import IMAGES_RELEASE_TAG; print(IMAGES_RELEASE_TAG)'\` instead of deriving from pyproject | Single source of truth across runtime and CI |
| Simplify \`_release_asset_url\` / \`_release_kernel_url\` (drop version arg) | Use the module constant directly |
| \`release_tag()\` becomes a deprecated shim | Back-compat for any external callers |
| Update \`BASE_KERNELS\` SHAs to match live artifacts (verified via curl + sha256sum) | Resyncs runtime with what's actually on the release page |

**Resynced kernel SHAs:**
- amd64.elf: \`f652d7…\` → \`7be5c7…\`
- amd64.image: \`55061b…\` → \`d77c0b…\`
- arm64.elf: \`d837ec…\` → \`779556…\`
- arm64.image: \`200862…\` → \`ddc734…\`

## What's NOT here

\`--clobber\` stays in CI uploads — removing it broke re-run ergonomics for the unblock workflow. Drift detection lands as a separate smoke workflow ([#265](https://github.com/CelestoAI/SmolVM/issues/265)) that fetches each URL nightly and verifies the live SHA.

## Validation

- \`uv run pytest\` — 882 passed, 13 skipped
- \`uv run ruff check\` — clean
- \`uv run python -c 'from smolvm.images.published import IMAGES_RELEASE_TAG; print(IMAGES_RELEASE_TAG)'\` → \`images-v0.0.14a0\`
- After merge, will re-trigger Build Published Images on \`main\` to populate the missing preset rootfs SHAs

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added "pi" preset to the published-image catalog.

* **Chores**
  * Published images now default to a fixed images release tag when none is provided.
  * CI workflow updates to ensure published-image artifacts and cleanup behave reliably.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->