### PR TITLE
fix(cli): show Linux QEMU install hint

### DIFF
--- a/src/smolvm/vm.py
+++ b/src/smolvm/vm.py
@@ -1582,10 +1582,7 @@ class SmolVMManager:
         """
         qemu_bin = self._find_qemu_binary()
         if qemu_bin is None:
-            raise SmolVMError(
-                "QEMU backend selected but no qemu-system binary was found. "
-                f"{_qemu_install_hint()}"
-            )
+            raise SmolVMError(f"qemu-system binary is missing; {_qemu_install_hint()}")
 
         if vm_info.network is None or vm_info.network.ssh_host_port is None:
             raise SmolVMError("QEMU backend requires a reserved ssh_host_port in VM network config")

--- a/src/smolvm/vm.py
+++ b/src/smolvm/vm.py
@@ -68,6 +68,63 @@ DEFAULT_SOCKET_DIR = Path("/tmp")
 
 # Backend-specific defaults
 QEMU_GUEST_IP = "10.0.2.15"
+
+
+def _linux_os_release_ids(os_release_path: Path = Path("/etc/os-release")) -> set[str]:
+    """Return Linux distribution IDs from /etc/os-release."""
+    ids: set[str] = set()
+    try:
+        lines = os_release_path.read_text().splitlines()
+    except OSError:
+        return ids
+
+    for line in lines:
+        key, sep, value = line.partition("=")
+        if sep != "=" or key not in {"ID", "ID_LIKE"}:
+            continue
+        value = value.strip().strip('"').strip("'")
+        ids.update(part.strip().lower() for part in value.split() if part.strip())
+    return ids
+
+
+def _qemu_system_package_for_host() -> str:
+    """Return the distro package that provides the host-arch qemu-system binary."""
+    arch = platform.machine().lower()
+    if arch in {"arm64", "aarch64"}:
+        return "qemu-system-arm"
+    return "qemu-system-x86"
+
+
+def _qemu_install_hint() -> str:
+    """Return a host-specific QEMU installation hint."""
+    system = platform.system()
+    if system == "Darwin":
+        return "Install QEMU with 'brew install qemu'."
+    if system == "Linux":
+        ids = _linux_os_release_ids()
+        qemu_system_pkg = _qemu_system_package_for_host()
+        if ids & {"debian", "ubuntu"}:
+            return (
+                "Install QEMU with 'sudo apt-get update && sudo apt-get install -y "
+                f"{qemu_system_pkg} qemu-utils'."
+            )
+        if ids & {"fedora", "rhel", "centos"}:
+            return f"Install QEMU with 'sudo dnf install -y {qemu_system_pkg} qemu-img'."
+        if ids & {"arch"}:
+            return f"Install QEMU with 'sudo pacman -S --needed {qemu_system_pkg} qemu-img'."
+        if ids & {"alpine"}:
+            qemu_system_bin_pkg = "qemu-system-aarch64"
+            if qemu_system_pkg == "qemu-system-x86":
+                qemu_system_bin_pkg = "qemu-system-x86_64"
+            return f"Install QEMU with 'sudo apk add {qemu_system_bin_pkg} qemu-img'."
+        return (
+            "Install QEMU with your Linux package manager, then make sure "
+            "qemu-system-x86_64 or qemu-system-aarch64 is on PATH."
+        )
+    return (
+        "Install QEMU for this operating system, then make sure qemu-system-x86_64 "
+        "or qemu-system-aarch64 is on PATH."
+    )
 QEMU_GATEWAY_IP = "10.0.2.2"
 QEMU_NETMASK = "255.255.255.0"
 QEMU_SLIRP_DNS = "10.0.2.3"
@@ -696,10 +753,7 @@ class SmolVMManager:
 
         qemu_bin = self._find_qemu_binary()
         if qemu_bin is None:
-            errors.append(
-                "QEMU not found. Install one of: qemu-system-aarch64, qemu-system-x86_64 "
-                "(macOS/Homebrew: brew install qemu)."
-            )
+            errors.append(f"QEMU not found. {_qemu_install_hint()}")
         elif platform.system() == "Darwin":
             try:
                 result = subprocess.run(
@@ -1530,7 +1584,7 @@ class SmolVMManager:
         if qemu_bin is None:
             raise SmolVMError(
                 "QEMU backend selected but no qemu-system binary was found. "
-                "Install with: brew install qemu"
+                f"{_qemu_install_hint()}"
             )
 
         if vm_info.network is None or vm_info.network.ssh_host_port is None:

--- a/tests/test_vm_qemu.py
+++ b/tests/test_vm_qemu.py
@@ -17,8 +17,54 @@
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
-from smolvm.types import PortForwardConfig, VMConfig
+import pytest
+
+from smolvm.exceptions import SmolVMError
+from smolvm.types import NetworkConfig, PortForwardConfig, VMConfig, VMInfo, VMState
 from smolvm.vm import SmolVMManager
+
+
+def _qemu_vm_info(tmp_path: Path) -> VMInfo:
+    """Return a minimal QEMU VMInfo for launch-command tests."""
+    kernel = tmp_path / "vmlinux"
+    rootfs = tmp_path / "rootfs.ext4"
+    kernel.touch()
+    rootfs.touch()
+    return VMInfo(
+        vm_id="vm-qemu",
+        status=VMState.CREATED,
+        config=VMConfig(
+            vm_id="vm-qemu",
+            kernel_path=kernel,
+            rootfs_path=rootfs,
+            backend="qemu",
+            boot_args="console=ttyS0 reboot=k panic=1 init=/init",
+        ),
+        network=NetworkConfig(
+            guest_ip="10.0.2.15",
+            tap_device="qemu-user",
+            guest_mac="52:54:00:12:34:56",
+            ssh_host_port=2200,
+        ),
+    )
+
+
+def test_start_qemu_missing_binary_uses_linux_install_hint(tmp_path: Path) -> None:
+    """Linux users should get a Linux package-manager hint, not Homebrew."""
+    sdk = SmolVMManager(data_dir=tmp_path / "data", socket_dir=tmp_path / "sockets", backend="qemu")
+
+    with (
+        patch.object(SmolVMManager, "_find_qemu_binary", return_value=None),
+        patch("smolvm.vm.platform.system", return_value="Linux"),
+        patch("smolvm.vm.platform.machine", return_value="x86_64"),
+        patch("smolvm.vm._linux_os_release_ids", return_value={"ubuntu", "debian"}),
+        pytest.raises(SmolVMError) as exc_info,
+    ):
+        sdk._start_qemu(_qemu_vm_info(tmp_path), tmp_path / "vm-qemu.log")
+
+    message = str(exc_info.value)
+    assert "sudo apt-get update && sudo apt-get install -y qemu-system-x86 qemu-utils" in message
+    assert "brew install qemu" not in message
 
 
 @patch("smolvm.vm.subprocess.Popen")


### PR DESCRIPTION
## Summary

- Replaces the hardcoded Homebrew QEMU install hint in the QEMU start failure path with an OS-aware helper.
- Shows apt/dnf/pacman/apk guidance on Linux where possible, based on `/etc/os-release`.
- Reuses the same helper in QEMU prerequisite checks so install guidance stays consistent.
- Adds a regression test that Linux users do not receive the macOS `brew install qemu` hint.

## Test plan

- [x] `uv run pytest tests/test_vm_qemu.py -q`
- [x] `uv run ruff check src/smolvm/vm.py tests/test_vm_qemu.py`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved "QEMU not found" guidance with OS- and architecture-aware install commands tailored to the host platform.

* **Bug Fixes**
  * Error messages now show the correct install hint for non-macOS hosts (removing macOS-specific text where inappropriate).

* **Tests**
  * Added tests to confirm Linux-specific install hints appear and macOS/Homebrew hints do not.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/CelestoAI/SmolVM/pull/295)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->