### PR TITLE
fix(ci): read IMAGES_RELEASE_TAG via awk to avoid Python import

### DIFF
--- a/.github/workflows/build-microvm-kernel.yml
+++ b/.github/workflows/build-microvm-kernel.yml
@@ -103,9 +103,11 @@ jobs:
             tag="$INPUT_TAG"
           else
             # Single source of truth — published.py::IMAGES_RELEASE_TAG.
-            # Doesn't auto-track pyproject version; bumped only when image
-            # artifacts are republished (see published.py docstring).
-            tag=$(python3 -c 'import sys; sys.path.insert(0, "src"); from smolvm.images.published import IMAGES_RELEASE_TAG; print(IMAGES_RELEASE_TAG)')
+            # Read it as a string instead of importing the package: this
+            # workflow installs only the apt packages it needs to build
+            # a kernel and skips the smolvm Python deps (paramiko etc),
+            # so `from smolvm.images.published import …` would ImportError.
+            tag=$(awk -F'"' '/^IMAGES_RELEASE_TAG[[:space:]]*=/{print $2; exit}' src/smolvm/images/published.py)
           fi
           echo "tag=${tag}" >> "$GITHUB_OUTPUT"
           echo "Release tag: ${tag}"

--- a/.github/workflows/build-microvm-kernel.yml
+++ b/.github/workflows/build-microvm-kernel.yml
@@ -109,6 +109,10 @@ jobs:
             # so `from smolvm.images.published import …` would ImportError.
             tag=$(awk -F'"' '/^IMAGES_RELEASE_TAG[[:space:]]*=/{print $2; exit}' src/smolvm/images/published.py)
           fi
+          if [ -z "$tag" ]; then
+            echo "ERROR: IMAGES_RELEASE_TAG could not be parsed from src/smolvm/images/published.py" >&2
+            exit 1
+          fi
           echo "tag=${tag}" >> "$GITHUB_OUTPUT"
           echo "Release tag: ${tag}"
 

--- a/.github/workflows/build-published-images.yml
+++ b/.github/workflows/build-published-images.yml
@@ -152,7 +152,9 @@ jobs:
             tag="$INPUT_TAG"
           else
             # Single source of truth — published.py::IMAGES_RELEASE_TAG.
-            tag=$(uv run python -c 'from smolvm.images.published import IMAGES_RELEASE_TAG; print(IMAGES_RELEASE_TAG)')
+            # Read as string rather than importing: avoids forcing every
+            # job to install smolvm's Python deps just to print one tag.
+            tag=$(awk -F'"' '/^IMAGES_RELEASE_TAG[[:space:]]*=/{print $2; exit}' src/smolvm/images/published.py)
           fi
           echo "tag=${tag}" >> "$GITHUB_OUTPUT"
           echo "Release tag: ${tag}"
@@ -300,7 +302,9 @@ jobs:
             tag="$INPUT_TAG"
           else
             # Single source of truth — published.py::IMAGES_RELEASE_TAG.
-            tag=$(uv run python -c 'from smolvm.images.published import IMAGES_RELEASE_TAG; print(IMAGES_RELEASE_TAG)')
+            # Read as string rather than importing: avoids forcing every
+            # job to install smolvm's Python deps just to print one tag.
+            tag=$(awk -F'"' '/^IMAGES_RELEASE_TAG[[:space:]]*=/{print $2; exit}' src/smolvm/images/published.py)
           fi
           echo "tag=${tag}" >> "$GITHUB_OUTPUT"
           echo "Release tag: ${tag}"

--- a/.github/workflows/build-published-images.yml
+++ b/.github/workflows/build-published-images.yml
@@ -156,6 +156,10 @@ jobs:
             # job to install smolvm's Python deps just to print one tag.
             tag=$(awk -F'"' '/^IMAGES_RELEASE_TAG[[:space:]]*=/{print $2; exit}' src/smolvm/images/published.py)
           fi
+          if [ -z "$tag" ]; then
+            echo "ERROR: IMAGES_RELEASE_TAG could not be parsed from src/smolvm/images/published.py" >&2
+            exit 1
+          fi
           echo "tag=${tag}" >> "$GITHUB_OUTPUT"
           echo "Release tag: ${tag}"
 
@@ -305,6 +309,10 @@ jobs:
             # Read as string rather than importing: avoids forcing every
             # job to install smolvm's Python deps just to print one tag.
             tag=$(awk -F'"' '/^IMAGES_RELEASE_TAG[[:space:]]*=/{print $2; exit}' src/smolvm/images/published.py)
+          fi
+          if [ -z "$tag" ]; then
+            echo "ERROR: IMAGES_RELEASE_TAG could not be parsed from src/smolvm/images/published.py" >&2
+            exit 1
           fi
           echo "tag=${tag}" >> "$GITHUB_OUTPUT"
           echo "Release tag: ${tag}"


### PR DESCRIPTION
## Why

The kernel build workflow runs only apt packages and skips the smolvm Python deps. After [#266](https://github.com/CelestoAI/SmolVM/pull/266) it reads \`IMAGES_RELEASE_TAG\` by importing the module:

\`\`\`bash
python3 -c 'import sys; sys.path.insert(0, \"src\"); from smolvm.images.published import IMAGES_RELEASE_TAG; print(IMAGES_RELEASE_TAG)'
\`\`\`

That import chains through \`smolvm/__init__.py → browser.py → facade.py → env.py → ssh.py → paramiko\` and the runner doesn't have paramiko, so:

\`\`\`
ModuleNotFoundError: No module named 'paramiko'
\`\`\`

Visible in [run 25397183754](https://github.com/CelestoAI/SmolVM/actions/runs/25397183754) — auto-triggered by #266 merging the \`build-microvm-kernel.yml\` comment update.

## Fix

Read the constant directly from the source file with one-line awk:

\`\`\`bash
tag=\$(awk -F'\"' '/^IMAGES_RELEASE_TAG[[:space:]]*=/{print \$2; exit}' src/smolvm/images/published.py)
\`\`\`

No package import, no Python deps, ~3ms. The constant is the source of truth either way; this just reads it as a string instead of evaluating it as Python.

Applied to \`build-published-images.yml\` too — same approach is faster there too (no implicit \`uv sync\` to print a string) and keeps both workflows consistent.

## Validation

\`\`\`
$ awk -F'\"' '/^IMAGES_RELEASE_TAG[[:space:]]*=/{print \$2; exit}' src/smolvm/images/published.py
images-v0.0.14a0
\`\`\`

Matches \`IMAGES_RELEASE_TAG\` in [published.py](src/smolvm/images/published.py).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Simplified release-tag resolution in build workflows to remove an external runtime dependency and streamline CI processing.
  * Added a fail-safe that stops the workflow when no release tag can be determined, improving build reliability and preventing accidental drafts or uploads.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->