### PR TITLE
fix(kernel): pin NETFILTER_ADVANCED and NETFILTER_XTABLES =y

### DIFF
--- a/kernel/microvm/config.fragment
+++ b/kernel/microvm/config.fragment
@@ -44,6 +44,8 @@ CONFIG_PACKET=y                 # why: AF_PACKET for some userspace tools
 # and Netavark reports the misleading error "invalid version number". Netavark's
 # default bridge rules use MASQUERADE, conntrack, and `-m comment`, so keep the
 # nftables pieces for those rules built in (we ship no loadable modules).
+CONFIG_NETFILTER_ADVANCED=y     # why: gates the xt match symbols below; off by default in x86_64_defconfig
+CONFIG_NETFILTER_XTABLES=y      # why: parent of XT_MATCH_COMMENT; x86_64_defconfig has it =m, dropped when MODULES is off
 CONFIG_NF_TABLES=y              # why: iptables-nft backend used by Ubuntu podman/netavark
 CONFIG_NF_TABLES_INET=y         # why: mixed IPv4/IPv6 nft table support for iptables-nft
 CONFIG_NFT_CT=y                 # why: netavark emits conntrack state rules

--- a/tests/test_kernel_config.py
+++ b/tests/test_kernel_config.py
@@ -35,6 +35,8 @@ def test_microvm_kernel_enables_podman_netavark_networking() -> None:
     symbols = _enabled_symbols(COMMON_FRAGMENT)
 
     required = {
+        "CONFIG_NETFILTER_ADVANCED",
+        "CONFIG_NETFILTER_XTABLES",
         "CONFIG_NF_TABLES",
         "CONFIG_NF_TABLES_INET",
         "CONFIG_NFT_CT",


### PR DESCRIPTION
## Summary

Fixes the amd64 [Build microvm Kernel](https://github.com/CelestoAI/SmolVM/actions/runs/25626038307/job/75221254099) failure introduced by #296.

`CONFIG_NETFILTER_XT_MATCH_COMMENT=y` was added to the common kernel fragment, but on amd64 the fragment-verification step in [kernel/microvm/build.sh](../blob/main/kernel/microvm/build.sh) caught the symbol going missing from `.config`. Root cause: `x86_64_defconfig` has `NETFILTER_ADVANCED` unset and `NETFILTER_XTABLES=m`. Because the fragment also pins `# CONFIG_MODULES is not set`, `olddefconfig` quietly drops the `=m` parent, and the leaf option falls with it. arm64's `defconfig` has both parents `=y` already, which is why CI was green there.

Fix: pin `NETFILTER_ADVANCED=y` and `NETFILTER_XTABLES=y` in the common fragment so the parents survive `olddefconfig` regardless of baseline. Also add both symbols to the required-set in `tests/test_kernel_config.py` so a future fragment regression surfaces at unit-test time, not only in the release workflow.

> [!NOTE]
> The arm64 cell of that same workflow run failed at the upload step with `asset under the same name already exists`. That is a separate, expected guard — `images-v0.0.14` is already a published release and the workflow refuses to clobber to protect the SHAs pinned in `BASE_KERNELS`. To actually ship the new kernel bytes the next step is bumping `IMAGES_RELEASE_TAG` per the protocol at [src/smolvm/images/published.py](../blob/main/src/smolvm/images/published.py#L138). Out of scope for this PR.

## Related Issues

- Follow-up to #296

## Testing

- `uv run ruff check kernel/microvm/ tests/test_kernel_config.py`
- `uv run pytest tests/test_kernel_config.py`
- Full kernel rebuild deferred to CI (cross-toolchain not available locally on macOS).

## Checklist

- [x] Scope is focused and limited to this change
- [x] Tests added/updated for behavior changes
- [x] Docs updated for user-visible changes (n/a — internal build config)
- [x] No secrets or sensitive data included

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced kernel networking support for MicroVM guests with improved iptables-nft tooling compatibility.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/CelestoAI/SmolVM/pull/297)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->