### PR TITLE
Telemetry

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -361,7 +361,7 @@ checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
 
 [[package]]
 name = "smolvm-core"
-version = "0.0.11"
+version = "0.0.14"
 dependencies = [
  "futures-util",
  "libc",

--- a/src/smolvm/facade.py
+++ b/src/smolvm/facade.py
@@ -76,6 +76,7 @@ from smolvm.types import (
     WorkspaceMount,
 )
 from smolvm.vm import SmolVMManager
+from smolvm.telemetry import TelemetryManager
 
 logger = logging.getLogger(__name__)
 
@@ -737,6 +738,15 @@ class SmolVM:
                 "make writable. Alternatively, set "
                 "WorkspaceMount(writable=True) on config.workspace_mounts."
             )
+        
+        # Initialize telemetry if enabled
+        self._telemetry: TelemetryManager | None = None
+        if config is not None and config.enable_telemetry:
+            telemetry_dir = (data_dir or Path.home() / ".smolvm") / "telemetry"
+            self._telemetry = TelemetryManager(
+                vm_id=config.vm_id,
+                telemetry_path=telemetry_dir / f"{config.vm_id}.json",
+            )
 
         self._ssh_user = ssh_user
         self._ssh_key_path = ssh_key_path
@@ -904,6 +914,10 @@ class SmolVM:
         """
         notify = on_progress or (lambda _msg: None)
 
+        # Record boot start for telemetry
+        if self._telemetry:
+            self._telemetry.record_boot_start()
+
         if self._info.status == VMState.RUNNING:
             logger.info("VM %s already running; start() is a no-op", self._vm_id)
             return self
@@ -925,7 +939,15 @@ class SmolVM:
                     "the rootfs at build time.",
                     {"vm_id": self._vm_id},
                 )
-            self.wait_for_ssh(timeout=boot_timeout, on_progress=on_progress)
+            try:
+                self.wait_for_ssh(timeout=boot_timeout, on_progress=on_progress)
+                if self._telemetry:
+                    self._telemetry.record_boot_ready()
+            except OperationTimeoutError as e:
+                if self._telemetry:
+                    self._telemetry.record_boot_failure(f"SSH timeout: {str(e)}")
+                raise
+
             if self._ssh is None:
                 self._ssh = SSHClient(
                     host=self._info.network.guest_ip,
@@ -1012,6 +1034,10 @@ class SmolVM:
 
     def delete(self) -> None:
         """Delete the VM and release all resources."""
+        # Clear telemetry data
+        if self._telemetry:
+            self._telemetry.clear()
+        
         self._cleanup_local_forwards()
         self._sdk.delete(self._vm_id)
         self._reset_runtime_state()
@@ -1083,8 +1109,21 @@ class SmolVM:
                 "Cannot run command: SSH client is not initialized",
                 {"vm_id": self._vm_id},
             )
-
-        return self._ssh.run(command, timeout=timeout, shell=shell)
+        start_time = time.time()
+        result = self._ssh.run(command, timeout=timeout, shell=shell)
+        
+        # Record command execution for telemetry
+        if self._telemetry:
+            duration_ms = int((time.time() - start_time) * 1000)
+            self._telemetry.record_command_execution(
+                command=command,
+                exit_code=result.exit_code,
+                stdout=result.stdout,
+                stderr=result.stderr,
+                duration_ms=duration_ms,
+            )
+        
+        return result
 
     def set_env_vars(self, env_vars: dict[str, str], *, merge: bool = True) -> list[str]:
         """Set environment variables on a running VM.
@@ -1548,6 +1587,9 @@ class SmolVM:
 
     def close(self) -> None:
         """Release underlying SDK resources for this facade instance."""
+        if self._telemetry:
+            # Optional: could add telemetry.close() if needed in future
+            pass
         self._sdk.close()
 
     # ------------------------------------------------------------------

--- a/src/smolvm/telemetry/__init__.py
+++ b/src/smolvm/telemetry/__init__.py
@@ -1,0 +1,26 @@
+# Copyright 2026 Celesto AI
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""VM-level telemetry collection and storage."""
+
+from smolvm.telemetry._types import BootEvent, BootStatus, CommandExecution, VMTelemetry
+from smolvm.telemetry.manager import TelemetryManager
+
+__all__ = [
+    "BootEvent",
+    "BootStatus",
+    "CommandExecution",
+    "VMTelemetry",
+    "TelemetryManager",
+]

--- a/src/smolvm/telemetry/_types.py
+++ b/src/smolvm/telemetry/_types.py
@@ -1,0 +1,62 @@
+# Copyright 2026 Celesto AI
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Telemetry data types for SmolVM."""
+
+from __future__ import annotations
+
+from datetime import datetime
+from enum import Enum
+from typing import Literal
+
+from pydantic import BaseModel, Field
+
+class BootStatus(str, Enum):
+    """Boot status of SmolVM."""
+
+    STARTED = "started"
+    READY = "ready"
+    FAILED = "failed"
+
+class BootEvent(BaseModel):
+    """Record of a VM boot attempt."""
+
+    timestamp: datetime
+    status: BootStatus
+    duration_ms: int | None = None
+    error: str | None = None
+
+    model_config = {"frozen": True}
+
+class CommandExecution(BaseModel):
+    """Record of an SSH command execution."""
+
+    timestamp: datetime
+    command: str
+    exit_code: int
+    stdout: str
+    stderr: str
+    duration_ms: int
+
+    model_config = {"frozen": True}
+
+class VMTelemetry(BaseModel):
+    """Telemetry snapshot for a VM."""
+
+    vm_id: str
+    created_at: datetime
+    boot_events: list[BootEvent] = Field(default_factory=list)
+    command_executions: list[CommandExecution] = Field(default_factory=list)
+
+    model_config = {"frozen": False}

--- a/src/smolvm/telemetry/manager.py
+++ b/src/smolvm/telemetry/manager.py
@@ -1,0 +1,147 @@
+# Copyright 2026 Celesto AI
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""VM telemetry recording and management for SmolVM."""
+
+from __future__ import annotations
+
+import json
+import logging
+from datetime import datetime
+from pathlib import Path
+from typing import Literal
+
+from smolvm.telemetry._types import BootEvent, BootStatus, CommandExecution, VMTelemetry
+
+logger = logging.getLogger(__name__)
+
+class TelemetryManager:
+    """Records and persists VM telemetry to JSON file."""
+
+    def __init__(self, vm_id: str, telemetry_path: Path) -> None:
+        self.vm_id = vm_id
+        self.telemetry_path = telemetry_path
+        self._data : VMTelemetry = VMTelemetry(vm_id=vm_id, created_at=datetime.now())
+        self._boot_start_time : float | None = None
+
+        # Load existing telemetry if file exists
+        if self.telemetry_path.exists():
+            try:
+                with open(self.telemetry_path, "r") as f:
+                    content = f.read().strip()
+                    if content:
+                        # JSON Lines format: load last non-empty line
+                        lines = [line for line in content.split("\n") if line.strip()]
+                        if lines:
+                            last_entry = json.loads(lines[-1])
+                            loaded = VMTelemetry(**last_entry)
+                            self._data = loaded
+            except (json.JSONDecodeError, OSError) as e:
+                logger.warning(f"Failed to load telemetry from {self.telemetry_path}: {e}")
+    
+    def record_boot_start(self) -> None:
+        """Record boot start timestamp."""
+        self._boot_start_time = datetime.now().timestamp()
+        event = BootEvent(
+            timestamp=datetime.now(),
+            status=BootStatus.STARTED,
+        )
+        self._data.boot_events.append(event)
+        self._persist()
+    
+    def record_boot_ready(self) -> None:
+        """Record successful boot completion."""
+        
+        if self._boot_start_time is None:
+            logger.warning("record_boot_ready called without prior record_boot_start")
+            self._boot_start_time = datetime.now().timestamp()  # Fallback to current time
+
+        duration_ms = int((datetime.now().timestamp() - self._boot_start_time) * 1000)
+        event = BootEvent(
+            timestamp=datetime.now(),
+            status=BootStatus.STARTED,
+        )
+        self._data.boot_events.append(event)
+        self._persist()
+    
+    def record_boot_ready(self) -> None:
+        """Record successful boot completion."""
+
+        if self._boot_start_time is None:
+            logger.warning("record_boot_ready called without prior record_boot_start")
+            self._boot_start_time = datetime.now().timestamp()  # Fallback to current time
+
+        duration_ms = int((datetime.now().timestamp() - self._boot_start_time) * 1000)
+        event = BootEvent(
+            timestamp=datetime.now(),
+            status=BootStatus.READY,
+            duration_ms=duration_ms,
+        )
+        self._data.boot_events.append(event)
+        self._persist()
+    
+    def record_boot_failed(self, error: str) -> None:
+        """Record boot failure with error message."""
+        if self._boot_start_time is None:
+            logger.warning("record_boot_failed called without prior record_boot_start")
+            self._boot_start_time = datetime.now().timestamp()  # Fallback to current time
+
+        duration_ms = int((datetime.now().timestamp() - self._boot_start_time) * 1000)
+        event = BootEvent(
+            timestamp=datetime.now(),
+            status=BootStatus.FAILED,
+            duration_ms=duration_ms,
+            error=error,
+        )
+        self._data.boot_events.append(event)
+        self._persist()
+    
+    def record_command_execution(
+        self,
+        command: str,
+        exit_code: int,
+        stdout: str,
+        stderr: str,
+        duration_ms: int,
+    ) -> None:
+        """Record SSH command execution."""
+
+        execution = CommandExecution(
+            timestamp=datetime.now(),
+            command=command,
+            exit_code=exit_code,
+            stdout=stdout,
+            stderr=stderr,
+            duration_ms=duration_ms,
+        )
+        self._data.command_executions.append(execution)
+        self._persist()
+    
+    def _persist(self) -> None:
+        """Write current telemetry to JSON file (JSON Lines format)."""
+        try:
+            self.telemetry_path.parent.mkdir(parents=True, exist_ok=True)
+            with open(self.telemetry_path, "a") as f:
+                f.write(self._data.model_dump_json() + "\n")
+        except OSError as e:
+            logger.error(f"Failed to persist telemetry to {self.telemetry_path}: {e}")
+        
+    def get_data(self) -> VMTelemetry:
+        """Get current telemetry data."""
+        return self._data
+    
+    def clear(self) -> None:
+        """Clear telemetry data (called on VM delete)."""
+        self._data = VMTelemetry(vm_id=self.vm_id, created_at=datetime.now())
+        # Don't delete file, just clear in-memory state

--- a/src/smolvm/types.py
+++ b/src/smolvm/types.py
@@ -309,6 +309,7 @@ class VMConfig(BaseModel):
             ``smolvm.authorized_key_b64=<base64>`` and read by ``/init``. Use
             this for published pre-built images that don't bake keys at build
             time, so each VM gets the launching user's key without rebuilding.
+        enable_telemetry: Whether to enable telemetry for this VM.
     """
 
     vm_id: Annotated[
@@ -337,6 +338,7 @@ class VMConfig(BaseModel):
     internet_settings: InternetSettings | None = None
     workspace_mounts: list[WorkspaceMount] = []
     ssh_public_key: str | None = None
+    enable_telemetry: bool = False
 
     @field_validator("vm_id", mode="before")
     @classmethod

--- a/tests/test_telemetry.py
+++ b/tests/test_telemetry.py
@@ -1,0 +1,119 @@
+import json
+import tempfile
+from datetime import datetime
+from pathlib import Path
+
+import pytest
+
+from smolvm.telemetry import BootStatus, CommandExecution, TelemetryManager, VMTelemetry
+
+
+class TestTelemetryManager:
+    """Test VM-level telemetry collection."""
+
+    def test_telemetry_initialization(self, tmp_path: Path) -> None:
+        """Test that TelemetryManager initializes correctly."""
+        telemetry_path = tmp_path / "test.json"
+        manager = TelemetryManager(vm_id="test-vm", telemetry_path=telemetry_path)
+        
+        assert manager.vm_id == "test-vm"
+        assert manager.telemetry_path == telemetry_path
+
+    def test_record_boot_start(self, tmp_path: Path) -> None:
+        """Test recording boot start event."""
+        telemetry_path = tmp_path / "test.json"
+        manager = TelemetryManager(vm_id="test-vm", telemetry_path=telemetry_path)
+        
+        manager.record_boot_start()
+        
+        assert len(manager.get_data().boot_events) == 1
+        assert manager.get_data().boot_events[0].status == BootStatus.STARTED
+
+    def test_record_boot_ready(self, tmp_path: Path) -> None:
+        """Test recording successful boot completion."""
+        import time
+        telemetry_path = tmp_path / "test.json"
+        manager = TelemetryManager(vm_id="test-vm", telemetry_path=telemetry_path)
+        
+        manager.record_boot_start()
+        time.sleep(0.1)  # Add 100ms delay
+        manager.record_boot_ready()
+        
+        assert len(manager.get_data().boot_events) == 2
+        assert manager.get_data().boot_events[1].status == BootStatus.READY
+        assert manager.get_data().boot_events[1].duration_ms is not None
+        assert manager.get_data().boot_events[1].duration_ms >= 100  # Should be ~100ms
+
+    def test_record_boot_failure(self, tmp_path: Path) -> None:
+        """Test recording boot failure with error message."""
+        telemetry_path = tmp_path / "test.json"
+        manager = TelemetryManager(vm_id="test-vm", telemetry_path=telemetry_path)
+        
+        error_msg = "SSH timeout after 30 seconds"
+        manager.record_boot_start()
+        manager.record_boot_failed(error_msg) 
+        
+        assert len(manager.get_data().boot_events) == 2
+        assert manager.get_data().boot_events[1].status == BootStatus.FAILED
+        assert manager.get_data().boot_events[1].error == error_msg
+
+    def test_record_command_execution(self, tmp_path: Path) -> None:
+        """Test recording SSH command execution."""
+        telemetry_path = tmp_path / "test.json"
+        manager = TelemetryManager(vm_id="test-vm", telemetry_path=telemetry_path)
+        
+        manager.record_command_execution(
+            command="uname -a",
+            exit_code=0,
+            stdout="Linux test-vm 5.10.0 #1 SMP ...",
+            stderr="",
+            duration_ms=150,
+        )
+        
+        assert len(manager.get_data().command_executions) == 1
+        exec_data = manager.get_data().command_executions[0]
+        assert exec_data.command == "uname -a"
+        assert exec_data.exit_code == 0
+        assert exec_data.duration_ms == 150
+
+    def test_persistence_to_json(self, tmp_path: Path) -> None:
+        """Test that telemetry is persisted to JSON file."""
+        telemetry_path = tmp_path / "test.json"
+        manager = TelemetryManager(vm_id="test-vm", telemetry_path=telemetry_path)
+        
+        manager.record_boot_start()
+        manager.record_boot_ready()
+        manager.record_command_execution(
+            command="ls",
+            exit_code=0,
+            stdout="/bin /etc /usr ...",
+            stderr="",
+            duration_ms=100,
+        )
+        
+        # Verify file exists and contains valid JSON
+        assert telemetry_path.exists()
+        with open(telemetry_path) as f:
+            lines = [line.strip() for line in f if line.strip()]
+            # JSON Lines format: one JSON object per line
+            assert len(lines) >= 3
+            for line in lines:
+                data = json.loads(line)
+                assert "vm_id" in data
+                assert data["vm_id"] == "test-vm"
+
+    def test_load_existing_telemetry(self, tmp_path: Path) -> None:
+        """Test that TelemetryManager loads existing telemetry file."""
+        telemetry_path = tmp_path / "test.json"
+        
+        # Create initial manager and record data
+        manager1 = TelemetryManager(vm_id="test-vm", telemetry_path=telemetry_path)
+        manager1.record_boot_start()
+        manager1.record_boot_ready()
+        
+        # Create new manager for same file
+        manager2 = TelemetryManager(vm_id="test-vm", telemetry_path=telemetry_path)
+        
+        # Should have loaded previous data
+        data = manager2.get_data()
+        assert len(data.boot_events) >= 2

--- a/tests/test_telemetry_live.py
+++ b/tests/test_telemetry_live.py
@@ -5,26 +5,31 @@ import json
 import time
 from pathlib import Path
 
-from smolvm import SmolVM
-from smolvm.types import VMConfig
+import pytest
 
-def test_telemetry_live() -> None:  # Return None, not bool
-    """Test telemetry with an actual VM."""
+from smolvm import SmolVM
+from smolvm.telemetry import TelemetryManager
+
+
+@pytest.mark.integration
+@pytest.mark.skipif(
+    not Path("/usr/bin/firecracker").exists() and not Path("/usr/local/bin/firecracker").exists(),
+    reason="Firecracker not installed; skipping live VM test",
+)
+def test_telemetry_live() -> None:
+    """Test telemetry with an actual VM (requires Firecracker)."""
     
     print("📝 Creating VM with telemetry enabled...")
     with SmolVM() as vm:
         print(f"✅ VM created: {vm.vm_id}")
         
         # Enable telemetry - let start() handle recording
-        from pathlib import Path
-        from smolvm.telemetry import TelemetryManager
         telemetry_dir = Path.home() / ".smolvm" / "telemetry"
         vm._telemetry = TelemetryManager(
             vm_id=vm.vm_id,
             telemetry_path=telemetry_dir / f"{vm.vm_id}.json",
         )
         
-        # DON'T manually record boot_start/ready - let start() do it
         print("\n🚀 Starting VM...")
         start_time = time.time()
         vm.start()  # This will record boot events automatically
@@ -49,21 +54,16 @@ def test_telemetry_live() -> None:  # Return None, not bool
     
     # Verify telemetry was recorded
     print("\n🔍 Checking telemetry...")
-    telemetry_file = Path.home() / ".smolvm" / "telemetry" / f"{vm.vm_id}.json"  # Use actual VM ID
+    telemetry_file = Path.home() / ".smolvm" / "telemetry" / f"{vm.vm_id}.json"
     
-    if not telemetry_file.exists():
-        print(f"❌ Telemetry file not found at {telemetry_file}")
-        return False
-    
+    assert telemetry_file.exists(), f"Telemetry file not found at {telemetry_file}"
     print(f"✅ Telemetry file found: {telemetry_file}")
     
     # Parse and display telemetry
     with open(telemetry_file) as f:
         lines = [line.strip() for line in f if line.strip()]
     
-    if not lines:
-        print("❌ Telemetry file is empty")
-        return False
+    assert len(lines) > 0, "Telemetry file is empty"
     
     # Get the last (most recent) record
     last_record = json.loads(lines[-1])
@@ -82,29 +82,17 @@ def test_telemetry_live() -> None:  # Return None, not bool
         print(f"     {i+1}. {status} (duration: {duration}ms) {error}")
     
     # Command executions
-    commands = last_record.get('command_executions', [])
-    print(f"\n   Command Executions: {len(commands)}")
-    for i, cmd in enumerate(commands):
+    commands_exec = last_record.get('command_executions', [])
+    print(f"\n   Command Executions: {len(commands_exec)}")
+    for i, cmd in enumerate(commands_exec):
         print(f"     {i+1}. {cmd['command']}")
         print(f"        Exit code: {cmd['exit_code']}, Duration: {cmd['duration_ms']}ms")
         if cmd['stdout']:
             stdout_preview = cmd['stdout'][:50].replace('\n', ' ')
             print(f"        Stdout: {stdout_preview}...")
     
+    # Assertions
+    assert len(boot_events) >= 2, f"Expected at least 2 boot events, got {len(boot_events)}"
+    assert len(commands_exec) >= 4, f"Expected at least 4 command executions, got {len(commands_exec)}"
+    
     print("\n✅ Telemetry test passed!")
-    # Don't return anything
-
-
-if __name__ == "__main__":
-    try:
-        test_telemetry_live()
-        print("✅ All assertions passed!")
-        exit(0)
-    except AssertionError as e:
-        print(f"\n❌ Assertion failed: {e}")
-        exit(1)
-    except Exception as e:
-        print(f"\n❌ Test failed with error: {e}")
-        import traceback
-        traceback.print_exc()
-        exit(1)

--- a/tests/test_telemetry_live.py
+++ b/tests/test_telemetry_live.py
@@ -1,0 +1,110 @@
+#!/usr/bin/env python3
+"""Manual test for telemetry with a real VM."""
+
+import json
+import time
+from pathlib import Path
+
+from smolvm import SmolVM
+from smolvm.types import VMConfig
+
+def test_telemetry_live() -> None:  # Return None, not bool
+    """Test telemetry with an actual VM."""
+    
+    print("📝 Creating VM with telemetry enabled...")
+    with SmolVM() as vm:
+        print(f"✅ VM created: {vm.vm_id}")
+        
+        # Enable telemetry - let start() handle recording
+        from pathlib import Path
+        from smolvm.telemetry import TelemetryManager
+        telemetry_dir = Path.home() / ".smolvm" / "telemetry"
+        vm._telemetry = TelemetryManager(
+            vm_id=vm.vm_id,
+            telemetry_path=telemetry_dir / f"{vm.vm_id}.json",
+        )
+        
+        # DON'T manually record boot_start/ready - let start() do it
+        print("\n🚀 Starting VM...")
+        start_time = time.time()
+        vm.start()  # This will record boot events automatically
+        boot_time = time.time() - start_time
+        print(f"✅ VM started in {boot_time:.2f}s")
+        
+        print("\n⚙️ Running commands...")
+        commands = [
+            "echo 'Command 1'",
+            "uname -a",
+            "ls -la /",
+            "whoami",
+        ]
+        
+        for cmd in commands:
+            result = vm.run(cmd)
+            print(f"  ✅ {cmd} -> exit_code={result.exit_code}")
+        
+        print("\n⏹️ Stopping VM...")
+        vm.stop()
+        print("✅ VM stopped")
+    
+    # Verify telemetry was recorded
+    print("\n🔍 Checking telemetry...")
+    telemetry_file = Path.home() / ".smolvm" / "telemetry" / f"{vm.vm_id}.json"  # Use actual VM ID
+    
+    if not telemetry_file.exists():
+        print(f"❌ Telemetry file not found at {telemetry_file}")
+        return False
+    
+    print(f"✅ Telemetry file found: {telemetry_file}")
+    
+    # Parse and display telemetry
+    with open(telemetry_file) as f:
+        lines = [line.strip() for line in f if line.strip()]
+    
+    if not lines:
+        print("❌ Telemetry file is empty")
+        return False
+    
+    # Get the last (most recent) record
+    last_record = json.loads(lines[-1])
+    
+    print(f"\n📊 Telemetry Summary:")
+    print(f"   VM ID: {last_record['vm_id']}")
+    print(f"   Created: {last_record['created_at']}")
+    
+    # Boot events
+    boot_events = last_record.get('boot_events', [])
+    print(f"\n   Boot Events: {len(boot_events)}")
+    for i, evt in enumerate(boot_events):
+        status = evt['status']
+        duration = evt.get('duration_ms', 'N/A')
+        error = evt.get('error', '')
+        print(f"     {i+1}. {status} (duration: {duration}ms) {error}")
+    
+    # Command executions
+    commands = last_record.get('command_executions', [])
+    print(f"\n   Command Executions: {len(commands)}")
+    for i, cmd in enumerate(commands):
+        print(f"     {i+1}. {cmd['command']}")
+        print(f"        Exit code: {cmd['exit_code']}, Duration: {cmd['duration_ms']}ms")
+        if cmd['stdout']:
+            stdout_preview = cmd['stdout'][:50].replace('\n', ' ')
+            print(f"        Stdout: {stdout_preview}...")
+    
+    print("\n✅ Telemetry test passed!")
+    # Don't return anything
+
+
+if __name__ == "__main__":
+    try:
+        test_telemetry_live()
+        print("✅ All assertions passed!")
+        exit(0)
+    except AssertionError as e:
+        print(f"\n❌ Assertion failed: {e}")
+        exit(1)
+    except Exception as e:
+        print(f"\n❌ Test failed with error: {e}")
+        import traceback
+        traceback.print_exc()
+        exit(1)


### PR DESCRIPTION
## Summary

Add an opt-in VM-level telemetry subsystem that records boot events (started/ready/failed) and SSH command executions (command, exit_code, stdout, stderr, duration_ms) per-VM. Data is persisted in JSON Lines. This enables lightweight local observability for debugging and performance analysis without requiring remote services.

Why: provide per-VM observability for debugging boot issues, tracking command failures/latency, and supplying audit-capable SSH transcripts — opt-in to respect privacy.


## Testing

What I ran locally:

1. Iterative unit tests and fixes:
uv run pytest test_telemetry.py -v (iterated while fixing telemetry manager/type/import issues)
2. Manual/integration run:
uv run pytest tests/test_telemetry_live.py::test_telemetry_live -v -s — passed (created an auto-config VM, exercised [start()](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html), multiple [run()](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html) commands, verified telemetry file and contents)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Optional telemetry for VM lifecycle (boot start/ready/failed) and per-command SSH execution (command, exit code, output, duration); disabled by default and toggleable via config.
  * Telemetry is persisted to a per-VM file for later inspection and can be cleared.

* **Tests**
  * New unit and live integration tests covering telemetry recording, persistence, loading, and end-to-end VM telemetry behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->