### PR TITLE
fix(kernel): enable Podman Netavark networking

### DIFF
--- a/kernel/microvm/config.fragment
+++ b/kernel/microvm/config.fragment
@@ -44,12 +44,12 @@ CONFIG_PACKET=y                 # why: AF_PACKET for some userspace tools
 # and Netavark reports the misleading error "invalid version number". Netavark's
 # default bridge rules use MASQUERADE, conntrack, and `-m comment`, so keep the
 # nftables pieces for those rules built in (we ship no loadable modules).
-CONFIG_NF_TABLES=y
-CONFIG_NF_TABLES_INET=y
-CONFIG_NFT_CT=y
-CONFIG_NFT_MASQ=y
-CONFIG_NFT_COMPAT=y
-CONFIG_NETFILTER_XT_MATCH_COMMENT=y
+CONFIG_NF_TABLES=y              # why: iptables-nft backend used by Ubuntu podman/netavark
+CONFIG_NF_TABLES_INET=y         # why: mixed IPv4/IPv6 nft table support for iptables-nft
+CONFIG_NFT_CT=y                 # why: netavark emits conntrack state rules
+CONFIG_NFT_MASQ=y               # why: netavark emits MASQUERADE rules for bridge egress NAT
+CONFIG_NFT_COMPAT=y             # why: allows xtables matches such as `-m comment` via nft
+CONFIG_NETFILTER_XT_MATCH_COMMENT=y  # why: netavark marks its chains with `-m comment`
 
 # ── vsock (host↔guest control channel) ──────────────────────────────
 # Both libkrun and Firecracker enable these; libkrun uses vsock for its

--- a/kernel/microvm/config.fragment
+++ b/kernel/microvm/config.fragment
@@ -47,6 +47,7 @@ CONFIG_PACKET=y                 # why: AF_PACKET for some userspace tools
 CONFIG_NF_TABLES=y              # why: iptables-nft backend used by Ubuntu podman/netavark
 CONFIG_NF_TABLES_INET=y         # why: mixed IPv4/IPv6 nft table support for iptables-nft
 CONFIG_NFT_CT=y                 # why: netavark emits conntrack state rules
+CONFIG_NFT_NAT=y                # why: registers nft nat chains such as POSTROUTING
 CONFIG_NFT_MASQ=y               # why: netavark emits MASQUERADE rules for bridge egress NAT
 CONFIG_NFT_COMPAT=y             # why: allows xtables matches such as `-m comment` via nft
 CONFIG_NETFILTER_XT_MATCH_COMMENT=y  # why: netavark marks its chains with `-m comment`

--- a/kernel/microvm/config.fragment
+++ b/kernel/microvm/config.fragment
@@ -38,6 +38,19 @@ CONFIG_NET=y                    # why: required for virtio-net + sshd
 CONFIG_INET=y                   # why: TCP/IP for SSH
 CONFIG_PACKET=y                 # why: AF_PACKET for some userspace tools
 
+# ── Container networking inside the guest ───────────────────────────
+# Podman/Netavark on Ubuntu defaults to iptables-nft. Without nf_tables,
+# `iptables --version` prints "Protocol not supported" instead of a version,
+# and Netavark reports the misleading error "invalid version number". Netavark's
+# default bridge rules use MASQUERADE, conntrack, and `-m comment`, so keep the
+# nftables pieces for those rules built in (we ship no loadable modules).
+CONFIG_NF_TABLES=y
+CONFIG_NF_TABLES_INET=y
+CONFIG_NFT_CT=y
+CONFIG_NFT_MASQ=y
+CONFIG_NFT_COMPAT=y
+CONFIG_NETFILTER_XT_MATCH_COMMENT=y
+
 # ── vsock (host↔guest control channel) ──────────────────────────────
 # Both libkrun and Firecracker enable these; libkrun uses vsock for its
 # init protocol, and we'll need it once the libkrun spike lands. Cheap

--- a/tests/test_kernel_config.py
+++ b/tests/test_kernel_config.py
@@ -38,6 +38,7 @@ def test_microvm_kernel_enables_podman_netavark_networking() -> None:
         "CONFIG_NF_TABLES",
         "CONFIG_NF_TABLES_INET",
         "CONFIG_NFT_CT",
+        "CONFIG_NFT_NAT",
         "CONFIG_NFT_MASQ",
         "CONFIG_NFT_COMPAT",
         "CONFIG_NETFILTER_XT_MATCH_COMMENT",

--- a/tests/test_kernel_config.py
+++ b/tests/test_kernel_config.py
@@ -43,4 +43,5 @@ def test_microvm_kernel_enables_podman_netavark_networking() -> None:
         "CONFIG_NFT_COMPAT",
         "CONFIG_NETFILTER_XT_MATCH_COMMENT",
     }
-    assert required <= symbols
+    missing = required - symbols
+    assert required <= symbols, f"missing symbols: {missing}"

--- a/tests/test_kernel_config.py
+++ b/tests/test_kernel_config.py
@@ -1,0 +1,45 @@
+# Copyright 2026 Celesto AI
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for SmolVM kernel config fragments."""
+
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+COMMON_FRAGMENT = REPO_ROOT / "kernel" / "microvm" / "config.fragment"
+
+
+def _enabled_symbols(fragment: Path) -> set[str]:
+    """Return symbols explicitly enabled in a kernel config fragment."""
+    symbols: set[str] = set()
+    for raw_line in fragment.read_text().splitlines():
+        line = raw_line.split("#", 1)[0].strip()
+        if line.startswith("CONFIG_") and line.endswith("=y"):
+            symbols.add(line.removesuffix("=y"))
+    return symbols
+
+
+def test_microvm_kernel_enables_podman_netavark_networking() -> None:
+    """Podman/Netavark needs nftables support for default bridge networking."""
+    symbols = _enabled_symbols(COMMON_FRAGMENT)
+
+    required = {
+        "CONFIG_NF_TABLES",
+        "CONFIG_NF_TABLES_INET",
+        "CONFIG_NFT_CT",
+        "CONFIG_NFT_MASQ",
+        "CONFIG_NFT_COMPAT",
+        "CONFIG_NETFILTER_XT_MATCH_COMMENT",
+    }
+    assert required <= symbols


### PR DESCRIPTION
## Summary

- Enables the minimal nftables kernel support Podman/Netavark needs for default bridge networking inside SmolVM guests.
- Fixes the observed `netavark: invalid version number` failure caused by `iptables-nft` failing with `Protocol not supported`.
- Adds a small regression test that the microvm kernel config keeps these required symbols enabled.

## Diagnosis

In `test-bot`, `podman run docker.io/library/busybox` failed after image pull with:

```text
Error: netavark: invalid version number
```

Inside the guest, `iptables --version` failed because the kernel lacked nf_tables support:

```text
iptables: Failed to initialize nft: Protocol not supported
```

Netavark's default bridge rules use MASQUERADE, conntrack state matching, NAT chains, and `-m comment`, so this PR enables the minimal symbols needed for that path:

- `CONFIG_NF_TABLES`
- `CONFIG_NF_TABLES_INET`
- `CONFIG_NFT_CT`
- `CONFIG_NFT_NAT`
- `CONFIG_NFT_MASQ`
- `CONFIG_NFT_COMPAT`
- `CONFIG_NETFILTER_XT_MATCH_COMMENT`

## Test plan

- [x] `uv run pytest tests/test_kernel_config.py -q`
- [x] `uv run ruff check tests/test_kernel_config.py`
- [x] Built the arm64 kernel locally in Docker using `kernel/microvm/build.sh`
- [x] Booted a QEMU sandbox with the locally built arm64 kernel
- [x] Installed `podman netavark aardvark-dns iptables` in that sandbox
- [x] Verified `iptables --version` reports `nf_tables`
- [x] Verified `podman run --rm docker.io/library/busybox true` exits 0 with default networking

## Note

This requires a new SmolVM kernel build/publish before new sandboxes get the fix. Existing sandboxes keep their current kernel.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Enabled built-in kernel networking features (nf_tables with inet, nft conntrack, NAT, MASQUERADE) and the xtables compatibility layer (including comment match) to better support modern container networking defaults.

* **Tests**
  * Added automated tests that verify the kernel configuration enables the required netfilter/nftables options.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/CelestoAI/SmolVM/pull/296)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->