### PR TITLE
fix(kernel): enable 9p + overlay for workspace mounts

### DIFF
--- a/kernel/microvm/config.fragment
+++ b/kernel/microvm/config.fragment
@@ -46,6 +46,22 @@ CONFIG_PACKET=y                 # why: AF_PACKET for some userspace tools
 CONFIG_VSOCKETS=y               # why: AF_VSOCK socket family
 CONFIG_VIRTIO_VSOCKETS=y        # why: virtio transport for vsock
 
+# ── Workspace mounts (--mount / --writable-mounts) ───────────────────
+# `smolvm create --mount <host-dir>` shares a host directory into the
+# guest using virtio-9p (a paravirt filesystem that speaks the 9P2000.L
+# protocol over a virtio transport). For read-only host shares the guest
+# stacks overlayfs on top so writes inside the VM stay in a tmpfs upper
+# layer and never leak back to the host.
+#
+# All four must be `=y` because CONFIG_MODULES is not set below — the
+# guest cannot modprobe these in later. Without these, the post-boot
+# `_ensure_9p_workspace_support` probe in facade.py raises
+# "guest is missing 9p or overlay kernel support".
+CONFIG_NET_9P=y                 # why: 9P protocol stack
+CONFIG_NET_9P_VIRTIO=y          # why: 9P over virtio transport (host share)
+CONFIG_9P_FS=y                  # why: VFS layer that mounts a 9P share
+CONFIG_OVERLAY_FS=y             # why: writable scratch over a read-only share
+
 # Note: RANDOM_TRUST_CPU / RANDOM_TRUST_BOOTLOADER are no longer Kconfig
 # symbols (removed during the random.c rewrite). Both are now defaulted
 # ON; override at runtime via the cmdline (random.trust_cpu=off, etc.).


### PR DESCRIPTION
## Summary

- `smolvm create --mount ./` regressed in #258 (universal in-house kernel everywhere): the QEMU+Ubuntu path now boots `kernel/microvm/`'s `vmlinux` instead of Ubuntu's stock kernel, and that fragment was missing `CONFIG_NET_9P` / `CONFIG_NET_9P_VIRTIO` / `CONFIG_9P_FS` / `CONFIG_OVERLAY_FS`. Since the same fragment also sets `# CONFIG_MODULES is not set`, the `_ensure_9p_workspace_support` apt-install fallback can never recover (no module loader, and `uname -r` doesn't match any Ubuntu kernel package). Result: the post-boot probe raises *"guest is missing 9p or overlay kernel support"*.
- Add the four missing symbols to `kernel/microvm/config.fragment` under a new "Workspace mounts" section. Deps (`NET`, `INET`, `VIRTIO`) are already `=y` in the same fragment, so `olddefconfig` has no reason to downgrade them.
- Comment block points back at the `_ensure_9p_workspace_support` probe so the failure mode and the fix stay linked for the next reader.

## Release follow-ups (not in this PR)

This change is source-only. To take effect, the next release needs:

1. CI's *Build microvm Kernel* workflow re-runs and publishes new `vmlinux-{amd64,arm64}.{elf,image}` artifacts.
2. `BASE_KERNELS[*].elf_sha256` / `image_sha256` in `src/smolvm/images/published.py` resynced to the new hashes (same pattern as #266).
3. `IMAGES_RELEASE_TAG` bumped past `images-v0.0.14a0` so existing 0.0.14 installs aren't pinned to the broken kernel.

## Test plan

- [ ] `sudo apt-get install -y flex bison libelf-dev libssl-dev && SMOLVM_VERIFY_ONLY=1 bash kernel/microvm/build.sh` (host where I authored this lacked `flex`, so I couldn't run the verifier locally — needs a clean run before merge).
- [ ] Full kernel build produces both ELF + Image artifacts on amd64 and arm64.
- [ ] `smolvm create --mount ./` with the rebuilt kernel: VM boots, host dir is visible inside the guest, files written through a writable mount appear on the host.
- [ ] Read-only mount (default `--mount`) lets the guest write into the overlay without touching the host directory.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enabled 9P network protocol and virtual I/O transport support for efficient workspace sharing between the host and microVM environments
  * Enabled 9P filesystem support for seamless file operations
  * Added overlay filesystem support to enhance container and storage capabilities within the microVM

<!-- end of auto-generated comment: release notes by coderabbit.ai -->