### PR TITLE
Init scripts: parse cmdline netmask and gateway DNS

### DIFF
--- a/scripts/ci/preset-init.sh
+++ b/scripts/ci/preset-init.sh
@@ -97,6 +97,8 @@ ip route add default via "${GATEWAY}" dev eth0 2>/dev/null || true
 
 if [ -n "$GATEWAY" ]; then
     echo "nameserver ${GATEWAY}" > /etc/resolv.conf
+    echo "nameserver 8.8.8.8" >> /etc/resolv.conf
+    echo "nameserver 8.8.4.4" >> /etc/resolv.conf
 else
     echo "nameserver 8.8.8.8" > /etc/resolv.conf
     echo "nameserver 8.8.4.4" >> /etc/resolv.conf

--- a/scripts/ci/preset-init.sh
+++ b/scripts/ci/preset-init.sh
@@ -49,22 +49,58 @@ mkdir -p /run/sshd /var/log
 
 # ── Networking ───────────────────────────────────────────────
 # Format: ip=<guest_ip>::<gateway>:<netmask>::eth0:off (kernel ip= param)
+netmask_to_prefix() {
+    IFS=.
+    set -- $1
+    IFS=' '
+
+    [ $# -eq 4 ] || return 1
+
+    PREFIX=0
+    ZERO_SEEN=0
+    for OCTET in "$@"; do
+        case "$OCTET" in
+            255) [ "$ZERO_SEEN" -eq 0 ] || return 1; PREFIX=$((PREFIX + 8)) ;;
+            254) [ "$ZERO_SEEN" -eq 0 ] || return 1; PREFIX=$((PREFIX + 7)); ZERO_SEEN=1 ;;
+            252) [ "$ZERO_SEEN" -eq 0 ] || return 1; PREFIX=$((PREFIX + 6)); ZERO_SEEN=1 ;;
+            248) [ "$ZERO_SEEN" -eq 0 ] || return 1; PREFIX=$((PREFIX + 5)); ZERO_SEEN=1 ;;
+            240) [ "$ZERO_SEEN" -eq 0 ] || return 1; PREFIX=$((PREFIX + 4)); ZERO_SEEN=1 ;;
+            224) [ "$ZERO_SEEN" -eq 0 ] || return 1; PREFIX=$((PREFIX + 3)); ZERO_SEEN=1 ;;
+            192) [ "$ZERO_SEEN" -eq 0 ] || return 1; PREFIX=$((PREFIX + 2)); ZERO_SEEN=1 ;;
+            128) [ "$ZERO_SEEN" -eq 0 ] || return 1; PREFIX=$((PREFIX + 1)); ZERO_SEEN=1 ;;
+            0) ZERO_SEEN=1 ;;
+            *) return 1 ;;
+        esac
+    done
+
+    echo "$PREFIX"
+}
+
 IP_CONFIG=$(cat /proc/cmdline | tr ' ' '\n' | grep '^ip=' | head -1)
 if [ -n "$IP_CONFIG" ]; then
-    GUEST_IP=$(echo "$IP_CONFIG" | cut -d= -f2 | cut -d: -f1)
-    GATEWAY=$(echo "$IP_CONFIG" | cut -d= -f2 | cut -d: -f3)
+    IP_FIELDS=$(echo "$IP_CONFIG" | cut -d= -f2-)
+    GUEST_IP=$(echo "$IP_FIELDS" | cut -d: -f1)
+    GATEWAY=$(echo "$IP_FIELDS" | cut -d: -f3)
+    NETMASK=$(echo "$IP_FIELDS" | cut -d: -f4)
 else
     GUEST_IP="172.16.0.2"
     GATEWAY="172.16.0.1"
+    NETMASK="255.255.255.0"
 fi
+
+PREFIX=$(netmask_to_prefix "$NETMASK") || PREFIX=24
 
 ip link set lo up
 ip link set eth0 up 2>/dev/null || true
-ip addr add "${GUEST_IP}/24" dev eth0 2>/dev/null || true
+ip addr add "${GUEST_IP}/${PREFIX}" dev eth0 2>/dev/null || true
 ip route add default via "${GATEWAY}" dev eth0 2>/dev/null || true
 
-echo "nameserver 8.8.8.8" > /etc/resolv.conf
-echo "nameserver 8.8.4.4" >> /etc/resolv.conf
+if [ -n "$GATEWAY" ]; then
+    echo "nameserver ${GATEWAY}" > /etc/resolv.conf
+else
+    echo "nameserver 8.8.8.8" > /etc/resolv.conf
+    echo "nameserver 8.8.4.4" >> /etc/resolv.conf
+fi
 
 hostname smolvm
 

--- a/src/smolvm/images/builder.py
+++ b/src/smolvm/images/builder.py
@@ -1183,23 +1183,59 @@ log_ts "root-ready"
 log_ts "net-config-start"
 # Configure from kernel command line ip= parameter
 # Format: ip=<guest_ip>::<gateway>:<netmask>::eth0:off
+netmask_to_prefix() {{
+    IFS=.
+    set -- $1
+    IFS=' '
+
+    [ $# -eq 4 ] || return 1
+
+    PREFIX=0
+    ZERO_SEEN=0
+    for OCTET in "$@"; do
+        case "$OCTET" in
+            255) [ "$ZERO_SEEN" -eq 0 ] || return 1; PREFIX=$((PREFIX + 8)) ;;
+            254) [ "$ZERO_SEEN" -eq 0 ] || return 1; PREFIX=$((PREFIX + 7)); ZERO_SEEN=1 ;;
+            252) [ "$ZERO_SEEN" -eq 0 ] || return 1; PREFIX=$((PREFIX + 6)); ZERO_SEEN=1 ;;
+            248) [ "$ZERO_SEEN" -eq 0 ] || return 1; PREFIX=$((PREFIX + 5)); ZERO_SEEN=1 ;;
+            240) [ "$ZERO_SEEN" -eq 0 ] || return 1; PREFIX=$((PREFIX + 4)); ZERO_SEEN=1 ;;
+            224) [ "$ZERO_SEEN" -eq 0 ] || return 1; PREFIX=$((PREFIX + 3)); ZERO_SEEN=1 ;;
+            192) [ "$ZERO_SEEN" -eq 0 ] || return 1; PREFIX=$((PREFIX + 2)); ZERO_SEEN=1 ;;
+            128) [ "$ZERO_SEEN" -eq 0 ] || return 1; PREFIX=$((PREFIX + 1)); ZERO_SEEN=1 ;;
+            0) ZERO_SEEN=1 ;;
+            *) return 1 ;;
+        esac
+    done
+
+    echo "$PREFIX"
+}}
+
 IP_CONFIG=$(cat /proc/cmdline | tr ' ' '\n' | grep '^ip=' | head -1)
 if [ -n "$IP_CONFIG" ]; then
-    GUEST_IP=$(echo "$IP_CONFIG" | cut -d= -f2 | cut -d: -f1)
-    GATEWAY=$(echo "$IP_CONFIG" | cut -d= -f2 | cut -d: -f3)
+    IP_FIELDS=$(echo "$IP_CONFIG" | cut -d= -f2-)
+    GUEST_IP=$(echo "$IP_FIELDS" | cut -d: -f1)
+    GATEWAY=$(echo "$IP_FIELDS" | cut -d: -f3)
+    NETMASK=$(echo "$IP_FIELDS" | cut -d: -f4)
 else
     GUEST_IP="172.16.0.2"
     GATEWAY="172.16.0.1"
+    NETMASK="255.255.255.0"
 fi
+
+PREFIX=$(netmask_to_prefix "$NETMASK") || PREFIX=24
 
 ip link set lo up
 ip link set eth0 up
-ip addr add "${{GUEST_IP}}/24" dev eth0 2>/dev/null || true
+ip addr add "${{GUEST_IP}}/${{PREFIX}}" dev eth0 2>/dev/null || true
 ip route add default via "${{GATEWAY}}" dev eth0 2>/dev/null || true
 
 # DNS
-echo "nameserver 8.8.8.8" > /etc/resolv.conf
-echo "nameserver 8.8.4.4" >> /etc/resolv.conf
+if [ -n "$GATEWAY" ]; then
+    echo "nameserver ${{GATEWAY}}" > /etc/resolv.conf
+else
+    echo "nameserver 8.8.8.8" > /etc/resolv.conf
+    echo "nameserver 8.8.4.4" >> /etc/resolv.conf
+fi
 
 hostname {custom_hostname}
 log_ts "net-ready"

--- a/src/smolvm/images/builder.py
+++ b/src/smolvm/images/builder.py
@@ -1232,6 +1232,8 @@ ip route add default via "${{GATEWAY}}" dev eth0 2>/dev/null || true
 # DNS
 if [ -n "$GATEWAY" ]; then
     echo "nameserver ${{GATEWAY}}" > /etc/resolv.conf
+    echo "nameserver 8.8.8.8" >> /etc/resolv.conf
+    echo "nameserver 8.8.4.4" >> /etc/resolv.conf
 else
     echo "nameserver 8.8.8.8" > /etc/resolv.conf
     echo "nameserver 8.8.4.4" >> /etc/resolv.conf

--- a/tests/test_build.py
+++ b/tests/test_build.py
@@ -35,6 +35,30 @@ def _ok_subprocess_run(
     return subprocess.CompletedProcess(cmd, 0, stdout="", stderr="")
 
 
+def test_base_init_script_uses_cmdline_netmask_and_gateway_dns() -> None:
+    script = ImageBuilder()._default_init_script()
+
+    assert "netmask_to_prefix()" in script
+    assert 'NETMASK=$(echo "$IP_FIELDS" | cut -d: -f4)' in script
+    assert 'PREFIX=$(netmask_to_prefix "$NETMASK") || PREFIX=24' in script
+    assert 'ip addr add "${GUEST_IP}/${PREFIX}" dev eth0' in script
+    assert 'if [ -n "$GATEWAY" ]; then' in script
+    assert 'echo "nameserver ${GATEWAY}" > /etc/resolv.conf' in script
+    assert 'ip addr add "${GUEST_IP}/24"' not in script
+
+
+def test_preset_init_script_uses_cmdline_netmask_and_gateway_dns() -> None:
+    script = Path("scripts/ci/preset-init.sh").read_text()
+
+    assert "netmask_to_prefix()" in script
+    assert 'NETMASK=$(echo "$IP_FIELDS" | cut -d: -f4)' in script
+    assert 'PREFIX=$(netmask_to_prefix "$NETMASK") || PREFIX=24' in script
+    assert 'ip addr add "${GUEST_IP}/${PREFIX}" dev eth0' in script
+    assert 'if [ -n "$GATEWAY" ]; then' in script
+    assert 'echo "nameserver ${GATEWAY}" > /etc/resolv.conf' in script
+    assert 'ip addr add "${GUEST_IP}/24"' not in script
+
+
 class TestDockerDiagnostics:
     """Tests for Docker availability diagnostics."""
 


### PR DESCRIPTION
### Motivation
- Fix hardcoded `/24` netmask and hardcoded Google DNS in the VM init scripts so VMs on non-/24 subnets and locked-down networks configure networking correctly.
- Keep the layered preset `/init` and the builder-generated base `/init` in sync so OpenClaw and layered presets behave identically.

### Description
- Added a `netmask_to_prefix()` shell helper to `scripts/ci/preset-init.sh` and the heredoc in `src/smolvm/images/builder.py` and use it to convert the `ip=` kernel netmask field to a CIDR prefix for `ip addr add` instead of always using `/24`.
- Parse `IP_FIELDS` from the kernel `ip=` parameter to extract `GUEST_IP`, `GATEWAY`, and `NETMASK`, compute `PREFIX`, and apply the address as `${GUEST_IP}/${PREFIX}`; keep original defaults when the `ip=` field is absent.
- Use the parsed `GATEWAY` as the primary `nameserver` and only fall back to `8.8.8.8`/`8.8.4.4` when the gateway is empty, applied in both init script paths.
- Added regression tests in `tests/test_build.py` asserting both `ImageBuilder()._default_init_script()` and `scripts/ci/preset-init.sh` include the new parsing, use `${PREFIX}`, and no longer hardcode `${GUEST_IP}/24`; updated `Cargo.lock` version entry observed.

### Testing
- Ran linter checks with `uv run ruff check tests/test_build.py src/smolvm/images/builder.py` which passed without errors.
- Verified shell syntax with `sh -n scripts/ci/preset-init.sh` and validated the generated builder init script with `sh -n /tmp/smolvm-init.sh` produced from `ImageBuilder()._default_init_script()`, both of which succeeded.
- Ran the targeted unit tests with `uv run python -m pytest tests/test_build.py -q` which passed, and exercised the full test suite with `uv run python -m pytest -q` which reported 883 passed, 13 skipped, and 2 failing network tests that surface due to the environment's read-only `/proc/sys/net/ipv4/ip_forward` rather than the init-script changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69faa2dc73f883288f02ecd20aa7881e)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Network configuration now derives and applies IP prefixes from provided netmasks (with a sensible fallback), enabling arbitrary network masks instead of fixed /24 subnets.
  * DNS selection prefers the gateway when available, falling back to public DNS as needed.

* **Tests**
  * Added tests validating netmask-based IP prefixing and gateway-preferred DNS behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->