### PR TITLE
fix(ci): skip kernel upload if asset already exists at target tag

### DIFF
--- a/.github/workflows/build-microvm-kernel.yml
+++ b/.github/workflows/build-microvm-kernel.yml
@@ -28,12 +28,13 @@ on:
         default: ""
       force_overwrite:
         description: >-
-          DANGEROUS. Replace any assets with the same name that already
-          live at this tag. Default false: the upload step fails loud on
-          a collision so an accidental re-run cannot silently swap
-          published bytes the shipped CLI's BASE_KERNELS SHAs depend on.
-          Tick this only for an intentional re-bake of the same tag
-          (e.g. a flaky CI run that needs a redo).
+          Replace any assets that already live at this tag. Default
+          false: the upload step skips assets that already exist (the
+          build still runs and verifies the current fragment compiles)
+          so an accidental re-run cannot silently swap published bytes
+          the shipped CLI's BASE_KERNELS SHAs depend on. Tick this only
+          for an intentional re-bake of the same tag (e.g. a flaky CI
+          run that needs a redo).
         type: boolean
         default: false
   push:
@@ -159,23 +160,31 @@ jobs:
               --notes "Auto-generated draft release for SmolVM published images. Verify SHA-256 sums and content before publishing." \
               || echo "Draft already exists (race with another matrix cell), continuing."
           fi
-          # Default (no --clobber): `gh release upload` returns non-zero
-          # on a same-name collision. Forces the dev to bump
-          # IMAGES_RELEASE_TAG (or pass a fresh `release_tag` input)
-          # rather than silently swapping published bytes that the
-          # shipped CLI's BASE_KERNELS SHAs depend on.
+          # Skip-if-exists. The bumping protocol at
+          # published.py::IMAGES_RELEASE_TAG couples a tag to one
+          # specific set of kernel bytes — same tag = same bytes — so a
+          # collision here means we re-ran the workflow against a tag
+          # that's already published. Skipping (rather than erroring) is
+          # the right call: the build still runs, so the current
+          # fragment is verified to compile, but published bytes the
+          # shipped CLI's BASE_KERNELS SHAs depend on are never swapped.
           # `force_overwrite=true` (workflow_dispatch only — push events
-          # cannot set it) opts back in for intentional re-bakes.
-          upload_args=()
-          if [ "${FORCE_OVERWRITE:-false}" = "true" ]; then
-            upload_args+=(--clobber)
-          fi
-          gh release upload "$TAG" \
-            --repo "$GITHUB_REPOSITORY" \
-            "${upload_args[@]}" \
+          # cannot set it) opts into clobbering for an intentional
+          # re-bake of the same tag.
+          existing="$(gh release view "$TAG" --repo "$GITHUB_REPOSITORY" --json assets --jq '.assets[].name' 2>/dev/null || true)"
+          for f in \
             "kernel-out/vmlinux-${ARCH}.elf" \
             "kernel-out/vmlinux-${ARCH}.image" \
-            "kernel-out/vmlinux-${ARCH}.config"
+            "kernel-out/vmlinux-${ARCH}.config"; do
+            name="$(basename "$f")"
+            if [ "${FORCE_OVERWRITE:-false}" = "true" ]; then
+              gh release upload "$TAG" --repo "$GITHUB_REPOSITORY" --clobber "$f"
+            elif printf '%s\n' "$existing" | grep -Fxq "$name"; then
+              echo "Skipping $name: already uploaded to $TAG."
+            else
+              gh release upload "$TAG" --repo "$GITHUB_REPOSITORY" "$f"
+            fi
+          done
 
       - name: Step summary
         env:
@@ -190,7 +199,7 @@ jobs:
           {
             echo "## microvm kernel build: \`${ARCH}\`"
             echo ""
-            echo "Uploaded to draft release [\`${TAG}\`](https://github.com/${GITHUB_REPOSITORY}/releases/tag/${TAG})."
+            echo "Target release: [\`${TAG}\`](https://github.com/${GITHUB_REPOSITORY}/releases/tag/${TAG}). Existing assets are skipped (see upload step log)."
             echo ""
             echo "| Artifact | Size | SHA-256 |"
             echo "| --- | --- | --- |"

--- a/.github/workflows/build-microvm-kernel.yml
+++ b/.github/workflows/build-microvm-kernel.yml
@@ -160,13 +160,24 @@ jobs:
           arch = os.environ["ARCH"]
           src = open("src/smolvm/images/published.py").read()
           tree = ast.parse(src)
+
+
+          def _is_base_kernels(node):
+              # Match both `BASE_KERNELS: dict[...] = {...}` (AnnAssign) and
+              # the un-annotated `BASE_KERNELS = {...}` (Assign) variants —
+              # an annotation drop must not silently kill the drift canary.
+              if isinstance(node, ast.AnnAssign):
+                  return isinstance(node.target, ast.Name) and node.target.id == "BASE_KERNELS"
+              if isinstance(node, ast.Assign):
+                  return any(
+                      isinstance(t, ast.Name) and t.id == "BASE_KERNELS"
+                      for t in node.targets
+                  )
+              return False
+
+
           for node in ast.walk(tree):
-              if (
-                  isinstance(node, ast.AnnAssign)
-                  and isinstance(node.target, ast.Name)
-                  and node.target.id == "BASE_KERNELS"
-                  and isinstance(node.value, ast.Dict)
-              ):
+              if _is_base_kernels(node) and isinstance(node.value, ast.Dict):
                   for k, v in zip(node.value.keys, node.value.values):
                       if (
                           isinstance(k, ast.Constant)
@@ -261,11 +272,18 @@ jobs:
           IMAGE_SIZE: ${{ steps.sha.outputs.image_size }}
           CACHE_HIT: ${{ steps.cache.outputs.cache-hit }}
           DRIFT_DETECTED: ${{ steps.upload.outputs.drift_detected }}
+          FORCE_OVERWRITE: ${{ inputs.force_overwrite }}
         run: |
+          if [ "${FORCE_OVERWRITE:-false}" = "true" ]; then
+            existing_assets_note="Existing assets were overwritten (see upload step log)."
+          else
+            existing_assets_note="Existing assets were skipped (see upload step log)."
+          fi
+          published_url="${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/blob/main/src/smolvm/images/published.py"
           {
             echo "## microvm kernel build: \`${ARCH}\`"
             echo ""
-            echo "Target release: [\`${TAG}\`](https://github.com/${GITHUB_REPOSITORY}/releases/tag/${TAG}). Existing assets are skipped (see upload step log)."
+            echo "Target release: [\`${TAG}\`](${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/releases/tag/${TAG}). ${existing_assets_note}"
             echo ""
             echo "| Artifact | Size | SHA-256 |"
             echo "| --- | --- | --- |"
@@ -276,6 +294,6 @@ jobs:
             if [ "${DRIFT_DETECTED:-0}" = "1" ]; then
               echo ""
               echo "> [!WARNING]"
-              echo "> Source on this branch builds different kernel bytes than \`BASE_KERNELS\` pins for \`${TAG}\`. Bump \`IMAGES_RELEASE_TAG\` in [\`src/smolvm/images/published.py\`](../blob/main/src/smolvm/images/published.py) to publish the new bytes."
+              echo "> Source on this branch builds different kernel bytes than \`BASE_KERNELS\` pins for \`${TAG}\`. Bump \`IMAGES_RELEASE_TAG\` in [\`src/smolvm/images/published.py\`](${published_url}) to publish the new bytes."
             fi
           } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/build-microvm-kernel.yml
+++ b/.github/workflows/build-microvm-kernel.yml
@@ -143,12 +143,55 @@ jobs:
             echo "image_size=${image_size}"
           } >> "$GITHUB_OUTPUT"
 
+      - name: Read pinned BASE_KERNELS SHAs
+        id: pinned
+        env:
+          ARCH: ${{ matrix.arch }}
+        run: |
+          # Extract the elf_sha256 / image_sha256 strings pinned in
+          # BASE_KERNELS for this arch. Used by the upload step's drift
+          # check: if upload skips because the asset already exists at
+          # the tag but the bytes we just built no longer match the pin,
+          # the source-on-main has diverged from the published bytes and
+          # IMAGES_RELEASE_TAG needs a bump. Empty output (e.g. brand-new
+          # arch with no pin yet) silently skips the drift check.
+          python3 - <<'PY' >> "$GITHUB_OUTPUT"
+          import ast, os
+          arch = os.environ["ARCH"]
+          src = open("src/smolvm/images/published.py").read()
+          tree = ast.parse(src)
+          for node in ast.walk(tree):
+              if (
+                  isinstance(node, ast.AnnAssign)
+                  and isinstance(node.target, ast.Name)
+                  and node.target.id == "BASE_KERNELS"
+                  and isinstance(node.value, ast.Dict)
+              ):
+                  for k, v in zip(node.value.keys, node.value.values):
+                      if (
+                          isinstance(k, ast.Constant)
+                          and k.value == arch
+                          and isinstance(v, ast.Call)
+                      ):
+                          for kw in v.keywords:
+                              if kw.arg in ("elf_sha256", "image_sha256") and isinstance(
+                                  kw.value, ast.Constant
+                              ):
+                                  short = "elf" if kw.arg == "elf_sha256" else "image"
+                                  print(f"{short}_sha={kw.value.value}")
+                  break
+          PY
+
       - name: Upload to GitHub Releases (draft)
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           TAG: ${{ steps.release.outputs.tag }}
           ARCH: ${{ matrix.arch }}
           FORCE_OVERWRITE: ${{ inputs.force_overwrite }}
+          ELF_SHA: ${{ steps.sha.outputs.elf_sha }}
+          IMAGE_SHA: ${{ steps.sha.outputs.image_sha }}
+          PINNED_ELF_SHA: ${{ steps.pinned.outputs.elf_sha }}
+          PINNED_IMAGE_SHA: ${{ steps.pinned.outputs.image_sha }}
         run: |
           # Idempotent draft create. Race between matrix cells handled the
           # same way as build-published-images.yml.
@@ -171,7 +214,16 @@ jobs:
           # `force_overwrite=true` (workflow_dispatch only — push events
           # cannot set it) opts into clobbering for an intentional
           # re-bake of the same tag.
+          #
+          # Drift canary: when an asset is skipped, compare the
+          # locally-built SHA against the BASE_KERNELS pin. If they
+          # differ, source on main builds different bytes than the CLI
+          # claims are published — emit a workflow warning so this
+          # doesn't go unnoticed across PRs. The .config artifact has no
+          # pin (it's a debugging aid, not a runtime input), so it's
+          # skipped silently.
           existing="$(gh release view "$TAG" --repo "$GITHUB_REPOSITORY" --json assets --jq '.assets[].name' 2>/dev/null || true)"
+          drift_detected=0
           for f in \
             "kernel-out/vmlinux-${ARCH}.elf" \
             "kernel-out/vmlinux-${ARCH}.image" \
@@ -179,12 +231,25 @@ jobs:
             name="$(basename "$f")"
             if [ "${FORCE_OVERWRITE:-false}" = "true" ]; then
               gh release upload "$TAG" --repo "$GITHUB_REPOSITORY" --clobber "$f"
-            elif printf '%s\n' "$existing" | grep -Fxq "$name"; then
-              echo "Skipping $name: already uploaded to $TAG."
-            else
+              continue
+            fi
+            if ! printf '%s\n' "$existing" | grep -Fxq "$name"; then
               gh release upload "$TAG" --repo "$GITHUB_REPOSITORY" "$f"
+              continue
+            fi
+            echo "Skipping $name: already uploaded to $TAG."
+            case "$name" in
+              *.elf)   local_sha="$ELF_SHA";   pinned_sha="$PINNED_ELF_SHA" ;;
+              *.image) local_sha="$IMAGE_SHA"; pinned_sha="$PINNED_IMAGE_SHA" ;;
+              *)       continue ;;
+            esac
+            if [ -n "$pinned_sha" ] && [ "$local_sha" != "$pinned_sha" ]; then
+              echo "::warning title=Kernel SHA drift::${name}: source on this branch builds ${local_sha} but BASE_KERNELS pins ${pinned_sha} at ${TAG}. Bump IMAGES_RELEASE_TAG in src/smolvm/images/published.py to publish the new bytes."
+              drift_detected=1
             fi
           done
+          echo "drift_detected=${drift_detected}" >> "$GITHUB_OUTPUT"
+        id: upload
 
       - name: Step summary
         env:
@@ -195,6 +260,7 @@ jobs:
           IMAGE_SHA: ${{ steps.sha.outputs.image_sha }}
           IMAGE_SIZE: ${{ steps.sha.outputs.image_size }}
           CACHE_HIT: ${{ steps.cache.outputs.cache-hit }}
+          DRIFT_DETECTED: ${{ steps.upload.outputs.drift_detected }}
         run: |
           {
             echo "## microvm kernel build: \`${ARCH}\`"
@@ -207,4 +273,9 @@ jobs:
             echo "| \`vmlinux-${ARCH}.image\` (QEMU) | $(numfmt --to=iec-i --suffix=B ${IMAGE_SIZE}) | \`${IMAGE_SHA}\` |"
             echo ""
             echo "Linux version: \`$(cat kernel/microvm/linux.version)\` · Cache hit: \`${CACHE_HIT}\`"
+            if [ "${DRIFT_DETECTED:-0}" = "1" ]; then
+              echo ""
+              echo "> [!WARNING]"
+              echo "> Source on this branch builds different kernel bytes than \`BASE_KERNELS\` pins for \`${TAG}\`. Bump \`IMAGES_RELEASE_TAG\` in [\`src/smolvm/images/published.py\`](../blob/main/src/smolvm/images/published.py) to publish the new bytes."
+            fi
           } >> "$GITHUB_STEP_SUMMARY"


### PR DESCRIPTION
## Summary

Fixes the arm64 cell of the [Build microvm Kernel](https://github.com/CelestoAI/SmolVM/actions/runs/25626038307/job/75221254094) failure, and replaces the safety property the old "fail loud on collision" behavior provided.

The workflow runs on every push that touches `kernel/microvm/**`, but the upload target is always the current `IMAGES_RELEASE_TAG`. After PR #296 landed and `images-v0.0.14` was already published with kernel assets, the upload step failed loud on a same-name collision:

```
asset under the same name already exists: [vmlinux-arm64.elf vmlinux-arm64.image vmlinux-arm64.config]
```

The previous "fail loud" behavior was meant to force a tag bump, but in practice it just turns every kernel-input PR into a red CI run that has to be ignored.

## What this PR does

**1. Skip-if-exists (per asset).** For each artifact, check whether it already exists at the target tag. If yes → log a skip line and continue. If no → upload normally. `force_overwrite=true` (workflow_dispatch only) still clobbers, for intentional re-bakes.

**2. Drift canary.** When the upload skips an asset, compare the locally-built SHA against the SHA pinned in `BASE_KERNELS` for this arch in [`src/smolvm/images/published.py`](../blob/main/src/smolvm/images/published.py). If they differ, source on this branch builds different kernel bytes than the CLI claims are published — emit a workflow `::warning::` annotation and a step-summary callout pointing at the bumping protocol. `vmlinux-<arch>.config` has no pin (it's a debugging aid, not a runtime input) so it's skipped silently.

The bumping protocol at [`published.py::IMAGES_RELEASE_TAG`](../blob/main/src/smolvm/images/published.py#L138) already guarantees that "new kernel bytes" and "new tag" travel together. The old collision-fail conflated *that* footgun with the much more common case of "the workflow ran twice for an unchanged tag." The drift canary surgically detects only the genuine source/published divergence.

## Behavior matrix

| Scenario | Old | New |
| --- | --- | --- |
| Kernel inputs unchanged, tag unchanged | ✅ cache hit, nothing to upload | ✅ cache hit, nothing to upload |
| Kernel inputs changed (same bytes), tag unchanged | ❌ upload errors out CI | ✅ build verifies, upload skipped |
| Kernel inputs changed (new bytes), tag NOT bumped | ❌ upload errors out CI (correctly) | ⚠️ build verifies, upload skipped, `::warning::` annotation flags drift |
| Kernel inputs changed, tag bumped | ✅ fresh draft, upload | ✅ fresh draft, upload |
| Re-bake same tag (`force_overwrite=true`) | ✅ `--clobber` | ✅ `--clobber` |

## Implementation notes

- Pin extraction uses `ast.parse` on `published.py` (robust against the multi-line `BaseKernel(...)` layout — a naive regex collides with the inner `_release_kernel_url("amd64", "elf")` call). Stdlib only; the workflow already runs `python3` for other steps.
- A new `Read pinned BASE_KERNELS SHAs` step exposes `pinned.outputs.{elf_sha,image_sha}`. Empty output (brand-new arch with no pin yet) silently skips drift detection.
- The upload step gained `id: upload` and a `drift_detected` output that the step summary reads to render the warning callout.

## Related

- Follow-up to #296 (which triggered the original collision)
- Independent of [#297](https://github.com/CelestoAI/SmolVM/pull/297) (the unrelated amd64 fragment-verification fix on the same run)

## Testing

- `python3 -c "import yaml; yaml.safe_load(...)"` — workflow YAML parses cleanly.
- Pin-extraction script tested locally against current `published.py` for both arches; outputs the expected `pinned_elf_sha` / `pinned_image_sha`.
- Full end-to-end deferred to the first CI run on this branch.

## Checklist

- [x] Scope is focused and limited to this change
- [x] Tests added/updated for behavior changes (n/a — workflow change, no unit-test surface)
- [x] Docs updated for user-visible changes (the `force_overwrite` input description is updated)
- [x] No secrets or sensitive data included

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added drift detection that compares locally-built kernel artifacts to pinned versions, emits a warning and a drift output when they differ, and advises bumping the images release tag.

* **Chores**
  * Build workflow now skips uploading assets that already exist at the target release by default; overwriting is opt-in.
  * Workflow summaries now indicate which assets were overwritten vs skipped and surface drift warnings.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/CelestoAI/SmolVM/pull/298)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->