### PR TITLE
chore: drop debian from GuestOS enum and auto-config paths

### DIFF
--- a/src/smolvm/cli/main.py
+++ b/src/smolvm/cli/main.py
@@ -1343,7 +1343,7 @@ def _run_list(*, include_all: bool, status_filter: str | None, json_output: bool
             return _emit_cli_error("list", 1, exc, json_output=json_output)
 
 
-_OS_HINT_KEYWORDS = ("ubuntu", "debian", "alpine")
+_OS_HINT_KEYWORDS = ("ubuntu", "alpine")
 
 
 def _guess_os_from_paths(vm: VMInfo) -> str | None:
@@ -1680,12 +1680,12 @@ def _run_create(args: argparse.Namespace) -> int:
                 "an S3 image is fixed by the image itself."
             )
 
-        # CLI default: roomier disk for debian/ubuntu so package installs
+        # CLI default: roomier disk for ubuntu so package installs
         # and apt cache don't fill the rootfs on a basic `smolvm create`.
         if (
             not use_s3_image
             and args.disk_size_mib is None
-            and resolved_guest_os in {GuestOS.DEBIAN, GuestOS.UBUNTU}
+            and resolved_guest_os is GuestOS.UBUNTU
         ):
             args.disk_size_mib = 4096
 

--- a/src/smolvm/facade.py
+++ b/src/smolvm/facade.py
@@ -86,12 +86,10 @@ _LOCAL_TUNNEL_START_TIMEOUT = 10.0
 _LOCAL_FORWARD_MAX_PORT_ATTEMPTS = 10
 _AUTO_CONFIG_DEFAULT_MEM_SIZE_MIB = {
     GuestOS.ALPINE: 512,
-    GuestOS.DEBIAN: 512,
     GuestOS.UBUNTU: 1024,
 }
 _AUTO_CONFIG_DEFAULT_DISK_SIZE_MIB = {
     GuestOS.ALPINE: 512,
-    GuestOS.DEBIAN: 2048,
     GuestOS.UBUNTU: 2048,
 }
 _UBUNTU_CURRENT_RELEASE_DATE = "20260406"
@@ -107,37 +105,6 @@ _QEMU_UBUNTU_AUTO_IMAGES: dict[str, str] = {
     "ubuntu-noble-minimal-qemu-aarch64": (
         "https://cloud-images.ubuntu.com/minimal/releases/noble/release/"
         "ubuntu-24.04-minimal-cloudimg-arm64.img"
-    ),
-}
-
-# Debian "genericcloud" is a single bootable qcow2 with the kernel + initrd
-# inside — no separate unpacked assets like Ubuntu publishes. SmolVM uses
-# firmware boot (OVMF/SeaBIOS) for this image, so only the rootfs URL matters.
-#
-# Pinned to a specific dated release (immutable URL) and verified against the
-# upstream SHA-512 digest from that release's SHA512SUMS file. Note the
-# filename inside the dated directory carries the build identifier
-# (e.g. ``-20260413-2447``); only the ``latest/`` symlink view exposes the
-# short un-suffixed name. We pin to the dated path for immutability, so the
-# filename here MUST include the build suffix.
-#
-# To bump:
-#   1. Pick a newer build under https://cloud.debian.org/images/cloud/bookworm/
-#   2. Copy the SHA-512 hex digests from its SHA512SUMS file into this registry
-#   3. Update both the URL build suffix and the _DEBIAN_CURRENT_RELEASE_TAG
-#   4. Verify the partition layout is still a single ext4 partition before
-#      committing — cloud-init growpart assumes this for the disk-resize path
-_DEBIAN_CURRENT_RELEASE_TAG = "20260413-2447"
-_DEBIAN_AUTO_IMAGES: dict[str, tuple[str, str]] = {
-    "debian-bookworm-genericcloud-qemu-x86_64": (
-        f"https://cloud.debian.org/images/cloud/bookworm/{_DEBIAN_CURRENT_RELEASE_TAG}/debian-12-genericcloud-amd64-{_DEBIAN_CURRENT_RELEASE_TAG}.qcow2",
-        "db11b13c4efcc37828ffadae521d101e85079d349e1418074087bb7d306f11ca"
-        "ccdc2b0b539d6fd50d623d40a898f83c6137268a048d7700397dc35b7dcbc927",
-    ),
-    "debian-bookworm-genericcloud-qemu-aarch64": (
-        f"https://cloud.debian.org/images/cloud/bookworm/{_DEBIAN_CURRENT_RELEASE_TAG}/debian-12-genericcloud-arm64-{_DEBIAN_CURRENT_RELEASE_TAG}.qcow2",
-        "15ad6c52e255c84eb0e91001c5907b27199d8a7164d8ac172cfe9c92850dfaf6"
-        "06a6c3161d6af7f0fd5a5fef2aa8dcd9a23c2eb0fedbfcddb38e2bc306cba98f",
     ),
 }
 
@@ -168,8 +135,6 @@ def _qemu_auto_config_image_name(guest_os: GuestOS = GuestOS.UBUNTU) -> str:
     image_arch = "aarch64" if arch in {"arm64", "aarch64"} else "x86_64"
     if guest_os is GuestOS.UBUNTU:
         return f"ubuntu-noble-minimal-qemu-{image_arch}"
-    if guest_os is GuestOS.DEBIAN:
-        return f"debian-bookworm-genericcloud-qemu-{image_arch}"
     raise ValueError(f"No prebuilt QEMU auto-config image for guest OS: {guest_os}")
 
 
@@ -564,81 +529,6 @@ def _build_auto_config(
         )
         return config, resolved_ssh_key_path
 
-    # Debian on QEMU: fetch the upstream genericcloud qcow2 and boot it via
-    # firmware (OVMF/SeaBIOS). On non-QEMU backends (firecracker, libkrun),
-    # fall through to the docker-build path below.
-    if resolved_os is GuestOS.DEBIAN and resolved_backend == BACKEND_QEMU:
-        if resolved_disk_size_mib < default_disk_size_mib:
-            raise ValueError(
-                f"debian auto-config on qemu requires disk_size_mib >= {default_disk_size_mib} "
-                f"(got {resolved_disk_size_mib})"
-            )
-        image_name = _qemu_auto_config_image_name(GuestOS.DEBIAN)
-        debian_entry = _DEBIAN_AUTO_IMAGES.get(image_name)
-        if debian_entry is None:
-            raise SmolVMError(
-                "No prebuilt Debian image registered for this host architecture",
-                {"image_name": image_name},
-            )
-        rootfs_url, rootfs_sha512 = debian_entry
-        image_manager = ImageManager()
-        pristine_rootfs = image_manager.ensure_rootfs_only(
-            image_name,
-            url=rootfs_url,
-            filename="rootfs.qcow2",
-            sha512=rootfs_sha512,
-            on_download=on_download,
-        )
-
-        if resolved_disk_size_mib > default_disk_size_mib:
-            rootfs_path, _resolved_size = _prepare_sized_qcow2(
-                cache_dir=image_manager.cache_dir,
-                base_image_name=image_name,
-                source_qcow2=pristine_rootfs,
-                target_mib=resolved_disk_size_mib,
-            )
-        else:
-            rootfs_path = pristine_rootfs
-
-        user_data = default_user_data(public_key_value)
-        seed_key = seed_cache_key(
-            ssh_public_key=public_key_value,
-            instance_id=f"smolvm-debian-{_DEBIAN_CURRENT_RELEASE_TAG}",
-            hostname="smolvm",
-            user_data=user_data,
-        )
-        seed_dir = image_manager.cache_dir / "cloud-init-seeds"
-        seed_path = seed_dir / f"{seed_key}.iso"
-        if not seed_path.exists():
-            build_seed_iso(
-                seed_path,
-                user_data=user_data,
-                meta_data=default_meta_data(
-                    instance_id=f"smolvm-debian-{_DEBIAN_CURRENT_RELEASE_TAG}",
-                    hostname="smolvm",
-                ),
-            )
-
-        resolved_vm_name = _resolve_vm_name(vm_name, prefix=name_prefix)
-        config = VMConfig(
-            vm_id=resolved_vm_name,
-            vcpu_count=1,
-            memory=resolved_memory,
-            boot_mode="firmware",
-            kernel_path=None,
-            rootfs_path=rootfs_path,
-            extra_drives=[seed_path],
-            ssh_capable=True,
-            backend=resolved_backend,
-        )
-        logger.info(
-            "Auto-configured VM: %s (os=%s, backend=%s, source=prebuilt-debian-firmware)",
-            resolved_vm_name,
-            resolved_os.value,
-            resolved_backend,
-        )
-        return config, resolved_ssh_key_path
-
     kernel_profile = KernelBootProfile.MICROVM_DIRECT
     boot_args = get_boot_profile_spec(kernel_profile).base_boot_args_for_backend(
         resolved_backend,
@@ -658,22 +548,13 @@ def _build_auto_config(
     kernel_fmt = _kernel_format_for_vmm(resolved_backend)  # type: ignore[arg-type]
     base_kernel_url = BASE_KERNELS[to_published_arch(platform.machine())].url_for(kernel_fmt)
 
-    if resolved_os is GuestOS.DEBIAN:
-        kernel, rootfs = builder.build_debian_ssh_key(
-            public_key_path,
-            name=image_name,
-            rootfs_size_mb=resolved_disk_size_mib,
-            kernel_profile=kernel_profile,
-            kernel_url=base_kernel_url,
-        )
-    else:
-        kernel, rootfs = builder.build_alpine_ssh_key(
-            public_key_path,
-            name=image_name,
-            rootfs_size_mb=resolved_disk_size_mib,
-            kernel_profile=kernel_profile,
-            kernel_url=base_kernel_url,
-        )
+    kernel, rootfs = builder.build_alpine_ssh_key(
+        public_key_path,
+        name=image_name,
+        rootfs_size_mb=resolved_disk_size_mib,
+        kernel_profile=kernel_profile,
+        kernel_url=base_kernel_url,
+    )
 
     resolved_vm_name = _resolve_vm_name(vm_name, prefix=name_prefix)
     config = VMConfig(
@@ -722,7 +603,7 @@ class SmolVM:
         data_dir: Override the default data directory.
         socket_dir: Override the default socket directory.
         backend: Runtime backend override (``firecracker``, ``qemu``, or ``auto``).
-        os: Guest OS for auto-config mode (``"alpine"`` or ``"debian"``).
+        os: Guest OS for auto-config mode (``"alpine"`` or ``"ubuntu"``).
         memory: Guest memory in MiB for auto-config mode (``SmolVM()`` only).
         disk_size: Root filesystem size in MiB for auto-config mode (``SmolVM()`` only).
         ssh_user: SSH user for :meth:`run` (default ``root``).
@@ -1656,7 +1537,7 @@ class SmolVM:
            boot path brings up SSH (used by prebuilt cloud images, S3
            images, and firmware-boot VMs).
         2. A microvm direct-kernel boot with ``init=/init`` in the kernel
-           command line (the alpine/debian docker-build path).
+           command line (the alpine docker-build path).
         3. A legacy initrd-backed boot with ``ssh_capable`` implicitly set.
         """
         config = self._info.config

--- a/src/smolvm/types.py
+++ b/src/smolvm/types.py
@@ -50,7 +50,6 @@ class GuestOS(str, Enum):
     """Supported guest operating systems for auto-configured VMs."""
 
     ALPINE = "alpine"
-    DEBIAN = "debian"
     UBUNTU = "ubuntu"
 
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -669,40 +669,6 @@ class TestCliCreate:
 
     @patch("smolvm.facade._build_auto_config")
     @patch("smolvm.facade.SmolVM")
-    def test_create_with_debian_os(
-        self,
-        mock_vm_cls: MagicMock,
-        mock_build_auto_config: MagicMock,
-        capsys: pytest.CaptureFixture,
-    ) -> None:
-        """`smolvm create --os debian` should thread the OS into auto-config."""
-        config = MagicMock(vm_id="project-spacex")
-        mock_build_auto_config.return_value = (config, "/tmp/id_ed25519")
-
-        vm = MagicMock()
-        vm.vm_id = "project-spacex"
-        vm.info.config.backend = "qemu"
-        vm.info.network = MagicMock(spec=NetworkConfig)
-        vm.info.network.guest_ip = "172.16.0.2"
-        vm.info.network.ssh_host_port = 2200
-        mock_vm_cls.return_value = vm
-
-        ret = main(["create", "--name", "project-spacex", "--os", "debian", "--json"])
-
-        assert ret == 0
-        mock_build_auto_config.assert_called_once_with(
-            vm_name="project-spacex",
-            os="debian",
-            backend=None,
-            memory=None,
-            disk_size_mib=4096,
-            ssh_key_path=None,
-        )
-        payload = json.loads(capsys.readouterr().out)
-        assert payload["data"]["vm"]["os"] == "debian"
-
-    @patch("smolvm.facade._build_auto_config")
-    @patch("smolvm.facade.SmolVM")
     def test_create_alpine_does_not_get_disk_size_default(
         self,
         mock_vm_cls: MagicMock,

--- a/tests/test_facade.py
+++ b/tests/test_facade.py
@@ -26,7 +26,7 @@ from smolvm.exceptions import (
 )
 from smolvm.facade import SmolVM, _build_auto_config
 from smolvm.images.cloud_init import seed_cache_key
-from smolvm.types import GuestOS, VMConfig, VMState
+from smolvm.types import VMConfig, VMState
 
 
 @pytest.fixture
@@ -221,193 +221,6 @@ class TestVMInit:
         created_config = mock_sdk.create.call_args[0][0]
         assert created_config.ssh_public_key == pubkey_value
 
-    @patch("smolvm.facade.SmolVMManager")
-    @patch("smolvm.images.builder.ImageBuilder")
-    @patch("smolvm.utils.ensure_ssh_key")
-    def test_autoconfigure_with_debian_firecracker_uses_debian_builder(
-        self,
-        mock_ensure_ssh_key: MagicMock,
-        mock_builder_cls: MagicMock,
-        mock_sdk_cls: MagicMock,
-        tmp_path: Path,
-    ) -> None:
-        """Debian on firecracker should still use the docker-build fallback."""
-        kernel = tmp_path / "auto-kernel"
-        rootfs = tmp_path / "auto-rootfs.ext4"
-        private_key = tmp_path / "id_ed25519"
-        public_key = tmp_path / "id_ed25519.pub"
-        kernel.touch()
-        rootfs.touch()
-        private_key.touch()
-        public_key.write_text("ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIMockKey user@test\n")
-
-        mock_ensure_ssh_key.return_value = (private_key, public_key)
-        mock_builder = MagicMock()
-        mock_builder.build_debian_ssh_key.return_value = (kernel, rootfs)
-        mock_builder_cls.return_value = mock_builder
-
-        mock_sdk = MagicMock()
-        mock_sdk.create.return_value = MagicMock(vm_id="vm001", status=VMState.CREATED)
-        mock_sdk_cls.return_value = mock_sdk
-
-        vm = SmolVM(os="debian", backend="firecracker")
-
-        assert vm.vm_id.startswith("sbx-")
-        mock_builder.build_debian_ssh_key.assert_called_once()
-        assert mock_builder.build_debian_ssh_key.call_args.args[0] == public_key
-        assert mock_builder.build_debian_ssh_key.call_args.kwargs["rootfs_size_mb"] == 2048
-        mock_builder.build_alpine_ssh_key.assert_not_called()
-        created_config = mock_sdk.create.call_args[0][0]
-        assert created_config.memory == 512
-        assert created_config.boot_mode == "direct_kernel"
-
-    @patch("smolvm.facade.SmolVMManager")
-    @patch("smolvm.images.builder.ImageBuilder")
-    @patch("smolvm.utils.ensure_ssh_key")
-    def test_autoconfigure_with_debian_enum_works(
-        self,
-        mock_ensure_ssh_key: MagicMock,
-        mock_builder_cls: MagicMock,
-        mock_sdk_cls: MagicMock,
-        tmp_path: Path,
-    ) -> None:
-        """GuestOS enum values should work for auto-config."""
-        kernel = tmp_path / "auto-kernel"
-        rootfs = tmp_path / "auto-rootfs.ext4"
-        private_key = tmp_path / "id_ed25519"
-        public_key = tmp_path / "id_ed25519.pub"
-        kernel.touch()
-        rootfs.touch()
-        private_key.touch()
-        public_key.write_text("ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIMockKey user@test\n")
-
-        mock_ensure_ssh_key.return_value = (private_key, public_key)
-        mock_builder = MagicMock()
-        mock_builder.build_debian_ssh_key.return_value = (kernel, rootfs)
-        mock_builder_cls.return_value = mock_builder
-
-        mock_sdk = MagicMock()
-        mock_sdk.create.return_value = MagicMock(vm_id="vm001", status=VMState.CREATED)
-        mock_sdk_cls.return_value = mock_sdk
-
-        SmolVM(os=GuestOS.DEBIAN, backend="firecracker")
-
-        mock_builder.build_debian_ssh_key.assert_called_once()
-
-    @patch("smolvm.images.builder.ImageBuilder")
-    @patch("smolvm.utils.ensure_ssh_key")
-    def test_build_auto_config_debian_firecracker_disk_override(
-        self,
-        mock_ensure_ssh_key: MagicMock,
-        mock_builder_cls: MagicMock,
-        tmp_path: Path,
-    ) -> None:
-        """Explicit disk sizes should override Debian defaults on firecracker."""
-        kernel = tmp_path / "auto-kernel"
-        rootfs = tmp_path / "auto-rootfs.ext4"
-        private_key = tmp_path / "id_ed25519"
-        public_key = tmp_path / "id_ed25519.pub"
-        kernel.touch()
-        rootfs.touch()
-        private_key.touch()
-        public_key.write_text("ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIMockKey user@test\n")
-
-        mock_ensure_ssh_key.return_value = (private_key, public_key)
-        mock_builder = MagicMock()
-        mock_builder.build_debian_ssh_key.return_value = (kernel, rootfs)
-        mock_builder_cls.return_value = mock_builder
-
-        _build_auto_config(os="debian", backend="firecracker", disk_size_mib=4096)
-
-        assert mock_builder.build_debian_ssh_key.call_args.kwargs["rootfs_size_mb"] == 4096
-
-    @patch("smolvm.facade._prepare_sized_qcow2")
-    @patch("smolvm.facade.ImageManager")
-    @patch("smolvm.images.builder.ImageBuilder")
-    @patch("smolvm.utils.ensure_ssh_key")
-    def test_autoconfigure_debian_qemu_uses_prebuilt_firmware_boot(
-        self,
-        mock_ensure_ssh_key: MagicMock,
-        mock_builder_cls: MagicMock,
-        mock_image_manager_cls: MagicMock,
-        mock_prepare_sized: MagicMock,
-        tmp_path: Path,
-    ) -> None:
-        """Debian on qemu should fetch the prebuilt qcow2 and use firmware boot."""
-        private_key = tmp_path / "id_ed25519"
-        public_key = tmp_path / "id_ed25519.pub"
-        private_key.touch()
-        public_key.write_text("ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIMockKey user@test\n")
-
-        pristine_rootfs = tmp_path / "debian-rootfs.qcow2"
-        pristine_rootfs.touch()
-
-        mock_ensure_ssh_key.return_value = (private_key, public_key)
-
-        mock_image_manager = MagicMock()
-        mock_image_manager.cache_dir = tmp_path / "cache"
-        mock_image_manager.ensure_rootfs_only.return_value = pristine_rootfs
-        mock_image_manager_cls.return_value = mock_image_manager
-
-        # _prepare_sized_qcow2 returns the same path when target == default.
-        mock_prepare_sized.return_value = (pristine_rootfs, 2048)
-
-        mock_builder_cls.return_value = MagicMock()
-
-        config, _ = _build_auto_config(os="debian", backend="qemu")
-
-        # Prebuilt path, not the docker fallback.
-        mock_image_manager.ensure_rootfs_only.assert_called_once()
-        mock_builder_cls.return_value.build_debian_ssh_key.assert_not_called()
-
-        assert config.boot_mode == "firmware"
-        assert config.kernel_path is None
-        assert config.rootfs_path == pristine_rootfs
-        assert len(config.extra_drives) == 1  # cloud-init seed ISO
-        assert config.extra_drives[0].suffix == ".iso"
-        assert config.backend == "qemu"
-
-    @patch("smolvm.facade._prepare_sized_qcow2")
-    @patch("smolvm.facade.ImageManager")
-    @patch("smolvm.utils.ensure_ssh_key")
-    def test_autoconfigure_debian_qemu_disk_override_triggers_resize(
-        self,
-        mock_ensure_ssh_key: MagicMock,
-        mock_image_manager_cls: MagicMock,
-        mock_prepare_sized: MagicMock,
-        tmp_path: Path,
-    ) -> None:
-        """--disk-size on debian/qemu should be forwarded to resize helper."""
-        private_key = tmp_path / "id_ed25519"
-        public_key = tmp_path / "id_ed25519.pub"
-        private_key.touch()
-        public_key.write_text("ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIMockKey user@test\n")
-
-        pristine = tmp_path / "pristine.qcow2"
-        sized = tmp_path / "sized.qcow2"
-        pristine.touch()
-        sized.touch()
-
-        mock_ensure_ssh_key.return_value = (private_key, public_key)
-        mock_image_manager = MagicMock()
-        mock_image_manager.cache_dir = tmp_path / "cache"
-        mock_image_manager.ensure_rootfs_only.return_value = pristine
-        mock_image_manager_cls.return_value = mock_image_manager
-        mock_prepare_sized.return_value = (sized, 4096)
-
-        config, _ = _build_auto_config(os="debian", backend="qemu", disk_size_mib=4096)
-
-        mock_prepare_sized.assert_called_once()
-        assert mock_prepare_sized.call_args.kwargs["target_mib"] == 4096
-        assert config.rootfs_path == sized
-
-    def test_autoconfigure_debian_qemu_rejects_undersized_disk(
-        self,
-        tmp_path: Path,
-    ) -> None:
-        """Debian/qemu should reject --disk-size below the default."""
-        with pytest.raises(ValueError, match="disk_size_mib >= 2048"):
-            _build_auto_config(os="debian", backend="qemu", disk_size_mib=1024)
 
     def test_autoconfigure_ubuntu_rejects_undersized_disk(
         self,
@@ -477,47 +290,19 @@ class TestVMInit:
         with pytest.raises(ValueError, match="auto-config mode"):
             SmolVM(sample_config, memory=1024)
 
-    def test_debian_pinned_urls_carry_build_suffix(self) -> None:
-        """Each pinned Debian URL must include the build tag in the filename.
-
-        Debian's dated release directories (e.g. ``bookworm/20260413-2447/``)
-        store files with the build tag *in the filename*, like
-        ``debian-12-genericcloud-arm64-20260413-2447.qcow2``. Only the
-        ``latest/`` symlink view exposes the un-suffixed short names. Pinning
-        to a dated directory with a short filename produces a 404 — this test
-        catches that exact mistake on a future bump.
-        """
-        from smolvm.facade import _DEBIAN_AUTO_IMAGES, _DEBIAN_CURRENT_RELEASE_TAG
-
-        assert _DEBIAN_AUTO_IMAGES, "_DEBIAN_AUTO_IMAGES must not be empty"
-        for image_name, (url, _sha512) in _DEBIAN_AUTO_IMAGES.items():
-            # The dated path must appear in the URL.
-            assert f"/{_DEBIAN_CURRENT_RELEASE_TAG}/" in url, (
-                f"{image_name}: URL missing dated release path "
-                f"{_DEBIAN_CURRENT_RELEASE_TAG!r}: {url}"
-            )
-            # The filename portion must also embed the build tag.
-            filename = url.rsplit("/", 1)[-1]
-            assert _DEBIAN_CURRENT_RELEASE_TAG in filename, (
-                f"{image_name}: filename {filename!r} is missing the build "
-                f"tag {_DEBIAN_CURRENT_RELEASE_TAG!r}. Inside dated release "
-                "directories the filename includes the build identifier; only "
-                "the 'latest/' symlink view uses the short name."
-            )
-
     def test_os_with_config_raises(self, sample_config: VMConfig) -> None:
         """Guest OS selection is only valid in zero-config mode."""
         with pytest.raises(ValueError, match="auto-config mode"):
-            SmolVM(sample_config, os="debian")
+            SmolVM(sample_config, os="ubuntu")
 
     def test_os_with_vm_id_raises(self) -> None:
         """Guest OS selection should be rejected when reconnecting to a VM."""
         with pytest.raises(ValueError, match="auto-config mode"):
-            SmolVM(vm_id="vm001", os="debian")
+            SmolVM(vm_id="vm001", os="ubuntu")
 
     def test_invalid_os_raises(self) -> None:
         """Unsupported guest OS names should raise a helpful error."""
-        with pytest.raises(ValueError, match="Valid values: alpine, debian, ubuntu"):
+        with pytest.raises(ValueError, match="Valid values: alpine, ubuntu"):
             _build_auto_config(os="fedora")
 
     @patch("smolvm.images.builder.ImageBuilder")
@@ -658,55 +443,6 @@ class TestVMInit:
         assert config.ssh_capable is True
         assert "AAAAC3NzaCustom" in actual_user_data
         mock_ensure_ssh_key.assert_not_called()
-
-    @patch("smolvm.facade.platform.machine", return_value="arm64")
-    @patch("smolvm.facade.build_seed_iso")
-    @patch("smolvm.facade.ImageManager")
-    @patch("smolvm.images.builder.ImageBuilder")
-    @patch("smolvm.utils.ensure_ssh_key")
-    def test_named_debian_auto_config_qemu_uses_prebuilt_image(
-        self,
-        mock_ensure_ssh_key: MagicMock,
-        mock_builder_cls: MagicMock,
-        mock_image_manager_cls: MagicMock,
-        mock_build_seed_iso: MagicMock,
-        _: MagicMock,
-        tmp_path: Path,
-    ) -> None:
-        """Debian on qemu should fetch the prebuilt qcow2 under an aarch64 cache key."""
-        rootfs = tmp_path / "rootfs.qcow2"
-        private_key = tmp_path / "id_ed25519"
-        public_key = tmp_path / "id_ed25519.pub"
-        rootfs.touch()
-        private_key.touch()
-        public_key.write_text("ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIMockKey user@test\n")
-
-        mock_ensure_ssh_key.return_value = (private_key, public_key)
-        mock_build_seed_iso.side_effect = lambda path, **kwargs: (
-            path.parent.mkdir(parents=True, exist_ok=True),
-            path.touch(),
-        )[-1]
-        mock_image_manager = MagicMock()
-        mock_image_manager.cache_dir = tmp_path
-        mock_image_manager.ensure_rootfs_only.return_value = rootfs
-        mock_image_manager_cls.return_value = mock_image_manager
-
-        config, _ = _build_auto_config(vm_name="project-spacex", os="debian", backend="qemu")
-
-        assert config.backend == "qemu"
-        assert config.boot_mode == "firmware"
-        assert config.kernel_path is None
-        assert config.rootfs_path == rootfs
-        assert config.ssh_capable is True
-        # Cloud-init seed ISO is attached.
-        assert config.extra_drives[0].suffix == ".iso"
-        # Prebuilt path, not the docker fallback.
-        mock_builder_cls.return_value.build_debian_ssh_key.assert_not_called()
-        mock_image_manager.ensure_rootfs_only.assert_called_once()
-        assert (
-            mock_image_manager.ensure_rootfs_only.call_args.args[0]
-            == "debian-bookworm-genericcloud-qemu-aarch64"
-        )
 
     @patch("smolvm.facade.SmolVMManager")
     def test_from_id(self, mock_sdk_cls: MagicMock) -> None:

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -537,4 +537,4 @@ def test_guest_os_public_export() -> None:
     """GuestOS should be importable from both public and types modules."""
     assert PublicGuestOS is GuestOS
     assert GuestOS.ALPINE.value == "alpine"
-    assert GuestOS.DEBIAN.value == "debian"
+    assert GuestOS.UBUNTU.value == "ubuntu"


### PR DESCRIPTION
## Why

\`smolvm create --os debian\` advertised a path that's no longer how we ship VMs:
- The QEMU/Debian branch fetched the genericcloud qcow2 from cloud.debian.org and booted via firmware + cloud-init seed
- The non-QEMU/Debian branch built a Debian rootfs from scratch via \`builder.build_debian_ssh_key\`

Both predate the published-image preset flow. Ubuntu is the documented default and what every preset uses. Debian was a parallel surface with its own external CDN dependency, its own cache-bumping protocol, its own test surface.

## Diff

\`\`\`
src/smolvm/types.py             -1
src/smolvm/facade.py           -137 (Debian QEMU branch, _DEBIAN_AUTO_IMAGES, _DEBIAN_CURRENT_RELEASE_TAG, dispatch in _build_auto_config)
src/smolvm/cli/main.py           -6 (_OS_HINT_KEYWORDS, disk-bump)
tests/test_facade.py           -272 (8 deleted Debian tests, plus DEBIAN→UBUNTU in 3 generic tests)
tests/test_cli.py               -34 (test_create_with_debian_os deleted)
tests/test_types.py             -1 (DEBIAN value assertion → UBUNTU)
                                ───
                              ~−418 LoC net
\`\`\`

## What's left as-is

- \`ImageBuilder.build_debian_ssh_key\` method body — orphaned now but still callable programmatically. Removing it touches builder.py + a handful of builder-level tests; out of scope here.
- The auto-config Ubuntu+QEMU path still hits \`cloud-images.ubuntu.com\` — same external-CDN concern as Debian, but with non-trivial fix (publish base rootfs as a release asset, bake \`/init\` in, rewire). Filed as #273.

## Validation

- \`uv run pytest\` — 873 passed, 13 skipped (down from 882, 9 deletions match)
- \`uv run ruff check\` on touched files — clean (3 ruff errors are pre-existing in unrelated lines)
- \`smolvm create --os debian\` now fails with: \`Unsupported guest OS 'debian'. Valid values: alpine, ubuntu.\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Removed Features**
  * Deprecated Debian guest OS support; SmolVM auto-config now exclusively supports Ubuntu and Alpine environments.
  * OS auto-detection no longer recognizes Debian image paths.

* **Changes**
  * Supported operating systems for auto-config mode updated to "ubuntu" or "alpine".
  * Enhanced validation: OS can only be specified during initial VM creation in auto-config mode, not when reconnecting to existing VMs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->