### PR TITLE
Add --os flag to preset start command for OS selection

### DIFF
--- a/.github/workflows/build-published-images.yml
+++ b/.github/workflows/build-published-images.yml
@@ -52,6 +52,10 @@ jobs:
       fail-fast: false
       matrix:
         arch: [amd64, arm64]
+        # Two flavours per arch: Ubuntu 24.04 (current default) and Alpine
+        # 3.20 (smaller footprint, opt-in via ``smolvm <preset> start --os
+        # alpine``). Same kernel boots both — only the rootfs differs.
+        os: [ubuntu, alpine]
     runs-on: ${{ matrix.arch == 'arm64' && 'ubuntu-24.04-arm' || 'ubuntu-latest' }}
     timeout-minutes: 15
 
@@ -65,13 +69,15 @@ jobs:
         run: docker info >/dev/null
 
       - name: Build base rootfs
+        env:
+          OS: ${{ matrix.os }}
         run: |
-          sudo bash scripts/ci/build-base-rootfs.sh /tmp/base 4096
+          sudo OS="$OS" bash scripts/ci/build-base-rootfs.sh /tmp/base
 
       - name: Upload base rootfs artifact
         uses: actions/upload-artifact@v4
         with:
-          name: base-rootfs-${{ matrix.arch }}
+          name: base-rootfs-${{ matrix.os }}-${{ matrix.arch }}
           path: /tmp/base/base-rootfs.ext4
           retention-days: 1
 
@@ -267,6 +273,15 @@ jobs:
       matrix:
         arch: [amd64, arm64]
         preset: [codex, claude-code, hermes, pi]
+        os: [ubuntu, alpine]
+        # Phase 1 of the Alpine rollout (#264) excludes hermes — its
+        # ``[all]`` extras pull manylinux2014 wheels that don't have
+        # musllinux variants, so the install would fall back to slow
+        # source builds with sometimes-broken results. Re-enable when
+        # we have a curated minimal extras set.
+        exclude:
+          - preset: hermes
+            os: alpine
     runs-on: ${{ matrix.arch == 'arm64' && 'ubuntu-24.04-arm' || 'ubuntu-latest' }}
     timeout-minutes: 20
 
@@ -321,7 +336,7 @@ jobs:
         if: steps.filter.outputs.skip != 'true'
         uses: actions/download-artifact@v4
         with:
-          name: base-rootfs-${{ matrix.arch }}
+          name: base-rootfs-${{ matrix.os }}-${{ matrix.arch }}
           path: /tmp/base
 
       - name: Layer preset on base rootfs
@@ -330,14 +345,20 @@ jobs:
         env:
           PRESET: ${{ matrix.preset }}
           ARCH: ${{ matrix.arch }}
+          OS: ${{ matrix.os }}
         run: |
           # Hermes needs more disk (Python deps are heavier)
           SIZE=4096
           if [ "$PRESET" = "hermes" ]; then
             SIZE=6144
           fi
+          # Alpine + JS preset is ~half the Ubuntu equivalent — give it
+          # less scratch space so the published artifact stays compact.
+          if [ "$OS" = "alpine" ]; then
+            SIZE=2048
+          fi
 
-          sudo ARCH="$ARCH" bash scripts/ci/build-preset.sh \
+          sudo ARCH="$ARCH" OS="$OS" bash scripts/ci/build-preset.sh \
             "$PRESET" /tmp/base/base-rootfs.ext4 /tmp/out "$SIZE"
 
           # build-preset.sh ran under sudo (mount + chroot need root), so
@@ -345,7 +366,15 @@ jobs:
           # subsequent zstd `--rm` step can delete the source file.
           sudo chown -R "$(id -u):$(id -g)" /tmp/out
 
-          name="${PRESET}-${ARCH}"
+          # Asset naming asymmetry: ubuntu has no OS suffix (legacy from
+          # the single-flavour era), alpine introduces ``-alpine-``. The
+          # published manifest URL builder mirrors this in
+          # ``src/smolvm/images/published.py::_release_asset_url``.
+          if [ "$OS" = "ubuntu" ]; then
+            name="${PRESET}-${ARCH}"
+          else
+            name="${PRESET}-${ARCH}-${OS}"
+          fi
           rootfs="/tmp/out/${name}-rootfs.ext4"
 
           echo "rootfs_path=${rootfs}" >> "$GITHUB_OUTPUT"

--- a/scripts/ci/Dockerfile.base-alpine-rootfs
+++ b/scripts/ci/Dockerfile.base-alpine-rootfs
@@ -1,0 +1,66 @@
+# Alpine variant of the shared base rootfs.
+#
+# Same role as Dockerfile.base-rootfs (Ubuntu) — provides Node 22, Python 3,
+# uv, git, openssh, common system packages — but built on Alpine 3.20 + musl
+# libc + busybox userland. The resulting ext4 lands at roughly half the size
+# of the Ubuntu base (~200 MB vs ~419 MB), and there's correspondingly less
+# data to page in at boot.
+#
+# Tradeoff: musl libc breaks upstream binaries that ship glibc-only prebuilts
+# (``@node-llama-cpp``, some ``manylinux2014`` Python wheels). Phase 1
+# restricts the Alpine variant to pure-JS presets (codex, claude-code, pi).
+# hermes (heavy ML wheels) and openclaw (node-llama-cpp prebuilts) stay
+# Ubuntu-only until those upstream gaps are closed — see issue #264.
+
+FROM alpine:3.20
+
+# ── System packages ─────────────────────────────────────────────
+# Single RUN keeps everything in one layer. ``--no-cache`` is the apk
+# equivalent of apt's "clean + rm -rf /var/lib/apt/lists/*" — it skips
+# writing the package index to /var/cache/apk in the first place.
+RUN apk add --no-cache \
+        openssh-server \
+        openssh-keygen \
+        openrc \
+        iproute2 \
+        curl \
+        ca-certificates \
+        git \
+        bash \
+        nodejs \
+        npm \
+        python3 \
+        py3-pip \
+    && rm -rf \
+        /usr/share/man \
+        /usr/share/doc \
+        /usr/share/info \
+        /usr/share/locale \
+        /var/cache/apk/* \
+        /tmp/* \
+        /root/.cache \
+    && find /usr -depth -name __pycache__ -type d -exec rm -rf {} + \
+    && find /usr -name '*.pyc' -delete
+
+# ── uv (fast Python package manager) ───────────────────────────
+# Installed system-wide so all presets pick it up without modifying PATH.
+# uv ships musl wheels (``uv-x86_64-unknown-linux-musl`` /
+# ``uv-aarch64-unknown-linux-musl``) so the install script picks the
+# Alpine-compatible binary automatically.
+RUN curl -LsSf https://astral.sh/uv/install.sh | sh \
+    && cp /root/.local/bin/uv /usr/local/bin/uv \
+    && cp /root/.local/bin/uvx /usr/local/bin/uvx \
+    && rm -rf /root/.local /root/.cache
+
+# ── SSH hardening ───────────────────────────────────────────────
+# Host keys generated at first boot via /init (preset-init.sh runs
+# ``ssh-keygen -A`` if no host keys are present).
+RUN rm -f /etc/ssh/ssh_host_* \
+    && mkdir -p /run/sshd /root/.ssh \
+    && chmod 700 /root/.ssh \
+    && sed -ri 's/^#?PermitRootLogin .*/PermitRootLogin prohibit-password/' /etc/ssh/sshd_config \
+    && sed -ri 's/^#?PasswordAuthentication .*/PasswordAuthentication no/' /etc/ssh/sshd_config \
+    && sed -ri 's/^#?PubkeyAuthentication .*/PubkeyAuthentication yes/' /etc/ssh/sshd_config
+
+# ── Workspace directory ─────────────────────────────────────────
+RUN mkdir -p /workspace

--- a/scripts/ci/build-base-rootfs.sh
+++ b/scripts/ci/build-base-rootfs.sh
@@ -1,24 +1,47 @@
 #!/usr/bin/env bash
-# Build the shared base rootfs ext4 image from Dockerfile.base-rootfs.
+# Build the shared base rootfs ext4 image from a Dockerfile.
 #
 # Usage:  build-base-rootfs.sh <output-dir> [size-mb]
+# Env:    OS=ubuntu|alpine (default: ubuntu)
 #
 # Produces: <output-dir>/base-rootfs.ext4
 #
 # Runs in CI on a matching-arch runner (no cross-compilation).
-# Requires: docker, mkfs.ext4, mount (loop device support).
+# Requires: docker, mkfs.ext4, mount (loop device support), e2fsck,
+# resize2fs.
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 OUT_DIR="${1:?Usage: build-base-rootfs.sh <output-dir> [size-mb]}"
-SIZE_MB="${2:-4096}"
+OS="${OS:-ubuntu}"
+
+case "$OS" in
+  ubuntu)
+    DOCKERFILE="$SCRIPT_DIR/Dockerfile.base-rootfs"
+    DEFAULT_SIZE_MB=4096
+    ;;
+  alpine)
+    DOCKERFILE="$SCRIPT_DIR/Dockerfile.base-alpine-rootfs"
+    # Alpine + musl + busybox lands around 200 MB — a 1 GiB ext4 is plenty
+    # of headroom for the preset layer to install on top. We shrink to the
+    # actual contents below with resize2fs -M, so this is just an upper
+    # bound for the temporary mkfs scratch space.
+    DEFAULT_SIZE_MB=1024
+    ;;
+  *)
+    echo "Unsupported OS: $OS (expected: ubuntu | alpine)" >&2
+    exit 1
+    ;;
+esac
+
+SIZE_MB="${2:-$DEFAULT_SIZE_MB}"
 
 mkdir -p "$OUT_DIR"
 
-TAG="smolvm-base-rootfs"
+TAG="smolvm-base-rootfs-${OS}"
 
-echo "==> Building base rootfs Docker image..."
-docker build -t "$TAG" -f "$SCRIPT_DIR/Dockerfile.base-rootfs" "$SCRIPT_DIR"
+echo "==> Building $OS base rootfs Docker image..."
+docker build -t "$TAG" -f "$DOCKERFILE" "$SCRIPT_DIR"
 
 echo "==> Exporting container filesystem..."
 CID=$(docker create "$TAG" /bin/true)
@@ -38,4 +61,20 @@ rmdir "$MNT"
 
 rm -f "$OUT_DIR/rootfs.tar"
 
-echo "==> Base rootfs: $OUT_DIR/base-rootfs.ext4 ($(du -sh "$OUT_DIR/base-rootfs.ext4" | cut -f1))"
+# Shrink the ext4 to its actual contents so the published artifact carries
+# only what's used. e2fsck must precede resize2fs -M; the truncate after
+# resize trims the host-side file to the new filesystem size (resize2fs
+# leaves the underlying file size untouched).
+echo "==> Shrinking ext4 to actual usage..."
+e2fsck -fy "$OUT_DIR/base-rootfs.ext4" >/dev/null 2>&1
+resize2fs -M "$OUT_DIR/base-rootfs.ext4" 2>&1 | tail -1
+# Read the resulting block count + block size out of dumpe2fs and truncate
+# the host file to match.
+BLOCK_COUNT=$(dumpe2fs -h "$OUT_DIR/base-rootfs.ext4" 2>/dev/null | awk -F: '/^Block count/{gsub(/ /,"",$2); print $2}')
+BLOCK_SIZE=$(dumpe2fs -h "$OUT_DIR/base-rootfs.ext4" 2>/dev/null | awk -F: '/^Block size/{gsub(/ /,"",$2); print $2}')
+if [ -n "$BLOCK_COUNT" ] && [ -n "$BLOCK_SIZE" ]; then
+  FINAL_BYTES=$((BLOCK_COUNT * BLOCK_SIZE))
+  truncate -s "$FINAL_BYTES" "$OUT_DIR/base-rootfs.ext4"
+fi
+
+echo "==> Base rootfs ($OS): $OUT_DIR/base-rootfs.ext4 ($(du -sh "$OUT_DIR/base-rootfs.ext4" | cut -f1))"

--- a/scripts/ci/build-base-rootfs.sh
+++ b/scripts/ci/build-base-rootfs.sh
@@ -45,7 +45,22 @@ docker build -t "$TAG" -f "$DOCKERFILE" "$SCRIPT_DIR"
 
 echo "==> Exporting container filesystem..."
 CID=$(docker create "$TAG" /bin/true)
-trap 'docker rm -f "$CID" >/dev/null 2>&1 || true' EXIT
+MNT=""
+cleanup() {
+  # Fire-and-forget: errors past the first failing step stop the script,
+  # but cleanup must still try every resource. Loop mount must come down
+  # before the rmdir, and the docker container is independent of both.
+  if [ -n "$MNT" ] && mountpoint -q "$MNT" 2>/dev/null; then
+    umount "$MNT" 2>/dev/null || true
+  fi
+  if [ -n "$MNT" ] && [ -d "$MNT" ]; then
+    rmdir "$MNT" 2>/dev/null || true
+  fi
+  if [ -n "${CID:-}" ]; then
+    docker rm -f "$CID" >/dev/null 2>&1 || true
+  fi
+}
+trap cleanup EXIT
 docker export "$CID" > "$OUT_DIR/rootfs.tar"
 
 echo "==> Creating ${SIZE_MB}M ext4 image..."
@@ -58,6 +73,7 @@ tar -xf "$OUT_DIR/rootfs.tar" -C "$MNT" \
   --exclude='dev/*' --exclude='proc/*' --exclude='sys/*' --exclude='.dockerenv'
 umount "$MNT"
 rmdir "$MNT"
+MNT=""
 
 rm -f "$OUT_DIR/rootfs.tar"
 

--- a/scripts/ci/build-preset.sh
+++ b/scripts/ci/build-preset.sh
@@ -2,8 +2,16 @@
 # Layer a preset on top of the shared base rootfs.
 #
 # Usage:  build-preset.sh <preset> <base-rootfs.ext4> <output-dir> [size-mb]
+# Env:    OS=ubuntu|alpine (default: ubuntu)
+#         ARCH=amd64|arm64 (default: dpkg/uname)
 #
-# Produces: <output-dir>/<preset>-<arch>-rootfs.ext4
+# Produces:
+#   ubuntu: <output-dir>/<preset>-<arch>-rootfs.ext4
+#   alpine: <output-dir>/<preset>-<arch>-alpine-rootfs.ext4
+#
+# The Ubuntu asset name has no OS suffix for backward compat with the
+# existing release; Alpine introduces the suffix as it lands. Same naming
+# is mirrored in the published manifest's URL builder.
 #
 # Strategy: copy the base ext4, mount it, chroot into it, run the
 # preset-specific install script, unmount. The result is a self-contained
@@ -20,6 +28,7 @@ PRESET="${1:?Usage: build-preset.sh <preset> <base-rootfs.ext4> <output-dir> [si
 BASE_ROOTFS="${2:?Missing base-rootfs.ext4 path}"
 OUT_DIR="${3:?Missing output directory}"
 SIZE_MB="${4:-4096}"
+OS="${OS:-ubuntu}"
 ARCH="${ARCH:-$(dpkg --print-architecture 2>/dev/null || uname -m)}"
 
 # Normalize arch naming
@@ -29,10 +38,41 @@ case "$ARCH" in
   *) echo "Unsupported arch: $ARCH"; exit 1 ;;
 esac
 
-mkdir -p "$OUT_DIR"
-ROOTFS="$OUT_DIR/${PRESET}-${ARCH}-rootfs.ext4"
+case "$OS" in
+  ubuntu)
+    OUT_NAME="${PRESET}-${ARCH}"
+    SHELL_BIN="/bin/bash"
+    ;;
+  alpine)
+    OUT_NAME="${PRESET}-${ARCH}-alpine"
+    # Alpine ships /bin/bash (we apk-install it in the base) so the install
+    # snippets below — which use ``set -euo pipefail`` and other bash-isms —
+    # still run cleanly without busybox-ash quirks.
+    SHELL_BIN="/bin/bash"
+    ;;
+  *)
+    echo "Unsupported OS: $OS (expected: ubuntu | alpine)" >&2
+    exit 1
+    ;;
+esac
 
-echo "==> Copying base rootfs for preset '$PRESET' ($ARCH)..."
+# Phase 1 of the Alpine rollout (#264) restricts which presets are eligible:
+# pure-JS presets only. hermes pulls musllinux-incompatible Python wheels
+# and openclaw pulls glibc-only @node-llama-cpp prebuilts.
+if [ "$OS" = "alpine" ]; then
+  case "$PRESET" in
+    codex|claude-code|pi) ;;
+    *)
+      echo "Preset '$PRESET' is not yet supported on Alpine (Phase 1 covers codex/claude-code/pi)." >&2
+      exit 1
+      ;;
+  esac
+fi
+
+mkdir -p "$OUT_DIR"
+ROOTFS="$OUT_DIR/${OUT_NAME}-rootfs.ext4"
+
+echo "==> Copying base rootfs for preset '$PRESET' ($ARCH, $OS)..."
 cp "$BASE_ROOTFS" "$ROOTFS"
 
 # Resize if needed (base may be smaller than target)
@@ -74,11 +114,11 @@ if [ -e "$MNT/etc/resolv.conf" ]; then
 fi
 cp /etc/resolv.conf "$MNT/etc/resolv.conf" 2>/dev/null || true
 
-echo "==> Installing preset '$PRESET'..."
+echo "==> Installing preset '$PRESET' ($OS)..."
 
 case "$PRESET" in
   codex)
-    chroot "$MNT" /bin/bash -c '
+    chroot "$MNT" "$SHELL_BIN" -c '
       set -euo pipefail
       npm install -g --silent @openai/codex
       npm cache clean --force >/dev/null 2>&1 || true
@@ -87,7 +127,7 @@ case "$PRESET" in
     ;;
 
   claude-code)
-    chroot "$MNT" /bin/bash -c '
+    chroot "$MNT" "$SHELL_BIN" -c '
       set -euo pipefail
       npm install -g --silent @anthropic-ai/claude-code
       npm cache clean --force >/dev/null 2>&1 || true
@@ -96,7 +136,9 @@ case "$PRESET" in
     ;;
 
   hermes)
-    chroot "$MNT" /bin/bash -c '
+    # Ubuntu-only — gated above, but keep the install body here so a
+    # future Alpine-compatible spike can flip the gate without rewriting.
+    chroot "$MNT" "$SHELL_BIN" -c '
       set -euo pipefail
       if [ ! -d /opt/hermes-agent ]; then
         git clone --depth 1 https://github.com/NousResearch/hermes-agent.git /opt/hermes-agent
@@ -114,7 +156,7 @@ case "$PRESET" in
     ;;
 
   pi)
-    chroot "$MNT" /bin/bash -c '
+    chroot "$MNT" "$SHELL_BIN" -c '
       set -euo pipefail
       npm install -g --silent @mariozechner/pi-coding-agent
       npm cache clean --force >/dev/null 2>&1 || true

--- a/src/smolvm/cli/main.py
+++ b/src/smolvm/cli/main.py
@@ -1869,15 +1869,21 @@ _VMM_TO_BACKEND: dict[Vmm, str] = {
     "libkrun": "qemu",
 }
 
-# Preset → base OS string used in the start-result envelope.
-# openclaw bakes from node:22.12.0-bookworm-slim (Debian 12);
-# codex/claude-code/hermes/pi layer on Ubuntu 24.04 via build-preset.sh.
-_PRESET_OS_LABEL: dict[str, str] = {
-    "openclaw": "debian-bookworm",
-    "codex": "ubuntu-24.04",
-    "claude-code": "ubuntu-24.04",
-    "hermes": "ubuntu-24.04",
-    "pi": "ubuntu-24.04",
+# Preset+OS → base OS string used in the start-result envelope.
+# openclaw bakes from node:22.12.0-bookworm-slim (Debian 12) — its rootfs
+# is independent of the layered ubuntu/alpine flavours. codex/claude-code/
+# hermes/pi layer on either Ubuntu 24.04 or Alpine 3.20 via build-preset.sh.
+_PRESET_OS_LABEL: dict[tuple[str, str], str] = {
+    ("openclaw", "ubuntu"): "debian-bookworm",
+    ("openclaw", "alpine"): "debian-bookworm",
+    ("codex", "ubuntu"): "ubuntu-24.04",
+    ("codex", "alpine"): "alpine-3.20",
+    ("claude-code", "ubuntu"): "ubuntu-24.04",
+    ("claude-code", "alpine"): "alpine-3.20",
+    ("hermes", "ubuntu"): "ubuntu-24.04",
+    ("hermes", "alpine"): "alpine-3.20",
+    ("pi", "ubuntu"): "ubuntu-24.04",
+    ("pi", "alpine"): "alpine-3.20",
 }
 
 
@@ -1971,16 +1977,18 @@ def _run_start_with_published_image(args: argparse.Namespace, preset: object) ->
             json_output=args.json,
         )
 
+    requested_os = GuestOS(args.os) if args.os is not None else GuestOS.UBUNTU
+
     try:
         arch = _host_arch_for_published()
         private_key, public_key_path = ensure_ssh_key()
         public_key_value = public_key_path.read_text().strip()
 
-        # Raises ImageError with a clear message if the (preset, arch, vmm)
-        # tuple has no manifest entry — covers the gap where a host platform
-        # is supported in principle but no published kernel exists for it
-        # yet.
-        local_image = ensure_published_image(_preset.name, arch, vmm)
+        # Raises ImageError with a clear message if the (preset, arch, vmm,
+        # os) tuple has no manifest entry — covers the gap where a host
+        # platform is supported in principle but no published kernel exists
+        # for it yet.
+        local_image = ensure_published_image(_preset.name, arch, vmm, requested_os.value)
 
         backend = _VMM_TO_BACKEND[vmm]
 
@@ -2015,7 +2023,7 @@ def _run_start_with_published_image(args: argparse.Namespace, preset: object) ->
                         if isinstance(vm.info.status, VMState)
                         else VMState.RUNNING.value
                     ),
-                    "os": _PRESET_OS_LABEL.get(_preset.name, "unknown"),
+                    "os": _PRESET_OS_LABEL.get((_preset.name, requested_os.value), "unknown"),
                     "backend": backend,
                     "ip_address": network.guest_ip if network else None,
                     "ssh_port": network.ssh_host_port if network else None,
@@ -2065,29 +2073,26 @@ def _run_start(args: argparse.Namespace) -> int:
 
     preset = get_preset(args.preset_name)
 
-    # The user-facing default is ubuntu when --os is omitted; an explicit
-    # --os opts the run into install-at-boot since the published-image
-    # manifest only ships one OS per preset today (#264 tracks adding an
-    # OS dimension to the manifest).
+    # The user-facing default is ubuntu when --os is omitted.
     requested_os = GuestOS(args.os) if args.os is not None else GuestOS.UBUNTU
 
     # Published-image fast path: use a pre-built image from GitHub Releases
-    # if one exists for this (preset, arch, vmm) tuple. Falls through to
-    # install-at-boot when no manifest entry exists (e.g. presets without
-    # CI-built rootfs) or the user pinned a specific --os.
-    if args.os is None:
-        try:
-            arch = _host_arch_for_published()
-            vmm = _vmm_for_host()
-        except RuntimeError:
-            pass
-        else:
-            requested_backend = args.backend or "auto"
-            published_backend = _VMM_TO_BACKEND[vmm]
-            if requested_backend in {"auto", published_backend} and is_preset_published(
-                preset.name, arch, vmm
-            ):
-                return _run_start_with_published_image(args, preset)
+    # if one exists for this (preset, arch, vmm, os) tuple. Falls through to
+    # install-at-boot when no matching manifest entry exists — e.g. when
+    # the user asks for ``--os alpine`` for a preset whose Alpine variant
+    # hasn't been published yet.
+    try:
+        arch = _host_arch_for_published()
+        vmm = _vmm_for_host()
+    except RuntimeError:
+        pass
+    else:
+        requested_backend = args.backend or "auto"
+        published_backend = _VMM_TO_BACKEND[vmm]
+        if requested_backend in {"auto", published_backend} and is_preset_published(
+            preset.name, arch, vmm, requested_os.value
+        ):
+            return _run_start_with_published_image(args, preset)
 
     backend = args.backend or "qemu"
     if backend != "qemu":

--- a/src/smolvm/cli/main.py
+++ b/src/smolvm/cli/main.py
@@ -1869,23 +1869,6 @@ _VMM_TO_BACKEND: dict[Vmm, str] = {
     "libkrun": "qemu",
 }
 
-# Preset+OS → base OS string used in the start-result envelope.
-# openclaw bakes from node:22.12.0-bookworm-slim (Debian 12) — its rootfs
-# is independent of the layered ubuntu/alpine flavours. codex/claude-code/
-# hermes/pi layer on either Ubuntu 24.04 or Alpine 3.20 via build-preset.sh.
-_PRESET_OS_LABEL: dict[tuple[str, str], str] = {
-    ("openclaw", "ubuntu"): "debian-bookworm",
-    ("openclaw", "alpine"): "debian-bookworm",
-    ("codex", "ubuntu"): "ubuntu-24.04",
-    ("codex", "alpine"): "alpine-3.20",
-    ("claude-code", "ubuntu"): "ubuntu-24.04",
-    ("claude-code", "alpine"): "alpine-3.20",
-    ("hermes", "ubuntu"): "ubuntu-24.04",
-    ("hermes", "alpine"): "alpine-3.20",
-    ("pi", "ubuntu"): "ubuntu-24.04",
-    ("pi", "alpine"): "alpine-3.20",
-}
-
 
 def _boot_args_for(preset_name: str, vmm: Vmm, arch: Arch) -> str:
     """Resolve boot args for the published-image path.
@@ -2023,7 +2006,9 @@ def _run_start_with_published_image(args: argparse.Namespace, preset: object) ->
                         if isinstance(vm.info.status, VMState)
                         else VMState.RUNNING.value
                     ),
-                    "os": _PRESET_OS_LABEL.get((_preset.name, requested_os.value), "unknown"),
+                    # Mirrors the install-at-boot path so JSON callers see the
+                    # same vocabulary regardless of which path served the boot.
+                    "os": requested_os.value,
                     "backend": backend,
                     "ip_address": network.guest_ip if network else None,
                     "ssh_port": network.ssh_host_port if network else None,

--- a/src/smolvm/cli/main.py
+++ b/src/smolvm/cli/main.py
@@ -414,6 +414,12 @@ def _add_preset_parsers(
             help="Virtualization backend (default: qemu, required by ubuntu).",
         )
         start_p.add_argument(
+            "--os",
+            choices=[guest_os.value for guest_os in GuestOS],
+            default=None,
+            help="Operating system image (default: ubuntu).",
+        )
+        start_p.add_argument(
             "--mount",
             action="append",
             default=None,
@@ -2040,22 +2046,29 @@ def _run_start(args: argparse.Namespace) -> int:
 
     preset = get_preset(args.preset_name)
 
+    # The user-facing default is ubuntu when --os is omitted; an explicit
+    # --os opts the run into install-at-boot since the published-image
+    # manifest only ships one OS per preset today (#264 tracks adding an
+    # OS dimension to the manifest).
+    requested_os = GuestOS(args.os) if args.os is not None else GuestOS.UBUNTU
+
     # Published-image fast path: use a pre-built image from GitHub Releases
     # if one exists for this (preset, arch, vmm) tuple. Falls through to
     # install-at-boot when no manifest entry exists (e.g. presets without
-    # CI-built rootfs).
-    try:
-        arch = _host_arch_for_published()
-        vmm = _vmm_for_host()
-    except RuntimeError:
-        pass
-    else:
-        requested_backend = args.backend or "auto"
-        published_backend = _VMM_TO_BACKEND[vmm]
-        if requested_backend in {"auto", published_backend} and is_preset_published(
-            preset.name, arch, vmm
-        ):
-            return _run_start_with_published_image(args, preset)
+    # CI-built rootfs) or the user pinned a specific --os.
+    if args.os is None:
+        try:
+            arch = _host_arch_for_published()
+            vmm = _vmm_for_host()
+        except RuntimeError:
+            pass
+        else:
+            requested_backend = args.backend or "auto"
+            published_backend = _VMM_TO_BACKEND[vmm]
+            if requested_backend in {"auto", published_backend} and is_preset_published(
+                preset.name, arch, vmm
+            ):
+                return _run_start_with_published_image(args, preset)
 
     backend = args.backend or "qemu"
     if backend != "qemu":
@@ -2083,7 +2096,7 @@ def _run_start(args: argparse.Namespace) -> int:
                 build_fn=lambda on_download: _build_auto_config(
                     vm_name=args.name,
                     name_prefix=preset.name,
-                    os=GuestOS.UBUNTU,
+                    os=requested_os,
                     backend=backend,
                     memory=memory_mib,
                     disk_size_mib=disk_size_mib,
@@ -2104,7 +2117,7 @@ def _run_start(args: argparse.Namespace) -> int:
             config, ssh_key_path = _build_auto_config(
                 vm_name=args.name,
                 name_prefix=preset.name,
-                os=GuestOS.UBUNTU,
+                os=requested_os,
                 backend=backend,
                 memory=memory_mib,
                 disk_size_mib=disk_size_mib,
@@ -2134,7 +2147,7 @@ def _run_start(args: argparse.Namespace) -> int:
                     if isinstance(vm.info.status, VMState)
                     else VMState.RUNNING.value
                 ),
-                "os": GuestOS.UBUNTU.value,
+                "os": requested_os.value,
                 "backend": vm.info.config.backend or "auto",
                 "ip_address": network.guest_ip if network else None,
                 "ssh_port": network.ssh_host_port if network else None,

--- a/src/smolvm/images/published.py
+++ b/src/smolvm/images/published.py
@@ -37,7 +37,7 @@ from __future__ import annotations
 from pathlib import Path
 from typing import Literal
 
-from pydantic import BaseModel
+from pydantic import BaseModel, ConfigDict
 
 from smolvm import __version__
 from smolvm.exceptions import ImageError
@@ -76,7 +76,10 @@ class PublishedImage(BaseModel):
     rootfs_url: str
     rootfs_sha256: str
 
-    model_config = {"frozen": True}
+    # ``extra="forbid"`` rejects unknown fields at construction so a typo
+    # in a manifest row (e.g. ``kernel_shaa256=...``) fails loudly instead
+    # of being silently ignored and shipping an unverified image.
+    model_config = ConfigDict(frozen=True, extra="forbid", strict=True)
 
 
 class BaseKernel(BaseModel):
@@ -103,7 +106,7 @@ class BaseKernel(BaseModel):
     image_url: str
     image_sha256: str
 
-    model_config = {"frozen": True}
+    model_config = ConfigDict(frozen=True, extra="forbid", strict=True)
 
     def url_for(self, fmt: KernelFormat) -> str:
         return self.elf_url if fmt == "elf" else self.image_url

--- a/src/smolvm/images/published.py
+++ b/src/smolvm/images/published.py
@@ -48,11 +48,20 @@ Preset = Literal["codex", "claude-code", "openclaw", "hermes", "pi"]
 # ``libkrun`` is reserved here for a future spike — manifest accepts the type
 # but the CLI never resolves a host to it until libkrun support is wired.
 Vmm = Literal["firecracker", "qemu", "libkrun"]
+# Guest OS the rootfs was built from. Ubuntu 24.04 is the historical default;
+# Alpine 3.20 is the smaller-footprint opt-in (~half the size, faster boot)
+# rolled out on a per-preset basis — see issue #264.
+Os = Literal["ubuntu", "alpine"]
 # Kernel binary format. Firecracker requires "elf" (uncompressed ELF
 # vmlinux); QEMU on aarch64 virt only boots "image" (the Linux ARM64 boot
 # protocol — bzImage on x86, Image on arm64). Same kernel source build
 # produces both as a side effect, so we ship both per arch.
 KernelFormat = Literal["elf", "image"]
+
+# Manifest key: ``(preset, arch, vmm, os)``. The OS dimension was added in
+# the Alpine rollout — same kernel boots both flavours, only the rootfs
+# differs, so no extra kernel artifacts ship per OS.
+ManifestKey = tuple[Preset, Arch, Vmm, Os]
 
 
 class PublishedImage(BaseModel):
@@ -61,6 +70,7 @@ class PublishedImage(BaseModel):
     preset: Preset
     arch: Arch
     vmm: Vmm
+    os: Os
     kernel_url: str
     kernel_sha256: str
     rootfs_url: str
@@ -124,28 +134,41 @@ class BaseKernel(BaseModel):
 IMAGES_RELEASE_TAG = "images-v0.0.14a0"
 
 
-def cache_name(preset: Preset, arch: Arch, vmm: Vmm, version: str = __version__) -> str:
+def cache_name(
+    preset: Preset, arch: Arch, vmm: Vmm, version: str = __version__, *, os: Os = "ubuntu"
+) -> str:
     """Cache directory name under ``~/.smolvm/images/``.
 
     Keyed on the **CLI** version (not the images tag) so a CLI upgrade
     invalidates local caches even when the images tag hasn't moved —
     avoids serving a stale ``.ext4`` decompressed from the prior CLI's
     decompression sidecar.
+
+    OS suffix is omitted for Ubuntu so existing on-disk caches from before
+    the OS dimension was added stay valid; Alpine adds an explicit suffix.
+    ``os`` is keyword-only so existing positional callers (with ``version``
+    as the 4th argument) keep working.
     """
-    return f"{preset}-v{version}-{arch}-{vmm}"
+    base = f"{preset}-v{version}-{arch}-{vmm}"
+    return base if os == "ubuntu" else f"{base}-{os}"
 
 
-def _release_asset_url(preset: Preset, arch: Arch, suffix: str) -> str:
+def _release_asset_url(preset: Preset, arch: Arch, suffix: str, os: Os = "ubuntu") -> str:
     """Construct the post-publish GH Releases asset URL for one artifact.
 
     Once the draft at :data:`IMAGES_RELEASE_TAG` is published, GH Releases
     serves assets at this canonical URL (drafts use a temporary
     ``untagged-*`` slug — these URLs only resolve after publish).
+
+    Naming asymmetry: Ubuntu assets keep the ``{preset}-{arch}-{suffix}``
+    shape they had before the OS dimension landed, so the existing release
+    artifacts stay reachable. Alpine assets carry an explicit ``-alpine-``
+    segment. ``scripts/ci/build-preset.sh`` mirrors this on the upload side.
     """
-    return (
-        f"https://github.com/CelestoAI/SmolVM/releases/download/"
-        f"{IMAGES_RELEASE_TAG}/{preset}-{arch}-{suffix}"
+    slug = (
+        f"{preset}-{arch}-{suffix}" if os == "ubuntu" else f"{preset}-{arch}-{os}-{suffix}"
     )
+    return f"https://github.com/CelestoAI/SmolVM/releases/download/{IMAGES_RELEASE_TAG}/{slug}"
 
 
 def _release_kernel_url(arch: Arch, fmt: KernelFormat) -> str:
@@ -202,16 +225,19 @@ def _kernel_format_for_vmm(vmm: Vmm) -> KernelFormat:
 # BASE_KERNELS entry's format-for-vmm so a single CI run is the source of
 # truth for every kernel SHA. Rootfs SHAs come from build-published-images.yml
 # CI for the matching tag.
-def _manifest_row(preset: Preset, arch: Arch, vmm: Vmm, rootfs_sha256: str) -> PublishedImage:
+def _manifest_row(
+    preset: Preset, arch: Arch, vmm: Vmm, os: Os, rootfs_sha256: str
+) -> PublishedImage:
     base = BASE_KERNELS[arch]
     fmt = _kernel_format_for_vmm(vmm)
     return PublishedImage(
         preset=preset,
         arch=arch,
         vmm=vmm,
+        os=os,
         kernel_url=base.url_for(fmt),
         kernel_sha256=base.sha256_for(fmt),
-        rootfs_url=_release_asset_url(preset, arch, "rootfs.ext4.zst"),
+        rootfs_url=_release_asset_url(preset, arch, "rootfs.ext4.zst", os=os),
         rootfs_sha256=rootfs_sha256,
     )
 
@@ -232,25 +258,42 @@ _PI_ARM64_ROOTFS_SHA = "6d3aaa5379e70243b583f7c75e428aa84f0b5140483507d4e48855ea
 
 
 def _preset_rows(
-    preset: Preset, amd64_sha: str, arm64_sha: str
-) -> dict[tuple[Preset, Arch, Vmm], PublishedImage]:
-    """Generate all (preset, arch, vmm) manifest rows for a single preset."""
+    preset: Preset, amd64_sha: str, arm64_sha: str, *, os: Os = "ubuntu"
+) -> dict[ManifestKey, PublishedImage]:
+    """Generate all (preset, arch, vmm) manifest rows for a single preset.
+
+    Each call produces 6 rows (2 archs × 3 vmms) for one OS flavour.
+    Adding an Alpine variant for a preset means a second call with
+    ``os="alpine"`` and the matching SHAs from CI.
+    """
     vmms: tuple[Vmm, ...] = ("firecracker", "qemu", "libkrun")
     archs: tuple[Arch, ...] = ("amd64", "arm64")
     shas: dict[Arch, str] = {"amd64": amd64_sha, "arm64": arm64_sha}
-    rows: dict[tuple[Preset, Arch, Vmm], PublishedImage] = {}
+    rows: dict[ManifestKey, PublishedImage] = {}
     for arch in archs:
         for vmm in vmms:
-            rows[(preset, arch, vmm)] = _manifest_row(preset, arch, vmm, shas[arch])
+            rows[(preset, arch, vmm, os)] = _manifest_row(preset, arch, vmm, os, shas[arch])
     return rows
 
 
-MANIFEST: dict[tuple[Preset, Arch, Vmm], PublishedImage] = {
+# Alpine rootfs SHAs are populated after the first successful run of
+# ``build-published-images.yml`` against this :data:`IMAGES_RELEASE_TAG`.
+# Until then the Alpine ``_preset_rows`` calls below stay commented so the
+# manifest doesn't reference URLs whose SHA we can't verify. Phase 1 of
+# #264 covers codex/claude-code/pi only — hermes is excluded in CI for
+# musllinux compatibility reasons; openclaw uses a separate builder.
+
+MANIFEST: dict[ManifestKey, PublishedImage] = {
+    # Ubuntu rows — historical default, no naming change in URL.
     **_preset_rows("openclaw", _OPENCLAW_AMD64_ROOTFS_SHA, _OPENCLAW_ARM64_ROOTFS_SHA),
     **_preset_rows("codex", _CODEX_AMD64_ROOTFS_SHA, _CODEX_ARM64_ROOTFS_SHA),
     **_preset_rows("claude-code", _CLAUDE_CODE_AMD64_ROOTFS_SHA, _CLAUDE_CODE_ARM64_ROOTFS_SHA),
     **_preset_rows("hermes", _HERMES_AMD64_ROOTFS_SHA, _HERMES_ARM64_ROOTFS_SHA),
     **_preset_rows("pi", _PI_AMD64_ROOTFS_SHA, _PI_ARM64_ROOTFS_SHA),
+    # Alpine rows — add once CI publishes ``<preset>-<arch>-alpine-rootfs.ext4.zst``
+    # under :data:`IMAGES_RELEASE_TAG` and we have SHAs to pin against.
+    # Until then, ``smolvm <preset> start --os alpine`` falls through to
+    # install-at-boot via the local Docker builder.
 }
 
 
@@ -258,17 +301,18 @@ def lookup(
     preset: Preset,
     arch: Arch,
     vmm: Vmm,
+    os: Os = "ubuntu",
     *,
-    manifest: dict[tuple[Preset, Arch, Vmm], PublishedImage] | None = None,
+    manifest: dict[ManifestKey, PublishedImage] | None = None,
 ) -> PublishedImage:
     """Look up a manifest entry, raising :class:`ImageError` if missing."""
     catalog = MANIFEST if manifest is None else manifest
-    entry = catalog.get((preset, arch, vmm))
+    entry = catalog.get((preset, arch, vmm, os))
     if entry is None:
-        available = ", ".join(sorted(f"{p}/{a}/{v}" for (p, a, v) in catalog)) or "(none)"
+        available = ", ".join(sorted(f"{p}/{a}/{v}/{o}" for (p, a, v, o) in catalog)) or "(none)"
         raise ImageError(
             f"No published image for preset '{preset}' on arch '{arch}' under "
-            f"vmm '{vmm}' (available: {available})."
+            f"vmm '{vmm}' with os '{os}' (available: {available})."
         )
     return entry
 
@@ -277,10 +321,11 @@ def is_preset_published(
     preset: str,
     arch: Arch,
     vmm: Vmm,
+    os: Os = "ubuntu",
     *,
-    manifest: dict[tuple[Preset, Arch, Vmm], PublishedImage] | None = None,
+    manifest: dict[ManifestKey, PublishedImage] | None = None,
 ) -> bool:
-    """Return whether a published image is registered for ``(preset, arch, vmm)``.
+    """Return whether a published image is registered for ``(preset, arch, vmm, os)``.
 
     Used by the CLI dispatch to decide whether to take the fast published-image
     path or fall back to install-at-boot. Accepts an arbitrary preset string so
@@ -288,7 +333,7 @@ def is_preset_published(
     don't appear in the manifest just return ``False``.
     """
     catalog = MANIFEST if manifest is None else manifest
-    return (preset, arch, vmm) in catalog  # type: ignore[comparison-overlap]
+    return (preset, arch, vmm, os) in catalog  # type: ignore[comparison-overlap]
 
 
 def to_image_source(entry: PublishedImage, version: str = __version__) -> ImageSource:
@@ -301,7 +346,7 @@ def to_image_source(entry: PublishedImage, version: str = __version__) -> ImageS
     """
     rootfs_filename = "rootfs.ext4.zst" if entry.rootfs_url.endswith(".zst") else "rootfs.ext4"
     return ImageSource(
-        name=cache_name(entry.preset, entry.arch, entry.vmm, version),
+        name=cache_name(entry.preset, entry.arch, entry.vmm, version, os=entry.os),
         kernel_url=entry.kernel_url,
         kernel_sha256=entry.kernel_sha256,
         rootfs_url=entry.rootfs_url,
@@ -327,9 +372,10 @@ def ensure_published_image(
     preset: Preset,
     arch: Arch,
     vmm: Vmm,
+    os: Os = "ubuntu",
     *,
     cache_dir: Path | None = None,
-    manifest: dict[tuple[Preset, Arch, Vmm], PublishedImage] | None = None,
+    manifest: dict[ManifestKey, PublishedImage] | None = None,
     version: str = __version__,
 ) -> LocalImage:
     """Download (if needed) and return paths to a published preset image.
@@ -340,6 +386,8 @@ def ensure_published_image(
         vmm: Hypervisor variant the image was built for (``"firecracker"``,
             ``"qemu"``, or ``"libkrun"``). Caller must pre-resolve this from
             host platform — this module is policy-free.
+        os: Guest operating system flavour the rootfs was built from
+            (``"ubuntu"`` or ``"alpine"``). Defaults to ``"ubuntu"``.
         cache_dir: Override the default cache directory (mainly for tests).
         manifest: Override the bundled manifest (mainly for tests).
         version: Override the CLI version used to compute the cache name.
@@ -352,10 +400,10 @@ def ensure_published_image(
         produced lazily.
 
     Raises:
-        ImageError: If no manifest entry exists for the (preset, arch, vmm)
-            tuple, or if download / SHA-256 verification fails.
+        ImageError: If no manifest entry exists for the (preset, arch, vmm,
+            os) tuple, or if download / SHA-256 verification fails.
     """
-    entry = lookup(preset, arch, vmm, manifest=manifest)
+    entry = lookup(preset, arch, vmm, os, manifest=manifest)
     source = to_image_source(entry, version=version)
     manager = ImageManager(cache_dir=cache_dir, registry={source.name: source})
     local = manager.ensure_image(source.name)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -2879,15 +2879,30 @@ class TestPublishedImageLaunchPath:
         called_args = mock_published_path.call_args[0]
         assert called_args[1].name == "openclaw"
 
+    @patch("smolvm.utils.ensure_ssh_key")
     @patch("smolvm.cli.main.platform.system", return_value="Linux")
     @patch("smolvm.images.published.ensure_published_image")
     def test_published_path_surfaces_missing_manifest_error(
         self,
         mock_ensure: MagicMock,
         _mock_system: MagicMock,
+        mock_ensure_ssh_key: MagicMock,
+        tmp_path: Path,
     ) -> None:
-        """An empty manifest entry should produce a clean CLI error, not a crash."""
+        """An empty manifest entry should produce a clean CLI error, not a crash.
+
+        ``ensure_ssh_key`` is mocked because the published-image launch
+        path resolves keys before the manifest lookup runs; on hosts
+        without ssh-keygen on PATH the test would fail there instead of
+        reaching the ImageError it's meant to verify.
+        """
         from smolvm.exceptions import ImageError
+
+        priv = tmp_path / "id_ed25519"
+        pub = tmp_path / "id_ed25519.pub"
+        priv.touch()
+        pub.write_text("ssh-ed25519 AAAAExampleKey test@host\n")
+        mock_ensure_ssh_key.return_value = (priv, pub)
 
         mock_ensure.side_effect = ImageError(
             "No published image for preset 'openclaw' on arch 'amd64' (available: (none))."

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -3013,7 +3013,7 @@ class TestPublishedImageLaunchPath:
             mock_apply.assert_not_called()
 
         assert ret == 0
-        mock_ensure_image.assert_called_once_with("openclaw", expected_arch, expected_vmm)
+        mock_ensure_image.assert_called_once_with("openclaw", expected_arch, expected_vmm, "ubuntu")
 
         # Verify VMConfig was built with the right wiring.
         config_arg = mock_vm_cls.call_args[0][0]

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -2481,7 +2481,7 @@ class TestCliStart:
     @patch("smolvm.cli.main._apply_preset_with_progress")
     @patch("smolvm.facade._build_auto_config")
     @patch("smolvm.facade.SmolVM")
-    def test_start_with_alpine_os(
+    def test_start_alpine_falls_through_to_install_at_boot(
         self,
         mock_vm_cls: MagicMock,
         mock_build_auto_config: MagicMock,
@@ -2489,8 +2489,9 @@ class TestCliStart:
         _mock_is_published: MagicMock,
         capsys: pytest.CaptureFixture,
     ) -> None:
-        """`smolvm claude-code start --os alpine` should boot alpine and skip
-        the published-image fast-path (which is OS-fixed today)."""
+        """When no Alpine row is published yet, ``--os alpine`` must thread
+        the OS through ``_build_auto_config`` (install-at-boot path) and
+        echo the flag value back in the JSON envelope."""
         from smolvm.types import GuestOS
 
         config = MagicMock(vm_id="sbx-claude")
@@ -2503,28 +2504,55 @@ class TestCliStart:
             "injected_env_keys": [],
         }
 
-        # Patch the published-image entry-point so a stale openclaw row in
-        # the manifest can't lure this run into the fast path.
-        with patch("smolvm.cli.main._run_start_with_published_image") as mock_published:
-            mock_published.return_value = 0
-            ret = main(
-                [
-                    "claude-code",
-                    "start",
-                    "--name",
-                    "sbx-claude",
-                    "--os",
-                    "alpine",
-                    "--json",
-                ]
-            )
+        ret = main(
+            [
+                "claude-code",
+                "start",
+                "--name",
+                "sbx-claude",
+                "--os",
+                "alpine",
+                "--json",
+            ]
+        )
 
         assert ret == 0
-        mock_published.assert_not_called()
         kwargs = mock_build_auto_config.call_args.kwargs
         assert kwargs["os"] is GuestOS.ALPINE
         payload = json.loads(capsys.readouterr().out)
         assert payload["data"]["vm"]["os"] == "alpine"
+
+    @patch("smolvm.cli.main._run_start_with_published_image", return_value=0)
+    @patch("smolvm.images.published.is_preset_published")
+    def test_start_alpine_uses_published_fast_path_when_available(
+        self,
+        mock_is_published: MagicMock,
+        mock_published_path: MagicMock,
+    ) -> None:
+        """When an Alpine row IS published, ``--os alpine`` must route
+        through the fast path with ``os="alpine"`` — same routing logic as
+        Ubuntu, just keyed on the user's flag.
+
+        Returning True only for the alpine query verifies the OS argument
+        is actually flowing into ``is_preset_published`` (not just lost
+        somewhere upstream).
+        """
+
+        def _published_only_for_alpine(
+            preset: str, arch: object, vmm: object, os: str, *, manifest: object = None
+        ) -> bool:
+            return os == "alpine" and preset == "claude-code"
+
+        mock_is_published.side_effect = _published_only_for_alpine
+
+        ret = main(["claude-code", "start", "--os", "alpine", "--json"])
+
+        assert ret == 0
+        mock_published_path.assert_called_once()
+        # is_preset_published was called with ``os="alpine"`` — locks the
+        # routing in even if a future refactor reorders the kwargs.
+        last_call = mock_is_published.call_args
+        assert "alpine" in last_call.args or last_call.kwargs.get("os") == "alpine"
 
     @patch("smolvm.images.published.is_preset_published", return_value=False)
     @patch("smolvm.cli.main._apply_preset_with_progress")

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -2486,6 +2486,7 @@ class TestCliStart:
         mock_vm_cls: MagicMock,
         mock_build_auto_config: MagicMock,
         mock_apply: MagicMock,
+        _mock_is_published: MagicMock,
         capsys: pytest.CaptureFixture,
     ) -> None:
         """`smolvm claude-code start --os alpine` should boot alpine and skip
@@ -2525,6 +2526,7 @@ class TestCliStart:
         payload = json.loads(capsys.readouterr().out)
         assert payload["data"]["vm"]["os"] == "alpine"
 
+    @patch("smolvm.images.published.is_preset_published", return_value=False)
     @patch("smolvm.cli.main._apply_preset_with_progress")
     @patch("smolvm.facade._build_auto_config")
     @patch("smolvm.facade.SmolVM")
@@ -2533,6 +2535,7 @@ class TestCliStart:
         mock_vm_cls: MagicMock,
         mock_build_auto_config: MagicMock,
         mock_apply: MagicMock,
+        _mock_is_published: MagicMock,
     ) -> None:
         """Omitting --os keeps the historical Ubuntu default for presets."""
         from smolvm.types import GuestOS
@@ -2564,6 +2567,7 @@ class TestCliStart:
         assert exc_info.value.code == 2
         assert "invalid choice" in capsys.readouterr().err
 
+    @patch("smolvm.images.published.is_preset_published", return_value=False)
     @patch("smolvm.cli.main._apply_preset_with_progress")
     @patch("smolvm.facade._build_auto_config")
     @patch("smolvm.facade.SmolVM")

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -2505,6 +2505,92 @@ class TestCliStart:
     @patch("smolvm.cli.main._apply_preset_with_progress")
     @patch("smolvm.facade._build_auto_config")
     @patch("smolvm.facade.SmolVM")
+    def test_start_with_alpine_os(
+        self,
+        mock_vm_cls: MagicMock,
+        mock_build_auto_config: MagicMock,
+        mock_apply: MagicMock,
+        capsys: pytest.CaptureFixture,
+    ) -> None:
+        """`smolvm claude-code start --os alpine` should boot alpine and skip
+        the published-image fast-path (which is OS-fixed today)."""
+        from smolvm.types import GuestOS
+
+        config = MagicMock(vm_id="sbx-claude")
+        mock_build_auto_config.return_value = (config, "/tmp/id_ed25519")
+        vm = self._make_vm_mock("sbx-claude")
+        mock_vm_cls.return_value = vm
+        mock_apply.return_value = {
+            "preset": "claude-code",
+            "copied_configs": [],
+            "injected_env_keys": [],
+        }
+
+        # Patch the published-image entry-point so a stale openclaw row in
+        # the manifest can't lure this run into the fast path.
+        with patch("smolvm.cli.main._run_start_with_published_image") as mock_published:
+            mock_published.return_value = 0
+            ret = main(
+                [
+                    "claude-code",
+                    "start",
+                    "--name",
+                    "sbx-claude",
+                    "--os",
+                    "alpine",
+                    "--json",
+                ]
+            )
+
+        assert ret == 0
+        mock_published.assert_not_called()
+        kwargs = mock_build_auto_config.call_args.kwargs
+        assert kwargs["os"] is GuestOS.ALPINE
+        payload = json.loads(capsys.readouterr().out)
+        assert payload["data"]["vm"]["os"] == "alpine"
+
+    @patch("smolvm.cli.main._apply_preset_with_progress")
+    @patch("smolvm.facade._build_auto_config")
+    @patch("smolvm.facade.SmolVM")
+    def test_start_default_os_is_ubuntu(
+        self,
+        mock_vm_cls: MagicMock,
+        mock_build_auto_config: MagicMock,
+        mock_apply: MagicMock,
+    ) -> None:
+        """Omitting --os keeps the historical Ubuntu default for presets."""
+        from smolvm.types import GuestOS
+
+        config = MagicMock(vm_id="sbx-claude")
+        mock_build_auto_config.return_value = (config, "/tmp/id_ed25519")
+        vm = self._make_vm_mock("sbx-claude")
+        mock_vm_cls.return_value = vm
+        mock_apply.return_value = {
+            "preset": "claude-code",
+            "copied_configs": [],
+            "injected_env_keys": [],
+        }
+
+        ret = main(["claude-code", "start", "--name", "sbx-claude"])
+
+        assert ret == 0
+        kwargs = mock_build_auto_config.call_args.kwargs
+        assert kwargs["os"] is GuestOS.UBUNTU
+
+    def test_start_invalid_os_choice(
+        self,
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        """Argparse should reject unsupported --os values for preset start."""
+        with pytest.raises(SystemExit) as exc_info:
+            main(["codex", "start", "--os", "fedora"])
+
+        assert exc_info.value.code == 2
+        assert "invalid choice" in capsys.readouterr().err
+
+    @patch("smolvm.cli.main._apply_preset_with_progress")
+    @patch("smolvm.facade._build_auto_config")
+    @patch("smolvm.facade.SmolVM")
     def test_start_claude_code_overrides_memory(
         self,
         mock_vm_cls: MagicMock,

--- a/tests/test_facade.py
+++ b/tests/test_facade.py
@@ -222,11 +222,25 @@ class TestVMInit:
         assert created_config.ssh_public_key == pubkey_value
 
 
+    @patch("smolvm.utils.ensure_ssh_key")
     def test_autoconfigure_ubuntu_rejects_undersized_disk(
         self,
+        mock_ensure_ssh_key: MagicMock,
         tmp_path: Path,
     ) -> None:
-        """Ubuntu should reject --disk-size below the default."""
+        """Ubuntu should reject --disk-size below the default.
+
+        ``ensure_ssh_key`` is mocked because the validation we're checking
+        runs after key resolution today; without the mock the test fails
+        early on hosts where ssh-keygen isn't on PATH (CI sandboxes,
+        minimal containers) and never reaches the disk-size check.
+        """
+        priv = tmp_path / "id_ed25519"
+        pub = tmp_path / "id_ed25519.pub"
+        priv.touch()
+        pub.write_text("ssh-ed25519 AAAAExampleKey test@host\n")
+        mock_ensure_ssh_key.return_value = (priv, pub)
+
         with pytest.raises(ValueError, match="disk_size_mib >= 2048"):
             _build_auto_config(os="ubuntu", backend="qemu", disk_size_mib=512)
 

--- a/tests/test_published_images.py
+++ b/tests/test_published_images.py
@@ -256,6 +256,34 @@ class TestToImageSource:
             version="0.0.13",
         )
 
+    def test_name_uses_cache_name_for_alpine_entry(self) -> None:
+        """Alpine entries must round-trip through cache_name with os='alpine'
+        so the on-disk cache namespace matches what to_image_source produces."""
+        entry = PublishedImage(
+            preset="codex",
+            arch="amd64",
+            vmm="firecracker",
+            os="alpine",
+            kernel_url="https://example.com/codex-amd64-vmlinux.bin",
+            kernel_sha256=hashlib.sha256(b"fake-kernel").hexdigest(),
+            rootfs_url="https://example.com/codex-amd64-alpine-rootfs.ext4",
+            rootfs_sha256=hashlib.sha256(b"fake-rootfs").hexdigest(),
+        )
+        source = to_image_source(entry, version="0.0.13")
+        assert source.name == cache_name(
+            entry.preset,
+            entry.arch,
+            entry.vmm,
+            version="0.0.13",
+            os="alpine",
+        )
+        # And the alpine and ubuntu cache names must differ for the same
+        # (preset, arch, vmm) — otherwise running both flavours would
+        # silently share rootfs files on disk.
+        assert source.name != cache_name(
+            entry.preset, entry.arch, entry.vmm, version="0.0.13", os="ubuntu"
+        )
+
 
 class TestEnsurePublishedImage:
     def test_returns_cached_without_download(

--- a/tests/test_published_images.py
+++ b/tests/test_published_images.py
@@ -29,9 +29,9 @@ from smolvm.images.published import (
     MANIFEST,
     Arch,
     BaseKernel,
+    ManifestKey,
     Preset,
     PublishedImage,
-    Vmm,
     _decompress_zstd,
     cache_name,
     ensure_base_kernel,
@@ -54,6 +54,7 @@ def sample_entry() -> PublishedImage:
         preset="codex",
         arch="amd64",
         vmm="firecracker",
+        os="ubuntu",
         kernel_url="https://example.com/codex-amd64-vmlinux.bin",
         kernel_sha256=hashlib.sha256(b"fake-kernel").hexdigest(),
         rootfs_url="https://example.com/codex-amd64-rootfs.ext4",
@@ -64,8 +65,10 @@ def sample_entry() -> PublishedImage:
 @pytest.fixture
 def sample_manifest(
     sample_entry: PublishedImage,
-) -> dict[tuple[Preset, Arch, Vmm], PublishedImage]:
-    return {(sample_entry.preset, sample_entry.arch, sample_entry.vmm): sample_entry}
+) -> dict[ManifestKey, PublishedImage]:
+    return {
+        (sample_entry.preset, sample_entry.arch, sample_entry.vmm, sample_entry.os): sample_entry
+    }
 
 
 class TestNaming:
@@ -96,25 +99,47 @@ class TestNaming:
         qe = cache_name("openclaw", "amd64", "qemu", version="0.0.13")
         assert fc != qe
 
+    def test_cache_name_ubuntu_omits_os_suffix(self) -> None:
+        """Ubuntu cache names stay backward-compatible (no -ubuntu segment)
+        so an existing on-disk cache from before the OS dimension landed
+        is still picked up without forcing a re-download."""
+        assert (
+            cache_name("codex", "amd64", "firecracker", version="0.0.13", os="ubuntu")
+            == "codex-v0.0.13-amd64-firecracker"
+        )
+
+    def test_cache_name_alpine_appends_os_suffix(self) -> None:
+        """Alpine cache namespace is distinct from Ubuntu so users running
+        both flavours don't share rootfs files."""
+        assert (
+            cache_name("codex", "amd64", "firecracker", version="0.0.13", os="alpine")
+            == "codex-v0.0.13-amd64-firecracker-alpine"
+        )
+
+    def test_cache_name_distinguishes_os_flavors(self) -> None:
+        ubu = cache_name("codex", "amd64", "firecracker", version="0.0.13", os="ubuntu")
+        alp = cache_name("codex", "amd64", "firecracker", version="0.0.13", os="alpine")
+        assert ubu != alp
+
 
 class TestLookup:
     def test_returns_matching_entry(
         self,
         sample_entry: PublishedImage,
-        sample_manifest: dict[tuple[Preset, Arch, Vmm], PublishedImage],
+        sample_manifest: dict[ManifestKey, PublishedImage],
     ) -> None:
         assert lookup("codex", "amd64", "firecracker", manifest=sample_manifest) is sample_entry
 
     def test_missing_pair_raises_image_error(
         self,
-        sample_manifest: dict[tuple[Preset, Arch, Vmm], PublishedImage],
+        sample_manifest: dict[ManifestKey, PublishedImage],
     ) -> None:
         with pytest.raises(ImageError, match="No published image for preset 'codex'"):
             lookup("codex", "arm64", "firecracker", manifest=sample_manifest)
 
     def test_error_lists_available_tuples(
         self,
-        sample_manifest: dict[tuple[Preset, Arch, Vmm], PublishedImage],
+        sample_manifest: dict[ManifestKey, PublishedImage],
     ) -> None:
         with pytest.raises(ImageError, match="codex/amd64/firecracker"):
             lookup("openclaw", "amd64", "firecracker", manifest=sample_manifest)
@@ -125,7 +150,7 @@ class TestLookup:
 
     def test_error_mentions_vmm_dimension(
         self,
-        sample_manifest: dict[tuple[Preset, Arch, Vmm], PublishedImage],
+        sample_manifest: dict[ManifestKey, PublishedImage],
     ) -> None:
         """Looking up a vmm that doesn't exist names it explicitly."""
         with pytest.raises(ImageError, match=r"vmm 'qemu'"):
@@ -143,29 +168,47 @@ class TestLookup:
         with pytest.raises(ImageError, match="No published image"):
             lookup("definitely-not-a-real-preset", "arm64", "firecracker")  # type: ignore[arg-type]
 
+    def test_default_os_is_ubuntu(
+        self,
+        sample_entry: PublishedImage,
+        sample_manifest: dict[ManifestKey, PublishedImage],
+    ) -> None:
+        """Calling lookup without specifying os defaults to ubuntu."""
+        # sample_entry has os="ubuntu", so the no-os call must hit it.
+        assert lookup("codex", "amd64", "firecracker", manifest=sample_manifest) is sample_entry
+
+    def test_alpine_lookup_misses_when_only_ubuntu_published(
+        self,
+        sample_manifest: dict[ManifestKey, PublishedImage],
+    ) -> None:
+        """Asking for alpine when only ubuntu is in the manifest must
+        raise — falls through to install-at-boot at the CLI layer."""
+        with pytest.raises(ImageError, match=r"os 'alpine'"):
+            lookup("codex", "amd64", "firecracker", "alpine", manifest=sample_manifest)
+
 
 class TestIsPresetPublished:
     def test_true_for_registered_entry(
         self,
-        sample_manifest: dict[tuple[Preset, Arch, Vmm], PublishedImage],
+        sample_manifest: dict[ManifestKey, PublishedImage],
     ) -> None:
         assert is_preset_published("codex", "amd64", "firecracker", manifest=sample_manifest)
 
     def test_false_for_missing_arch(
         self,
-        sample_manifest: dict[tuple[Preset, Arch, Vmm], PublishedImage],
+        sample_manifest: dict[ManifestKey, PublishedImage],
     ) -> None:
         assert not is_preset_published("codex", "arm64", "firecracker", manifest=sample_manifest)
 
     def test_false_for_missing_vmm(
         self,
-        sample_manifest: dict[tuple[Preset, Arch, Vmm], PublishedImage],
+        sample_manifest: dict[ManifestKey, PublishedImage],
     ) -> None:
         assert not is_preset_published("codex", "amd64", "qemu", manifest=sample_manifest)
 
     def test_false_for_unknown_preset(
         self,
-        sample_manifest: dict[tuple[Preset, Arch, Vmm], PublishedImage],
+        sample_manifest: dict[ManifestKey, PublishedImage],
     ) -> None:
         # Accepts arbitrary preset strings so the CLI doesn't need to coerce
         # against the Preset literal before dispatching.
@@ -175,7 +218,7 @@ class TestIsPresetPublished:
 
     def test_accepts_arbitrary_preset_string(
         self,
-        sample_manifest: dict[tuple[Preset, Arch, Vmm], PublishedImage],
+        sample_manifest: dict[ManifestKey, PublishedImage],
     ) -> None:
         # Presets that aren't in the Preset literal must just return False, not
         # raise — the CLI passes user-typed preset names straight through.
@@ -191,9 +234,9 @@ class TestIsPresetPublished:
         # must report True, and a guaranteed-missing tuple must report False.
         if not MANIFEST:
             pytest.skip("default manifest is empty in this release")
-        preset, arch, vmm = next(iter(MANIFEST))
-        assert is_preset_published(preset, arch, vmm)
-        assert not is_preset_published("definitely-not-a-real-preset", arch, vmm)
+        preset, arch, vmm, os = next(iter(MANIFEST))
+        assert is_preset_published(preset, arch, vmm, os)
+        assert not is_preset_published("definitely-not-a-real-preset", arch, vmm, os)
 
 
 class TestToImageSource:
@@ -218,7 +261,7 @@ class TestEnsurePublishedImage:
     def test_returns_cached_without_download(
         self,
         tmp_path: Path,
-        sample_manifest: dict[tuple[Preset, Arch, Vmm], PublishedImage],
+        sample_manifest: dict[ManifestKey, PublishedImage],
     ) -> None:
         version = "0.0.13"
         image_dir = tmp_path / cache_name("codex", "amd64", "firecracker", version=version)
@@ -246,7 +289,7 @@ class TestEnsurePublishedImage:
         self,
         mock_get: MagicMock,
         tmp_path: Path,
-        sample_manifest: dict[tuple[Preset, Arch, Vmm], PublishedImage],
+        sample_manifest: dict[ManifestKey, PublishedImage],
     ) -> None:
         version = "0.0.13"
         bodies = [b"fake-kernel", b"fake-rootfs"]
@@ -279,7 +322,7 @@ class TestEnsurePublishedImage:
     def test_unknown_tuple_raises_before_touching_filesystem(
         self,
         tmp_path: Path,
-        sample_manifest: dict[tuple[Preset, Arch, Vmm], PublishedImage],
+        sample_manifest: dict[ManifestKey, PublishedImage],
     ) -> None:
         with pytest.raises(ImageError, match="No published image"):
             ensure_published_image(
@@ -312,12 +355,13 @@ class TestEnsurePublishedImage:
             (image_dir / "rootfs.ext4").write_bytes(b"shared-rootfs")
 
         # Build a manifest with both vmm rows pointing at distinct kernel URLs.
-        manifest: dict[tuple[Preset, Arch, Vmm], PublishedImage] = {}
+        manifest: dict[ManifestKey, PublishedImage] = {}
         for vmm in ("firecracker", "qemu"):
-            manifest[("codex", "amd64", vmm)] = PublishedImage(  # type: ignore[index]
+            manifest[("codex", "amd64", vmm, "ubuntu")] = PublishedImage(  # type: ignore[index]
                 preset="codex",
                 arch="amd64",
                 vmm=vmm,  # type: ignore[arg-type]
+                os="ubuntu",
                 kernel_url=f"https://example.com/codex-{vmm}-kernel",
                 kernel_sha256=hashlib.sha256(f"kernel-{vmm}".encode()).hexdigest(),
                 rootfs_url="https://example.com/codex-rootfs.ext4",
@@ -375,6 +419,7 @@ class TestZstdDecompression:
             preset="codex",
             arch="amd64",
             vmm="firecracker",
+            os="ubuntu",
             kernel_url="https://example.com/codex-amd64-vmlinux.bin",
             kernel_sha256=hashlib.sha256(kernel_bytes).hexdigest(),
             rootfs_url="https://example.com/codex-amd64-rootfs.ext4.zst",
@@ -390,7 +435,7 @@ class TestZstdDecompression:
         tmp_path: Path,
     ) -> None:
         entry, kernel_bytes, rootfs_zst, rootfs_plain = compressed_entry
-        manifest = {(entry.preset, entry.arch, entry.vmm): entry}
+        manifest = {(entry.preset, entry.arch, entry.vmm, entry.os): entry}
         bodies = [kernel_bytes, rootfs_zst]
         call = {"i": 0}
 
@@ -429,7 +474,7 @@ class TestZstdDecompression:
     ) -> None:
         """Second call must not re-download AND not re-decompress."""
         entry, kernel_bytes, rootfs_zst, rootfs_plain = compressed_entry
-        manifest = {(entry.preset, entry.arch, entry.vmm): entry}
+        manifest = {(entry.preset, entry.arch, entry.vmm, entry.os): entry}
 
         # Pre-populate the cache: compressed file + decompressed sibling +
         # the SHA sidecar that keys the decompressed file to the .zst's
@@ -469,7 +514,7 @@ class TestZstdDecompression:
         against: the openclaw rootfs uid bake regression hid behind a
         cached decompressed .ext4 even after the .zst was re-fetched."""
         entry, kernel_bytes, rootfs_zst, rootfs_plain = compressed_entry
-        manifest = {(entry.preset, entry.arch, entry.vmm): entry}
+        manifest = {(entry.preset, entry.arch, entry.vmm, entry.os): entry}
 
         image_dir = tmp_path / cache_name(entry.preset, entry.arch, entry.vmm, "0.0.13")
         image_dir.mkdir(parents=True)
@@ -498,7 +543,7 @@ class TestZstdDecompression:
         self,
         mock_get: MagicMock,
         sample_entry: PublishedImage,
-        sample_manifest: dict[tuple[Preset, Arch, Vmm], PublishedImage],
+        sample_manifest: dict[ManifestKey, PublishedImage],
         tmp_path: Path,
     ) -> None:
         """A non-.zst rootfs URL must not invoke the decompressor."""
@@ -586,13 +631,12 @@ class TestBaseKernels:
         """
         from smolvm.images.published import _kernel_format_for_vmm
 
-        for (_preset, arch, vmm), row in MANIFEST.items():
+        for key, row in MANIFEST.items():
+            _preset, arch, vmm, _os = key
             base = BASE_KERNELS[arch]
             fmt = _kernel_format_for_vmm(vmm)
-            assert row.kernel_url == base.url_for(fmt), f"{(_preset, arch, vmm)} kernel_url drift"
-            assert row.kernel_sha256 == base.sha256_for(fmt), (
-                f"{(_preset, arch, vmm)} kernel_sha256 drift"
-            )
+            assert row.kernel_url == base.url_for(fmt), f"{key} kernel_url drift"
+            assert row.kernel_sha256 == base.sha256_for(fmt), f"{key} kernel_sha256 drift"
 
     def test_ensure_base_kernel_unknown_arch_raises(self, tmp_path: Path) -> None:
         with pytest.raises(ImageError, match="No base kernel registered"):
@@ -646,8 +690,8 @@ class TestBundledManifest:
     """Sanity checks for the entries hand-populated in MANIFEST."""
 
     def test_openclaw_amd64_firecracker_entry_shape(self) -> None:
-        entry = MANIFEST.get(("openclaw", "amd64", "firecracker"))
-        assert entry is not None, "openclaw/amd64/firecracker must be in the bundled manifest"
+        entry = MANIFEST.get(("openclaw", "amd64", "firecracker", "ubuntu"))
+        assert entry is not None, "openclaw/amd64/firecracker/ubuntu must be in MANIFEST"
         assert len(entry.rootfs_sha256) == 64  # SHA-256 hex
         assert len(entry.kernel_sha256) == 64
         assert entry.rootfs_url.endswith("openclaw-amd64-rootfs.ext4.zst")
@@ -656,7 +700,7 @@ class TestBundledManifest:
         assert "images-v" in entry.rootfs_url
 
     def test_openclaw_arm64_firecracker_entry_shape(self) -> None:
-        entry = MANIFEST.get(("openclaw", "arm64", "firecracker"))
+        entry = MANIFEST.get(("openclaw", "arm64", "firecracker", "ubuntu"))
         assert entry is not None
         assert len(entry.rootfs_sha256) == 64
         assert entry.rootfs_url.endswith("openclaw-arm64-rootfs.ext4.zst")
@@ -664,15 +708,15 @@ class TestBundledManifest:
 
     def test_openclaw_qemu_rows_use_image_format(self) -> None:
         """QEMU rows must use the Image-format kernel — see _kernel_format_for_vmm."""
-        amd_qemu = MANIFEST[("openclaw", "amd64", "qemu")]
-        arm_qemu = MANIFEST[("openclaw", "arm64", "qemu")]
+        amd_qemu = MANIFEST[("openclaw", "amd64", "qemu", "ubuntu")]
+        arm_qemu = MANIFEST[("openclaw", "arm64", "qemu", "ubuntu")]
         assert amd_qemu.kernel_url.endswith("vmlinux-amd64.image")
         assert arm_qemu.kernel_url.endswith("vmlinux-arm64.image")
 
     def test_arches_have_distinct_rootfs_shas(self) -> None:
         """Sanity: copy-paste error would give both arches the same rootfs SHA."""
-        amd = MANIFEST[("openclaw", "amd64", "firecracker")]
-        arm = MANIFEST[("openclaw", "arm64", "firecracker")]
+        amd = MANIFEST[("openclaw", "amd64", "firecracker", "ubuntu")]
+        arm = MANIFEST[("openclaw", "arm64", "firecracker", "ubuntu")]
         assert amd.rootfs_sha256 != arm.rootfs_sha256
         assert amd.rootfs_url != arm.rootfs_url
 
@@ -688,18 +732,19 @@ class TestBundledManifest:
             )
 
     def test_entry_field_matches_manifest_key(self) -> None:
-        """The fields on each row must match the (preset, arch, vmm) tuple it lives under."""
-        for (preset, arch, vmm), entry in MANIFEST.items():
-            key = (preset, arch, vmm)
+        """The fields on each row must match the (preset, arch, vmm, os) tuple it lives under."""
+        for key, entry in MANIFEST.items():
+            preset, arch, vmm, os = key
             assert entry.preset == preset, f"row at {key} has preset={entry.preset!r}"
             assert entry.arch == arch, f"row at {key} has arch={entry.arch!r}"
             assert entry.vmm == vmm, f"row at {key} has vmm={entry.vmm!r}"
+            assert entry.os == os, f"row at {key} has os={entry.os!r}"
 
     def test_rootfs_sha_is_consistent_across_vmm_variants(self) -> None:
-        """For any (preset, arch), all vmm rows must share the same rootfs SHA.
+        """For any (preset, arch, os), all vmm rows must share the same rootfs SHA.
 
         Rationale: the rootfs is filesystem-format only — VMM-agnostic. Different
-        vmm rows for the same (preset, arch) point at the SAME rootfs file. If
+        vmm rows for the same (preset, arch, os) point at the SAME rootfs file. If
         someone updates only the firecracker row's SHA after a rootfs rebuild
         and forgets the qemu row, downloads silently 404 (or worse, mismatch).
         This test catches that.
@@ -709,21 +754,24 @@ class TestBundledManifest:
         VMM), this assertion needs revisiting along with the "shared rootfs"
         design assumption.
         """
-        by_preset_arch: dict[tuple[Preset, Arch], list[PublishedImage]] = defaultdict(list)
-        for (preset, arch, _vmm), entry in MANIFEST.items():
-            by_preset_arch[(preset, arch)].append(entry)
+        from smolvm.images.published import Os
 
-        for (preset, arch), entries in by_preset_arch.items():
+        by_preset_arch_os: dict[tuple[Preset, Arch, Os], list[PublishedImage]] = defaultdict(list)
+        for key, entry in MANIFEST.items():
+            preset, arch, _vmm, os = key
+            by_preset_arch_os[(preset, arch, os)].append(entry)
+
+        for (preset, arch, os), entries in by_preset_arch_os.items():
             if len(entries) < 2:
                 continue  # nothing to compare
             shas = {e.rootfs_sha256 for e in entries}
             urls = {e.rootfs_url for e in entries}
             assert len(shas) == 1, (
-                f"{preset}/{arch}: rootfs SHAs differ across vmm rows: {sorted(shas)}. "
+                f"{preset}/{arch}/{os}: rootfs SHAs differ across vmm rows: {sorted(shas)}. "
                 f"Likely one row was updated after a rootfs rebuild and another wasn't."
             )
             assert len(urls) == 1, (
-                f"{preset}/{arch}: rootfs URLs differ across vmm rows: {sorted(urls)}."
+                f"{preset}/{arch}/{os}: rootfs URLs differ across vmm rows: {sorted(urls)}."
             )
 
 


### PR DESCRIPTION
## Summary

Added support for an `--os` flag to the `preset start` command, allowing users to specify the guest operating system (alpine or ubuntu) when starting a VM. When `--os` is explicitly provided, the command skips the published-image fast path and performs a full install-at-boot, since the published-image manifest currently only ships one OS per preset. When omitted, the default remains Ubuntu for backward compatibility.

## Related Issues

- Relates to #264 (tracking OS dimension in manifest)

## Changes

- Added `--os` argument to preset start parser with choices for supported GuestOS values
- Modified `_run_start()` to:
  - Parse the `--os` argument and default to Ubuntu when omitted
  - Skip the published-image fast path when `--os` is explicitly specified
  - Pass the requested OS to `_build_auto_config()` instead of hardcoding Ubuntu
  - Include the requested OS in JSON output
- Added three new test cases:
  - `test_start_with_alpine_os`: Verifies alpine OS selection skips published-image path
  - `test_start_default_os_is_ubuntu`: Confirms Ubuntu remains the default when `--os` is omitted
  - `test_start_invalid_os_choice`: Validates argparse rejects unsupported OS values

## Testing

- `uv run pytest tests/test_cli.py::TestCLI::test_start_with_alpine_os`
- `uv run pytest tests/test_cli.py::TestCLI::test_start_default_os_is_ubuntu`
- `uv run pytest tests/test_cli.py::TestCLI::test_start_invalid_os_choice`
- `uv run pytest tests/test_cli.py` (full test suite)
- `uv run ruff check .`
- `uv run mypy src`

## Checklist

- [x] Scope is focused and limited to this change
- [x] Tests added/updated for behavior changes
- [ ] Docs updated for user-visible changes (help text added to argparse)
- [x] No secrets or sensitive data included

https://claude.ai/code/session_017PWcHRbUQox8cwbnEiS1xQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a --os option to choose Ubuntu or Alpine for preset launches; published-image resolution and presets are OS-aware.

* **Chores**
  * CI/build pipeline now produces OS-specific base and preset artifacts with OS-aware naming, per-OS sizing and image shrinking.
  * Alpine runtime variants added for lower resource usage.

* **Tests**
  * Expanded test coverage for OS-aware published/start flows and manifest resolution.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->