### PR TITLE
fix(security): use tar filter='data' instead of 'fully_trusted'

### DIFF
--- a/src/smolvm/dashboard/server.py
+++ b/src/smolvm/dashboard/server.py
@@ -219,13 +219,13 @@ def _extract_dashboard_dist(archive_path: Path, extract_dir: Path) -> Path:
             if member_path.is_absolute() or ".." in member_path.parts:
                 raise RuntimeError(f"Unsafe path in dashboard archive: {member.name}")
 
-        try:
+        if hasattr(tarfile, "data_filter"):
             tar.extractall(path=extract_dir, filter="data")
-        except TypeError:
+        else:
             # Python < 3.12 without PEP 706 backport — fall back to
             # unfiltered extraction.  The path validation above guards
             # against absolute/.. paths; tar.filter is defense-in-depth.
-            tar.extractall(path=extract_dir)
+            tar.extractall(path=extract_dir)  # noqa: S202
 
     dist_dir = extract_dir / "dist"
     if dist_dir.is_dir() and (dist_dir / "index.html").is_file():

--- a/src/smolvm/dashboard/server.py
+++ b/src/smolvm/dashboard/server.py
@@ -220,8 +220,11 @@ def _extract_dashboard_dist(archive_path: Path, extract_dir: Path) -> Path:
                 raise RuntimeError(f"Unsafe path in dashboard archive: {member.name}")
 
         try:
-            tar.extractall(path=extract_dir, filter="fully_trusted")
+            tar.extractall(path=extract_dir, filter="data")
         except TypeError:
+            # Python < 3.12 without PEP 706 backport — fall back to
+            # unfiltered extraction.  The path validation above guards
+            # against absolute/.. paths; tar.filter is defense-in-depth.
             tar.extractall(path=extract_dir)
 
     dist_dir = extract_dir / "dist"

--- a/src/smolvm/host/manager.py
+++ b/src/smolvm/host/manager.py
@@ -25,7 +25,7 @@ import stat
 import tarfile
 import tempfile
 from enum import Enum
-from pathlib import Path
+from pathlib import Path, PurePosixPath
 
 import requests
 from pydantic import BaseModel
@@ -292,15 +292,15 @@ class HostManager:
             with tarfile.open(tarball_path, "r:gz") as tar:
                 # Security: validate member paths to prevent path traversal
                 for member in tar.getmembers():
-                    if member.name.startswith("/") or ".." in member.name:
+                    if member.name.startswith("/") or ".." in PurePosixPath(member.name).parts:
                         raise HostError(f"Refusing to extract suspicious path: {member.name}")
-                try:
+                if hasattr(tarfile, "data_filter"):
                     tar.extractall(path=tmp_dir, filter="data")
-                except TypeError:
+                else:
                     # Python < 3.12 without PEP 706 backport — fall back to
                     # unfiltered extraction.  The path validation above
                     # guards against absolute/.. paths.
-                    tar.extractall(path=tmp_dir)
+                    tar.extractall(path=tmp_dir)  # noqa: S202
 
             # Find the firecracker binary in extracted contents
             # Tarball structure: release-{version}-{arch}/firecracker-{version}-{arch}

--- a/src/smolvm/host/manager.py
+++ b/src/smolvm/host/manager.py
@@ -294,7 +294,13 @@ class HostManager:
                 for member in tar.getmembers():
                     if member.name.startswith("/") or ".." in member.name:
                         raise HostError(f"Refusing to extract suspicious path: {member.name}")
-                tar.extractall(path=tmp_dir)
+                try:
+                    tar.extractall(path=tmp_dir, filter="data")
+                except TypeError:
+                    # Python < 3.12 without PEP 706 backport — fall back to
+                    # unfiltered extraction.  The path validation above
+                    # guards against absolute/.. paths.
+                    tar.extractall(path=tmp_dir)
 
             # Find the firecracker binary in extracted contents
             # Tarball structure: release-{version}-{arch}/firecracker-{version}-{arch}

--- a/tests/test_tar_extraction_security.py
+++ b/tests/test_tar_extraction_security.py
@@ -34,13 +34,44 @@ def _make_tarball_with_member(arcname: str) -> bytes:
         tar.addfile(info, io.BytesIO(data))
     return buf.getvalue()
 
-
 def _mock_response(tarball_bytes: bytes) -> MagicMock:
     mock_response = MagicMock()
     mock_response.raise_for_status = MagicMock()
     mock_response.iter_content = lambda chunk_size: iter([tarball_bytes])
     return mock_response
 
+def _make_spying_tar_open(
+    original_open, extractall_calls: list[dict]
+):
+    """Return a ``tarfile.open`` replacement that records *extractall* kwargs.
+
+    Using a factory keeps the spy class in one place so every test shares the
+    same implementation.
+    """
+
+    class _SpyingTarFile:
+        """Wraps a real TarFile to record extractall calls."""
+
+        def __init__(self, real_tar: tarfile.TarFile) -> None:
+            self._tar = real_tar
+
+        def getmembers(self):
+            return self._tar.getmembers()
+
+        def extractall(self, **kwargs):
+            extractall_calls.append(kwargs)
+            return self._tar.extractall(**kwargs)  # noqa: S202
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *args):
+            return self._tar.__exit__(*args)
+
+    def _spying_open(*args, **kwargs):
+        return _SpyingTarFile(original_open(*args, **kwargs))
+
+    return _spying_open
 
 class TestHostManagerTarExtraction:
     """Verify path-traversal guards in HostManager._download_and_extract."""
@@ -161,32 +192,8 @@ class TestHostManagerTarExtraction:
         dest.parent.mkdir(parents=True, exist_ok=True)
         hm = HostManager()
 
-        # Patch tarfile.open to spy on the TarFile object
-        original_open = tarfile.open
-
         extractall_calls: list[dict] = []
-
-        class SpyingTarFile:
-            """Wraps a real TarFile to record extractall calls."""
-
-            def __init__(self, real_tar: tarfile.TarFile) -> None:
-                self._tar = real_tar
-
-            def getmembers(self):
-                return self._tar.getmembers()
-
-            def extractall(self, **kwargs):
-                extractall_calls.append(kwargs)
-                return self._tar.extractall(**kwargs)
-
-            def __enter__(self):
-                return self
-
-            def __exit__(self, *args):
-                return self._tar.__exit__(*args)
-
-        def spying_open(*args, **kwargs):
-            return SpyingTarFile(original_open(*args, **kwargs))
+        spying_open = _make_spying_tar_open(tarfile.open, extractall_calls)
 
         with mock_get, patch("smolvm.host.manager.tarfile.open", side_effect=spying_open):
             hm._download_and_extract(
@@ -199,7 +206,6 @@ class TestHostManagerTarExtraction:
             assert extractall_calls[0].get("filter") == "data"
         else:
             assert "filter" not in extractall_calls[0]
-
 
 class TestDashboardExtractDist:
     """Verify path-traversal guards in _extract_dashboard_dist."""
@@ -261,28 +267,8 @@ class TestDashboardExtractDist:
         with tarfile.open(archive, "w:gz") as tar:
             tar.add(content, arcname=".")
 
-        original_open = tarfile.open
         extractall_calls: list[dict] = []
-
-        class SpyingTarFile:
-            def __init__(self, real_tar: tarfile.TarFile) -> None:
-                self._tar = real_tar
-
-            def getmembers(self):
-                return self._tar.getmembers()
-
-            def extractall(self, **kwargs):
-                extractall_calls.append(kwargs)
-                return self._tar.extractall(**kwargs)
-
-            def __enter__(self):
-                return self
-
-            def __exit__(self, *args):
-                return self._tar.__exit__(*args)
-
-        def spying_open(*args, **kwargs):
-            return SpyingTarFile(original_open(*args, **kwargs))
+        spying_open = _make_spying_tar_open(tarfile.open, extractall_calls)
 
         with patch("smolvm.dashboard.server.tarfile.open", side_effect=spying_open):
             result = _extract_dashboard_dist(archive, tmp_path / "extract")

--- a/tests/test_tar_extraction_security.py
+++ b/tests/test_tar_extraction_security.py
@@ -15,6 +15,7 @@
 """Tests for tar extraction security (PR #290 follow-up)."""
 
 import io
+import sys
 import tarfile
 from pathlib import Path
 from unittest.mock import MagicMock, patch
@@ -22,6 +23,36 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 from smolvm.exceptions import HostError
+
+
+# ---------------------------------------------------------------------------
+# The dashboard server module has heavy top-level imports (fastapi, uvicorn,
+# websockets …) that live in the optional ``dashboard`` extra.  The CI test
+# matrix only installs the ``dev`` extra, so those packages are absent.
+# ``_extract_dashboard_dist`` is a pure-stdlib helper (tarfile / pathlib)
+# that does not need any of them.  We inject lightweight stubs into
+# ``sys.modules`` so the module can be imported without pulling in the real
+# packages.
+# ---------------------------------------------------------------------------
+_DASHBOARD_STUB_MODULES: list[str] = [
+    "fastapi",
+    "fastapi.middleware",
+    "fastapi.middleware.cors",
+    "fastapi.responses",
+    "fastapi.staticfiles",
+    "uvicorn",
+    "websockets",
+    "smolvm.dashboard.commands",
+    "smolvm.dashboard.connection_manager",
+    "smolvm.dashboard.poller",
+]
+
+
+def _ensure_dashboard_importable() -> None:  # pragma: no cover
+    """Insert stubs for optional dashboard dependencies if missing."""
+    for mod_name in _DASHBOARD_STUB_MODULES:
+        if mod_name not in sys.modules:
+            sys.modules[mod_name] = MagicMock()
 
 
 def _make_tarball_with_member(arcname: str) -> bytes:
@@ -209,6 +240,10 @@ class TestHostManagerTarExtraction:
 
 class TestDashboardExtractDist:
     """Verify path-traversal guards in _extract_dashboard_dist."""
+
+    @pytest.fixture(autouse=True)
+    def _stub_optional_deps(self) -> None:
+        _ensure_dashboard_importable()
 
     def test_rejects_dotdot_in_member(self, tmp_path: Path) -> None:
         """Member names containing '..' path parts must be rejected."""

--- a/tests/test_tar_extraction_security.py
+++ b/tests/test_tar_extraction_security.py
@@ -1,0 +1,295 @@
+# Copyright 2026 Celesto AI
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for tar extraction security (PR #290 follow-up)."""
+
+import io
+import tarfile
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from smolvm.exceptions import HostError
+
+
+def _make_tarball_with_member(arcname: str) -> bytes:
+    """Create a minimal .tar.gz containing a single file at *arcname*."""
+    buf = io.BytesIO()
+    with tarfile.open(fileobj=buf, mode="w:gz") as tar:
+        info = tarfile.TarInfo(name=arcname)
+        data = b"hello"
+        info.size = len(data)
+        tar.addfile(info, io.BytesIO(data))
+    return buf.getvalue()
+
+
+def _mock_response(tarball_bytes: bytes) -> MagicMock:
+    mock_response = MagicMock()
+    mock_response.raise_for_status = MagicMock()
+    mock_response.iter_content = lambda chunk_size: iter([tarball_bytes])
+    return mock_response
+
+
+class TestHostManagerTarExtraction:
+    """Verify path-traversal guards in HostManager._download_and_extract."""
+
+    def test_rejects_dotdot_in_member_name(self, tmp_path: Path) -> None:
+        """Member names containing '..' must be rejected."""
+        from smolvm.host.manager import HostManager
+
+        tarball_bytes = _make_tarball_with_member("foo/../../etc/passwd")
+        mock_get = patch(
+            "smolvm.host.manager.requests.get",
+            return_value=_mock_response(tarball_bytes),
+        )
+
+        hm = HostManager()
+        dest = tmp_path / "fc"
+        with mock_get, pytest.raises(HostError, match="suspicious path"):
+            hm._download_and_extract(
+                url="http://example.com/fc.tgz", dest=dest,
+                version="v1.13.0", arch="x86_64",
+            )
+
+    def test_rejects_absolute_member_name(self, tmp_path: Path) -> None:
+        """Member names starting with '/' must be rejected."""
+        from smolvm.host.manager import HostManager
+
+        tarball_bytes = _make_tarball_with_member("/etc/passwd")
+        mock_get = patch(
+            "smolvm.host.manager.requests.get",
+            return_value=_mock_response(tarball_bytes),
+        )
+
+        hm = HostManager()
+        dest = tmp_path / "fc"
+        with mock_get, pytest.raises(HostError, match="suspicious path"):
+            hm._download_and_extract(
+                url="http://example.com/fc.tgz", dest=dest,
+                version="v1.13.0", arch="x86_64",
+            )
+
+    def test_rejects_dotdot_at_start(self, tmp_path: Path) -> None:
+        """Member name starting with '..' (no slash prefix) must be rejected."""
+        from smolvm.host.manager import HostManager
+
+        tarball_bytes = _make_tarball_with_member("../../etc/shadow")
+        mock_get = patch(
+            "smolvm.host.manager.requests.get",
+            return_value=_mock_response(tarball_bytes),
+        )
+
+        hm = HostManager()
+        dest = tmp_path / "fc"
+        with mock_get, pytest.raises(HostError, match="suspicious path"):
+            hm._download_and_extract(
+                url="http://example.com/fc.tgz", dest=dest,
+                version="v1.13.0", arch="x86_64",
+            )
+
+    def test_accepts_valid_member_name(self, tmp_path: Path) -> None:
+        """Legitimate member names should extract without error."""
+        from smolvm.host.manager import HostManager
+
+        version = "v1.13.0"
+        arch = "x86_64"
+        inner_dir = f"release-{version}-{arch}"
+        binary_name = f"firecracker-{version}-{arch}"
+
+        # Build a real tarball with a binary inside
+        inner_path = tmp_path / inner_dir
+        inner_path.mkdir()
+        fake_binary = inner_path / binary_name
+        fake_binary.write_text("#!/bin/sh\necho firecracker")
+
+        tarball_path = tmp_path / "fc.tgz"
+        with tarfile.open(tarball_path, "w:gz") as tar:
+            tar.add(inner_path, arcname=inner_dir)
+
+        mock_get = patch(
+            "smolvm.host.manager.requests.get",
+            return_value=_mock_response(tarball_path.read_bytes()),
+        )
+
+        dest = tmp_path / "bin" / "firecracker"
+        dest.parent.mkdir(parents=True, exist_ok=True)
+        hm = HostManager()
+        with mock_get:
+            hm._download_and_extract(
+                url="http://example.com/fc.tgz", dest=dest,
+                version=version, arch=arch,
+            )
+
+        assert dest.exists()
+
+    def test_uses_data_filter_when_available(self, tmp_path: Path) -> None:
+        """When tarfile.data_filter exists, extractall(filter='data') is called."""
+        from smolvm.host.manager import HostManager
+
+        version = "v1.13.0"
+        arch = "x86_64"
+        inner_dir = f"release-{version}-{arch}"
+        binary_name = f"firecracker-{version}-{arch}"
+
+        inner_path = tmp_path / inner_dir
+        inner_path.mkdir()
+        fake_binary = inner_path / binary_name
+        fake_binary.write_text("#!/bin/sh\necho firecracker")
+
+        tarball_path = tmp_path / "fc.tgz"
+        with tarfile.open(tarball_path, "w:gz") as tar:
+            tar.add(inner_path, arcname=inner_dir)
+
+        mock_get = patch(
+            "smolvm.host.manager.requests.get",
+            return_value=_mock_response(tarball_path.read_bytes()),
+        )
+
+        dest = tmp_path / "bin" / "firecracker"
+        dest.parent.mkdir(parents=True, exist_ok=True)
+        hm = HostManager()
+
+        # Patch tarfile.open to spy on the TarFile object
+        original_open = tarfile.open
+
+        extractall_calls: list[dict] = []
+
+        class SpyingTarFile:
+            """Wraps a real TarFile to record extractall calls."""
+
+            def __init__(self, real_tar: tarfile.TarFile) -> None:
+                self._tar = real_tar
+
+            def getmembers(self):
+                return self._tar.getmembers()
+
+            def extractall(self, **kwargs):
+                extractall_calls.append(kwargs)
+                return self._tar.extractall(**kwargs)
+
+            def __enter__(self):
+                return self
+
+            def __exit__(self, *args):
+                return self._tar.__exit__(*args)
+
+        def spying_open(*args, **kwargs):
+            return SpyingTarFile(original_open(*args, **kwargs))
+
+        with mock_get, patch("smolvm.host.manager.tarfile.open", side_effect=spying_open):
+            hm._download_and_extract(
+                url="http://example.com/fc.tgz", dest=dest,
+                version=version, arch=arch,
+            )
+
+        assert len(extractall_calls) == 1
+        if hasattr(tarfile, "data_filter"):
+            assert extractall_calls[0].get("filter") == "data"
+        else:
+            assert "filter" not in extractall_calls[0]
+
+
+class TestDashboardExtractDist:
+    """Verify path-traversal guards in _extract_dashboard_dist."""
+
+    def test_rejects_dotdot_in_member(self, tmp_path: Path) -> None:
+        """Member names containing '..' path parts must be rejected."""
+        from smolvm.dashboard.server import _extract_dashboard_dist
+
+        tarball_bytes = _make_tarball_with_member("dist/../../../etc/passwd")
+        archive = tmp_path / "archive.tar.gz"
+        archive.write_bytes(tarball_bytes)
+
+        with pytest.raises(RuntimeError, match="Unsafe path"):
+            _extract_dashboard_dist(archive, tmp_path / "extract")
+
+    def test_rejects_absolute_member(self, tmp_path: Path) -> None:
+        """Member names starting with '/' must be rejected."""
+        from smolvm.dashboard.server import _extract_dashboard_dist
+
+        tarball_bytes = _make_tarball_with_member("/etc/passwd")
+        archive = tmp_path / "archive.tar.gz"
+        archive.write_bytes(tarball_bytes)
+
+        with pytest.raises(RuntimeError, match="Unsafe path"):
+            _extract_dashboard_dist(archive, tmp_path / "extract")
+
+    def test_extracts_valid_archive(self, tmp_path: Path) -> None:
+        """A clean archive with dist/index.html extracts and returns dist dir."""
+        from smolvm.dashboard.server import _extract_dashboard_dist
+
+        # Create a real tarball with dist/index.html
+        content = tmp_path / "staging"
+        content.mkdir()
+        dist = content / "dist"
+        dist.mkdir()
+        (dist / "index.html").write_text("<html></html>")
+
+        archive = tmp_path / "archive.tar.gz"
+        with tarfile.open(archive, "w:gz") as tar:
+            tar.add(content, arcname=".")
+
+        extract_dir = tmp_path / "extract"
+        result = _extract_dashboard_dist(archive, extract_dir)
+
+        assert result.is_dir()
+        assert (result / "index.html").is_file()
+
+    def test_uses_data_filter_guard(self, tmp_path: Path) -> None:
+        """_extract_dashboard_dist uses hasattr guard for data_filter."""
+        from smolvm.dashboard.server import _extract_dashboard_dist
+
+        content = tmp_path / "staging"
+        content.mkdir()
+        dist = content / "dist"
+        dist.mkdir()
+        (dist / "index.html").write_text("<html></html>")
+
+        archive = tmp_path / "archive.tar.gz"
+        with tarfile.open(archive, "w:gz") as tar:
+            tar.add(content, arcname=".")
+
+        original_open = tarfile.open
+        extractall_calls: list[dict] = []
+
+        class SpyingTarFile:
+            def __init__(self, real_tar: tarfile.TarFile) -> None:
+                self._tar = real_tar
+
+            def getmembers(self):
+                return self._tar.getmembers()
+
+            def extractall(self, **kwargs):
+                extractall_calls.append(kwargs)
+                return self._tar.extractall(**kwargs)
+
+            def __enter__(self):
+                return self
+
+            def __exit__(self, *args):
+                return self._tar.__exit__(*args)
+
+        def spying_open(*args, **kwargs):
+            return SpyingTarFile(original_open(*args, **kwargs))
+
+        with patch("smolvm.dashboard.server.tarfile.open", side_effect=spying_open):
+            result = _extract_dashboard_dist(archive, tmp_path / "extract")
+
+        assert result.is_dir()
+        assert len(extractall_calls) == 1
+        if hasattr(tarfile, "data_filter"):
+            assert extractall_calls[0].get("filter") == "data"
+        else:
+            assert "filter" not in extractall_calls[0]


### PR DESCRIPTION
## Summary

Replaces `filter='fully_trusted'` with `filter='data'` in tar extraction calls across two files. Also adds `filter='data'` where extraction had no filter at all.

## Problem

`fully_trusted` trusts all archive members without restriction. A malicious archive can:
- Write files outside the target directory via absolute or `../` paths (path traversal)
- Set dangerous file permissions (setuid/setgid)
- Create device files or FIFOs in unexpected locations

While both extraction sites already had manual path validation, `fully_trusted` offers no defense-in-depth against permission-based attacks.

## Solution

The `data` filter ([PEP 706](https://peps.python.org/pep-0706/)) restricts tar members to:
- No absolute paths
- No `..` path components
- No character/block devices, FIFOs, or setuid/setgid files

Both sites fall back gracefully on Python < 3.12 where the filter parameter is unavailable, preserving the existing manual path validation as a safety net.

## Files changed

- `src/smolvm/dashboard/server.py` (line 223): `fully_trusted` → `data`
- `src/smolvm/host/manager.py` (line 297): Added `filter='data'` with fallback

## Security impact

- **Before**: Archive contents trusted fully; only path traversal guarded manually
- **After**: `data` filter blocks path traversal, dangerous permissions, and device files
- **No breaking changes**: Legitimate archives extract identically; only malicious members are rejected

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved protection against path‑traversal during archive extraction in dashboard and host installation flows.
  * Extraction now leverages safer filtering when available, with a secure fallback for older environments to maintain compatibility.

* **Tests**
  * Added comprehensive tests to validate safe extraction behavior, rejection of malicious archive entries, and compatibility across Python versions.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/CelestoAI/SmolVM/pull/290)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->