### PR TITLE
[smolvm-core] Rust binding version bump 0.0.11 to 0.0.14

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,7 +28,7 @@ classifiers = [
     "Topic :: System :: Emulators",
 ]
 dependencies = [
-    "smolvm-core~=0.0.11",
+    "smolvm-core~=0.0.14",
     "paramiko>=3.0",
     "pycdlib>=1.14.0",
     "pydantic>=2.0",

--- a/smolvm-core/Cargo.toml
+++ b/smolvm-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "smolvm-core"
-version = "0.0.11"
+version = "0.0.14"
 description = "Rust-native core package for SmolVM"
 documentation = "https://docs.rs/smolvm-core"
 readme = "README.md"


### PR DESCRIPTION
## Summary

Briefly describe what changed and why.

## Related Issues

- Closes #

## Testing

List what you ran locally (or write "not run" with reason).

- `uv run pytest`
- `uv run ruff check .`
- `uv run mypy src`

## Checklist

- [ ] Scope is focused and limited to this change
- [ ] Tests added/updated for behavior changes
- [ ] Docs updated for user-visible changes
- [ ] No secrets or sensitive data included


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Package version advanced to 0.0.14.
  * Project dependency updated to use the new 0.0.14 package release to align versions across the project.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->