### PR TITLE
ci: require explicit opt-in to overwrite release assets

### DIFF
--- a/.github/workflows/build-microvm-kernel.yml
+++ b/.github/workflows/build-microvm-kernel.yml
@@ -26,6 +26,16 @@ on:
           published.py.
         type: string
         default: ""
+      force_overwrite:
+        description: >-
+          DANGEROUS. Replace any assets with the same name that already
+          live at this tag. Default false: the upload step fails loud on
+          a collision so an accidental re-run cannot silently swap
+          published bytes the shipped CLI's BASE_KERNELS SHAs depend on.
+          Tick this only for an intentional re-bake of the same tag
+          (e.g. a flaky CI run that needs a redo).
+        type: boolean
+        default: false
   push:
     paths:
       - "kernel/microvm/**"
@@ -137,6 +147,7 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           TAG: ${{ steps.release.outputs.tag }}
           ARCH: ${{ matrix.arch }}
+          FORCE_OVERWRITE: ${{ inputs.force_overwrite }}
         run: |
           # Idempotent draft create. Race between matrix cells handled the
           # same way as build-published-images.yml.
@@ -148,12 +159,20 @@ jobs:
               --notes "Auto-generated draft release for SmolVM published images. Verify SHA-256 sums and content before publishing." \
               || echo "Draft already exists (race with another matrix cell), continuing."
           fi
-          # --clobber overwrites prior artifacts. NOTE: allows silent SHA
-          # drift relative to BASE_KERNELS — drift detection via live SHA
-          # smoke test is a separate workflow.
+          # Default (no --clobber): `gh release upload` returns non-zero
+          # on a same-name collision. Forces the dev to bump
+          # IMAGES_RELEASE_TAG (or pass a fresh `release_tag` input)
+          # rather than silently swapping published bytes that the
+          # shipped CLI's BASE_KERNELS SHAs depend on.
+          # `force_overwrite=true` (workflow_dispatch only — push events
+          # cannot set it) opts back in for intentional re-bakes.
+          upload_args=()
+          if [ "${FORCE_OVERWRITE:-false}" = "true" ]; then
+            upload_args+=(--clobber)
+          fi
           gh release upload "$TAG" \
             --repo "$GITHUB_REPOSITORY" \
-            --clobber \
+            "${upload_args[@]}" \
             "kernel-out/vmlinux-${ARCH}.elf" \
             "kernel-out/vmlinux-${ARCH}.image" \
             "kernel-out/vmlinux-${ARCH}.config"

--- a/.github/workflows/build-published-images.yml
+++ b/.github/workflows/build-published-images.yml
@@ -36,6 +36,16 @@ on:
           Leave empty to use IMAGES_RELEASE_TAG from published.py.
         type: string
         default: ""
+      force_overwrite:
+        description: >-
+          DANGEROUS. Replace any assets with the same name that already
+          live at this tag. Default false: the upload step fails loud on
+          a collision so an accidental re-run cannot silently swap
+          published bytes the shipped CLI's MANIFEST SHAs depend on.
+          Tick this only for an intentional re-bake of the same tag
+          (e.g. a flaky CI run that needs a redo).
+        type: boolean
+        default: false
 
 permissions:
   contents: write  # required to create/upload to GitHub Releases
@@ -224,6 +234,7 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           TAG: ${{ steps.release.outputs.tag }}
           NAME: ${{ steps.build.outputs.name }}
+          FORCE_OVERWRITE: ${{ inputs.force_overwrite }}
         run: |
           if ! gh release view "$TAG" --repo "$GITHUB_REPOSITORY" >/dev/null 2>&1; then
             gh release create "$TAG" \
@@ -234,14 +245,19 @@ jobs:
               || echo "Draft already exists (race with another matrix cell), continuing."
           fi
 
-          # --clobber overwrites any prior asset with the same name, so
-          # re-runs of the workflow for the same tag replace existing
-          # artifacts. NOTE: this allows silent SHA drift relative to the
-          # manifest. Catching that requires a smoke test that verifies
-          # live bytes against recorded SHAs — tracked separately.
+          # Default (no --clobber): `gh release upload` returns non-zero
+          # on a same-name collision. Forces the dev to bump
+          # IMAGES_RELEASE_TAG (or pass a fresh `release_tag` input)
+          # rather than silently swapping published bytes that the
+          # shipped CLI's MANIFEST SHAs depend on.
+          # `force_overwrite=true` opts back in for intentional re-bakes.
+          upload_args=()
+          if [ "${FORCE_OVERWRITE:-false}" = "true" ]; then
+            upload_args+=(--clobber)
+          fi
           gh release upload "$TAG" \
             --repo "$GITHUB_REPOSITORY" \
-            --clobber \
+            "${upload_args[@]}" \
             "${NAME}-rootfs.ext4.zst"
 
       - name: Step summary
@@ -409,6 +425,7 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           TAG: ${{ steps.release.outputs.tag }}
           NAME: ${{ steps.build.outputs.name }}
+          FORCE_OVERWRITE: ${{ inputs.force_overwrite }}
         run: |
           if ! gh release view "$TAG" --repo "$GITHUB_REPOSITORY" >/dev/null 2>&1; then
             gh release create "$TAG" \
@@ -419,14 +436,19 @@ jobs:
               || echo "Draft already exists (race with another matrix cell), continuing."
           fi
 
-          # --clobber overwrites any prior asset with the same name, so
-          # re-runs of the workflow for the same tag replace existing
-          # artifacts. NOTE: this allows silent SHA drift relative to the
-          # manifest. Catching that requires a smoke test that verifies
-          # live bytes against recorded SHAs — tracked separately.
+          # Default (no --clobber): `gh release upload` returns non-zero
+          # on a same-name collision. Forces the dev to bump
+          # IMAGES_RELEASE_TAG (or pass a fresh `release_tag` input)
+          # rather than silently swapping published bytes that the
+          # shipped CLI's MANIFEST SHAs depend on.
+          # `force_overwrite=true` opts back in for intentional re-bakes.
+          upload_args=()
+          if [ "${FORCE_OVERWRITE:-false}" = "true" ]; then
+            upload_args+=(--clobber)
+          fi
           gh release upload "$TAG" \
             --repo "$GITHUB_REPOSITORY" \
-            --clobber \
+            "${upload_args[@]}" \
             "${NAME}-rootfs.ext4.zst"
 
       - name: Step summary


### PR DESCRIPTION
## Summary

- Both release-uploading workflows used `gh release upload --clobber` unconditionally, which silently replaced any asset of the same name at the target tag — exactly the footgun we just hit when merging #279 auto-triggered `build-microvm-kernel.yml` against the live `images-v0.0.14a0` tag (cancelled in time).
- Drop the unconditional `--clobber`. Gate it behind a new `force_overwrite` `workflow_dispatch` input (default `false`). `push` events cannot set the input, so they always run with the safe default and `gh release upload` returns non-zero on a same-name collision — forcing a tag bump rather than a silent byte-swap.
- Manual workflow_dispatch can still tick the box for an intentional re-bake (e.g. a flaky CI run that needs a redo).
- Three call sites swept: `build-microvm-kernel.yml` + the `openclaw` and `preset` jobs in `build-published-images.yml`.

## Expected red CI on merge

The post-merge `build-microvm-kernel` run on main **will fail at the upload step** — main's `IMAGES_RELEASE_TAG` is still `images-v0.0.14a0` and that tag already has these exact asset names. That red CI is the new friction working as intended. The follow-up PR bumps `IMAGES_RELEASE_TAG` to `images-v0.0.14` (fresh tag, no collision) and resyncs `BASE_KERNELS` SHAs.

## Test plan

- [ ] `python3 -c "import yaml; ..."` — both workflows still parse (already verified locally).
- [ ] After merge, observe the kernel-build run on main fails at "Upload to GitHub Releases (draft)" with `HTTP 422: already_exists`. That confirms the new default works.
- [ ] Land follow-up PR with `IMAGES_RELEASE_TAG = "images-v0.0.14"`; the kernel-build run on that merge succeeds (fresh tag, no collision).
- [ ] Manually dispatch `Build microvm Kernel` against `images-v0.0.14` with `force_overwrite=true`; confirm it re-uploads cleanly. Then dispatch again with `force_overwrite=false`; confirm it fails at upload. Together those two runs prove both branches of the conditional.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced build workflows with a configurable force-overwrite option for release uploads.
  * Microvm kernel and published image build workflows now support optional asset replacement.
  * By default, uploads preserve existing release assets; the new option allows intentional re-builds to replace assets without manual version changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->