### PR TITLE
feat(cli): add `smolvm resume` for stopped sandboxes

### DIFF
--- a/src/smolvm/cli/main.py
+++ b/src/smolvm/cli/main.py
@@ -837,12 +837,7 @@ def build_parser() -> argparse.ArgumentParser:
         help="Start a stopped sandbox.",
     )
     start_parser.add_argument("vm_id", metavar="sandbox", help="Name or ID of the sandbox.")
-    start_parser.add_argument(
-        "--boot-timeout",
-        type=_positive_float,
-        default=30.0,
-        help="Seconds to wait for the sandbox to boot (default: 30).",
-    )
+    _add_boot_timeout_arg(start_parser)
     start_parser.add_argument(
         "--json",
         action="store_true",

--- a/src/smolvm/cli/main.py
+++ b/src/smolvm/cli/main.py
@@ -832,6 +832,23 @@ def build_parser() -> argparse.ArgumentParser:
         help="Emit machine-readable JSON output.",
     )
 
+    start_parser = subparsers.add_parser(
+        "start",
+        help="Start a stopped sandbox.",
+    )
+    start_parser.add_argument("vm_id", metavar="sandbox", help="Name or ID of the sandbox.")
+    start_parser.add_argument(
+        "--boot-timeout",
+        type=_positive_float,
+        default=30.0,
+        help="Seconds to wait for the sandbox to boot (default: 30).",
+    )
+    start_parser.add_argument(
+        "--json",
+        action="store_true",
+        help="Emit machine-readable JSON output.",
+    )
+
     snapshot_parser = subparsers.add_parser(
         "snapshot",
         help="Save and restore sandbox state.",
@@ -2545,6 +2562,33 @@ def _run_resume(args: argparse.Namespace) -> int:
             vm.close()
 
 
+def _run_vm_start(args: argparse.Namespace) -> int:
+    """Handle ``smolvm start``."""
+    from smolvm.facade import SmolVM
+
+    vm: SmolVM | None = None
+    try:
+        vm = SmolVM.from_id(args.vm_id)
+        vm.start(boot_timeout=args.boot_timeout)
+
+        data = _vm_lifecycle_payload(vm.vm_id, VMState.RUNNING)
+        if args.json:
+            emit_json("start", 0, data=data)
+        else:
+            _render_vm_lifecycle_result(
+                data,
+                message=f"Started VM '{vm.vm_id}'.",
+                title="VM Started",
+                border_style="green",
+            )
+        return 0
+    except Exception as exc:
+        return _emit_cli_error("start", 1, exc, json_output=args.json)
+    finally:
+        if vm is not None:
+            vm.close()
+
+
 def _run_snapshot(args: argparse.Namespace) -> int:
     """Handle ``smolvm snapshot`` commands."""
     from smolvm.facade import SmolVM
@@ -3299,6 +3343,9 @@ def main(argv: Sequence[str] | None = None) -> int:
 
     if args.command == "resume":
         return _run_resume(args)
+
+    if args.command == "start":
+        return _run_vm_start(args)
 
     if args.command == "snapshot":
         return _run_snapshot(args)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1020,6 +1020,51 @@ class TestCliPauseResume:
         assert payload["data"]["vm"]["status"] == "running"
 
 
+class TestCliVmStart:
+    """Tests for `smolvm start`."""
+
+    @patch("smolvm.facade.SmolVM")
+    def test_start_success(
+        self,
+        mock_vm_cls: MagicMock,
+        capsys: pytest.CaptureFixture,
+    ) -> None:
+        """`smolvm start` should start a stopped VM and report the result."""
+        vm = MagicMock()
+        vm.vm_id = "vm001"
+        mock_vm_cls.from_id.return_value = vm
+
+        ret = main(["start", "vm001"])
+
+        assert ret == 0
+        mock_vm_cls.from_id.assert_called_once_with("vm001")
+        vm.start.assert_called_once_with(boot_timeout=30.0)
+        vm.close.assert_called_once()
+        out = capsys.readouterr().out
+        assert "Started VM 'vm001'." in out
+        assert "running" in out
+
+    @patch("smolvm.facade.SmolVM")
+    def test_start_json(
+        self,
+        mock_vm_cls: MagicMock,
+        capsys: pytest.CaptureFixture,
+    ) -> None:
+        """`smolvm start --json` should emit the shared envelope."""
+        vm = MagicMock()
+        vm.vm_id = "vm001"
+        mock_vm_cls.from_id.return_value = vm
+
+        ret = main(["start", "vm001", "--json"])
+
+        assert ret == 0
+        payload = json.loads(capsys.readouterr().out)
+        assert payload["command"] == "start"
+        assert payload["ok"] is True
+        assert payload["data"]["vm"]["name"] == "vm001"
+        assert payload["data"]["vm"]["status"] == "running"
+
+
 class TestCliSnapshot:
     """Tests for `smolvm snapshot` subcommands."""
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1064,6 +1064,22 @@ class TestCliVmStart:
         assert payload["data"]["vm"]["name"] == "vm001"
         assert payload["data"]["vm"]["status"] == "running"
 
+    @patch("smolvm.facade.SmolVM")
+    def test_start_forwards_boot_timeout(
+        self,
+        mock_vm_cls: MagicMock,
+    ) -> None:
+        """`smolvm start --boot-timeout` should forward the value to the facade."""
+        vm = MagicMock()
+        vm.vm_id = "vm001"
+        mock_vm_cls.from_id.return_value = vm
+
+        ret = main(["start", "vm001", "--boot-timeout", "75"])
+
+        assert ret == 0
+        vm.start.assert_called_once_with(boot_timeout=75.0)
+        vm.close.assert_called_once()
+
 
 class TestCliSnapshot:
     """Tests for `smolvm snapshot` subcommands."""


### PR DESCRIPTION
Closes #292.

## Summary
- `smolvm resume` now handles both stopped and paused sandboxes by going through the existing `vm.start()` facade path.
- Adds `--boot-timeout` to `smolvm resume` so stopped sandboxes can use the same boot wait control the old `start` command had. 

## Test plan

- [x] `uv run pytest tests/test_cli.py::TestCliPauseResume -q`
- [x] `uv run pytest tests/test_cli.py -q` — 147 passed

Note: `uv run ruff check src/smolvm/cli/main.py tests/test_cli.py` still reports pre-existing lint issues outside this change.
