### PR TITLE
chore(images): bump IMAGES_RELEASE_TAG to images-v0.0.14 + resync kernel SHAs

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "smolvm"
-version = "0.0.14"
+version = "0.0.14.1"
 description = "Secure, isolated computers that AI agents can use to browse, run code, and get real work done. Free and open-source from Celesto AI"
 readme = "README.md"
 license = "Apache-2.0"

--- a/src/smolvm/images/published.py
+++ b/src/smolvm/images/published.py
@@ -130,11 +130,12 @@ class BaseKernel(BaseModel):
 #      step summaries into ``BASE_KERNELS`` and ``MANIFEST``.
 #   3. Promote the draft release on GitHub.
 #
-# CI still passes ``--clobber`` to ``gh release upload`` for
-# operational ergonomics, so SHA drift is technically possible. A
-# follow-up smoke test should fetch each ``rootfs_url`` / ``kernel_url``
-# and verify the live bytes match the recorded SHA.
-IMAGES_RELEASE_TAG = "images-v0.0.14a0"
+# CI no longer passes ``--clobber`` by default (see ``ci`` PR #280) — a
+# bump that forgets to land its SHA-resync commit will fail loud at the
+# upload step instead of silently swapping bytes under the existing
+# pins. Re-bakes against the same tag must opt in via the
+# ``force_overwrite`` workflow_dispatch input.
+IMAGES_RELEASE_TAG = "images-v0.0.14"
 
 
 def cache_name(

--- a/src/smolvm/images/published.py
+++ b/src/smolvm/images/published.py
@@ -201,16 +201,16 @@ BASE_KERNELS: dict[Arch, BaseKernel] = {
     "amd64": BaseKernel(
         arch="amd64",
         elf_url=_release_kernel_url("amd64", "elf"),
-        elf_sha256="7be5c70c5fd5b12771aad71f6eddf8bf82006c3886c28be2e2f04be0812cd56b",
+        elf_sha256="18f11160fcf0dd329207faea7ed9af4f6fe0bdc7307c1e132dd3db7f02914a18",
         image_url=_release_kernel_url("amd64", "image"),
-        image_sha256="d77c0b8c9fa6bbf163c04aee2067b374ff5a952b10040ed407dbc659a2af2552",
+        image_sha256="ceac26ef7218ee907a0f0108fa4f30f95da3c8ab1c87056a85760f8d15fac801",
     ),
     "arm64": BaseKernel(
         arch="arm64",
         elf_url=_release_kernel_url("arm64", "elf"),
-        elf_sha256="77795663bf9b0fe229d2a8e77bc454cf56cbe2ba94130320ec235fc31a73d92b",
+        elf_sha256="b8b319c5253bcf9930cc0c3e75df76298a4a741441d83b8c3ad0a87b2c7ad2ba",
         image_url=_release_kernel_url("arm64", "image"),
-        image_sha256="ddc7344a2e1298bcdc467dd900236456c08159734ac43cae9b104ded506e3839",
+        image_sha256="0a4d0f69f07070c344b0301de541b50e3bde6c5d39a134869b8f57cf8add389c",
     ),
 }
 


### PR DESCRIPTION
## Summary

- Closes the loop on #279 + #280: the kernel-9p-overlay fix needs new kernel artifacts published, but the existing `images-v0.0.14a0` tag is what the shipped 0.0.14 CLI's `BASE_KERNELS` SHAs are pinned against. Re-baking that tag would silently break every existing 0.0.14 install on first VM boot (SHA mismatch).
- Bump `IMAGES_RELEASE_TAG` from `images-v0.0.14a0` → `images-v0.0.14` (the alpha-suffix was a holdover from before #276 cut the stable 0.0.14 release).
- Resync the four `BASE_KERNELS[*].{elf,image}_sha256` constants to the bytes that workflow_dispatch run [25410665868](https://github.com/CelestoAI/SmolVM/actions/runs/25410665868) just published to the new tag.
- The 10 preset rootfs assets `MANIFEST` references were copied byte-for-byte from `images-v0.0.14a0` to `images-v0.0.14` (`gh release download` → `gh release upload`); their SHAs in `published.py` did not need to change. Pre/post-flight checks verified all 10 still match exactly.

## State at the new tag

| File | Source | SHA preserved? |
| --- | --- | --- |
| `vmlinux-{amd64,arm64}.{elf,image}` | newly built by run #25410665868 with the 9p+overlay kernel | n/a — fresh artifacts, SHAs resynced in this PR |
| `vmlinux-{amd64,arm64}.config` | same run | informational, not pinned |
| `<preset>-<arch>-rootfs.ext4.zst` × 10 | copied bytewise from `images-v0.0.14a0` | yes — verified pre + post |

## Why split the bump and the SHA resync into two commits

Reviewable separately. Commit 1 is the "we're moving the goalposts" decision; commit 2 is the mechanical "here are the bytes those goalposts now point at." A future bisector pinpoints either failure cleanly.

## Drive-by

Cleaned up the now-stale `--clobber overwrites... silent SHA drift...` paragraph above `IMAGES_RELEASE_TAG` — that footgun is gone after #280.

## Test plan

- [x] `uv run --extra dev pytest tests/test_build.py tests/test_images.py tests/test_published_images.py` — 124/124 passing.
- [x] Pre-flight: 10 rootfs SHAs at `images-v0.0.14a0` match every `_*_ROOTFS_SHA` constant in `published.py`.
- [x] Post-flight: same 10 SHAs at `images-v0.0.14` match the same constants — bytes preserved through download+upload.
- [x] Verified `images-v0.0.14` now contains 16 assets (6 kernel + 10 rootfs).
- [ ] (After merge) Confirm `smoke-published-images.yml` passes against the new tag.
- [ ] (After merge) `smolvm create --mount ./` actually mounts a workspace — the original failure mode that started this whole chain.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Released stable kernel images (images-v0.0.14), moving from the previous alpha tag.
  * Updated kernel binaries for amd64 and arm64 with refreshed verification checksums.
  * Incremented project package version to 0.0.14.1.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->