### PR TITLE
Add legacy report fetcher computer-use demo

### DIFF
--- a/examples/cua/legacy_report_fetcher/README.md
+++ b/examples/cua/legacy_report_fetcher/README.md
@@ -1,20 +1,20 @@
 # Legacy report fetcher computer-use demo
 
-This demo shows a computer-use agent logging into a legacy reporting portal, downloading files through a browser, and handing those files to an existing pipeline.
+This demo shows an agent using a browser to get reports from an old web app and hand those reports to a normal data pipeline.
 
-The whole workflow runs inside a SmolVM browser sandbox. The demo folder is mounted into the sandbox, the fake legacy app starts from the sandbox shell, the agent controls the browser over CDP, and all file work happens through `vm.run()` commands inside the sandbox.
+The workflow runs in a SmolVM browser sandbox. The fake Acme portal starts inside the sandbox, the agent uses the browser, the sandbox checks the files, and the final reports are copied back to your machine for the pipeline.
 
 ## What it demonstrates
 
-- A browser agent can use a legacy web app when there is no API.
-- SmolVM gives that agent an isolated computer with a live browser view.
-- The agent uses the browser for clicks and downloads.
-- The sandbox shell can list and recover downloaded files when the model stops early.
-- The harness copies report files from the sandbox to the host before running the pipeline.
+- An agent can use a legacy web app when there is no API.
+- SmolVM gives the agent an isolated computer with a live browser you can watch.
+- The workflow does not trust the agent saying “done”; it checks that the files exist.
+- The sandbox shell can list and recover report files when browser downloads are unreliable.
+- The harness copies verified files from the sandbox to the host before running the pipeline.
 
 ## Run it
 
-This demo needs two host-side Python packages: `openai` for the computer-use model and `playwright` to connect to the browser over CDP.
+This demo needs two host-side Python packages: `openai` for the computer-use model and `playwright` to connect to the sandbox browser over CDP.
 
 ```bash
 export OPENAI_API_KEY=...
@@ -23,10 +23,40 @@ uv run --with openai --with playwright examples/cua/legacy_report_fetcher/run_de
 
 Open the printed live URL to watch the browser.
 
-For a recording-friendly run, keep `--mode live`. For a quieter run:
+For a quieter run without the live browser view:
 
 ```bash
 uv run --with openai --with playwright examples/cua/legacy_report_fetcher/run_demo.py --mode headless
+```
+
+Optional flags:
+
+```bash
+--report-date 2026-05-07   # defaults to yesterday
+--max-steps 24             # max computer-use turns
+--boot-timeout 180         # seconds to wait for the sandbox to boot
+```
+
+## What you should see
+
+The script prints progress as it moves through the workflow:
+
+```txt
+Starting SmolVM browser sandbox...
+Starting Acme legacy portal inside the sandbox...
+Starting OpenAI computer-use browser task...
+Listing sandbox downloads and copying reports to the host...
+Running the existing-pipeline import on the host handoff folder...
+```
+
+A successful run ends with pipeline output like:
+
+```txt
+Found manifest.json for acme_legacy_reports
+Imported orders_2026-05-07.csv: 3 rows into orders
+Imported inventory_2026-05-07.csv: 3 rows into inventory
+Stored normalized data in .../artifacts/warehouse/acme.sqlite
+Run complete.
 ```
 
 ## Output
@@ -55,13 +85,13 @@ username: ops@acme.test
 password: demo-password
 ```
 
-## Architecture
+## How it works
 
 ```txt
 Host folder mounted into sandbox
 └── /workspace/legacy_report_fetcher
     ├── portal/      # fake Acme Legacy Reports Portal
-    ├── ops/         # sandbox-side operational scripts
+    ├── ops/         # sandbox-side helper scripts
     ├── pipeline/    # existing-pipeline stand-in
     └── artifacts/   # host-side handoff output
 ```
@@ -73,3 +103,5 @@ http://127.0.0.1:8000
 ```
 
 That server runs inside the SmolVM sandbox, not on the host laptop.
+
+The important reliability step is after the agent finishes. The harness lists the sandbox download folder, recovers files if needed, copies the verified CSVs to the host, writes `manifest.json`, and then runs the pipeline.

--- a/examples/cua/legacy_report_fetcher/README.md
+++ b/examples/cua/legacy_report_fetcher/README.md
@@ -1,0 +1,75 @@
+# Legacy report fetcher computer-use demo
+
+This demo shows a computer-use agent logging into a legacy reporting portal, downloading files through a browser, and handing those files to an existing pipeline.
+
+The whole workflow runs inside a SmolVM browser sandbox. The demo folder is mounted into the sandbox, the fake legacy app starts from the sandbox shell, the agent controls the browser over CDP, and all file work happens through `vm.run()` commands inside the sandbox.
+
+## What it demonstrates
+
+- A browser agent can use a legacy web app when there is no API.
+- SmolVM gives that agent an isolated computer with a live browser view.
+- The agent uses the browser for clicks and downloads.
+- The sandbox shell handles files, hashes, manifests, and pipeline handoff.
+- A writable mount makes output appear on the host for live calls and recordings.
+
+## Run it
+
+This demo needs two host-side Python packages: `openai` for the computer-use model and `playwright` to connect to the browser over CDP.
+
+```bash
+export OPENAI_API_KEY=...
+uv run --with openai --with playwright examples/cua/legacy_report_fetcher/run_demo.py --mode live
+```
+
+Open the printed live URL to watch the browser.
+
+For a recording-friendly run, keep `--mode live`. For a quieter run:
+
+```bash
+uv run --with openai --with playwright examples/cua/legacy_report_fetcher/run_demo.py --mode headless
+```
+
+## Output
+
+Generated files appear under:
+
+```txt
+examples/cua/legacy_report_fetcher/artifacts/
+  inbox/acme/<report-date>/
+    orders_<report-date>.csv
+    inventory_<report-date>.csv
+    manifest.json
+  warehouse/
+    acme.sqlite
+  screenshots/
+    01-portal-login.png
+    02-after-downloads.png
+```
+
+Browser session logs and video are collected in the SmolVM browser artifacts directory printed by the script.
+
+## Fake portal credentials
+
+```txt
+username: ops@acme.test
+password: demo-password
+```
+
+## Architecture
+
+```txt
+Host folder mounted writable into sandbox
+└── /workspace/legacy_report_fetcher
+    ├── portal/      # fake Acme Legacy Reports Portal
+    ├── ops/         # sandbox-side operational scripts
+    ├── pipeline/    # existing-pipeline stand-in
+    └── artifacts/   # output visible on the host
+```
+
+The browser opens the portal at:
+
+```txt
+http://127.0.0.1:8000
+```
+
+That server runs inside the SmolVM sandbox, not on the host laptop.

--- a/examples/cua/legacy_report_fetcher/README.md
+++ b/examples/cua/legacy_report_fetcher/README.md
@@ -9,8 +9,8 @@ The whole workflow runs inside a SmolVM browser sandbox. The demo folder is moun
 - A browser agent can use a legacy web app when there is no API.
 - SmolVM gives that agent an isolated computer with a live browser view.
 - The agent uses the browser for clicks and downloads.
-- The sandbox shell handles files, hashes, manifests, and pipeline handoff.
-- A writable mount makes output appear on the host for live calls and recordings.
+- The sandbox shell can list and recover downloaded files when the model stops early.
+- The harness copies report files from the sandbox to the host before running the pipeline.
 
 ## Run it
 
@@ -58,12 +58,12 @@ password: demo-password
 ## Architecture
 
 ```txt
-Host folder mounted writable into sandbox
+Host folder mounted into sandbox
 └── /workspace/legacy_report_fetcher
     ├── portal/      # fake Acme Legacy Reports Portal
     ├── ops/         # sandbox-side operational scripts
     ├── pipeline/    # existing-pipeline stand-in
-    └── artifacts/   # output visible on the host
+    └── artifacts/   # host-side handoff output
 ```
 
 The browser opens the portal at:

--- a/examples/cua/legacy_report_fetcher/ops/finalize_downloads.py
+++ b/examples/cua/legacy_report_fetcher/ops/finalize_downloads.py
@@ -1,0 +1,125 @@
+#!/usr/bin/env python3
+
+# Copyright 2026 Celesto AI
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Move downloaded reports into the pipeline handoff folder and write a manifest."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import shutil
+import time
+from datetime import date
+from pathlib import Path
+
+
+def sha256_file(path: Path) -> str:
+    """Return the SHA-256 digest for a file."""
+    digest = hashlib.sha256()
+    with path.open("rb") as file:
+        for chunk in iter(lambda: file.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def wait_for_downloads(downloads_dir: Path, filenames: list[str], timeout: float) -> None:
+    """Wait for browser downloads to appear and finish."""
+    deadline = time.time() + timeout
+    while time.time() < deadline:
+        missing = [name for name in filenames if not (downloads_dir / name).exists()]
+        partial = list(downloads_dir.glob("*.crdownload"))
+        if not missing and not partial:
+            return
+        time.sleep(0.5)
+
+    missing = [name for name in filenames if not (downloads_dir / name).exists()]
+    if missing:
+        raise RuntimeError(
+            "Missing expected report download(s): "
+            + ", ".join(str(downloads_dir / name) for name in missing)
+        )
+    raise RuntimeError("Report downloads did not finish before the timeout.")
+
+
+def finalize_downloads(
+    *,
+    root: Path,
+    session_id: str,
+    report_date: str,
+    downloads_dir: Path | None = None,
+    inbox_dir: Path | None = None,
+    timeout: float = 30.0,
+) -> Path:
+    """Copy downloaded files into the handoff folder and write manifest.json."""
+    downloads = downloads_dir or Path(f"/opt/smolvm-browser/downloads/{session_id}")
+    inbox = inbox_dir or root / "artifacts" / "inbox" / "acme" / report_date
+    expected = [f"orders_{report_date}.csv", f"inventory_{report_date}.csv"]
+
+    wait_for_downloads(downloads, expected, timeout)
+    inbox.mkdir(parents=True, exist_ok=True)
+
+    files: list[dict[str, str | int]] = []
+    for filename in expected:
+        source = downloads / filename
+        target = inbox / filename
+        shutil.copy2(source, target)
+        files.append(
+            {
+                "name": filename,
+                "path": str(target),
+                "size_bytes": target.stat().st_size,
+                "sha256": sha256_file(target),
+                "status": "downloaded",
+            }
+        )
+
+    manifest = {
+        "source": "acme_legacy_reports",
+        "run_date": date.today().isoformat(),
+        "report_date": report_date,
+        "status": "success",
+        "files": files,
+    }
+    manifest_path = inbox / "manifest.json"
+    manifest_path.write_text(json.dumps(manifest, indent=2) + "\n", encoding="utf-8")
+    return manifest_path
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Finalize downloaded Acme reports.")
+    parser.add_argument("--root", required=True, type=Path)
+    parser.add_argument("--session-id", required=True)
+    parser.add_argument("--report-date", required=True)
+    parser.add_argument("--downloads-dir", type=Path)
+    parser.add_argument("--inbox-dir", type=Path)
+    parser.add_argument("--timeout", type=float, default=30.0)
+    args = parser.parse_args()
+
+    manifest_path = finalize_downloads(
+        root=args.root,
+        session_id=args.session_id,
+        report_date=args.report_date,
+        downloads_dir=args.downloads_dir,
+        inbox_dir=args.inbox_dir,
+        timeout=args.timeout,
+    )
+    print(f"Wrote manifest: {manifest_path}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/examples/cua/legacy_report_fetcher/ops/finalize_downloads.py
+++ b/examples/cua/legacy_report_fetcher/ops/finalize_downloads.py
@@ -47,12 +47,16 @@ def wait_for_downloads(downloads_dir: Path, filenames: list[str], timeout: float
         time.sleep(0.5)
 
     missing = [name for name in filenames if not (downloads_dir / name).exists()]
+    existing = ", ".join(sorted(path.name for path in downloads_dir.glob("*"))) or "<empty>"
     if missing:
         raise RuntimeError(
             "Missing expected report download(s): "
             + ", ".join(str(downloads_dir / name) for name in missing)
+            + f". Found in {downloads_dir}: {existing}"
         )
-    raise RuntimeError("Report downloads did not finish before the timeout.")
+    raise RuntimeError(
+        f"Report downloads did not finish before the timeout. Found in {downloads_dir}: {existing}"
+    )
 
 
 def finalize_downloads(

--- a/examples/cua/legacy_report_fetcher/ops/start_portal.py
+++ b/examples/cua/legacy_report_fetcher/ops/start_portal.py
@@ -1,0 +1,82 @@
+#!/usr/bin/env python3
+
+# Copyright 2026 Celesto AI
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Start the fake legacy portal from inside the SmolVM sandbox."""
+
+from __future__ import annotations
+
+import argparse
+import socket
+import subprocess
+import time
+from pathlib import Path
+
+
+def port_is_ready(host: str, port: int) -> bool:
+    """Return True when a local TCP port accepts connections."""
+    try:
+        socket.create_connection((host, port), timeout=1).close()
+    except OSError:
+        return False
+    return True
+
+
+def wait_for_port(host: str, port: int, timeout: float = 15.0) -> None:
+    """Wait until the portal is accepting connections."""
+    deadline = time.time() + timeout
+    while time.time() < deadline:
+        if port_is_ready(host, port):
+            return
+        time.sleep(0.25)
+    raise RuntimeError(f"Acme portal did not start on {host}:{port}")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Start the Acme legacy reports portal.")
+    parser.add_argument("--root", required=True, help="Mounted demo root inside the sandbox.")
+    parser.add_argument("--host", default="127.0.0.1")
+    parser.add_argument("--port", type=int, default=8000)
+    args = parser.parse_args()
+
+    if port_is_ready(args.host, args.port):
+        print(f"Acme portal already ready at http://{args.host}:{args.port}")
+        return 0
+
+    root = Path(args.root)
+    portal_dir = root / "portal"
+    with open("/tmp/acme-portal.log", "a", encoding="utf-8") as log:
+        subprocess.Popen(
+            [
+                "python3",
+                str(portal_dir / "server.py"),
+                "--host",
+                args.host,
+                "--port",
+                str(args.port),
+            ],
+            cwd=portal_dir,
+            stdout=log,
+            stderr=subprocess.STDOUT,
+            start_new_session=True,
+        )
+
+    wait_for_port(args.host, args.port)
+    print(f"Acme portal ready at http://{args.host}:{args.port}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/examples/cua/legacy_report_fetcher/pipeline/import_reports.py
+++ b/examples/cua/legacy_report_fetcher/pipeline/import_reports.py
@@ -1,0 +1,97 @@
+#!/usr/bin/env python3
+
+# Copyright 2026 Celesto AI
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Small stand-in for an existing report import pipeline."""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import json
+import sqlite3
+from pathlib import Path
+
+TABLE_COLUMNS = {
+    "orders": ["report_date", "order_id", "customer", "region", "amount"],
+    "inventory": ["report_date", "sku", "name", "on_hand", "warehouse"],
+}
+
+
+def _table_for_file(path: Path) -> str:
+    if path.name.startswith("orders_"):
+        return "orders"
+    if path.name.startswith("inventory_"):
+        return "inventory"
+    raise ValueError(f"Unknown report file: {path.name}")
+
+
+def _ensure_table(conn: sqlite3.Connection, table: str, columns: list[str]) -> None:
+    column_sql = ", ".join(f'"{column}" TEXT' for column in columns)
+    conn.execute(f'CREATE TABLE IF NOT EXISTS "{table}" ({column_sql})')
+
+
+def _import_csv(conn: sqlite3.Connection, table: str, path: Path) -> int:
+    columns = TABLE_COLUMNS[table]
+    _ensure_table(conn, table, columns)
+    conn.execute(f'DELETE FROM "{table}" WHERE report_date = ?', (path.stem.rsplit("_", 1)[-1],))
+
+    with path.open(newline="", encoding="utf-8") as file:
+        rows = list(csv.DictReader(file))
+
+    placeholders = ", ".join("?" for _ in columns)
+    column_sql = ", ".join(f'"{column}"' for column in columns)
+    conn.executemany(
+        f'INSERT INTO "{table}" ({column_sql}) VALUES ({placeholders})',
+        [[row.get(column, "") for column in columns] for row in rows],
+    )
+    return len(rows)
+
+
+def import_reports(inbox_dir: Path) -> Path:
+    """Import report files described by manifest.json into SQLite."""
+    manifest_path = inbox_dir / "manifest.json"
+    manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+    warehouse_dir = inbox_dir.parents[2] / "warehouse"
+    warehouse_dir.mkdir(parents=True, exist_ok=True)
+    db_path = warehouse_dir / "acme.sqlite"
+
+    print(f"Found manifest.json for {manifest['source']}")
+    print(f"Report date: {manifest['report_date']}")
+
+    with sqlite3.connect(db_path) as conn:
+        for item in manifest["files"]:
+            path = Path(item["path"])
+            table = _table_for_file(path)
+            row_count = _import_csv(conn, table, path)
+            print(f"Imported {path.name}: {row_count} rows into {table}")
+        conn.commit()
+
+    print(f"Stored normalized data in {db_path}")
+    print("Run complete.")
+    return db_path
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Import Acme report CSV files into SQLite.")
+    parser.add_argument("inbox_dir", type=Path)
+    args = parser.parse_args()
+
+    import_reports(args.inbox_dir)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/examples/cua/legacy_report_fetcher/portal/server.py
+++ b/examples/cua/legacy_report_fetcher/portal/server.py
@@ -1,0 +1,288 @@
+#!/usr/bin/env python3
+
+# Copyright 2026 Celesto AI
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tiny fake legacy reporting portal for the computer-use demo."""
+
+# ruff: noqa: E501
+
+from __future__ import annotations
+
+import argparse
+import csv
+import html
+import io
+from datetime import date, timedelta
+from http import HTTPStatus
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from urllib.parse import parse_qs, urlparse
+
+USERNAME = "ops@acme.test"
+PASSWORD = "demo-password"
+SESSION_COOKIE = "acme_session=demo"
+
+
+ORDERS_ROWS = [
+    {"order_id": "A-1001", "customer": "Northstar Grocers", "region": "West", "amount": "1280.50"},
+    {"order_id": "A-1002", "customer": "Bluebird Supply", "region": "East", "amount": "420.00"},
+    {"order_id": "A-1003", "customer": "Summit Hardware", "region": "Central", "amount": "867.25"},
+]
+
+INVENTORY_ROWS = [
+    {"sku": "SKU-RED-001", "name": "Red Widget", "on_hand": "48", "warehouse": "SFO"},
+    {"sku": "SKU-BLU-014", "name": "Blue Widget", "on_hand": "125", "warehouse": "JFK"},
+    {"sku": "SKU-GRN-021", "name": "Green Widget", "on_hand": "17", "warehouse": "ORD"},
+]
+
+
+def _default_report_date() -> str:
+    return (date.today() - timedelta(days=1)).isoformat()
+
+
+def _csv_bytes(rows: list[dict[str, str]], report_date: str) -> bytes:
+    buffer = io.StringIO()
+    writer = csv.DictWriter(buffer, fieldnames=["report_date", *rows[0].keys()])
+    writer.writeheader()
+    for row in rows:
+        writer.writerow({"report_date": report_date, **row})
+    return buffer.getvalue().encode("utf-8")
+
+
+class PortalHandler(BaseHTTPRequestHandler):
+    """Serve login, reports, and CSV downloads."""
+
+    server_version = "AcmeLegacyReports/1.0"
+
+    def do_GET(self) -> None:  # noqa: N802 - stdlib handler name
+        parsed = urlparse(self.path)
+        if parsed.path in {"/", "/login"}:
+            self._send_login()
+            return
+        if parsed.path == "/reports":
+            if not self._is_authenticated():
+                self._redirect("/login")
+                return
+            self._send_reports()
+            return
+        if parsed.path.startswith("/download/"):
+            if not self._is_authenticated():
+                self._redirect("/login")
+                return
+            self._send_download(parsed.path.rsplit("/", 1)[-1], parse_qs(parsed.query))
+            return
+        self.send_error(HTTPStatus.NOT_FOUND, "Not found")
+
+    def do_POST(self) -> None:  # noqa: N802 - stdlib handler name
+        parsed = urlparse(self.path)
+        if parsed.path != "/login":
+            self.send_error(HTTPStatus.NOT_FOUND, "Not found")
+            return
+
+        length = int(self.headers.get("Content-Length", "0"))
+        body = self.rfile.read(length).decode("utf-8")
+        fields = parse_qs(body)
+        username = fields.get("username", [""])[0]
+        password = fields.get("password", [""])[0]
+        if username == USERNAME and password == PASSWORD:
+            self.send_response(HTTPStatus.SEE_OTHER)
+            self.send_header("Location", "/reports")
+            self.send_header("Set-Cookie", f"{SESSION_COOKIE}; Path=/; SameSite=Lax")
+            self.end_headers()
+            return
+
+        self._send_login(error="Invalid username or password.")
+
+    def log_message(self, format: str, *args: object) -> None:
+        print(f"[acme-portal] {self.address_string()} - {format % args}")
+
+    def _is_authenticated(self) -> bool:
+        return SESSION_COOKIE in self.headers.get("Cookie", "")
+
+    def _send_html(self, body: str, *, status: HTTPStatus = HTTPStatus.OK) -> None:
+        content = body.encode("utf-8")
+        self.send_response(status)
+        self.send_header("Content-Type", "text/html; charset=utf-8")
+        self.send_header("Content-Length", str(len(content)))
+        self.end_headers()
+        self.wfile.write(content)
+
+    def _redirect(self, location: str) -> None:
+        self.send_response(HTTPStatus.SEE_OTHER)
+        self.send_header("Location", location)
+        self.end_headers()
+
+    def _send_login(self, error: str | None = None) -> None:
+        error_html = f'<p class="error">{html.escape(error)}</p>' if error else ""
+        self._send_html(
+            f"""
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <title>Acme Legacy Reports Portal</title>
+  <style>
+    body {{ margin: 0; background: #d8dde6; color: #1f2937; font-family: Arial, sans-serif; }}
+    .topbar {{ background: #143a66; color: white; padding: 14px 22px; border-bottom: 4px solid #aeb8c8; }}
+    .shell {{ width: 760px; margin: 58px auto; background: #f5f7fb; border: 1px solid #8b98aa; box-shadow: 0 2px 0 #fff inset; }}
+    .panel-title {{ background: #e6ebf3; border-bottom: 1px solid #aeb8c8; padding: 12px 16px; font-weight: bold; }}
+    form {{ padding: 22px; display: grid; gap: 14px; }}
+    label {{ font-weight: bold; }}
+    input {{ width: 100%; box-sizing: border-box; padding: 8px; border: 1px solid #7d8796; font-size: 15px; }}
+    button {{ width: 180px; padding: 9px 12px; background: #245f9f; color: white; border: 1px solid #143a66; font-weight: bold; cursor: pointer; }}
+    .hint {{ color: #4b5563; font-size: 13px; }}
+    .error {{ color: #9f1239; font-weight: bold; }}
+  </style>
+</head>
+<body>
+  <div class="topbar">Acme Legacy Reports Portal</div>
+  <main class="shell">
+    <div class="panel-title">Secure report access</div>
+    <form method="post" action="/login">
+      {error_html}
+      <p class="hint">Authorized operations users only. Use your assigned portal credentials.</p>
+      <label for="username">Username</label>
+      <input id="username" name="username" autocomplete="username" autofocus>
+      <label for="password">Password</label>
+      <input id="password" name="password" type="password" autocomplete="current-password">
+      <button type="submit">Sign in</button>
+    </form>
+  </main>
+</body>
+</html>
+"""
+        )
+
+    def _send_reports(self) -> None:
+        report_date = _default_report_date()
+        self._send_html(
+            f"""
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <title>Reports - Acme Legacy Reports Portal</title>
+  <style>
+    body {{ margin: 0; background: #d8dde6; color: #1f2937; font-family: Arial, sans-serif; }}
+    .topbar {{ background: #143a66; color: white; padding: 14px 22px; border-bottom: 4px solid #aeb8c8; }}
+    .layout {{ display: grid; grid-template-columns: 220px 1fr; min-height: calc(100vh - 52px); }}
+    nav {{ background: #edf1f7; border-right: 1px solid #9aa7b8; padding: 18px; }}
+    nav a {{ display: block; color: #143a66; padding: 8px 4px; font-weight: bold; }}
+    main {{ padding: 24px; }}
+    .panel {{ background: #f8fafc; border: 1px solid #8b98aa; max-width: 920px; }}
+    .panel-title {{ background: #e6ebf3; border-bottom: 1px solid #aeb8c8; padding: 12px 16px; font-weight: bold; }}
+    .content {{ padding: 18px; display: grid; gap: 16px; }}
+    .row {{ display: grid; grid-template-columns: 180px 1fr; gap: 12px; align-items: center; }}
+    input[type="date"] {{ width: 180px; padding: 7px; }}
+    button {{ width: 190px; padding: 9px 12px; background: #245f9f; color: white; border: 1px solid #143a66; font-weight: bold; cursor: pointer; }}
+    .downloads {{ display: none; border-top: 1px solid #cbd5e1; padding-top: 16px; }}
+    .download-card {{ background: white; border: 1px solid #c4ccd8; margin: 8px 0; padding: 12px; }}
+    .download-card a {{ color: #0f4c81; font-weight: bold; }}
+    .muted {{ color: #64748b; font-size: 13px; }}
+  </style>
+</head>
+<body>
+  <div class="topbar">Acme Legacy Reports Portal</div>
+  <div class="layout">
+    <nav>
+      <a href="/reports">Daily Reports</a>
+      <a href="#">Scheduled Jobs</a>
+      <a href="#">Audit Log</a>
+    </nav>
+    <main>
+      <section class="panel">
+        <div class="panel-title">Daily report downloads</div>
+        <div class="content">
+          <p class="muted">Generate yesterday's operational report files for the downstream data pipeline.</p>
+          <div class="row">
+            <label for="report-date">Report date</label>
+            <input id="report-date" type="date" value="{report_date}">
+          </div>
+          <div class="row">
+            <span>Report types</span>
+            <div>
+              <label><input id="orders" type="checkbox" checked> Orders CSV</label><br>
+              <label><input id="inventory" type="checkbox" checked> Inventory CSV</label><br>
+              <label><input id="settlements" type="checkbox"> Settlements PDF</label>
+            </div>
+          </div>
+          <button id="generate" type="button">Generate reports</button>
+          <div id="downloads" class="downloads" aria-live="polite">
+            <strong>Reports are ready.</strong>
+            <div class="download-card" data-report="orders">
+              Orders CSV — <a id="orders-link" href="/download/orders?date={report_date}" download>Download Orders CSV</a>
+            </div>
+            <div class="download-card" data-report="inventory">
+              Inventory CSV — <a id="inventory-link" href="/download/inventory?date={report_date}" download>Download Inventory CSV</a>
+            </div>
+          </div>
+        </div>
+      </section>
+    </main>
+  </div>
+<script>
+  const dateInput = document.getElementById('report-date');
+  const downloads = document.getElementById('downloads');
+  const ordersLink = document.getElementById('orders-link');
+  const inventoryLink = document.getElementById('inventory-link');
+  function refreshLinks() {{
+    const reportDate = dateInput.value;
+    ordersLink.href = `/download/orders?date=${{encodeURIComponent(reportDate)}}`;
+    inventoryLink.href = `/download/inventory?date=${{encodeURIComponent(reportDate)}}`;
+  }}
+  document.getElementById('generate').addEventListener('click', () => {{
+    refreshLinks();
+    downloads.style.display = 'block';
+  }});
+  dateInput.addEventListener('change', refreshLinks);
+</script>
+</body>
+</html>
+"""
+        )
+
+    def _send_download(self, report_name: str, query: dict[str, list[str]]) -> None:
+        report_date = query.get("date", [_default_report_date()])[0]
+        if report_name == "orders":
+            rows = ORDERS_ROWS
+        elif report_name == "inventory":
+            rows = INVENTORY_ROWS
+        else:
+            self.send_error(HTTPStatus.NOT_FOUND, "Unknown report")
+            return
+
+        content = _csv_bytes(rows, report_date)
+        filename = f"{report_name}_{report_date}.csv"
+        self.send_response(HTTPStatus.OK)
+        self.send_header("Content-Type", "text/csv; charset=utf-8")
+        self.send_header("Content-Disposition", f'attachment; filename="{filename}"')
+        self.send_header("Content-Length", str(len(content)))
+        self.end_headers()
+        self.wfile.write(content)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Run the fake Acme legacy reports portal.")
+    parser.add_argument("--host", default="127.0.0.1")
+    parser.add_argument("--port", type=int, default=8000)
+    args = parser.parse_args()
+
+    server = ThreadingHTTPServer((args.host, args.port), PortalHandler)
+    print(f"Acme Legacy Reports Portal listening on http://{args.host}:{args.port}", flush=True)
+    server.serve_forever()
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/examples/cua/legacy_report_fetcher/portal/server.py
+++ b/examples/cua/legacy_report_fetcher/portal/server.py
@@ -51,6 +51,14 @@ def _default_report_date() -> str:
     return (date.today() - timedelta(days=1)).isoformat()
 
 
+def _safe_report_date(value: str) -> str:
+    """Return a safe ISO report date for filenames and headers."""
+    try:
+        return date.fromisoformat(value).isoformat()
+    except ValueError:
+        return _default_report_date()
+
+
 def _csv_bytes(rows: list[dict[str, str]], report_date: str) -> bytes:
     buffer = io.StringIO()
     writer = csv.DictWriter(buffer, fieldnames=["report_date", *rows[0].keys()])
@@ -253,7 +261,7 @@ class PortalHandler(BaseHTTPRequestHandler):
         )
 
     def _send_download(self, report_name: str, query: dict[str, list[str]]) -> None:
-        report_date = query.get("date", [_default_report_date()])[0]
+        report_date = _safe_report_date(query.get("date", [_default_report_date()])[0])
         if report_name == "orders":
             rows = ORDERS_ROWS
         elif report_name == "inventory":

--- a/examples/cua/legacy_report_fetcher/run_demo.py
+++ b/examples/cua/legacy_report_fetcher/run_demo.py
@@ -163,6 +163,47 @@ def downloads_ready(vm: SmolVM, session_id: str, report_date: str) -> bool:
     return result.ok
 
 
+def wait_until_downloads_ready(
+    vm: SmolVM,
+    session_id: str,
+    report_date: str,
+    *,
+    timeout: float = 20.0,
+) -> None:
+    """Wait until both report files exist in the sandbox download folder."""
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        if downloads_ready(vm, session_id, report_date):
+            return
+        time.sleep(0.5)
+    raise RuntimeError(list_downloads(vm, session_id).strip())
+
+
+def ensure_report_downloads(
+    page: Any,
+    vm: SmolVM,
+    session_id: str,
+    report_date: str,
+) -> None:
+    """Verify downloads, then recover with direct CDP clicks if the agent stopped early."""
+    if downloads_ready(vm, session_id, report_date):
+        return
+
+    log(
+        "Agent stopped before the CSV files appeared in the sandbox; "
+        "using CDP to click the report download links."
+    )
+    page.goto(f"{PORTAL_URL}/reports", wait_until="domcontentloaded")
+    with suppress(Exception):
+        page.fill("#report-date", report_date)
+    page.click("#generate")
+    page.wait_for_selector("#orders-link", timeout=5000)
+    page.click("#orders-link")
+    page.wait_for_timeout(500)
+    page.click("#inventory-link")
+    wait_until_downloads_ready(vm, session_id, report_date)
+
+
 def finalize_downloads(vm: SmolVM, session_id: str, report_date: str) -> str:
     """Finalize report files using the sandbox shell."""
     return vm_exec(
@@ -627,6 +668,7 @@ def main() -> int:
         if "done" not in agent_result.final_answer.lower():
             raise RuntimeError(f"Agent did not confirm completion: {agent_result.final_answer}")
 
+        ensure_report_downloads(page, vm, session.session_id, args.report_date)
         log(list_downloads(vm, session.session_id).strip())
         session.screenshot(screenshots_dir / "02-after-downloads.png", full_page=False)
         finalize_output = run_with_heartbeat(

--- a/examples/cua/legacy_report_fetcher/run_demo.py
+++ b/examples/cua/legacy_report_fetcher/run_demo.py
@@ -142,6 +142,27 @@ def start_legacy_app(vm: SmolVM) -> None:
     log(output.strip())
 
 
+def expected_download_filenames(report_date: str) -> list[str]:
+    """Return the report filenames the demo expects Chromium to create."""
+    return [f"orders_{report_date}.csv", f"inventory_{report_date}.csv"]
+
+
+def downloads_ready(vm: SmolVM, session_id: str, report_date: str) -> bool:
+    """Return True when both expected downloads exist in the sandbox."""
+    download_dir = guest_download_dir(session_id)
+    expected = expected_download_filenames(report_date)
+    script = (
+        "from pathlib import Path; "
+        f"p=Path({download_dir!r}); "
+        f"expected={expected!r}; "
+        "missing=[name for name in expected if not (p/name).exists()]; "
+        "partial=list(p.glob('*.crdownload')); "
+        "raise SystemExit(1 if missing or partial else 0)"
+    )
+    result = vm.run(shlex.join(["python3", "-c", script]), timeout=20)
+    return result.ok
+
+
 def finalize_downloads(vm: SmolVM, session_id: str, report_date: str) -> str:
     """Finalize report files using the sandbox shell."""
     return vm_exec(
@@ -397,6 +418,10 @@ Download exactly these two reports for {report_date}:
 - Orders CSV
 - Inventory CSV
 
+Important: clicking Generate reports is not enough. After the reports are ready,
+you must click the visible "Download Orders CSV" link and the visible
+"Download Inventory CSV" link.
+
 Do not download Settlements PDF or any other file.
 Stay on http://127.0.0.1:8000 or localhost only.
 After both CSV files have downloaded, respond only with: done
@@ -410,6 +435,7 @@ def run_computer_use_agent(
     report_date: str,
     model: str,
     max_steps: int,
+    verify_downloads: Callable[[], bool] | None = None,
 ) -> AgentResult:
     """Run OpenAI computer-use against the existing CDP-connected browser page."""
     from openai import OpenAI
@@ -426,6 +452,7 @@ def run_computer_use_agent(
     )
     log(f"submitted task to model={model}")
 
+    validation_retries = 0
     for step_number in range(1, max_steps + 1):
         computer_call = first_computer_call(response)
         if computer_call is None:
@@ -433,7 +460,29 @@ def run_computer_use_agent(
             if not final_answer:
                 raise RuntimeError("The model stopped without returning a final answer.")
             log(f"agent final answer: {final_answer}")
-            return AgentResult(final_answer=final_answer, steps=step_number - 1)
+            if verify_downloads is None or verify_downloads():
+                return AgentResult(final_answer=final_answer, steps=step_number - 1)
+            if validation_retries >= 2:
+                return AgentResult(final_answer=final_answer, steps=step_number - 1)
+
+            validation_retries += 1
+            log(
+                "Agent said it was done, but the sandbox download folder is still missing "
+                "one or both CSV files; asking it to continue."
+            )
+            response = client.responses.create(
+                model=model,
+                tools=[{"type": "computer"}],
+                previous_response_id=response.id,
+                input=(
+                    "The sandbox download folder is still missing one or both CSV files. "
+                    "You probably generated the reports but did not click the actual "
+                    "download links. Continue using the browser. Click Generate reports if "
+                    "needed, then click both visible links: Download Orders CSV and "
+                    "Download Inventory CSV. Do not answer done until you have clicked both."
+                ),
+            )
+            continue
 
         check_safety(computer_call)
         actions = list(getattr(computer_call, "actions", []) or [])
@@ -573,6 +622,7 @@ def main() -> int:
             report_date=args.report_date,
             model=args.model,
             max_steps=args.max_steps,
+            verify_downloads=lambda: downloads_ready(vm, session.session_id, args.report_date),
         )
         if "done" not in agent_result.final_answer.lower():
             raise RuntimeError(f"Agent did not confirm completion: {agent_result.final_answer}")

--- a/examples/cua/legacy_report_fetcher/run_demo.py
+++ b/examples/cua/legacy_report_fetcher/run_demo.py
@@ -170,6 +170,40 @@ def run_pipeline(vm: SmolVM, report_date: str) -> str:
     )
 
 
+def guest_download_dir(session_id: str) -> str:
+    """Return the browser download folder inside the sandbox."""
+    return f"/opt/smolvm-browser/downloads/{session_id}"
+
+
+def configure_browser_downloads(browser: Any, download_dir: str) -> None:
+    """Tell Chromium to save clicked downloads into the sandbox download folder."""
+    cdp = browser.new_browser_cdp_session()
+    cdp.send(
+        "Browser.setDownloadBehavior",
+        {
+            "behavior": "allow",
+            "downloadPath": download_dir,
+            "eventsEnabled": True,
+        },
+    )
+
+
+def list_downloads(vm: SmolVM, session_id: str) -> str:
+    """List current browser downloads for debugging and validation."""
+    return vm_exec(
+        vm,
+        "python3",
+        "-c",
+        (
+            "from pathlib import Path; "
+            f"p=Path({guest_download_dir(session_id)!r}); "
+            "print('download_dir:', p); "
+            "print('files:', ', '.join(sorted(x.name for x in p.glob('*'))) or '<empty>')"
+        ),
+        timeout=20,
+    )
+
+
 def normalize_key(key: str) -> str:
     """Translate computer-use key names to Playwright key names."""
     normalized = key.strip()
@@ -522,6 +556,10 @@ def main() -> int:
 
         log("Connecting to Chromium over CDP")
         browser = session.connect_playwright()
+        download_dir = guest_download_dir(session.session_id)
+        vm_exec(vm, "mkdir", "-p", download_dir, timeout=20)
+        configure_browser_downloads(browser, download_dir)
+        log(f"Browser downloads will be saved in {download_dir}")
         context = browser.contexts[0] if browser.contexts else browser.new_context()
         page = context.pages[0] if context.pages else context.new_page()
         log(f"Opening portal at {PORTAL_URL}")
@@ -539,6 +577,7 @@ def main() -> int:
         if "done" not in agent_result.final_answer.lower():
             raise RuntimeError(f"Agent did not confirm completion: {agent_result.final_answer}")
 
+        log(list_downloads(vm, session.session_id).strip())
         session.screenshot(screenshots_dir / "02-after-downloads.png", full_page=False)
         finalize_output = run_with_heartbeat(
             "Finalizing downloaded reports inside the sandbox",

--- a/examples/cua/legacy_report_fetcher/run_demo.py
+++ b/examples/cua/legacy_report_fetcher/run_demo.py
@@ -179,7 +179,13 @@ def wait_until_downloads_ready(
         if downloads_ready(vm, session_id, report_date):
             return
         time.sleep(0.5)
-    raise RuntimeError(list_downloads(vm, session_id).strip())
+    raise RuntimeError(
+        f"Timed out waiting for report downloads for session {session_id}. "
+        f"Rerun: uv run --with openai --with playwright "
+        f"examples/cua/legacy_report_fetcher/run_demo.py --mode live "
+        f"--report-date {report_date}\n"
+        f"{list_downloads(vm, session_id).strip()}"
+    )
 
 
 def ensure_report_downloads(
@@ -202,7 +208,7 @@ def ensure_report_downloads(
     page.click("#generate")
     page.wait_for_selector("#orders-link", timeout=5000)
     page.click("#orders-link")
-    page.wait_for_timeout(500)
+    page.wait_for_selector("#inventory-link", timeout=5000)
     page.click("#inventory-link")
     try:
         wait_until_downloads_ready(vm, session_id, report_date, timeout=8.0)
@@ -627,7 +633,7 @@ def run_computer_use_agent(
 
 
 def require_host_dependencies() -> None:
-    """Fail before booting a sandbox if host-side demo packages are missing."""
+    """Fail before booting a sandbox if demo Python packages are missing."""
     missing: list[str] = []
     for module_name, package_name in (
         ("openai", "openai"),
@@ -637,11 +643,21 @@ def require_host_dependencies() -> None:
             missing.append(package_name)
 
     if missing:
-        packages = " ".join(missing)
+        package_flags = " ".join(f"--with {package_name}" for package_name in missing)
         raise RuntimeError(
-            "Install the demo's host-side Python dependencies before starting SmolVM: "
-            f"uv run --with {packages} examples/cua/legacy_report_fetcher/run_demo.py --mode live"
+            "Install the demo dependencies on your computer, then rerun: "
+            f"uv run {package_flags} examples/cua/legacy_report_fetcher/run_demo.py --mode live"
         )
+
+
+def parse_report_date(value: str) -> str:
+    """Validate a report date before it becomes part of file paths."""
+    if ".." in value or "/" in value or "\\" in value or os.sep in value:
+        raise argparse.ArgumentTypeError("Report date must be YYYY-MM-DD.")
+    try:
+        return date.fromisoformat(value).isoformat()
+    except ValueError as exc:
+        raise argparse.ArgumentTypeError("Report date must be YYYY-MM-DD.") from exc
 
 
 def parse_args() -> argparse.Namespace:
@@ -660,6 +676,7 @@ def parse_args() -> argparse.Namespace:
     )
     parser.add_argument(
         "--report-date",
+        type=parse_report_date,
         default=(date.today() - timedelta(days=1)).isoformat(),
         help="Report date to download. Defaults to yesterday.",
     )
@@ -736,10 +753,8 @@ def main() -> int:
             max_steps=args.max_steps,
             verify_downloads=lambda: downloads_ready(vm, session.session_id, args.report_date),
         )
-        if "done" not in agent_result.final_answer.lower():
-            raise RuntimeError(f"Agent did not confirm completion: {agent_result.final_answer}")
-
         ensure_report_downloads(page, vm, session.session_id, args.report_date)
+        log(f"Agent final answer after file verification: {agent_result.final_answer}")
         session.screenshot(screenshots_dir / "02-after-downloads.png", full_page=False)
         inbox = run_with_heartbeat(
             "Listing sandbox downloads and copying reports to the host",

--- a/examples/cua/legacy_report_fetcher/run_demo.py
+++ b/examples/cua/legacy_report_fetcher/run_demo.py
@@ -20,9 +20,12 @@ from __future__ import annotations
 
 import argparse
 import base64
+import hashlib
 import importlib.util
+import json
 import os
 import shlex
+import subprocess
 import sys
 import threading
 import time
@@ -201,35 +204,103 @@ def ensure_report_downloads(
     page.click("#orders-link")
     page.wait_for_timeout(500)
     page.click("#inventory-link")
+    try:
+        wait_until_downloads_ready(vm, session_id, report_date, timeout=8.0)
+        return
+    except RuntimeError:
+        log(
+            "CDP clicks still did not create files in the sandbox download folder; "
+            "using the sandbox shell to fetch the generated CSV files."
+        )
+
+    download_reports_with_vm_shell(vm, session_id, report_date)
     wait_until_downloads_ready(vm, session_id, report_date)
 
 
-def finalize_downloads(vm: SmolVM, session_id: str, report_date: str) -> str:
-    """Finalize report files using the sandbox shell."""
-    return vm_exec(
-        vm,
-        "python3",
-        f"{GUEST_ROOT}/ops/finalize_downloads.py",
-        "--root",
-        GUEST_ROOT,
-        "--session-id",
-        session_id,
-        "--report-date",
-        report_date,
-        timeout=60,
+def download_reports_with_vm_shell(vm: SmolVM, session_id: str, report_date: str) -> None:
+    """Fetch report files from the local portal using the sandbox shell."""
+    download_dir = guest_download_dir(session_id)
+    script = "\n".join(
+        [
+            "from pathlib import Path",
+            "from urllib.parse import urlencode",
+            "from urllib.request import Request, urlopen",
+            f"download_dir = Path({download_dir!r})",
+            "download_dir.mkdir(parents=True, exist_ok=True)",
+            f"report_date = {report_date!r}",
+            "base_url = 'http://127.0.0.1:8000/download/'",
+            "for name in ('orders', 'inventory'):",
+            "    query = urlencode({'date': report_date})",
+            "    url = base_url + name + '?' + query",
+            "    request = Request(url, headers={'Cookie': 'acme_session=demo'})",
+            "    with urlopen(request, timeout=10) as response:",
+            "        data = response.read()",
+            "    target = download_dir / f'{name}_{report_date}.csv'",
+            "    target.write_bytes(data)",
+            "    print(target)",
+        ]
     )
+    vm_exec(vm, "python3", "-c", script, timeout=30)
 
 
-def run_pipeline(vm: SmolVM, report_date: str) -> str:
-    """Run the existing-pipeline stand-in inside the sandbox."""
-    inbox = f"{GUEST_ROOT}/artifacts/inbox/acme/{report_date}"
-    return vm_exec(
-        vm,
-        "python3",
-        f"{GUEST_ROOT}/pipeline/import_reports.py",
-        inbox,
-        timeout=120,
+def copy_file_from_vm(vm: SmolVM, guest_path: str, host_path: Path) -> Path:
+    """Copy one file from the sandbox to the host."""
+    log(f"Copying {guest_path} to {host_path}")
+    return Path(vm.download_file(guest_path, host_path))
+
+
+def sha256_file(path: Path) -> str:
+    """Return a SHA-256 digest for a local file."""
+    digest = hashlib.sha256()
+    with path.open("rb") as file:
+        for chunk in iter(lambda: file.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def copy_reports_to_host(vm: SmolVM, session_id: str, report_date: str) -> Path:
+    """List sandbox downloads, then copy reports to the host handoff folder."""
+    log(list_downloads(vm, session_id).strip())
+    inbox = DEMO_DIR / "artifacts" / "inbox" / "acme" / report_date
+    inbox.mkdir(parents=True, exist_ok=True)
+
+    files: list[dict[str, str | int]] = []
+    for filename in expected_download_filenames(report_date):
+        guest_path = f"{guest_download_dir(session_id)}/{filename}"
+        local_path = copy_file_from_vm(vm, guest_path, inbox / filename)
+        files.append(
+            {
+                "name": filename,
+                "path": str(local_path),
+                "size_bytes": local_path.stat().st_size,
+                "sha256": sha256_file(local_path),
+                "status": "downloaded",
+            }
+        )
+
+    manifest = {
+        "source": "acme_legacy_reports",
+        "run_date": date.today().isoformat(),
+        "report_date": report_date,
+        "status": "success",
+        "files": files,
+    }
+    manifest_path = inbox / "manifest.json"
+    manifest_path.write_text(json.dumps(manifest, indent=2) + "\n", encoding="utf-8")
+    return inbox
+
+
+def run_pipeline(inbox: Path) -> str:
+    """Run the existing-pipeline stand-in on the host handoff folder."""
+    result = subprocess.run(
+        [sys.executable, str(DEMO_DIR / "pipeline" / "import_reports.py"), str(inbox)],
+        capture_output=True,
+        text=True,
+        check=False,
     )
+    if result.returncode != 0:
+        raise RuntimeError(result.stderr.strip() or result.stdout)
+    return result.stdout
 
 
 def guest_download_dir(session_id: str) -> str:
@@ -669,23 +740,22 @@ def main() -> int:
             raise RuntimeError(f"Agent did not confirm completion: {agent_result.final_answer}")
 
         ensure_report_downloads(page, vm, session.session_id, args.report_date)
-        log(list_downloads(vm, session.session_id).strip())
         session.screenshot(screenshots_dir / "02-after-downloads.png", full_page=False)
-        finalize_output = run_with_heartbeat(
-            "Finalizing downloaded reports inside the sandbox",
-            lambda: finalize_downloads(vm, session.session_id, args.report_date),
+        inbox = run_with_heartbeat(
+            "Listing sandbox downloads and copying reports to the host",
+            lambda: copy_reports_to_host(vm, session.session_id, args.report_date),
             interval_seconds=5.0,
         )
-        print(finalize_output.strip())
+        print(f"Copied reports and wrote manifest: {inbox / 'manifest.json'}")
         print("\nPipeline output:")
         pipeline_output = run_with_heartbeat(
-            "Running the existing-pipeline import inside the sandbox",
-            lambda: run_pipeline(vm, args.report_date),
+            "Running the existing-pipeline import on the host handoff folder",
+            lambda: run_pipeline(inbox),
             interval_seconds=5.0,
         )
         print(pipeline_output.strip())
         print("\nLocal handoff folder:")
-        print(DEMO_DIR / "artifacts" / "inbox" / "acme" / args.report_date)
+        print(inbox)
     finally:
         if session is not None:
             run_with_heartbeat(

--- a/examples/cua/legacy_report_fetcher/run_demo.py
+++ b/examples/cua/legacy_report_fetcher/run_demo.py
@@ -1,0 +1,570 @@
+#!/usr/bin/env python3
+
+# Copyright 2026 Celesto AI
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Demo: use a SmolVM computer-use agent to fetch legacy reports."""
+
+from __future__ import annotations
+
+import argparse
+import base64
+import importlib.util
+import os
+import shlex
+import sys
+import threading
+import time
+from collections.abc import Callable
+from contextlib import suppress
+from dataclasses import dataclass
+from datetime import date, timedelta
+from pathlib import Path
+from typing import Any, TypeVar
+from urllib.parse import urlparse
+
+from smolvm import BrowserSession, BrowserSessionConfig, CommandResult, SmolVM, WorkspaceMount
+
+DEMO_DIR = Path(__file__).resolve().parent
+GUEST_ROOT = "/workspace/legacy_report_fetcher"
+PORTAL_URL = "http://127.0.0.1:8000"
+DEFAULT_MODEL = "gpt-5.4"
+DEFAULT_MAX_STEPS = 24
+
+T = TypeVar("T")
+
+_KEY_MAP = {
+    "ALT": "Alt",
+    "BACKSPACE": "Backspace",
+    "CMD": "Meta",
+    "COMMAND": "Meta",
+    "CTRL": "Control",
+    "CONTROL": "Control",
+    "DELETE": "Delete",
+    "DOWN": "ArrowDown",
+    "END": "End",
+    "ENTER": "Enter",
+    "ESC": "Escape",
+    "ESCAPE": "Escape",
+    "HOME": "Home",
+    "LEFT": "ArrowLeft",
+    "OPTION": "Alt",
+    "PAGEDOWN": "PageDown",
+    "PAGEUP": "PageUp",
+    "RETURN": "Enter",
+    "RIGHT": "ArrowRight",
+    "SHIFT": "Shift",
+    "SPACE": " ",
+    "TAB": "Tab",
+    "UP": "ArrowUp",
+}
+
+
+@dataclass(frozen=True)
+class AgentResult:
+    """Final result from the computer-use loop."""
+
+    final_answer: str
+    steps: int
+
+
+def log(message: str) -> None:
+    """Print progress to stderr so stdout can stay demo-friendly."""
+    print(f"[legacy-report-demo] {message}", file=sys.stderr, flush=True)
+
+
+def run_with_heartbeat(
+    label: str,
+    func: Callable[[], T],
+    *,
+    interval_seconds: float = 10.0,
+) -> T:
+    """Run a blocking step and log periodically so the demo never looks stuck."""
+    started = time.monotonic()
+    stop = threading.Event()
+
+    def heartbeat() -> None:
+        while not stop.wait(interval_seconds):
+            elapsed = int(time.monotonic() - started)
+            log(f"{label} still running ({elapsed}s elapsed)")
+
+    log(f"{label}...")
+    thread = threading.Thread(target=heartbeat, daemon=True)
+    thread.start()
+    try:
+        result = func()
+    except Exception:
+        elapsed = int(time.monotonic() - started)
+        log(f"{label} failed after {elapsed}s")
+        raise
+    finally:
+        stop.set()
+        thread.join(timeout=0.2)
+
+    elapsed = int(time.monotonic() - started)
+    log(f"{label} complete ({elapsed}s)")
+    return result
+
+
+def vm_exec(vm: SmolVM, *args: str, timeout: int = 60) -> str:
+    """Run a short shell command inside the SmolVM sandbox."""
+    result: CommandResult = vm.run(shlex.join(args), timeout=timeout)
+    if not result.ok:
+        raise RuntimeError(result.stderr.strip() or result.stdout)
+    return result.stdout
+
+
+def start_legacy_app(vm: SmolVM) -> None:
+    """Start the mounted fake legacy app inside the sandbox."""
+    output = vm_exec(
+        vm,
+        "python3",
+        f"{GUEST_ROOT}/ops/start_portal.py",
+        "--root",
+        GUEST_ROOT,
+        "--host",
+        "127.0.0.1",
+        "--port",
+        "8000",
+        timeout=30,
+    )
+    log(output.strip())
+
+
+def finalize_downloads(vm: SmolVM, session_id: str, report_date: str) -> str:
+    """Finalize report files using the sandbox shell."""
+    return vm_exec(
+        vm,
+        "python3",
+        f"{GUEST_ROOT}/ops/finalize_downloads.py",
+        "--root",
+        GUEST_ROOT,
+        "--session-id",
+        session_id,
+        "--report-date",
+        report_date,
+        timeout=60,
+    )
+
+
+def run_pipeline(vm: SmolVM, report_date: str) -> str:
+    """Run the existing-pipeline stand-in inside the sandbox."""
+    inbox = f"{GUEST_ROOT}/artifacts/inbox/acme/{report_date}"
+    return vm_exec(
+        vm,
+        "python3",
+        f"{GUEST_ROOT}/pipeline/import_reports.py",
+        inbox,
+        timeout=120,
+    )
+
+
+def normalize_key(key: str) -> str:
+    """Translate computer-use key names to Playwright key names."""
+    normalized = key.strip()
+    if not normalized:
+        return normalized
+    upper = normalized.upper()
+    if upper in _KEY_MAP:
+        return _KEY_MAP[upper]
+    if len(normalized) == 1:
+        return normalized
+    return normalized
+
+
+def hold_keys(page: Any, keys: list[str] | None) -> list[str]:
+    """Hold modifier keys before a mouse action."""
+    normalized = [normalize_key(key) for key in keys or [] if key.strip()]
+    for key in normalized:
+        page.keyboard.down(key)
+    return normalized
+
+
+def release_keys(page: Any, keys: list[str]) -> None:
+    """Release modifier keys after a mouse action."""
+    for key in reversed(keys):
+        with suppress(Exception):
+            page.keyboard.up(key)
+
+
+def click_button(button: str) -> str:
+    """Map model button labels to Playwright button labels."""
+    if button == "wheel":
+        return "middle"
+    return "left" if button in {"back", "forward"} else button
+
+
+def run_action(page: Any, action: Any) -> None:
+    """Apply one OpenAI computer-use action through Playwright/CDP."""
+    action_type = getattr(action, "type", None)
+    held_keys = hold_keys(page, getattr(action, "keys", None))
+    try:
+        if action_type == "click":
+            button = getattr(action, "button", "left")
+            if button == "back":
+                with suppress(Exception):
+                    page.go_back(wait_until="domcontentloaded")
+                return
+            if button == "forward":
+                with suppress(Exception):
+                    page.go_forward(wait_until="domcontentloaded")
+                return
+            page.mouse.click(action.x, action.y, button=click_button(button))
+            return
+        if action_type == "double_click":
+            page.mouse.dblclick(action.x, action.y)
+            return
+        if action_type == "move":
+            page.mouse.move(action.x, action.y)
+            return
+        if action_type == "scroll":
+            page.mouse.move(action.x, action.y)
+            page.mouse.wheel(action.scroll_x, action.scroll_y)
+            return
+        if action_type == "keypress":
+            for key in getattr(action, "keys", []) or []:
+                page.keyboard.press(normalize_key(key))
+            return
+        if action_type == "type":
+            page.keyboard.type(action.text)
+            return
+        if action_type == "drag":
+            path = list(getattr(action, "path", []) or [])
+            if not path:
+                return
+            page.mouse.move(path[0].x, path[0].y)
+            page.mouse.down()
+            for point in path[1:]:
+                page.mouse.move(point.x, point.y, steps=8)
+            page.mouse.up()
+            return
+        if action_type == "wait":
+            page.wait_for_timeout(1500)
+            return
+        if action_type == "screenshot":
+            return
+        raise RuntimeError(f"Unsupported computer action: {action_type}")
+    finally:
+        release_keys(page, held_keys)
+
+
+def describe_action(action: Any) -> str:
+    """Return a compact description for demo logs."""
+    action_type = getattr(action, "type", "unknown")
+    if action_type in {"click", "double_click", "move", "scroll"}:
+        x = getattr(action, "x", "?")
+        y = getattr(action, "y", "?")
+        return f"{action_type}@({x},{y})"
+    if action_type == "type":
+        text = getattr(action, "text", "")
+        return f"type {text[:32]!r}"
+    if action_type == "keypress":
+        return "keypress " + "+".join(getattr(action, "keys", []) or [])
+    return str(action_type)
+
+
+def run_actions(page: Any, actions: list[Any]) -> None:
+    """Apply a batch of model actions, then let the page settle."""
+    for action in actions:
+        run_action(page, action)
+    page.wait_for_timeout(500)
+    with suppress(Exception):
+        page.wait_for_load_state("domcontentloaded", timeout=2000)
+
+
+def capture_data_url(page: Any) -> str:
+    """Capture the current browser viewport for the computer-use model."""
+    png_bytes = page.screenshot(type="png", full_page=False)
+    encoded = base64.b64encode(png_bytes).decode("ascii")
+    return f"data:image/png;base64,{encoded}"
+
+
+def extract_text(response: Any) -> str:
+    """Extract final text from an OpenAI Responses API response."""
+    output_text = getattr(response, "output_text", None)
+    if isinstance(output_text, str) and output_text.strip():
+        return output_text.strip()
+
+    chunks: list[str] = []
+    for item in getattr(response, "output", []):
+        if getattr(item, "type", None) != "message":
+            continue
+        for part in getattr(item, "content", []) or []:
+            text = getattr(part, "text", None)
+            if isinstance(text, str) and text.strip():
+                chunks.append(text.strip())
+    return "\n".join(chunks).strip()
+
+
+def first_computer_call(response: Any) -> Any | None:
+    """Return the first computer-use tool call, if present."""
+    for item in getattr(response, "output", []):
+        if getattr(item, "type", None) == "computer_call":
+            return item
+    return None
+
+
+def ensure_local_page(context: Any, page: Any, start_url: str) -> Any:
+    """Keep the agent on the local demo portal."""
+    allowed_hosts = {"127.0.0.1", "localhost"}
+    selected = page
+    for candidate in list(context.pages):
+        if candidate.is_closed():
+            continue
+        parsed = urlparse(candidate.url)
+        if parsed.scheme in {"about", "data", "blob"} or parsed.hostname in allowed_hosts:
+            selected = candidate
+            continue
+        log(f"closed blocked page: {candidate.url}")
+        with suppress(Exception):
+            candidate.close()
+
+    if selected.is_closed():
+        selected = context.new_page()
+        selected.goto(start_url, wait_until="domcontentloaded")
+    with suppress(Exception):
+        selected.bring_to_front()
+    return selected
+
+
+def check_safety(computer_call: Any) -> None:
+    """Stop if the model asks for human review before an action."""
+    checks = getattr(computer_call, "pending_safety_checks", []) or []
+    if not checks:
+        return
+    messages = [check.message for check in checks if getattr(check, "message", None)]
+    raise RuntimeError(
+        "The model requested a guarded action that needs human review: "
+        + "; ".join(messages or ["pending safety checks"])
+    )
+
+
+def task_prompt(start_url: str, report_date: str) -> str:
+    """Build the task for the computer-use agent."""
+    return f"""
+Start from {start_url}.
+
+Use the browser to log into Acme Legacy Reports Portal.
+Username: ops@acme.test
+Password: demo-password
+
+Download exactly these two reports for {report_date}:
+- Orders CSV
+- Inventory CSV
+
+Do not download Settlements PDF or any other file.
+Stay on http://127.0.0.1:8000 or localhost only.
+After both CSV files have downloaded, respond only with: done
+""".strip()
+
+
+def run_computer_use_agent(
+    *,
+    page: Any,
+    start_url: str,
+    report_date: str,
+    model: str,
+    max_steps: int,
+) -> AgentResult:
+    """Run OpenAI computer-use against the existing CDP-connected browser page."""
+    from openai import OpenAI
+
+    client = OpenAI()
+    context = page.context
+    page.goto(start_url, wait_until="domcontentloaded")
+    page = ensure_local_page(context, page, start_url)
+
+    response = client.responses.create(
+        model=model,
+        tools=[{"type": "computer"}],
+        input=task_prompt(start_url, report_date),
+    )
+    log(f"submitted task to model={model}")
+
+    for step_number in range(1, max_steps + 1):
+        computer_call = first_computer_call(response)
+        if computer_call is None:
+            final_answer = extract_text(response)
+            if not final_answer:
+                raise RuntimeError("The model stopped without returning a final answer.")
+            log(f"agent final answer: {final_answer}")
+            return AgentResult(final_answer=final_answer, steps=step_number - 1)
+
+        check_safety(computer_call)
+        actions = list(getattr(computer_call, "actions", []) or [])
+        log(
+            f"step {step_number}/{max_steps}: "
+            + (" | ".join(describe_action(action) for action in actions) or "<no action>")
+        )
+        run_actions(page, actions)
+        page = ensure_local_page(context, page, start_url)
+        screenshot_data_url = capture_data_url(page)
+
+        response = client.responses.create(
+            model=model,
+            tools=[{"type": "computer"}],
+            previous_response_id=response.id,
+            input=[
+                {
+                    "type": "computer_call_output",
+                    "call_id": computer_call.call_id,
+                    "output": {
+                        "type": "computer_screenshot",
+                        "image_url": screenshot_data_url,
+                        "detail": "original",
+                    },
+                }
+            ],
+        )
+
+    raise RuntimeError(f"The computer-use loop exceeded max_steps={max_steps}.")
+
+
+def require_host_dependencies() -> None:
+    """Fail before booting a sandbox if host-side demo packages are missing."""
+    missing: list[str] = []
+    for module_name, package_name in (
+        ("openai", "openai"),
+        ("playwright", "playwright"),
+    ):
+        if importlib.util.find_spec(module_name) is None:
+            missing.append(package_name)
+
+    if missing:
+        packages = " ".join(missing)
+        raise RuntimeError(
+            "Install the demo's host-side Python dependencies before starting SmolVM: "
+            f"uv run --with {packages} examples/cua/legacy_report_fetcher/run_demo.py --mode live"
+        )
+
+
+def parse_args() -> argparse.Namespace:
+    """Parse CLI arguments."""
+    parser = argparse.ArgumentParser(
+        description="Run the SmolVM legacy report fetcher computer-use demo."
+    )
+    parser.add_argument("--mode", choices=("headless", "live"), default="live")
+    parser.add_argument("--model", default=os.environ.get("COMPUTER_USE_MODEL", DEFAULT_MODEL))
+    parser.add_argument("--max-steps", type=int, default=DEFAULT_MAX_STEPS)
+    parser.add_argument(
+        "--boot-timeout",
+        type=float,
+        default=180.0,
+        help="Seconds to wait for the SmolVM browser sandbox to boot.",
+    )
+    parser.add_argument(
+        "--report-date",
+        default=(date.today() - timedelta(days=1)).isoformat(),
+        help="Report date to download. Defaults to yesterday.",
+    )
+    return parser.parse_args()
+
+
+def main() -> int:
+    """Run the demo."""
+    args = parse_args()
+    require_host_dependencies()
+    if not os.environ.get("OPENAI_API_KEY"):
+        raise RuntimeError("Set OPENAI_API_KEY before running the computer-use demo.")
+
+    screenshots_dir = DEMO_DIR / "artifacts" / "screenshots"
+    screenshots_dir.mkdir(parents=True, exist_ok=True)
+
+    session: BrowserSession | None = None
+    try:
+        session = run_with_heartbeat(
+            "Preparing SmolVM browser session and mounted demo folder",
+            lambda: BrowserSession(
+                BrowserSessionConfig(
+                    mode=args.mode,
+                    record_video=args.mode == "live",
+                    allow_downloads=True,
+                    viewport={"width": 1440, "height": 900},
+                    workspace_mounts=[
+                        WorkspaceMount(
+                            host_path=DEMO_DIR,
+                            guest_path=GUEST_ROOT,
+                            writable=True,
+                        )
+                    ],
+                )
+            ),
+            interval_seconds=10.0,
+        )
+        run_with_heartbeat(
+            f"Starting SmolVM browser sandbox (timeout {int(args.boot_timeout)}s)",
+            lambda: session.start(boot_timeout=args.boot_timeout, on_progress=log),
+            interval_seconds=10.0,
+        )
+        print(f"Session: {session.session_id}")
+        print(f"VM: {session.vm_id}")
+        print(f"CDP URL: {session.cdp_url}")
+        print(f"Live URL: {session.live_url or '<headless>'}")
+        print(f"Artifacts: {session.artifacts_dir}")
+
+        vm = session.vm
+        run_with_heartbeat(
+            "Starting Acme legacy portal inside the sandbox",
+            lambda: start_legacy_app(vm),
+            interval_seconds=5.0,
+        )
+
+        log("Connecting to Chromium over CDP")
+        browser = session.connect_playwright()
+        context = browser.contexts[0] if browser.contexts else browser.new_context()
+        page = context.pages[0] if context.pages else context.new_page()
+        log(f"Opening portal at {PORTAL_URL}")
+        page.goto(PORTAL_URL, wait_until="domcontentloaded")
+        session.screenshot(screenshots_dir / "01-portal-login.png", full_page=False)
+
+        log("Starting OpenAI computer-use browser task")
+        agent_result = run_computer_use_agent(
+            page=page,
+            start_url=PORTAL_URL,
+            report_date=args.report_date,
+            model=args.model,
+            max_steps=args.max_steps,
+        )
+        if "done" not in agent_result.final_answer.lower():
+            raise RuntimeError(f"Agent did not confirm completion: {agent_result.final_answer}")
+
+        session.screenshot(screenshots_dir / "02-after-downloads.png", full_page=False)
+        finalize_output = run_with_heartbeat(
+            "Finalizing downloaded reports inside the sandbox",
+            lambda: finalize_downloads(vm, session.session_id, args.report_date),
+            interval_seconds=5.0,
+        )
+        print(finalize_output.strip())
+        print("\nPipeline output:")
+        pipeline_output = run_with_heartbeat(
+            "Running the existing-pipeline import inside the sandbox",
+            lambda: run_pipeline(vm, args.report_date),
+            interval_seconds=5.0,
+        )
+        print(pipeline_output.strip())
+        print("\nLocal handoff folder:")
+        print(DEMO_DIR / "artifacts" / "inbox" / "acme" / args.report_date)
+    finally:
+        if session is not None:
+            run_with_heartbeat(
+                "Stopping SmolVM browser sandbox",
+                session.stop,
+                interval_seconds=5.0,
+            )
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/smolvm/browser.py
+++ b/src/smolvm/browser.py
@@ -9,6 +9,7 @@ import shlex
 import socket
 import uuid
 import webbrowser
+from collections.abc import Callable
 from contextlib import suppress
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
@@ -16,7 +17,7 @@ from typing import Any
 
 from smolvm.exceptions import BrowserSessionNotFoundError, SmolVMError
 from smolvm.facade import SmolVM
-from smolvm.runtime.backends import BACKEND_QEMU, resolve_backend
+from smolvm.runtime.backends import BACKEND_AUTO, BACKEND_QEMU, resolve_backend
 from smolvm.runtime.boot_profiles import (
     KernelBootProfile,
     get_boot_profile_spec,
@@ -117,11 +118,17 @@ def _build_browser_vm_config(
     from smolvm.images.builder import ImageBuilder
     from smolvm.utils import ensure_ssh_key
 
-    resolved_backend = resolve_backend(browser_config.backend)
+    requested_backend = (
+        BACKEND_QEMU
+        if browser_config.backend == BACKEND_AUTO and browser_config.workspace_mounts
+        else browser_config.backend
+    )
+    resolved_backend = resolve_backend(requested_backend)
     private_key, public_key = ensure_ssh_key()
     resolved_ssh_key_path = ssh_key_path or str(private_key)
 
     builder = ImageBuilder()
+    kernel_url = builder.qemu_kernel_url_for_host() if resolved_backend == BACKEND_QEMU else None
     # TODO: Make the browser runtime pluggable so BrowserSessionConfig.browser
     # can select alternative engines (for example Lightpanda) without changing
     # the surrounding session lifecycle or backend abstractions.
@@ -139,6 +146,7 @@ def _build_browser_vm_config(
         name=image_name,
         rootfs_size_mb=browser_config.disk_size_mib,
         kernel_profile=_BROWSER_KERNEL_PROFILE,
+        kernel_url=kernel_url,
     )
 
     config = VMConfig(
@@ -152,6 +160,7 @@ def _build_browser_vm_config(
         retain_disk_on_delete=browser_config.profile_mode == "persistent",
         env_vars=browser_config.env_vars,
         port_forwards=port_forwards,
+        workspace_mounts=browser_config.workspace_mounts,
         ssh_public_key=public_key.read_text().strip(),
     )
     return config, resolved_ssh_key_path
@@ -281,6 +290,13 @@ class BrowserSession:
         return self._info.vm_id
 
     @property
+    def vm(self) -> SmolVM:
+        """Underlying SmolVM instance for shell commands and file transfer."""
+        if self._vm is None:
+            raise SmolVMError("Browser session VM is unavailable.")
+        return self._vm
+
+    @property
     def info(self) -> BrowserSessionInfo:
         """Current browser session info."""
         return self._info
@@ -320,7 +336,12 @@ class BrowserSession:
         self._info = self._state.get_browser_session(self._info.session_id)
         return self
 
-    def start(self, boot_timeout: float = _DEFAULT_BROWSER_BOOT_TIMEOUT) -> BrowserSession:
+    def start(
+        self,
+        boot_timeout: float = _DEFAULT_BROWSER_BOOT_TIMEOUT,
+        *,
+        on_progress: Callable[[str], None] | None = None,
+    ) -> BrowserSession:
         """Start the browser session and expose its CDP/live endpoints."""
         if self._session_config.network_policy_id is not None:
             raise SmolVMError(
@@ -340,8 +361,8 @@ class BrowserSession:
 
         try:
             if self._vm.status in {VMState.CREATED, VMState.STOPPED}:
-                self._vm.start(boot_timeout=boot_timeout)
-            self._vm.wait_for_ssh(timeout=boot_timeout)
+                self._vm.start(boot_timeout=boot_timeout, on_progress=on_progress)
+            self._vm.wait_for_ssh(timeout=boot_timeout, on_progress=on_progress)
 
             debug_ready = self._wait_for_guest_port(_BROWSER_DEBUG_PORT, timeout=1.0)
             live_ready = (

--- a/src/smolvm/runtime/qemu.py
+++ b/src/smolvm/runtime/qemu.py
@@ -250,7 +250,7 @@ class QemuRuntimeAdapter(RuntimeAdapter):
             try:
                 with self._client(control_socket_path, timeout=0.2):
                     return
-            except SmolVMError:
+            except (OSError, SmolVMError):
                 time.sleep(0.05)
 
         raise SmolVMError(

--- a/src/smolvm/types.py
+++ b/src/smolvm/types.py
@@ -480,6 +480,7 @@ class BrowserSessionConfig(BaseModel):
     allow_downloads: bool = True
     network_policy_id: str | None = None
     env_vars: dict[str, str] = {}
+    workspace_mounts: list[WorkspaceMount] = []
     mem_size_mib: Annotated[int, Field(ge=512, le=16384)] = 2048
     disk_size_mib: Annotated[int, Field(ge=2048, le=16384)] = 4096
 
@@ -531,6 +532,17 @@ class BrowserSessionConfig(BaseModel):
 
         if self.network_policy_id is not None and not self.network_policy_id.strip():
             raise ValueError("network_policy_id cannot be empty")
+
+        seen_tags: set[str] = set()
+        seen_guest_paths: set[str] = set()
+        for index, mount in enumerate(self.workspace_mounts):
+            tag = mount.resolved_tag(index)
+            if tag in seen_tags:
+                raise ValueError(f"Duplicate workspace mount tag: {tag}")
+            if mount.guest_path in seen_guest_paths:
+                raise ValueError(f"Duplicate workspace guest_path: {mount.guest_path}")
+            seen_tags.add(tag)
+            seen_guest_paths.add(mount.guest_path)
 
         return self
 

--- a/tests/test_browser.py
+++ b/tests/test_browser.py
@@ -29,6 +29,7 @@ from smolvm.types import (
     PortForwardConfig,
     VMConfig,
     VMState,
+    WorkspaceMount,
 )
 
 
@@ -78,9 +79,7 @@ def test_build_browser_vm_config_uses_persistent_disk_reuse(
     mock_ensure_ssh_key.return_value = (private_key, public_key)
     mock_builder = MagicMock()
     mock_builder.build_browser_rootfs.return_value = (kernel, rootfs)
-    mock_builder.qemu_kernel_url_for_host.side_effect = AssertionError(
-        "browser QEMU path should not use the desktop kernel helper"
-    )
+    mock_builder.qemu_kernel_url_for_host.return_value = "https://example.invalid/kernel.image"
     mock_builder_cls.return_value = mock_builder
 
     browser_config = BrowserSessionConfig(
@@ -107,8 +106,61 @@ def test_build_browser_vm_config_uses_persistent_disk_reuse(
         mock_builder.build_browser_rootfs.call_args.kwargs["kernel_profile"]
         == KernelBootProfile.MICROVM_DIRECT
     )
-    assert "kernel_url" not in mock_builder.build_browser_rootfs.call_args.kwargs
+    assert (
+        mock_builder.build_browser_rootfs.call_args.kwargs["kernel_url"]
+        == "https://example.invalid/kernel.image"
+    )
+    mock_builder.qemu_kernel_url_for_host.assert_called_once_with()
     mock_allocate_host_port.assert_called_once()
+
+
+@patch("smolvm.utils.ensure_ssh_key")
+@patch("smolvm.images.builder.ImageBuilder")
+def test_build_browser_vm_config_passes_workspace_mounts_and_selects_qemu(
+    mock_builder_cls: MagicMock,
+    mock_ensure_ssh_key: MagicMock,
+    tmp_path: Path,
+) -> None:
+    """Browser sessions with host mounts should run on QEMU and pass mounts through."""
+    kernel = tmp_path / "kernel"
+    rootfs = tmp_path / "rootfs.ext4"
+    private_key = tmp_path / "id_ed25519"
+    public_key = tmp_path / "id_ed25519.pub"
+    mounted = tmp_path / "demo"
+    kernel.touch()
+    rootfs.touch()
+    private_key.touch()
+    mounted.mkdir()
+    public_key.write_text("ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIMock user@test\n")
+
+    mock_ensure_ssh_key.return_value = (private_key, public_key)
+    mock_builder = MagicMock()
+    mock_builder.build_browser_rootfs.return_value = (kernel, rootfs)
+    mock_builder.qemu_kernel_url_for_host.return_value = "https://example.invalid/kernel.image"
+    mock_builder_cls.return_value = mock_builder
+
+    mount = WorkspaceMount(
+        host_path=mounted,
+        guest_path="/workspace/legacy_report_fetcher",
+        writable=True,
+    )
+    browser_config = BrowserSessionConfig(
+        session_id="browser-mounted",
+        backend="auto",
+        workspace_mounts=[mount],
+    )
+
+    vm_config, _ = _build_browser_vm_config(
+        session_id="browser-mounted",
+        browser_config=browser_config,
+    )
+
+    assert vm_config.backend == "qemu"
+    assert vm_config.workspace_mounts == [mount]
+    assert (
+        mock_builder.build_browser_rootfs.call_args.kwargs["kernel_url"]
+        == "https://example.invalid/kernel.image"
+    )
 
 
 @patch("smolvm.utils.ensure_ssh_key")
@@ -133,6 +185,7 @@ def test_build_browser_vm_config_allocates_qemu_live_port_forwards(
     mock_ensure_ssh_key.return_value = (private_key, public_key)
     mock_builder = MagicMock()
     mock_builder.build_browser_rootfs.return_value = (kernel, rootfs)
+    mock_builder.qemu_kernel_url_for_host.return_value = "https://example.invalid/kernel.image"
     mock_builder_cls.return_value = mock_builder
 
     browser_config = BrowserSessionConfig(
@@ -234,6 +287,7 @@ def test_browser_session_start_persists_ready_state(
     assert session.status == BrowserSessionState.READY
     assert session.cdp_url == "http://127.0.0.1:39222"
     assert session.live_url == "http://127.0.0.1:36080/vnc.html?autoconnect=1&resize=scale"
+    assert session.vm is vm
     persisted = session.refresh().info
     assert persisted.status == BrowserSessionState.READY
     assert persisted.debug_port == 39222

--- a/tests/test_legacy_report_fetcher_demo.py
+++ b/tests/test_legacy_report_fetcher_demo.py
@@ -1,0 +1,113 @@
+# Copyright 2026 Celesto AI
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Unit tests for the legacy report fetcher demo helpers."""
+
+from __future__ import annotations
+
+import csv
+import importlib.util
+import json
+import sqlite3
+from pathlib import Path
+from types import ModuleType
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+DEMO_ROOT = REPO_ROOT / "examples" / "cua" / "legacy_report_fetcher"
+
+
+def _load_module(name: str, path: Path) -> ModuleType:
+    spec = importlib.util.spec_from_file_location(name, path)
+    assert spec is not None
+    assert spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def _write_csv(path: Path, fieldnames: list[str], rows: list[dict[str, str]]) -> None:
+    with path.open("w", newline="", encoding="utf-8") as file:
+        writer = csv.DictWriter(file, fieldnames=fieldnames)
+        writer.writeheader()
+        writer.writerows(rows)
+
+
+def test_finalize_downloads_writes_manifest_and_pipeline_imports(tmp_path: Path) -> None:
+    """The sandbox-side helper should create the expected handoff and SQLite output."""
+    finalize = _load_module(
+        "legacy_finalize_downloads",
+        DEMO_ROOT / "ops" / "finalize_downloads.py",
+    )
+    pipeline = _load_module(
+        "legacy_import_reports",
+        DEMO_ROOT / "pipeline" / "import_reports.py",
+    )
+
+    report_date = "2026-05-06"
+    downloads = tmp_path / "downloads"
+    root = tmp_path / "demo"
+    downloads.mkdir()
+    root.mkdir()
+
+    _write_csv(
+        downloads / f"orders_{report_date}.csv",
+        ["report_date", "order_id", "customer", "region", "amount"],
+        [
+            {
+                "report_date": report_date,
+                "order_id": "A-1",
+                "customer": "Acme",
+                "region": "West",
+                "amount": "10",
+            }
+        ],
+    )
+    _write_csv(
+        downloads / f"inventory_{report_date}.csv",
+        ["report_date", "sku", "name", "on_hand", "warehouse"],
+        [
+            {
+                "report_date": report_date,
+                "sku": "SKU-1",
+                "name": "Widget",
+                "on_hand": "3",
+                "warehouse": "SFO",
+            }
+        ],
+    )
+
+    manifest_path = finalize.finalize_downloads(
+        root=root,
+        session_id="browser-test",
+        report_date=report_date,
+        downloads_dir=downloads,
+        timeout=0.1,
+    )
+
+    manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+    assert manifest["status"] == "success"
+    assert [item["name"] for item in manifest["files"]] == [
+        f"orders_{report_date}.csv",
+        f"inventory_{report_date}.csv",
+    ]
+    assert all(item["sha256"] for item in manifest["files"])
+
+    db_path = pipeline.import_reports(manifest_path.parent)
+
+    assert db_path == root / "artifacts" / "warehouse" / "acme.sqlite"
+    with sqlite3.connect(db_path) as conn:
+        orders_count = conn.execute("SELECT COUNT(*) FROM orders").fetchone()[0]
+        inventory_count = conn.execute("SELECT COUNT(*) FROM inventory").fetchone()[0]
+    assert orders_count == 1
+    assert inventory_count == 1

--- a/tests/test_legacy_report_fetcher_demo.py
+++ b/tests/test_legacy_report_fetcher_demo.py
@@ -16,12 +16,16 @@
 
 from __future__ import annotations
 
+import argparse
 import csv
 import importlib.util
 import json
 import sqlite3
+import sys
 from pathlib import Path
 from types import ModuleType
+
+import pytest
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
 DEMO_ROOT = REPO_ROOT / "examples" / "cua" / "legacy_report_fetcher"
@@ -32,6 +36,7 @@ def _load_module(name: str, path: Path) -> ModuleType:
     assert spec is not None
     assert spec.loader is not None
     module = importlib.util.module_from_spec(spec)
+    sys.modules[name] = module
     spec.loader.exec_module(module)
     return module
 
@@ -41,6 +46,39 @@ def _write_csv(path: Path, fieldnames: list[str], rows: list[dict[str, str]]) ->
         writer = csv.DictWriter(file, fieldnames=fieldnames)
         writer.writeheader()
         writer.writerows(rows)
+
+
+def test_parse_report_date_accepts_iso_date() -> None:
+    """The CLI should normalize valid report dates."""
+    run_demo = _load_module("legacy_run_demo", DEMO_ROOT / "run_demo.py")
+
+    assert run_demo.parse_report_date("2026-05-07") == "2026-05-07"
+
+
+@pytest.mark.parametrize(
+    "value",
+    [
+        "2026/05/07",
+        "2026-05-07/../../tmp",
+        "../../tmp/pwn",
+        "2026-05-07\\tmp",
+        "not-a-date",
+    ],
+)
+def test_parse_report_date_rejects_unsafe_values(value: str) -> None:
+    """The CLI should reject values that could escape the artifact directory."""
+    run_demo = _load_module("legacy_run_demo", DEMO_ROOT / "run_demo.py")
+
+    with pytest.raises(argparse.ArgumentTypeError, match="YYYY-MM-DD"):
+        run_demo.parse_report_date(value)
+
+
+def test_portal_download_date_is_safe_for_headers() -> None:
+    """The portal should not place raw query strings into download headers."""
+    portal = _load_module("legacy_portal", DEMO_ROOT / "portal" / "server.py")
+
+    assert portal._safe_report_date("2026-05-07") == "2026-05-07"
+    assert portal._safe_report_date("2026-05-07\r\nBad: header") == portal._default_report_date()
 
 
 def test_finalize_downloads_writes_manifest_and_pipeline_imports(tmp_path: Path) -> None:

--- a/tests/test_snapshot_qemu.py
+++ b/tests/test_snapshot_qemu.py
@@ -21,6 +21,7 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 from smolvm.exceptions import SmolVMError, VMNotFoundError
+from smolvm.runtime.qemu import QemuRuntimeAdapter
 from smolvm.types import SnapshotArtifacts, SnapshotInfo, VMConfig, VMState
 from smolvm.vm import SmolVMManager
 
@@ -81,6 +82,36 @@ def _mock_qmp_client() -> MagicMock:
     client.__enter__.return_value = client
     client.__exit__.return_value = False
     return client
+
+
+def test_wait_for_runtime_retries_when_qmp_greeting_times_out(tmp_path: Path) -> None:
+    """QEMU may create the QMP socket before its greeting is readable."""
+    context = MagicMock()
+    adapter = QemuRuntimeAdapter(context)
+    process = MagicMock()
+    process.poll.return_value = None
+    control_socket_path = tmp_path / "qmp-vm001.sock"
+    attempts = 0
+
+    class _ReadyClient:
+        def __enter__(self) -> "_ReadyClient":
+            return self
+
+        def __exit__(self, *args: object) -> bool:
+            return False
+
+    def _client_side_effect(_path: Path, timeout: float = 5.0) -> _ReadyClient:
+        nonlocal attempts
+        del timeout
+        attempts += 1
+        if attempts == 1:
+            raise TimeoutError("timed out")
+        return _ReadyClient()
+
+    with patch.object(adapter, "_client", side_effect=_client_side_effect):
+        adapter._wait_for_runtime(process, control_socket_path, timeout=1.0)
+
+    assert attempts == 2
 
 
 def test_pause_and_resume_qemu_vm(

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -34,6 +34,7 @@ from smolvm.types import (
     VMConfig,
     VMInfo,
     VMState,
+    WorkspaceMount,
 )
 
 
@@ -446,6 +447,29 @@ class TestBrowserSessionConfig:
         """Video recording is only valid for live-mode sessions."""
         with pytest.raises(ValidationError, match="record_video requires mode='live'"):
             BrowserSessionConfig(record_video=True)
+
+    def test_workspace_mounts_are_supported(self, tmp_path: Path) -> None:
+        """Browser sessions should accept host mounts for demo app code and artifacts."""
+        mount = WorkspaceMount(host_path=tmp_path, guest_path="/workspace/demo", writable=True)
+
+        config = BrowserSessionConfig(workspace_mounts=[mount])
+
+        assert config.workspace_mounts == [mount]
+
+    def test_workspace_mount_guest_paths_must_be_unique(self, tmp_path: Path) -> None:
+        """Browser sessions should reject ambiguous mount targets."""
+        first = tmp_path / "first"
+        second = tmp_path / "second"
+        first.mkdir()
+        second.mkdir()
+
+        with pytest.raises(ValidationError, match="Duplicate workspace guest_path"):
+            BrowserSessionConfig(
+                workspace_mounts=[
+                    WorkspaceMount(host_path=first, guest_path="/workspace/demo"),
+                    WorkspaceMount(host_path=second, guest_path="/workspace/demo"),
+                ]
+            )
 
     def test_session_state_values(self) -> None:
         """All browser session lifecycle states should exist."""


### PR DESCRIPTION
## Summary
- add a SmolVM computer-use demo for logging into a fake Acme legacy reports portal and downloading CSV reports
- add browser-session workspace mounts plus a public `session.vm` accessor for sandbox shell operations
- use the QEMU-compatible browser kernel, retry transient QMP startup timeouts, and add tests for the new paths

## Testing
- `uv run ruff check src/smolvm/browser.py src/smolvm/runtime/qemu.py src/smolvm/types.py tests/test_browser.py tests/test_types.py tests/test_snapshot_qemu.py tests/test_legacy_report_fetcher_demo.py examples/cua/legacy_report_fetcher`
- `uv run pytest tests/test_browser.py tests/test_types.py::TestBrowserSessionConfig tests/test_snapshot_qemu.py::test_wait_for_runtime_retries_when_qmp_greeting_times_out tests/test_legacy_report_fetcher_demo.py -q`
- manually started SmolVM browser sessions in headless/live mode with a writable mount


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Runnable demo that boots a sandboxed browser, drives an agent to fetch two CSV reports, finalizes artifacts (CSVs, manifest, checksums), and imports them into a local SQLite pipeline.
  * CLI utilities to start the fake portal, finalize downloads into an inbox, and import reports into the warehouse.
  * Workspace mount support and VM startup progress callback for browser sessions.

* **Bug Fixes**
  * More resilient QEMU readiness retries when probing control sockets.

* **Tests**
  * Coverage for demo flow, manifest/finalization, QEMU retry behavior, and workspace-mount validation.

* **Documentation**
  * README documenting the legacy-report demo, prerequisites, run modes, artifacts layout, and example credentials.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->