### PR TITLE
Add Windows guest support (Phase 1: boot user-supplied qcow2)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -217,3 +217,7 @@ play.ipynb
 # Claude Code agent local state — session locks, settings, scheduled-task
 # bookkeeping. None of this is meant to be committed.
 .claude/
+
+# Working notes / scratch markdown that should not ship with the repo.
+notes/
+*.iso

--- a/docs/deep-dive/windows-guest-qemu.md
+++ b/docs/deep-dive/windows-guest-qemu.md
@@ -1,0 +1,497 @@
+# Running Windows 11 as a Guest under QEMU/KVM
+
+Research notes informing SmolVM's Windows-guest backend. Sources are linked
+inline; the consensus recommendations here come from cross-referencing QEMU
+upstream, libvirt, Red Hat, Proxmox, Arch, Microsoft, TianoCore (EDK II) and
+the virtio-win project.
+
+## The picture in one paragraph
+
+A modern Windows 11 guest under QEMU is not just "the Linux command line with
+a Windows ISO." Microsoft requires **UEFI + Secure Boot + TPM 2.0**, which
+forces **q35 + split OVMF (.secboot build) + swtpm** as a baseline. On top of
+that, Windows performance hinges on two paravirt knobs the Linux guests don't
+need: **Hyper-V enlightenments** (so Windows takes its fast in-guest paths)
+and a **virtio-scsi** disk + the **virtio-win** driver ISO loaded mid-install
+so Windows can see the disk at all. Everything else (CPU pinning, NUMA,
+hugepages, tap+bridge networking, vhost-net) is opt-in tuning that doesn't
+apply to a short-lived sandbox.
+
+## The reference command line
+
+A safe, production-quality starting point for a Windows 11 guest on a modern
+Linux KVM host (Debian/Ubuntu paths shown). Every flag is sourced in the
+per-area sections below.
+
+```bash
+# Sidecar: per-VM software TPM
+swtpm socket \
+  --tpmstate dir=/var/lib/smolvm/win11/tpm \
+  --ctrl type=unixio,path=/var/lib/smolvm/win11/tpm/swtpm-sock \
+  --tpm2 --daemon
+
+# The VM itself
+qemu-system-x86_64 \
+  -name win11 \
+  -machine type=pc-q35-9.1,accel=kvm,kernel-irqchip=on,smm=on,vmport=off \
+  -cpu host,hv_relaxed,hv_vapic,hv_spinlocks=0x1fff,hv_vpindex,hv_runtime,\
+hv_time,hv_synic,hv_stimer,hv_frequencies,hv_tlbflush,hv_ipi,hv_reset,\
++kvm_pv_eoi,+kvm_pv_unhalt \
+  -smp 4,sockets=1,cores=4,threads=1 \
+  -object memory-backend-memfd,id=mem,size=8G,share=on \
+  -machine memory-backend=mem \
+  \
+  -global driver=cfi.pflash01,property=secure,value=on \
+  -global ICH9-LPC.disable_s3=1 \
+  -drive if=pflash,format=raw,unit=0,readonly=on,\
+file=/usr/share/OVMF/OVMF_CODE_4M.secboot.fd \
+  -drive if=pflash,format=raw,unit=1,\
+file=/var/lib/smolvm/win11/OVMF_VARS.fd \
+  \
+  -chardev socket,id=chrtpm,path=/var/lib/smolvm/win11/tpm/swtpm-sock \
+  -tpmdev emulator,id=tpm0,chardev=chrtpm \
+  -device tpm-crb,tpmdev=tpm0 \
+  \
+  -object iothread,id=iothr0 \
+  -device virtio-scsi-pci,id=scsi0,iothread=iothr0,num_queues=4 \
+  -blockdev '{"driver":"qcow2","node-name":"win11-fmt",\
+"file":{"driver":"file","filename":"/var/lib/smolvm/win11/disk.qcow2",\
+"aio":"io_uring","cache":{"direct":true,"no-flush":false}},\
+"discard":"unmap","detect-zeroes":"unmap",\
+"cache":{"direct":true,"no-flush":false}}' \
+  -device scsi-hd,bus=scsi0.0,drive=win11-fmt,id=win11-disk,bootindex=2 \
+  \
+  -drive file=/path/to/Win11.iso,media=cdrom,if=none,id=installmedia \
+  -device ide-cd,bus=ide.0,drive=installmedia,bootindex=1 \
+  -drive file=/path/to/virtio-win.iso,media=cdrom,if=none,id=drivermedia \
+  -device ide-cd,bus=ide.1,drive=drivermedia \
+  \
+  -netdev user,id=net0,hostfwd=tcp::2222-:22 \
+  -device virtio-net-pci,netdev=net0,mac=52:54:00:5d:00:01 \
+  \
+  -device virtio-vga-gl -display sdl,gl=on \
+  -device qemu-xhci,id=xhci \
+  -device usb-tablet,bus=xhci.0
+```
+
+Two non-obvious flag choices in there, both learned from real-world testing
+([end-to-end walkthrough below](#end-to-end-bring-up-walkthrough) has the
+gory details):
+
+- **Install + driver CDs are on `ide-cd` (AHCI/SATA), not `scsi-cd`.** Windows
+  has inbox AHCI drivers but no inbox virtio-scsi driver, so putting the
+  install media on virtio-scsi works at boot (OVMF reads it) but breaks the
+  moment the user loads `vioscsi` mid-install — Windows switches its SCSI
+  driver and loses access to the install media on the same bus, producing
+  the classic *"A media driver your computer needs is missing"* error. Each
+  AHCI port holds exactly one drive, so the two CDs go on `ide.0` and
+  `ide.1`.
+- **`usb-tablet` needs an explicit `qemu-xhci`.** `pc-q35-*` ships no
+  default USB host controller (unlike `pc-i440fx-*` which provides PIIX3
+  USB on `usb-bus.0`), so plugging the tablet directly fails to find a bus.
+
+One-time per-VM prep:
+
+```bash
+sudo install -d -m 0700 /var/lib/smolvm/win11/tpm
+sudo cp /usr/share/OVMF/OVMF_VARS_4M.ms.fd /var/lib/smolvm/win11/OVMF_VARS.fd
+qemu-img create -f qcow2 -o preallocation=falloc,cluster_size=64K \
+  /var/lib/smolvm/win11/disk.qcow2 64G
+```
+
+## Per-area synthesis
+
+### 1. Machine type: q35, not i440fx
+
+q35 emulates the 2007 Q35 + ICH9 chipset with a **PCIe root complex, AHCI
+SATA, EHCI/UHCI USB 2.0** — i440fx is the 1996 PIIX3 box with legacy PCI and
+IDE. Red Hat already deprecated i440fx in RHEL 10[^rh-q35] and Windows 11's
+Secure Boot story requires the SMM-protected pflash that the documented
+recipe pairs with q35.[^tianocore-smm] Pin a versioned machine type
+(`pc-q35-9.1`) so Windows' hardware fingerprint stays stable across QEMU
+upgrades (affects activation).
+
+Key sub-options:
+
+- `accel=kvm` — in-kernel hypervisor.
+- `kernel-irqchip=on` — fastest interrupt path.
+- `smm=on` — required for Secure Boot variable protection.[^edk2-readme]
+- `vmport=off` — drop the VMware backdoor port; Windows has no driver for
+  it.[^qemu-invocation]
+
+### 2. Hyper-V enlightenments: not optional
+
+When QEMU advertises the Hyper-V CPUID leaves, Windows switches on its
+**paravirt fast paths** — synthetic timers, paravirt spinlocks, paravirt IPIs
+and TLB shoot-downs, MSR-based clocksource — that replace expensive
+trap-and-emulate operations.[^qemu-hyperv] QEMU upstream's own guidance:
+*"enable all currently implemented Hyper-V enlightenments with the following
+exceptions: hv-syndbg, hv-passthrough, hv-enforce-cpuid should not be enabled
+in production."*[^qemu-hyperv] The flag set above
+(`hv_relaxed,hv_vapic,hv_spinlocks=0x1fff,hv_vpindex,hv_runtime,hv_time,
+hv_synic,hv_stimer,hv_frequencies,hv_tlbflush,hv_ipi,hv_reset`) is the
+convergent baseline across QEMU upstream, libvirt, Proxmox, and Red
+Hat.[^proxmox-hyperv][^rh-windows]
+
+**Don't** set `kvm=off` or override `hv_vendor_id` by default. The historical
+Nvidia "Error 43" workaround has been unnecessary since Nvidia driver R465
+(March 2021).[^nvidia-r465]
+
+### 3. CPU topology: shape it, don't let QEMU default
+
+`-smp 4` without shape can hand Windows 10/11 Home **a single usable vCPU** —
+Home caps at 1 socket, Pro at 2, and QEMU pre-6.2 defaults to
+sockets-first.[^win-sockets] Always pass `sockets=1,cores=N,threads=1` for
+guests up to ~64 vCPUs.
+
+### 4. Firmware: split OVMF + Microsoft-keys VARS + SMM
+
+Windows 11 mandates UEFI + Secure Boot + TPM 2.0.[^win11-spec] That maps to a
+specific firmware shape:
+
+- **`OVMF_CODE_4M.secboot.fd`** (read-only, shared) — the `.secboot` build is
+  compiled with `SECURE_BOOT_ENABLE` *and* `SMM_REQUIRE`; only this build
+  enforces Secure Boot.[^edk2-readme]
+- **Per-VM copy of `OVMF_VARS_4M.ms.fd`** (writable) — the `.ms` template has
+  the Microsoft Windows Production PCA 2011 and Microsoft UEFI CA 2011 keys
+  pre-enrolled in `db`.[^debian-sb]
+- **`-machine smm=on` + `-global driver=cfi.pflash01,property=secure,value=on`
+  + `-global ICH9-LPC.disable_s3=1`** — only with all three does SMM actually
+  protect the variable store from in-guest tampering.[^debian-sb][^edk2-readme]
+
+**Use the 4M-suffix images on Debian/Ubuntu.** The Arch wiki specifically
+warns that the 2M variants cause Windows 11 setup to fail to detect TPM
+2.0.[^arch-qemu]
+
+Distro paths to discover:
+
+| Distro | CODE file | VARS file (with Microsoft keys enrolled) |
+|---|---|---|
+| Debian / Ubuntu | `/usr/share/OVMF/OVMF_CODE_4M.secboot.fd` | `/usr/share/OVMF/OVMF_VARS_4M.ms.fd` |
+| Fedora / RHEL | `/usr/share/edk2/ovmf/OVMF_CODE.secboot.fd` | `/usr/share/edk2/ovmf/OVMF_VARS.secboot.fd` |
+| Arch | `/usr/share/edk2/x64/OVMF_CODE.secboot.4m.fd` | `/usr/share/edk2/x64/OVMF_VARS.4m.fd` |
+| macOS Homebrew | `/opt/homebrew/share/qemu/edk2-x86_64-code.fd` | `/opt/homebrew/share/qemu/edk2-i386-vars.fd` |
+
+### 5. vTPM via swtpm
+
+swtpm is a separate userspace daemon (`brew install swtpm` or distro
+packages) that emulates a TPM 2.0 over a Unix socket; QEMU connects to it as
+a client via `-tpmdev emulator,id=tpm0,chardev=chrtpm`.[^qemu-tpm] Use
+**`tpm-crb`** for Windows 11 — it's the modern interface that matches what
+physical Windows 11 hardware uses; `tpm-tis` is the older fallback if a
+specific build doesn't detect the TPM.[^qemu-tpm]
+
+**macOS caveat: `swtpm` builds via Homebrew, but the rest of the stack falls
+apart.** Windows x86_64 on Apple Silicon QEMU is TCG-only (no HVF for x86 on
+ARM) — correctness-OK, unusably slow.[^homebrew-swtpm] Windows-on-ARM under
+HVF + ARM swtpm + `virt` machine is the only practical Mac path, with QEMU
+explicitly warning of TPM PPI errors.[^qemu-tpm] **Treat Windows guests as
+Linux-host-only for v1.**
+
+### 6. Disks: virtio-scsi with the works
+
+The convergent recipe from Red Hat, Proxmox, and QEMU upstream is
+**virtio-scsi-single + IOThread + qcow2 + cache=none + discard=unmap +
+detect-zeroes=unmap + aio=io_uring**.[^proxmox-perf][^qemu-virtio-blk-scsi][^anteru-trim]
+
+- **virtio-scsi over virtio-blk** because it supports many LUNs per PCI slot,
+  real SCSI UNMAP for qcow2 shrink, persistent reservations, and
+  CD-ROMs.[^qemu-virtio-blk-scsi] Windows boots off SCSI fine *after*
+  `vioscsi` is loaded from the virtio-win ISO during install — without it,
+  setup sees no disk.[^anteru-trim]
+- **`cache=none`** (= `cache.direct=true, cache.no-flush=false`) avoids
+  double-caching while Windows still flushes correctly.[^suse-cache] **Never
+  `cache=unsafe`** outside throwaway OS installs.
+- **`aio=io_uring`** on kernels ≥ 5.13 / QEMU ≥ 6.0; otherwise fall back to
+  `aio=threads` (works on any backing storage including
+  NFS).[^blockbridge-aio] `aio=native` only with `O_DIRECT` + raw block
+  storage.
+- **`discard=unmap` + `detect-zeroes=unmap`** plumb Windows' TRIM commands
+  (issued weekly by Optimize Drives once the disk is flagged thin-provisioned)
+  all the way down to qcow2 cluster deallocation — the qcow2 file actually
+  shrinks.[^anteru-trim] Known wart: virtio-win issue #666 (Win10 Optimize
+  against vioscsi can take 10–15 min vs ~5s bare-metal, but still
+  works).[^virtiowin-666]
+- **`num_queues=N`** sized to vCPU count; the Windows `vioscsi` driver has
+  been multiqueue-aware since 2016.[^rh-vioscsi-mq]
+- **`-object iothread`** to move block I/O off the main QEMU event loop —
+  ~15% latency improvement at QD=1.[^proxmox-perf]
+- **`qemu-img create -o preallocation=falloc,cluster_size=64K`** to avoid
+  first-write allocation stalls without paying the time cost of
+  `preallocation=full`.[^qemu-img]
+
+### 7. Networking: keep SLIRP + hostfwd as the default
+
+SLIRP (userspace NAT) is slow and ICMP-broken, but requires zero root and
+zero host config — which matches SmolVM's existing posture for Linux guests.
+For Windows + the NetKVM virtio-net driver, the backend is transparent:
+NetKVM sees a virtio-net PCI device and doesn't care whether SLIRP,
+tap+bridge, macvtap, or vhost is behind it.[^netkvm]
+
+```
+-netdev user,id=net0,hostfwd=tcp::2222-:22
+-device virtio-net-pci,netdev=net0,mac=52:54:00:...
+```
+
+Host SSHes the guest with `ssh -p 2222 Administrator@127.0.0.1`. Use a stable
+locally-administered MAC (`52:54:00:` OUI) so Windows doesn't keep prompting
+"is this a public network?" on each boot.[^qemu-net]
+
+**Opt-in upgrades** to document but not ship as default:
+
+- **`qemu-bridge-helper` + libvirt's `virbr0`** when the user already has
+  libvirt installed — `-netdev bridge,br=virbr0`, no root needed at run time
+  after a one-line `/etc/qemu/bridge.conf`.[^mike42-helper]
+- **`tap + vhost=on`** for ~8× throughput; needs persistent root-created
+  tap.[^kvm-vhost]
+- **Skip macvtap** — the host-can't-talk-to-guest gotcha will burn
+  users.[^cmu-macvtap]
+
+### 8. CPU pinning, NUMA, hugepages: skip for sandboxes
+
+For a short-lived sandbox VM, **none of this is worth the complexity.**
+Honest numbers from Red Hat's own benchmark: static 1 GiB hugepages beat THP
+by **1–2%** on realistic workloads.[^rh-thp] CPU pinning saves single-digit %
+only under host contention and *removes* the scheduler's ability to
+load-balance.[^rh-cpupin] NUMA is irrelevant on the single-socket consumer
+hosts SmolVM targets.[^proxmox-numa]
+
+**Default to:** topology shaped as `sockets=1,cores=N,threads=1`,
+`memory-backend-memfd` (lets THP work), one IOThread per disk, no pinning,
+no static hugepages, no explicit NUMA. Expose pinning/hugepages as
+`--pin-cpus` / `--hugepages` opt-in flags for users running long-lived
+Windows VMs.
+
+## End-to-end bring-up walkthrough
+
+What follows is the step-by-step the user actually walks through to take a
+blank `disk.qcow2` to a Windows desktop with SSH reachable on
+`localhost:2222`. Each step calls out gotchas we hit; the QEMU configuration
+choices above were made specifically so this walkthrough works at all.
+
+### 0. Pre-flight — running on a headless host
+
+If the QEMU host has no graphical session (server, SSH-only access), the
+`-display vnc=127.0.0.1:0` variant of the reference command line is the
+right pick — and the user connects from their laptop via an SSH tunnel:
+
+```
+# On the laptop, forward both the VNC display and the guest-SSH port:
+ssh -L 5900:127.0.0.1:5900 -L 2222:127.0.0.1:2222 <user>@<qemu-host>
+
+# Then on the laptop:
+vncviewer 127.0.0.1:5900
+ssh -p 2222 <guest-user>@127.0.0.1   # after sshd is up in the guest
+```
+
+Keep that first tunnel session open while you work; closing it tears down
+both forwards.
+
+### 1. OVMF boot menu — pick the Windows ISO
+
+At the splash screen, hit **Esc** for the boot menu. You'll see entries
+named `UEFI QEMU CD-ROM` and `UEFI QEMU CD-ROM 2`. The first one (no `2`)
+is the Windows installer — that's what `bootindex=1` on the install media
+gives us. The second is the virtio-win disc, which is not UEFI-bootable
+and would just fall through.
+
+### 2. Load the vioscsi driver — *required* to see the disk
+
+At **"Where do you want to install Windows?"** (new 24H2 wording is **"Install
+drivers to display drives"**) the disk list is empty because the boot disk
+is on virtio-scsi and Windows has no inbox driver for it. Click **Load
+Driver → Browse**, then navigate to the **virtio-win CD** (labeled something
+like `virtio-win-0.1.285`) and pick:
+
+```
+vioscsi → w11 → amd64
+```
+
+Click **OK**, select **Red Hat VirtIO SCSI controller**, then **Next**. The
+64 GiB disk appears. Optionally load **NetKVM** and **Balloon** from the
+same dialog now to save a step during OOBE.
+
+### 3. OOBE — bypass the internet wall
+
+Windows 11 OOBE refuses to continue past the network screen until it has
+internet. Without NetKVM loaded yet, you're stuck. Two ways out:
+
+**Right answer — install NetKVM inline.** `Shift+F10` opens a Command
+Prompt. Find the virtio-win drive letter, then load the driver:
+
+```cmd
+wmic logicaldisk get caption,volumename
+pnputil /add-driver E:\NetKVM\w11\amd64\netkvm.inf /install
+```
+
+(Replace `E:` with whatever drive letter the virtio-win CD got.) Close the
+window; OOBE detects the NIC within seconds, SLIRP hands out a DHCP lease
+on `10.0.2.15`, and you can continue.
+
+**Shortcut — skip the internet requirement.** Same `Shift+F10`, then:
+
+```cmd
+start ms-cxh:localonly
+```
+
+This jumps straight to local-account creation. On older Windows 11 builds
+the magic spell was `OOBE\BYPASSNRO` instead (deprecated in 24H2).
+
+### 4. OOBE — local account, not Microsoft account
+
+At the sign-in screen, same `Shift+F10 → start ms-cxh:localonly` trick
+opens a local-account creation dialog. Use a known username/password (you
+need both for SSH later). For a sandbox, never link to a real Microsoft
+account.
+
+### 5. Post-install — OpenSSH server, the careful way
+
+The supported path is the Windows Update capability:
+
+```powershell
+Add-WindowsCapability -Online -Name OpenSSH.Server~~~~0.0.1.0
+```
+
+**Critical gotcha:** this command returns a success-shaped object
+(`Online: True`, `RestartNeeded: False`) **even when the underlying download
+from Microsoft's CDN is blocked, queued, or otherwise failing**. Verify
+explicitly:
+
+```powershell
+Get-WindowsCapability -Online -Name OpenSSH.Server~~~~0.0.1.0 |
+  Format-List Name,State
+```
+
+`State : NotPresent` means it didn't install. In practice the install often
+completes only after a Windows-Update-triggered reboot has finished a
+separate background update — there's no clean signal, you just retry. Once
+`State : Installed`:
+
+```powershell
+Start-Service sshd
+Set-Service sshd -StartupType Automatic
+New-NetFirewallRule -Name sshd -DisplayName 'OpenSSH Server (sshd)' `
+  -Enabled True -Direction Inbound -Protocol TCP -Action Allow -LocalPort 22
+```
+
+The capability install usually adds the firewall rule itself; the
+`New-NetFirewallRule` call is idempotent.
+
+**WU-independent fallback.** If the capability install keeps failing,
+download `OpenSSH-Win64.zip` from `github.com/PowerShell/Win32-OpenSSH`
+releases and run `install-sshd.ps1`. Deterministic, no Windows Update
+dependency, ~20 seconds. For SmolVM's eventual `windows` preset this is the
+better default — fewer externalities.
+
+### 6. Post-install — full virtio driver set
+
+Open the virtio-win CD in Explorer and run **`virtio-win-guest-tools.exe`**.
+This installs the remaining drivers (Balloon, vioserial, viorng, vioinput,
+viogpu) plus the QEMU Guest Agent in one shot. Reboot when prompted.
+
+### 7. Snapshot the baseline
+
+In the guest: **Start → Power → Shut down** (a *clean* shutdown — don't
+power-off the QEMU process). Once Windows is off and `start-vm.sh` has
+exited:
+
+```bash
+cp ~/win11-vm/disk.qcow2 ~/win11-vm/disk-baseline.qcow2
+```
+
+That gives you a snapshot of the "freshly installed, all drivers in,
+SSH-able" state. Any future experiment that breaks Windows rolls back in
+seconds:
+
+```bash
+cp ~/win11-vm/disk-baseline.qcow2 ~/win11-vm/disk.qcow2
+```
+
+For SmolVM's eventual model this is the *base image* — every sandbox is
+either a clone of (or a qcow2 overlay on top of) this baseline.
+
+### 8. Automation — `autounattend.xml`
+
+The entire walkthrough above is interactive. Windows Setup supports a
+standard answer file (`autounattend.xml`) that drives the installer
+unattended end-to-end: region/keyboard, viostor driver pre-load, partition
+table, local-account creation, OOBE skip, plus `FirstLogonCommands` to
+install OpenSSH and virtio-win-guest-tools. Microsoft documents the schema
+at [learn.microsoft.com/en-us/windows-hardware/customize/desktop/unattend/](https://learn.microsoft.com/en-us/windows-hardware/customize/desktop/unattend/).
+
+The mechanics: build a tiny FAT-formatted ISO containing just
+`autounattend.xml` at the root (`genisoimage -V autounattend -o
+autounattend.iso autounattend.xml`), attach it as a third CD-ROM, boot the
+Windows installer normally. Windows Setup auto-detects the answer file on
+any attached removable media — no flag to QEMU required.
+
+This is **not** yet implemented for this repo. Punch-list item for the
+SmolVM `windows` preset: ship a parameterized `autounattend.xml.j2` so a
+fresh Windows base image can be built from `Win11.iso + virtio-win.iso`
+with no human input.
+
+## Implications for SmolVM (phase 1 scope)
+
+Refining the "boot only" phase 1 with what we now know:
+
+1. **Data-model change** — add `guest_os: Literal["linux","windows"]` to
+   `ImageSource`/`LocalImage`, threading through to the QEMU command builder.
+2. **OVMF discovery on x86_64** — `host/_accel.py` currently checks aarch64
+   OVMF paths only (`vm.py:137-153`). Add an x86_64 search covering the four
+   distro paths above. Raise a clear error when missing — don't auto-download.
+3. **Per-VM VARS file** — copy `OVMF_VARS_4M.ms.fd` into the VM's state
+   directory on first boot.
+4. **swtpm sidecar** — new lifecycle component. Spawn
+   `swtpm socket --tpm2 --daemon` before QEMU, tear down on VM stop.
+   Linux-host-only for v1 (skip macOS).
+5. **Switch the disk default to virtio-scsi for Windows** — current QEMU
+   backend uses virtio-blk; Windows wants virtio-scsi with iothread +
+   `discard=unmap` + `detect-zeroes=unmap` + `aio=io_uring`.
+6. **virtio-win ISO handling** — fetch + cache it like other published
+   images, attach as a second CD-ROM during install. The user supplies the
+   Windows ISO.
+7. **CPU/machine flag preset** — bundle the q35 + hyperv enlightenments +
+   SMM string as a `WindowsGuestProfile` rather than scattering them across
+   the QEMU command builder.
+8. **Networking stays on `user,hostfwd=`** — same as Linux guests today,
+   just port-forward 22 to the Windows OpenSSH server.
+9. **No 9p workspace mounts in v1** — Windows 9p support is experimental;
+   document `--no-workspace` as the default for Windows guests.
+10. **Drop CPU pinning / NUMA / hugepages from scope entirely** for v1.
+    Maybe `--memfd-memory-backend` as a quiet default change so THP works.
+
+This keeps phase 1 to: data-model flag + x86_64 OVMF discovery + per-VM VARS
+handling + swtpm spawn/teardown + disk-profile switch + virtio-win attach.
+
+---
+
+[^qemu-hyperv]: QEMU — Hyper-V Enlightenments, <https://www.qemu.org/docs/master/system/i386/hyperv.html>
+[^rh-windows]: Red Hat RHEL 10 — Optimizing Windows VMs, <https://docs.redhat.com/en/documentation/red_hat_enterprise_linux/10/html/configuring_and_managing_windows_virtual_machines/optimizing-windows-virtual-machines>
+[^proxmox-hyperv]: Proxmox forum — Windows CPU flags, <https://forum.proxmox.com/threads/vm-cpu-flags-usage-which-ones-should-be-enabled-for-max-performance-and-how.156457/>
+[^nvidia-r465]: Nvidia KB 5173 — GeForce GPU passthrough for Windows VMs, <https://nvidia.custhelp.com/app/answers/detail/a_id/5173/>
+[^rh-q35]: Red Hat RHEL 10 — Converting VMs to the Q35 machine type, <https://docs.redhat.com/en/documentation/red_hat_enterprise_linux/10/html/configuring_and_managing_windows_virtual_machines/converting-virtual-machines-to-q35>
+[^tianocore-smm]: TianoCore wiki — Testing SMM with QEMU/KVM/libvirt, <https://github.com/tianocore/tianocore.github.io/wiki/Testing-SMM-with-QEMU,-KVM-and-libvirt>
+[^qemu-invocation]: QEMU manual — Invocation (`-machine` sub-options), <https://www.qemu.org/docs/master/system/invocation.html>
+[^win11-spec]: Microsoft — Windows 11 Specifications, <https://www.microsoft.com/en-us/windows/windows-11-specifications>
+[^edk2-readme]: TianoCore — OvmfPkg/README, <https://github.com/tianocore/edk2/blob/master/OvmfPkg/README>
+[^debian-sb]: Debian Wiki — SecureBoot/VirtualMachine, <https://wiki.debian.org/SecureBoot/VirtualMachine>
+[^arch-qemu]: Arch Wiki — QEMU, <https://wiki.archlinux.org/title/QEMU>
+[^qemu-tpm]: QEMU TPM Device specs, <https://qemu-project.gitlab.io/qemu/specs/tpm.html>
+[^homebrew-swtpm]: Homebrew formula — swtpm, <https://formulae.brew.sh/formula/swtpm>
+[^win-sockets]: Codeinsecurity — Windows 10 socket/core limits teardown, <https://codeinsecurity.wordpress.com/2022/04/07/cpu-socket-and-core-count-limits-in-windows-10-and-how-to-remove-them/>
+[^qemu-virtio-blk-scsi]: QEMU blog — Configuring virtio-blk and virtio-scsi, <https://www.qemu.org/2021/01/19/virtio-blk-scsi-configuration/>
+[^proxmox-perf]: Proxmox wiki — Qemu/KVM Virtual Machines, <https://pve.proxmox.com/wiki/Qemu/KVM_Virtual_Machines>
+[^suse-cache]: SUSE — Disk Cache Modes, <https://documentation.suse.com/sles/12-SP5/html/SLES-all/cha-cachemodes.html>
+[^blockbridge-aio]: Blockbridge — Optimizing Proxmox iothreads, aio, io_uring, <https://kb.blockbridge.com/technote/proxmox-aio-vs-iouring/>
+[^anteru-trim]: Anteru — QEMU, KVM and trim, <https://anteru.net/blog/2020/qemu-kvm-and-trim/>
+[^virtiowin-666]: virtio-win issue #666 — Win10 Optimize with vioscsi, <https://github.com/virtio-win/kvm-guest-drivers-windows/issues/666>
+[^rh-vioscsi-mq]: Red Hat Bugzilla 1210166 — vioscsi multiqueue, <https://bugzilla.redhat.com/show_bug.cgi?id=1210166>
+[^qemu-img]: QEMU qemu-img docs, <https://www.qemu.org/docs/master/tools/qemu-img.html>
+[^netkvm]: virtio-win/kvm-guest-drivers-windows — NetKVM, <https://deepwiki.com/virtio-win/kvm-guest-drivers-windows/2-network-drivers-(netkvm)>
+[^qemu-net]: QEMU/Networking — Wikibooks, <https://en.wikibooks.org/wiki/QEMU/Networking>
+[^mike42-helper]: mike42.me — qemu-bridge-helper on Debian 10, <https://mike42.me/blog/2019-08-how-to-use-the-qemu-bridge-helper-on-debian-10>
+[^kvm-vhost]: linux-kvm.org — UsingVhost, <https://www.linux-kvm.org/page/UsingVhost>
+[^cmu-macvtap]: CMU — KVM Macvtap vs bridging, <https://www.math.cmu.edu/~gautam/sj/blog/20140303-kvm-macvtap.html>
+[^rh-thp]: Red Hat Developers — THP vs 1 GiB hugepage benchmark, <https://developers.redhat.com/blog/2021/04/27/benchmarking-transparent-versus-1gib-static-huge-page-performance-in-linux-virtual-machines>
+[^rh-cpupin]: Red Hat OpenStack — emulatorpin in NFV, <https://docs.redhat.com/en/documentation/red_hat_openstack_platform/10/html/ovs-dpdk_end_to_end_troubleshooting_guide/using_virsh_emulatorpin_in_virtual_environments_with_nfv>
+[^proxmox-numa]: Proxmox NUMA wiki, <https://pve.proxmox.com/wiki/NUMA>

--- a/docs/deep-dive/windows-guest-qemu.md
+++ b/docs/deep-dive/windows-guest-qemu.md
@@ -1,9 +1,14 @@
 # Running Windows 11 as a Guest under QEMU/KVM
 
-Research notes informing SmolVM's Windows-guest backend. Sources are linked
-inline; the consensus recommendations here come from cross-referencing QEMU
-upstream, libvirt, Red Hat, Proxmox, Arch, Microsoft, TianoCore (EDK II) and
-the virtio-win project.
+Boot a Windows 11 desktop inside SmolVM that behaves like a real Windows
+PC. Useful when you need to run Windows-only software, test something
+against Windows, or hand an agent a Windows desktop without touching your
+own machine.
+
+This page explains every QEMU flag the Windows path needs and why,
+distilled from QEMU upstream, libvirt, Red Hat, Proxmox, Arch, Microsoft,
+TianoCore (EDK II), and the virtio-win project. Sources are linked
+inline; full citations live in the footnotes at the bottom.
 
 ## The picture in one paragraph
 
@@ -228,7 +233,7 @@ For Windows + the NetKVM virtio-net driver, the backend is transparent:
 NetKVM sees a virtio-net PCI device and doesn't care whether SLIRP,
 tap+bridge, macvtap, or vhost is behind it.[^netkvm]
 
-```
+```bash
 -netdev user,id=net0,hostfwd=tcp::2222-:22
 -device virtio-net-pci,netdev=net0,mac=52:54:00:...
 ```
@@ -275,7 +280,7 @@ If the QEMU host has no graphical session (server, SSH-only access), the
 `-display vnc=127.0.0.1:0` variant of the reference command line is the
 right pick — and the user connects from their laptop via an SSH tunnel:
 
-```
+```bash
 # On the laptop, forward both the VNC display and the guest-SSH port:
 ssh -L 5900:127.0.0.1:5900 -L 2222:127.0.0.1:2222 <user>@<qemu-host>
 
@@ -303,7 +308,7 @@ is on virtio-scsi and Windows has no inbox driver for it. Click **Load
 Driver → Browse**, then navigate to the **virtio-win CD** (labeled something
 like `virtio-win-0.1.285`) and pick:
 
-```
+```cmd
 vioscsi → w11 → amd64
 ```
 

--- a/src/smolvm/cli/main.py
+++ b/src/smolvm/cli/main.py
@@ -717,20 +717,28 @@ def build_parser() -> argparse.ArgumentParser:
         "--name",
         help="Name for the sandbox (default: auto-generated).",
     )
-    image_group = create_parser.add_mutually_exclusive_group()
-    image_group.add_argument(
+    # --os and --image are not in an argparse mutex group: Windows guests
+    # need BOTH (--os windows + --image /path/to/win11.qcow2). The facade
+    # rejects illegal combos (e.g. --os alpine + S3 image) at runtime with
+    # a clearer message than argparse can produce.
+    create_parser.add_argument(
         "--os",
         choices=[guest_os.value for guest_os in GuestOS],
         default=None,
-        help="Operating system image (default: auto-detected based on backend).",
+        help=(
+            "Operating system image (default: auto-detected based on backend). "
+            "--os windows requires --image with a local Windows qcow2 path."
+        ),
     )
-    image_group.add_argument(
+    create_parser.add_argument(
         "--image",
         default=None,
         help=(
-            "Image URI (e.g. s3://bucket/path/to/image/). "
-            "Configure S3-compatible stores via SMOLVM_S3_ENDPOINT_URL, "
-            "SMOLVM_S3_ACCESS_KEY_ID, SMOLVM_S3_SECRET_ACCESS_KEY env vars."
+            "Image URI: S3 URI (e.g. s3://bucket/path/to/image/) or a local "
+            "filesystem path / file:// URI to a pre-built qcow2 (used with "
+            "--os windows). Configure S3-compatible stores via "
+            "SMOLVM_S3_ENDPOINT_URL, SMOLVM_S3_ACCESS_KEY_ID, "
+            "SMOLVM_S3_SECRET_ACCESS_KEY env vars."
         ),
     )
     create_parser.add_argument(
@@ -1700,8 +1708,10 @@ def _run_create(args: argparse.Namespace) -> int:
     from smolvm.facade import (
         SmolVM,
         _build_auto_config,
+        _build_local_image_config,
         _build_s3_image_config,
         _default_guest_os_for_backend,
+        _is_local_image,
     )
     from smolvm.runtime.backends import resolve_backend
 
@@ -1714,9 +1724,33 @@ def _run_create(args: argparse.Namespace) -> int:
         if args.mounts and args.backend in (None, "auto"):
             args.backend = "qemu"
 
+        # Windows guests only boot on QEMU (firmware boot + swtpm). Auto-pick
+        # QEMU when the user did not pin a backend; reject explicit
+        # non-QEMU choices upfront with a one-sentence error.
+        if args.os == "windows":
+            if args.backend in (None, "auto"):
+                args.backend = "qemu"
+            elif args.backend != "qemu":
+                raise ValueError(
+                    f"--os windows requires --backend qemu (got --backend "
+                    f"{args.backend!r}); drop --backend or pass --backend qemu."
+                )
+
         resolved_backend = resolve_backend(args.backend)
         image_uri: str | None = getattr(args, "image", None)
         use_s3_image = image_uri is not None
+        use_local_image = use_s3_image and _is_local_image(image_uri)
+
+        # S3 images carry their own OS in the manifest, so --os would
+        # conflict. Local images need --os to disambiguate, so the pair
+        # is allowed there. (The argparse mutex used to enforce this
+        # blanket; with local images now supported we have to gate by
+        # image kind explicitly.)
+        if use_s3_image and not use_local_image and args.os is not None:
+            raise ValueError(
+                "--image (S3) and --os are mutually exclusive; the S3 image "
+                "manifest already names the OS — drop --os."
+            )
 
         resolved_guest_os = (
             GuestOS(args.os)
@@ -1742,7 +1776,45 @@ def _run_create(args: argparse.Namespace) -> int:
         ):
             args.disk_size_mib = 4096
 
-        if use_s3_image:
+        if use_local_image:
+            # Local image path (Windows POC). The build is a file existence
+            # check — fast, no download — but we still funnel through the
+            # same builder/progress shape so the JSON/non-JSON branches
+            # stay parallel to the S3 path.
+            if not args.json:
+                console = console_stdout()
+                vm = _build_and_boot_with_progress(
+                    console=console,
+                    build_fn=lambda on_download: _build_local_image_config(  # noqa: ARG005
+                        image=image_uri,
+                        os_input=args.os,
+                        backend=args.backend,
+                        memory=args.memory_mib,
+                        ssh_key_path=None,
+                        vm_name=args.name,
+                    ),
+                    boot_timeout=args.boot_timeout,
+                    mounts=args.mounts,
+                    writable_mounts=args.writable_mounts,
+                )
+            else:
+                config, ssh_key_path = _build_local_image_config(
+                    image=image_uri,
+                    os_input=args.os,
+                    backend=args.backend,
+                    memory=args.memory_mib,
+                    ssh_key_path=None,
+                    vm_name=args.name,
+                )
+                vm = SmolVM(
+                    config,
+                    ssh_key_path=ssh_key_path,
+                    mounts=args.mounts,
+                    writable_mounts=args.writable_mounts,
+                )
+                vm.start(boot_timeout=args.boot_timeout)
+                vm.wait_for_ssh(timeout=args.boot_timeout)
+        elif use_s3_image:
             # S3 image path
             if not args.json:
                 console = console_stdout()

--- a/src/smolvm/facade.py
+++ b/src/smolvm/facade.py
@@ -356,16 +356,14 @@ def _build_local_image_config(
     """
     if os_input is None:
         raise ValueError(
-            "Local images need an explicit os= parameter (e.g. "
-            'os="windows"). The file alone doesn\'t tell us which '
-            "operating system is inside."
+            'Local images need os= (e.g. SmolVM(os="windows", image="..."))'
+            " so SmolVM knows which operating system is inside the file."
         )
     guest_os = _normalize_guest_os(os_input)
     if guest_os is not GuestOS.WINDOWS:
         raise ValueError(
-            f"Local images are only supported for os='windows' in this "
-            f"release (got os={guest_os.value!r}). Linux guests use "
-            "auto-config or S3-published images."
+            f"Local images currently only support os='windows' (got "
+            f"os={guest_os.value!r}); use auto-config or an S3 image for Linux."
         )
 
     parsed = urlparse(image)
@@ -373,7 +371,7 @@ def _build_local_image_config(
     local_path = Path(raw_path).expanduser().resolve()
     if not local_path.is_file():
         raise ValueError(
-            f"Local image not found at {local_path}. Pass image= as an "
+            f"Local image {local_path} does not exist; pass image= as an "
             "absolute path or file:// URI to an existing qcow2 file."
         )
 
@@ -384,8 +382,8 @@ def _build_local_image_config(
             raise ValueError(str(exc)) from exc
         if resolved_backend != BACKEND_QEMU:
             raise ValueError(
-                f"Windows guests only run on the QEMU backend (got "
-                f"backend={backend!r})."
+                f"Windows guests only run on the QEMU backend; drop "
+                f'backend={backend!r} or pass backend="qemu".'
             )
 
     if ssh_key_path is None:
@@ -765,18 +763,16 @@ class SmolVM:
         # their own OS info in the manifest, so os= would conflict.
         if image is not None and os is not None and not _is_local_image(image):
             raise ValueError(
-                "image and os are mutually exclusive for S3 images — the "
-                "image manifest already defines the operating system. (For "
-                "local images, os= is required since the file alone doesn't "
-                "self-identify.)"
+                "image and os are mutually exclusive for S3 images (the "
+                "manifest already names the OS); drop one of them."
             )
 
         if (config is not None or vm_id is not None) and (
             memory is not None or disk_size is not None or os is not None
         ):
             raise ValueError(
-                "memory, disk_size, and os can only be set when both "
-                "config and vm_id are omitted (auto-config mode)."
+                "memory, disk_size, and os only apply in auto-config mode; "
+                "drop them or drop config=/vm_id=."
             )
 
         # Phase 1 Windows guest scope locks. Each is intentionally narrow
@@ -785,20 +781,19 @@ class SmolVM:
         if os is not None and _normalize_guest_os(os) is GuestOS.WINDOWS:
             if image is None:
                 raise ValueError(
-                    "Windows guests need a pre-installed disk image. Pass "
-                    'image="/path/to/win11.qcow2".\n'
-                    "See docs/deep-dive/windows-guest-qemu.md for how to "
-                    "build one."
+                    "Windows guests need a pre-installed disk image; pass "
+                    'image="/path/to/win11.qcow2" (see '
+                    "docs/deep-dive/windows-guest-qemu.md to build one)."
                 )
             if mounts:
                 raise ValueError(
                     "Workspace mounts (mounts=) are not yet supported for "
-                    "Windows guests in this release."
+                    "Windows guests in this release; drop the mounts= arg."
                 )
             if internet_settings is not None:
                 raise ValueError(
                     "Egress controls (internet_settings=) are not yet "
-                    "supported for Windows guests in this release."
+                    "supported for Windows guests; drop the internet_settings= arg."
                 )
 
         # Workspace mounts currently require the QEMU backend (virtio-9p).

--- a/src/smolvm/facade.py
+++ b/src/smolvm/facade.py
@@ -525,6 +525,15 @@ def _build_auto_config(
 
     resolved_backend = resolve_backend(backend)
     resolved_os = _normalize_guest_os(os or _default_guest_os_for_backend(resolved_backend))
+    if resolved_os is GuestOS.WINDOWS:
+        # Auto-config builds a Linux SSH-ready VM from a built or downloaded
+        # base image; Windows has no equivalent path because we don't ship a
+        # base qcow2. The user must supply their own pre-installed image.
+        raise ValueError(
+            "Windows guests need a pre-installed disk image; pass "
+            'image="/path/to/win11.qcow2" (see '
+            "docs/deep-dive/windows-guest-qemu.md to build one)."
+        )
     resolved_ssh_key_path, public_key_path = _resolve_auto_config_public_key(ssh_key_path)
     public_key_value = public_key_path.read_text().strip()
 

--- a/src/smolvm/facade.py
+++ b/src/smolvm/facade.py
@@ -42,6 +42,7 @@ from contextlib import suppress
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Literal
+from urllib.parse import urlparse
 
 from smolvm._naming import generate_sandbox_name
 from smolvm.env import inject_env_vars, read_env_vars, remove_env_vars
@@ -87,10 +88,13 @@ _LOCAL_FORWARD_MAX_PORT_ATTEMPTS = 10
 _AUTO_CONFIG_DEFAULT_MEM_SIZE_MIB = {
     GuestOS.ALPINE: 512,
     GuestOS.UBUNTU: 1024,
+    GuestOS.WINDOWS: 4096,
 }
 _AUTO_CONFIG_DEFAULT_DISK_SIZE_MIB = {
     GuestOS.ALPINE: 512,
     GuestOS.UBUNTU: 2048,
+    # WINDOWS: not used. The Windows path always supplies a pre-built
+    # qcow2 in Phase 1, so we don't size or grow a disk for it.
 }
 _UBUNTU_CURRENT_RELEASE_DATE = "20260406"
 # Ubuntu cloud-images rootfs URLs. Post-0.0.14a0 we no longer fetch Ubuntu's
@@ -313,6 +317,108 @@ def _build_auto_config_image_name(
     if disk_size_mib != default_disk_size_mib:
         image_name = f"{image_name}-{disk_size_mib}m"
     return image_name
+
+
+def _is_local_image(image: str) -> bool:
+    """Return True when *image* points at a host filesystem path.
+
+    Locals are absolute paths (``/abs/...``), tilde-relative paths
+    (``~/...``), bare relative paths, and ``file://`` URIs. Anything
+    with a non-file scheme (``s3://``, ``http(s)://``, etc.) is remote.
+    """
+    parsed = urlparse(image)
+    if parsed.scheme == "":
+        return True
+    return parsed.scheme == "file"
+
+
+def _build_local_image_config(
+    *,
+    image: str,
+    os_input: GuestOS | str | None,
+    backend: str | None,
+    memory: int | None,
+    ssh_key_path: str | None,
+    vm_name: str | None = None,
+    name_prefix: str = "sbx",
+) -> tuple[VMConfig, str | None]:
+    """Build a VMConfig from a host filesystem image (path or ``file://``).
+
+    Required when *os_input* is set — the file alone doesn't tell us
+    which OS is inside. For Phase 1, only Windows is meaningfully
+    supported on this path; Linux users still go through auto-config
+    or S3.
+
+    The qcow2 is used **shared** (no per-VM overlay clone), so concurrent
+    ``SmolVM(image=...)`` calls against the same baseline corrupt each
+    other. Document loudly when surfacing this path. Phase 2 introduces
+    qcow2 overlay cloning for Windows base images.
+    """
+    if os_input is None:
+        raise ValueError(
+            "Local images need an explicit os= parameter (e.g. "
+            'os="windows"). The file alone doesn\'t tell us which '
+            "operating system is inside."
+        )
+    guest_os = _normalize_guest_os(os_input)
+    if guest_os is not GuestOS.WINDOWS:
+        raise ValueError(
+            f"Local images are only supported for os='windows' in this "
+            f"release (got os={guest_os.value!r}). Linux guests use "
+            "auto-config or S3-published images."
+        )
+
+    parsed = urlparse(image)
+    raw_path = parsed.path if parsed.scheme == "file" else image
+    local_path = Path(raw_path).expanduser().resolve()
+    if not local_path.is_file():
+        raise ValueError(
+            f"Local image not found at {local_path}. Pass image= as an "
+            "absolute path or file:// URI to an existing qcow2 file."
+        )
+
+    if backend is not None:
+        try:
+            resolved_backend = resolve_backend(backend)
+        except ValueError as exc:
+            raise ValueError(str(exc)) from exc
+        if resolved_backend != BACKEND_QEMU:
+            raise ValueError(
+                f"Windows guests only run on the QEMU backend (got "
+                f"backend={backend!r})."
+            )
+
+    if ssh_key_path is None:
+        from smolvm.utils import ensure_ssh_key
+
+        private_key, _ = ensure_ssh_key()
+        ssh_key_path = str(private_key)
+
+    resolved_vm_name = _resolve_vm_name(vm_name, prefix=name_prefix)
+
+    # Memory defaults follow the deep-dive recommendation: 4 GiB for
+    # Windows 11 (it runs at 2 GiB minimum but Edge + Defender want more).
+    default_mem_mib = _AUTO_CONFIG_DEFAULT_MEM_SIZE_MIB.get(GuestOS.WINDOWS, 4096)
+
+    config = VMConfig(
+        vm_id=resolved_vm_name,
+        vcpu_count=4,
+        memory=memory if memory is not None else default_mem_mib,
+        guest_os=GuestOS.WINDOWS,
+        kernel_path=None,
+        rootfs_path=local_path,
+        backend=BACKEND_QEMU,
+        boot_mode="firmware",
+        boot_args="",  # ignored in firmware mode
+        ssh_capable=False,  # Phase 1: SSH-into-Windows is Phase 2
+        disk_mode="shared",  # Phase 1: no overlay cloning for Windows qcow2s
+    )
+    logger.info(
+        "Configured Windows VM from local image: %s (image=%s)",
+        resolved_vm_name,
+        local_path,
+    )
+    return config, ssh_key_path
 
 
 def _build_s3_image_config(
@@ -654,10 +760,15 @@ class SmolVM:
         if image is not None and (config is not None or vm_id is not None):
             raise ValueError("image cannot be combined with config or vm_id.")
 
-        if image is not None and os is not None:
+        # Local images (file:// URIs and absolute / ~ paths) need os= to be
+        # set since the file alone doesn't self-identify. S3 images carry
+        # their own OS info in the manifest, so os= would conflict.
+        if image is not None and os is not None and not _is_local_image(image):
             raise ValueError(
-                "image and os are mutually exclusive — the image already "
-                "defines the operating system."
+                "image and os are mutually exclusive for S3 images — the "
+                "image manifest already defines the operating system. (For "
+                "local images, os= is required since the file alone doesn't "
+                "self-identify.)"
             )
 
         if (config is not None or vm_id is not None) and (
@@ -667,6 +778,28 @@ class SmolVM:
                 "memory, disk_size, and os can only be set when both "
                 "config and vm_id are omitted (auto-config mode)."
             )
+
+        # Phase 1 Windows guest scope locks. Each is intentionally narrow
+        # so misconfigurations fail fast with a plain-English message
+        # before we burn time materializing rootfs / firmware.
+        if os is not None and _normalize_guest_os(os) is GuestOS.WINDOWS:
+            if image is None:
+                raise ValueError(
+                    "Windows guests need a pre-installed disk image. Pass "
+                    'image="/path/to/win11.qcow2".\n'
+                    "See docs/deep-dive/windows-guest-qemu.md for how to "
+                    "build one."
+                )
+            if mounts:
+                raise ValueError(
+                    "Workspace mounts (mounts=) are not yet supported for "
+                    "Windows guests in this release."
+                )
+            if internet_settings is not None:
+                raise ValueError(
+                    "Egress controls (internet_settings=) are not yet "
+                    "supported for Windows guests in this release."
+                )
 
         # Workspace mounts currently require the QEMU backend (virtio-9p).
         # When no backend was pinned and mounts were requested — either via
@@ -684,14 +817,26 @@ class SmolVM:
             backend = BACKEND_QEMU
 
         if image is not None:
-            # S3 image mode
-            logger.info("Resolving image from %s...", image)
-            config, ssh_key_path = _build_s3_image_config(
-                image=image,
-                backend=backend,
-                memory=memory,
-                ssh_key_path=ssh_key_path,
-            )
+            if _is_local_image(image):
+                # Local image mode (file:// or path) — needs os= to
+                # disambiguate; the file alone doesn't self-identify.
+                logger.info("Resolving local image at %s...", image)
+                config, ssh_key_path = _build_local_image_config(
+                    image=image,
+                    os_input=os,
+                    backend=backend,
+                    memory=memory,
+                    ssh_key_path=ssh_key_path,
+                )
+            else:
+                # S3 image mode
+                logger.info("Resolving image from %s...", image)
+                config, ssh_key_path = _build_s3_image_config(
+                    image=image,
+                    backend=backend,
+                    memory=memory,
+                    ssh_key_path=ssh_key_path,
+                )
         elif config is None and vm_id is None:
             # Auto-configuration mode
             logger.info("No config provided; auto-configuring standard SSH VM...")

--- a/src/smolvm/runtime/base.py
+++ b/src/smolvm/runtime/base.py
@@ -75,6 +75,11 @@ class RuntimeContext:
 
     data_dir: Path
     socket_dir: Path
+    firmware_dir: Path
+    """Per-VM firmware state root. Each VM gets a subdirectory
+    ``firmware_dir/{vm_id}/`` containing its OVMF NVRAM (``OVMF_VARS.fd``)
+    and swtpm state (``swtpm/``). Empty for VMs that don't use UEFI
+    firmware boot. Created by the manager during ``create()``."""
     log_files: dict[str, TextIO]
     process_handles: dict[int, subprocess.Popen[bytes]]
     resolve_boot_args: Callable[[VMInfo], str]

--- a/src/smolvm/runtime/guest_platforms.py
+++ b/src/smolvm/runtime/guest_platforms.py
@@ -1,0 +1,383 @@
+# Copyright 2026 Celesto AI
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Guest-OS-specific QEMU command fragments.
+
+A ``GuestPlatformSpec`` is a pure-data description of the bits that differ
+between guest operating systems when assembling a ``qemu-system-x86_64`` (or
+``qemu-system-aarch64``) command line: machine sub-options, CPU extra flags,
+firmware (OVMF) split-pflash, sidecar requirements (swtpm for Windows), root
+disk controller and CD-ROM bus topology, and a small set of "skip this Linux
+default" flags.
+
+The QEMU command builder in ``smolvm.runtime.qemu_args`` reads these fields
+and concatenates them into argv. There is one spec per supported guest OS:
+
+- ``_LINUX_SPEC``: every field at its default value, so the builder produces
+  byte-identical output to the pre-refactor ``_start_qemu``.
+- Windows spec: built by ``_build_windows_spec`` (Phase 2 — currently raises
+  ``NotImplementedError``). When present, encodes q35+SMM, OVMF Secure Boot
+  pflash split, swtpm requirement, virtio-scsi root disk, IDE CD-ROMs,
+  qemu-xhci+usb-tablet topology, and Hyper-V enlightenments.
+
+This module deliberately uses a frozen ``@dataclass`` (mirroring
+``BootProfileSpec`` in ``boot_profiles.py``) rather than a ``Protocol`` with
+concrete subclasses — there are only two implementations, and one of them
+(Linux) is the no-op default-valued instance. Polymorphism would be ceremony
+without payoff.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Literal
+
+from smolvm.types import GuestOS
+
+
+@dataclass(frozen=True, slots=True)
+class FirmwareSpec:
+    """OVMF/EDK2 split-pflash firmware specification.
+
+    QEMU loads UEFI firmware as a pair of pflash drives: a read-only,
+    cross-VM ``code`` file (the firmware binary) plus a writable per-VM
+    ``vars`` file (the UEFI non-volatile variable store — Secure Boot keys,
+    boot order, BootCurrent). The ``vars_template_path`` is the system-wide
+    template; each VM gets a copy materialized into its per-VM firmware
+    directory at create time.
+    """
+
+    code_path: Path
+    """Read-only firmware binary (``OVMF_CODE.secboot.fd`` etc.). Shared
+    across every VM on the host."""
+
+    vars_template_path: Path
+    """Read-only NVRAM template (``OVMF_VARS.ms.fd`` etc.) with the
+    Microsoft Secure Boot keys pre-enrolled. Copied per-VM."""
+
+    secure_boot: bool = True
+    """When True, the QEMU command line emits the ``-global`` flags that
+    mark the second pflash unit as a SMM-protected "secure" pflash, so the
+    guest OS cannot tamper with Secure Boot variables at runtime."""
+
+
+@dataclass(frozen=True, slots=True)
+class GuestPlatformSpec:
+    """Static, per-guest-OS knobs consumed when assembling a QEMU command line.
+
+    This is *data*, not behaviour. ``smolvm.runtime.qemu_args.build_qemu_argv``
+    reads these fields and translates them into argv fragments. Every field
+    has a Linux-compatible default so the all-default instance (``_LINUX_SPEC``)
+    produces byte-identical output to the pre-refactor ``_start_qemu``.
+    """
+
+    guest_os: GuestOS
+    name: Literal["linux", "windows"]
+
+    # --- forced settings (None = leave as VMConfig says) -------------------
+    forced_boot_mode: Literal["direct_kernel", "firmware"] | None = None
+    """Defensive sanity check: when set, ``build_qemu_argv`` asserts the
+    VMConfig's boot_mode matches. The authoritative invariant lives on
+    ``VMConfig._check_boot_mode_consistency`` — this field exists only so
+    a misconfigured VM is caught loudly inside the builder."""
+
+    skip_kernel_cmdline_injection: bool = False
+    """When True, ``build_qemu_argv`` skips passing ``-kernel``/``-append``/
+    ``-initrd`` entirely. Used by Windows (no Linux kernel)."""
+
+    skip_workspace_mounts: bool = False
+    """When True, ``build_qemu_argv`` ignores ``config.workspace_mounts``.
+    Windows has no usable 9p client today."""
+
+    # --- machine / cpu fragments appended after the existing q35/virt base -
+    machine_extra_opts: tuple[str, ...] = ()
+    """Comma-appended after the base machine string. Empty for Linux;
+    Windows uses ``('smm=on', 'vmport=off', 'kernel-irqchip=on')``."""
+
+    cpu_extra_flags: tuple[str, ...] = ()
+    """Comma-appended to ``-cpu host``. Empty for Linux; Windows uses the
+    Hyper-V enlightenment set (``hv_relaxed,hv_vapic,...``)."""
+
+    extra_globals: tuple[str, ...] = ()
+    """Each emitted as ``-global <value>``. Empty for Linux; Windows uses
+    the SMM-protected pflash and S3-disable globals."""
+
+    extra_objects: tuple[str, ...] = ()
+    """Each emitted as ``-object <value>``. Empty for Linux; Windows uses
+    ``iothread,id=iothr0`` and ``memory-backend-memfd,...``."""
+
+    extra_devices: tuple[str, ...] = ()
+    """Each emitted as ``-device <value>``. Emitted in declaration order
+    — declare controllers before consumers (e.g. ``qemu-xhci`` before
+    ``usb-tablet,bus=xhci.0``)."""
+
+    # --- block / disk topology ---------------------------------------------
+    root_disk_controller: Literal["virtio-blk-pci", "virtio-scsi-pci"] | None = None
+    """When None, the root disk is emitted as a bare ``virtio-blk-pci``
+    device (the Linux default). When set, the builder emits a controller
+    of this type first, then the root drive as ``root_disk_device`` bound
+    to that controller."""
+
+    root_disk_device: Literal["virtio-blk", "scsi-hd"] = "virtio-blk"
+    """Drive device kind. ``scsi-hd`` is bound to a virtio-scsi controller
+    declared via ``root_disk_controller``. Windows uses ``scsi-hd``."""
+
+    cdrom_bus: Literal["ide"] | None = None
+    """How ``.iso`` files in ``extra_drives`` are attached. ``None`` (the
+    Linux default) keeps the existing behaviour — ISO is attached on the
+    same virtio-blk bus as any other extra drive. ``"ide"`` (Windows)
+    switches to ``ide-cd`` so Windows' inbox AHCI driver can read install
+    media even before the ``vioscsi`` driver is loaded mid-install. Each
+    AHCI port holds exactly one drive, so the builder round-robins ISO
+    entries across ``ide.0..ide.5``."""
+
+    # --- firmware + sidecars ----------------------------------------------
+    firmware: FirmwareSpec | None = None
+    """When set, the builder emits split-pflash drives instead of letting
+    QEMU pick the default firmware. Windows always sets this; Linux
+    aarch64 still uses the legacy ``-bios`` path for now."""
+
+    requires_swtpm: bool = False
+    """When True, ``QemuRuntimeAdapter.start()`` spawns a per-VM swtpm
+    sidecar before QEMU and tears it down after. Windows requires this."""
+
+    swtpm_device_model: Literal["tpm-crb", "tpm-tis"] = "tpm-crb"
+    """The TPM frontend device the guest sees. ``tpm-crb`` matches what
+    physical Windows 11 hardware uses; ``tpm-tis`` is the older fallback."""
+
+
+_LINUX_SPEC: GuestPlatformSpec = GuestPlatformSpec(
+    guest_os=GuestOS.ALPINE,
+    name="linux",
+)
+"""All-defaults spec for Linux guests (Alpine, Ubuntu). Produces byte-
+identical QEMU argv to the pre-refactor ``_start_qemu`` when fed through
+``build_qemu_argv``. Used for ``GuestOS.ALPINE`` and ``GuestOS.UBUNTU``."""
+
+
+# Distro-by-distro CODE+VARS pairs for x86_64 OVMF Secure Boot firmware.
+# Probed in order; the first existing pair wins. The CODE file is the
+# read-only firmware binary built with SECURE_BOOT_ENABLE + SMM_REQUIRE;
+# the VARS file is the NVRAM template with Microsoft Secure Boot keys
+# pre-enrolled (so Windows boot manager passes Secure Boot verification).
+#
+# Sources for paths: docs/deep-dive/windows-guest-qemu.md §4 ("Firmware:
+# split OVMF + Microsoft-keys VARS + SMM") — distro install paths table.
+_X86_64_OVMF_CANDIDATE_PAIRS: tuple[tuple[str, str], ...] = (
+    # Debian / Ubuntu — ovmf package, 4 MiB Secure Boot build
+    (
+        "/usr/share/OVMF/OVMF_CODE_4M.secboot.fd",
+        "/usr/share/OVMF/OVMF_VARS_4M.ms.fd",
+    ),
+    # Debian / Ubuntu — legacy 2 MiB build (older releases)
+    (
+        "/usr/share/OVMF/OVMF_CODE.secboot.fd",
+        "/usr/share/OVMF/OVMF_VARS.ms.fd",
+    ),
+    # Fedora / RHEL — edk2-ovmf package
+    (
+        "/usr/share/edk2/ovmf/OVMF_CODE.secboot.fd",
+        "/usr/share/edk2/ovmf/OVMF_VARS.secboot.fd",
+    ),
+    (
+        "/usr/share/edk2-ovmf/OVMF_CODE.secboot.fd",
+        "/usr/share/edk2-ovmf/OVMF_VARS.secboot.fd",
+    ),
+    # Arch Linux — edk2-ovmf package, 4 MiB Secure Boot build
+    (
+        "/usr/share/edk2/x64/OVMF_CODE.secboot.4m.fd",
+        "/usr/share/edk2/x64/OVMF_VARS.4m.fd",
+    ),
+    # macOS Homebrew — bundled with qemu (Apple Silicon)
+    (
+        "/opt/homebrew/share/qemu/edk2-x86_64-code.fd",
+        "/opt/homebrew/share/qemu/edk2-i386-vars.fd",
+    ),
+    # macOS Homebrew — Intel
+    (
+        "/usr/local/share/qemu/edk2-x86_64-code.fd",
+        "/usr/local/share/qemu/edk2-i386-vars.fd",
+    ),
+)
+
+
+def _find_x86_64_ovmf() -> FirmwareSpec | None:
+    """Locate a matching x86_64 OVMF code+vars pair on the host.
+
+    Probes the distro-by-distro candidate pairs in order; first complete
+    pair (both files exist) wins. Returns ``None`` if no Secure Boot
+    OVMF is present — caller emits a plain-English install hint.
+
+    Pairs are matched by distro, so we don't accidentally combine a
+    Debian CODE with a Fedora VARS template and end up with a Secure
+    Boot variable store from the wrong NVRAM layout.
+    """
+    for code_path_str, vars_path_str in _X86_64_OVMF_CANDIDATE_PAIRS:
+        code_path = Path(code_path_str)
+        vars_path = Path(vars_path_str)
+        if code_path.is_file() and vars_path.is_file():
+            return FirmwareSpec(
+                code_path=code_path,
+                vars_template_path=vars_path,
+                secure_boot=True,
+            )
+    return None
+
+
+def _x86_64_ovmf_install_hint() -> str:
+    """Return a plain-English install hint when no x86_64 OVMF is found."""
+    return (
+        "x86_64 Windows guests need the OVMF Secure Boot firmware. "
+        "On Debian/Ubuntu run 'sudo apt-get install -y ovmf'. "
+        "On Fedora/RHEL run 'sudo dnf install -y edk2-ovmf'. "
+        "On Arch run 'sudo pacman -S --needed edk2-ovmf'. "
+        "On macOS, OVMF ships with QEMU — 'brew reinstall qemu' if it's missing."
+    )
+
+
+# Hyper-V "enlightenments" — paravirtualised guest interfaces Windows
+# enables when it detects a Hyper-V-compatible hypervisor. KVM exposes
+# these via the CPUID leaves Windows looks at, so a properly-flagged
+# QEMU/KVM guest takes Windows' fast in-guest paths (synthetic timers,
+# paravirt spinlocks, paravirt IPI/TLB-flush, MSR-based clocksource)
+# instead of trapping for emulated x86 hardware.
+#
+# This is the convergent baseline across QEMU upstream, libvirt's
+# <hyperv mode='passthrough'/>, Proxmox's Windows-OS-type default, and
+# Red Hat's RHEL Windows-guest guide. See docs/deep-dive/windows-guest-
+# qemu.md §2 for the per-flag rationale.
+_WINDOWS_HV_FLAGS: tuple[str, ...] = (
+    "hv_relaxed",
+    "hv_vapic",
+    "hv_spinlocks=0x1fff",
+    "hv_vpindex",
+    "hv_runtime",
+    "hv_time",
+    "hv_synic",
+    "hv_stimer",
+    "hv_frequencies",
+    "hv_tlbflush",
+    "hv_ipi",
+    "hv_reset",
+    "+kvm_pv_eoi",
+    "+kvm_pv_unhalt",
+)
+
+# q35 machine sub-options Windows 11 needs:
+#  - smm=on            SMM emulation; required for OVMF Secure Boot to
+#                      protect NVRAM writes from in-guest tampering.
+#  - vmport=off        Disables the VMware backdoor I/O port. Windows
+#                      has no driver for it; dropping it reduces attack
+#                      surface (default 'auto' enables it under KVM).
+#  - kernel-irqchip=on KVM handles APIC/IOAPIC in-kernel — the fast path.
+_WINDOWS_MACHINE_OPTS: tuple[str, ...] = (
+    "smm=on",
+    "vmport=off",
+    "kernel-irqchip=on",
+)
+
+# -global flags required when SMM owns the pflash NVRAM. Without these
+# the guest OS could forge Secure Boot variable writes at runtime.
+_WINDOWS_SMM_GLOBALS: tuple[str, ...] = (
+    "driver=cfi.pflash01,property=secure,value=on",
+    "ICH9-LPC.disable_s3=1",
+)
+
+
+def _build_windows_spec(*, host_system: str, arch: str) -> GuestPlatformSpec:
+    """Build the Windows ``GuestPlatformSpec`` for this host.
+
+    Combines:
+      - The Hyper-V enlightenments baseline.
+      - q35 SMM/vmport/kernel-irqchip machine sub-options.
+      - SMM-protected pflash + S3-disable globals.
+      - virtio-scsi root disk with scsi-hd device (Windows ``vioscsi`` driver).
+      - IDE/AHCI bus for ``.iso`` extras so Windows' inbox AHCI driver can
+        always read install media, regardless of whether ``vioscsi`` has
+        been loaded mid-install.
+      - qemu-xhci + usb-tablet (q35 ships no default USB controller).
+      - swtpm + tpm-crb sidecar requirement.
+      - OVMF Secure Boot firmware (split CODE/VARS).
+
+    Raises:
+        NotImplementedError: When the host is non-Linux (macOS host +
+            Windows guest requires HVF for x86_64, which doesn't exist —
+            see docs/deep-dive/windows-guest-qemu.md §5 "macOS caveat").
+        NotImplementedError: When the host arch isn't x86_64 — Windows
+            ARM64 under QEMU on Apple Silicon is theoretically possible
+            but out of Phase 1 scope.
+        ValueError: When no OVMF Secure Boot firmware is found on the host.
+    """
+    if host_system != "Linux":
+        raise NotImplementedError(
+            "Windows guests are only supported on Linux hosts in this release. "
+            "macOS host + Windows guest needs HVF for x86_64 (doesn't exist), "
+            "or Windows-on-ARM under HVF (out of scope). "
+            "See docs/deep-dive/windows-guest-qemu.md §5."
+        )
+    arch_lower = arch.lower()
+    if arch_lower not in {"x86_64", "amd64"}:
+        raise NotImplementedError(
+            f"Windows guests on {arch} are not supported. "
+            "Phase 1 targets x86_64 hosts only."
+        )
+
+    firmware = _find_x86_64_ovmf()
+    if firmware is None:
+        raise ValueError(_x86_64_ovmf_install_hint())
+
+    return GuestPlatformSpec(
+        guest_os=GuestOS.WINDOWS,
+        name="windows",
+        forced_boot_mode="firmware",
+        skip_kernel_cmdline_injection=True,
+        skip_workspace_mounts=True,
+        machine_extra_opts=_WINDOWS_MACHINE_OPTS,
+        cpu_extra_flags=_WINDOWS_HV_FLAGS,
+        extra_globals=_WINDOWS_SMM_GLOBALS,
+        extra_objects=(),  # iothread/memfd deferred to Phase 2 perf work
+        extra_devices=(
+            "qemu-xhci,id=xhci",
+            "usb-tablet,bus=xhci.0",
+        ),
+        root_disk_controller="virtio-scsi-pci",
+        root_disk_device="scsi-hd",
+        cdrom_bus="ide",
+        firmware=firmware,
+        requires_swtpm=True,
+        swtpm_device_model="tpm-crb",
+    )
+
+
+def get_guest_platform(
+    guest_os: GuestOS,
+    *,
+    host_system: str,
+    arch: str,
+) -> GuestPlatformSpec:
+    """Return the platform spec for *guest_os*, resolving host-dependent paths.
+
+    Linux guests (Alpine, Ubuntu) get the all-defaults ``_LINUX_SPEC``.
+    Windows guests get a spec built from ``_build_windows_spec``, which
+    probes the host for OVMF firmware paths.
+    """
+    if guest_os is GuestOS.WINDOWS:
+        return _build_windows_spec(host_system=host_system, arch=arch)
+    return _LINUX_SPEC
+
+
+# Suppress unused-import warning for `field` when this module is later extended
+# with mutable defaults via dataclasses.field(default_factory=...).
+_ = field

--- a/src/smolvm/runtime/guest_platforms.py
+++ b/src/smolvm/runtime/guest_platforms.py
@@ -239,11 +239,10 @@ def _find_x86_64_ovmf() -> FirmwareSpec | None:
 def _x86_64_ovmf_install_hint() -> str:
     """Return a plain-English install hint when no x86_64 OVMF is found."""
     return (
-        "x86_64 Windows guests need the OVMF Secure Boot firmware. "
-        "On Debian/Ubuntu run 'sudo apt-get install -y ovmf'. "
-        "On Fedora/RHEL run 'sudo dnf install -y edk2-ovmf'. "
-        "On Arch run 'sudo pacman -S --needed edk2-ovmf'. "
-        "On macOS, OVMF ships with QEMU — 'brew reinstall qemu' if it's missing."
+        "Install OVMF Secure Boot firmware to boot Windows guests "
+        "(Debian/Ubuntu: `sudo apt-get install -y ovmf`; Fedora/RHEL: "
+        "`sudo dnf install -y edk2-ovmf`; Arch: `sudo pacman -S --needed "
+        "edk2-ovmf`; macOS: `brew reinstall qemu`)."
     )
 
 

--- a/src/smolvm/runtime/qemu.py
+++ b/src/smolvm/runtime/qemu.py
@@ -18,7 +18,10 @@ from __future__ import annotations
 
 import asyncio
 import logging
+import os
+import platform
 import shutil
+import signal
 import subprocess
 import time
 from contextlib import suppress
@@ -36,12 +39,149 @@ from smolvm.runtime.base import (
     SnapshotCreateResult,
     SnapshotRestoreRequest,
 )
-from smolvm.types import SnapshotArtifacts, VMInfo, VMState
+from smolvm.runtime.guest_platforms import GuestPlatformSpec, get_guest_platform
+from smolvm.types import GuestOS, SnapshotArtifacts, VMInfo, VMState
 from smolvm.utils import which
 
 logger = logging.getLogger(__name__)
 
 QEMU_ROOT_NODE_NAME = "rootdisk0"
+
+
+class _SwtpmSidecar:
+    """Per-VM swtpm (software TPM 2.0) process.
+
+    Owned by :class:`QemuRuntimeAdapter`. Linux-host only — swtpm is a
+    Linux-native daemon. The adapter spawns this before QEMU and tears
+    it down after, passing the data-channel socket into the QEMU command
+    line as ``-chardev socket,id=chrtpm,path=...``.
+
+    Statelessness: the sidecar carries no in-memory bookkeeping. Each
+    ``start`` / ``stop`` call rederives paths from ``vm_id`` and the
+    runtime context, so the adapter can construct a new sidecar instance
+    for a different lifecycle phase without coordination.
+    """
+
+    def __init__(
+        self,
+        *,
+        vm_id: str,
+        firmware_dir: Path,
+        context: RuntimeContext,
+    ) -> None:
+        self._vm_id = vm_id
+        self._state_dir = firmware_dir / vm_id / "swtpm"
+        self._socket_path = self._state_dir / "swtpm-sock"
+        self._pidfile = self._state_dir / "swtpm.pid"
+        self._context = context
+
+    @property
+    def socket_path(self) -> Path:
+        """Path to the swtpm data-channel Unix socket QEMU connects to."""
+        return self._socket_path
+
+    @property
+    def pidfile_path(self) -> Path:
+        """Path to swtpm's pidfile (used by the adapter for liveness checks)."""
+        return self._pidfile
+
+    def start(self, *, timeout: float = 5.0) -> int:
+        """Spawn ``swtpm socket --tpm2 --daemon ...`` and return its pid.
+
+        Raises:
+            SmolVMError: When ``swtpm`` isn't on PATH, when the swtpm
+                process exits non-zero, when the data socket never
+                appears within *timeout* seconds, or when the pidfile
+                isn't written.
+        """
+        # Clean any stale state from a previous run.
+        with suppress(FileNotFoundError):
+            self._socket_path.unlink()
+        with suppress(FileNotFoundError):
+            self._pidfile.unlink()
+        self._state_dir.mkdir(parents=True, exist_ok=True)
+
+        swtpm_bin = which("swtpm")
+        if swtpm_bin is None:
+            raise SmolVMError(
+                "Windows guests need the swtpm software TPM emulator. "
+                "Install it with 'sudo apt-get install -y swtpm swtpm-tools' "
+                "on Debian/Ubuntu, 'sudo dnf install -y swtpm swtpm-tools' "
+                "on Fedora/RHEL, or 'sudo pacman -S --needed swtpm' on Arch."
+            )
+
+        try:
+            subprocess.run(
+                [
+                    str(swtpm_bin),
+                    "socket",
+                    "--tpmstate",
+                    f"dir={self._state_dir}",
+                    "--ctrl",
+                    f"type=unixio,path={self._socket_path}",
+                    "--tpm2",
+                    "--daemon",
+                    "--pid",
+                    f"file={self._pidfile}",
+                ],
+                check=True,
+                capture_output=True,
+                text=True,
+            )
+        except subprocess.CalledProcessError as exc:
+            raise SmolVMError(
+                "Failed to start swtpm sidecar for Windows guest",
+                {
+                    "vm_id": self._vm_id,
+                    "stderr": (exc.stderr or "").strip(),
+                },
+            ) from exc
+
+        deadline = time.time() + timeout
+        while time.time() < deadline:
+            if self._socket_path.exists():
+                break
+            time.sleep(0.05)
+        if not self._socket_path.exists():
+            raise SmolVMError(
+                "swtpm spawned but its control socket never appeared",
+                {"socket_path": str(self._socket_path), "timeout": timeout},
+            )
+        if not self._pidfile.exists():
+            raise SmolVMError(
+                "swtpm spawned but no pidfile was written",
+                {"pidfile": str(self._pidfile)},
+            )
+        return int(self._pidfile.read_text().strip())
+
+    def stop(self) -> None:
+        """Stop the swtpm daemon and remove the socket + pidfile.
+
+        Best-effort: missing files are ignored; a process that's already
+        gone is fine. The adapter calls this after stopping QEMU and on
+        QEMU startup failure.
+        """
+        if self._pidfile.exists():
+            try:
+                pid = int(self._pidfile.read_text().strip())
+            except ValueError:
+                pid = -1
+            if pid > 0 and self._context.is_process_running(pid):
+                with suppress(ProcessLookupError, OSError):
+                    os.kill(pid, signal.SIGTERM)
+                deadline = time.time() + 5.0
+                while (
+                    time.time() < deadline
+                    and self._context.is_process_running(pid)
+                ):
+                    time.sleep(0.05)
+                if self._context.is_process_running(pid):
+                    with suppress(ProcessLookupError, OSError):
+                        os.kill(pid, signal.SIGKILL)
+        with suppress(FileNotFoundError):
+            self._pidfile.unlink()
+        with suppress(FileNotFoundError):
+            self._socket_path.unlink()
 
 
 class QemuRuntimeAdapter(RuntimeAdapter):
@@ -53,10 +193,22 @@ class QemuRuntimeAdapter(RuntimeAdapter):
         self._context = context
 
     def start(self, vm_info: VMInfo, *, log_path: Path, boot_timeout: float) -> RuntimeLaunch:
-        """Start QEMU with a persistent QMP socket."""
+        """Start QEMU (and a swtpm sidecar if the guest OS needs one)."""
+        platform_spec = self._resolve_platform_spec(vm_info)
+
         control_socket_path = self._control_socket_path(vm_info.vm_id)
         if control_socket_path.exists():
             self._context.unlink_socket(control_socket_path)
+
+        firmware_vars_path = self._firmware_vars_path(vm_info, platform_spec)
+        swtpm_sidecar: _SwtpmSidecar | None = None
+        if platform_spec.requires_swtpm:
+            swtpm_sidecar = _SwtpmSidecar(
+                vm_id=vm_info.vm_id,
+                firmware_dir=self._context.firmware_dir,
+                context=self._context,
+            )
+            swtpm_sidecar.start()
 
         process: Any | None = None
         try:
@@ -66,6 +218,8 @@ class QemuRuntimeAdapter(RuntimeAdapter):
                 control_socket_path=control_socket_path,
                 start_paused=False,
                 root_node_name=QEMU_ROOT_NODE_NAME,
+                firmware_vars_path=firmware_vars_path,
+                swtpm_socket=(swtpm_sidecar.socket_path if swtpm_sidecar else None),
             )
             self._wait_for_runtime(process, control_socket_path, boot_timeout)
             return RuntimeLaunch(
@@ -80,15 +234,15 @@ class QemuRuntimeAdapter(RuntimeAdapter):
             if control_socket_path.exists():
                 with suppress(Exception):
                     self._context.unlink_socket(control_socket_path)
+            if swtpm_sidecar is not None:
+                with suppress(Exception):
+                    swtpm_sidecar.stop()
             raise
 
     def stop(self, vm_info: VMInfo, *, timeout: float) -> None:
-        """Stop a QEMU VM process."""
+        """Stop a QEMU VM process and any swtpm sidecar it owns."""
         if vm_info.pid and self._context.is_process_running(vm_info.pid):
             try:
-                import os
-                import signal
-
                 os.kill(vm_info.pid, signal.SIGTERM)
                 self._context.wait_for_process(vm_info.pid, timeout)
             except (OSError, SmolVMError):
@@ -105,8 +259,51 @@ class QemuRuntimeAdapter(RuntimeAdapter):
                 {"pid": vm_info.pid},
             )
 
+        # Tear down the swtpm sidecar after QEMU is gone. We rederive
+        # whether one ran from vm_info.config.guest_os so the stop path
+        # has no in-memory dependency on what start() captured.
+        if vm_info.config.guest_os is GuestOS.WINDOWS:
+            sidecar = _SwtpmSidecar(
+                vm_id=vm_info.vm_id,
+                firmware_dir=self._context.firmware_dir,
+                context=self._context,
+            )
+            with suppress(Exception):
+                sidecar.stop()
+
         if vm_info.control_socket_path and vm_info.control_socket_path.exists():
             self._context.unlink_socket(vm_info.control_socket_path)
+
+    @staticmethod
+    def _resolve_platform_spec(vm_info: VMInfo) -> GuestPlatformSpec:
+        """Resolve the guest platform spec for *vm_info*.
+
+        Surfaces the macOS-host + Windows-guest rejection (and any other
+        host-incompatibility raised by the spec factory) as a ``SmolVMError``
+        with the VM ID in context, so the runtime adapter's error path
+        is consistent with the rest of the SmolVM SDK.
+        """
+        try:
+            return get_guest_platform(
+                vm_info.config.guest_os,
+                host_system=platform.system(),
+                arch=platform.machine(),
+            )
+        except (NotImplementedError, ValueError) as exc:
+            raise SmolVMError(
+                str(exc),
+                {"vm_id": vm_info.vm_id, "guest_os": vm_info.config.guest_os.value},
+            ) from exc
+
+    def _firmware_vars_path(
+        self,
+        vm_info: VMInfo,
+        platform_spec: GuestPlatformSpec,
+    ) -> Path | None:
+        """Resolve the per-VM OVMF VARS path, when the guest needs one."""
+        if platform_spec.firmware is None:
+            return None
+        return self._context.firmware_dir / vm_info.vm_id / "OVMF_VARS.fd"
 
     def pause(self, vm_info: VMInfo) -> None:
         """Pause a running QEMU VM."""

--- a/src/smolvm/runtime/qemu_args.py
+++ b/src/smolvm/runtime/qemu_args.py
@@ -41,6 +41,11 @@ from smolvm.types import VMInfo
 # QEMU's compiled-in default ever changes upstream.
 QEMU_SLIRP_DNS = "10.0.2.3"
 
+# Number of AHCI/SATA ports the q35 ICH9 chipset exposes. ISO extras with
+# cdrom_bus="ide" occupy ide.0..ide.5 in order; any beyond port 5 fall back
+# to virtio-blk-pci so the QEMU command line stays valid.
+_Q35_AHCI_PORTS = 6
+
 
 # Candidate UEFI firmware locations for aarch64 QEMU firmware-boot.
 # Searched in order; the first existing file wins. macOS Homebrew ships
@@ -358,15 +363,22 @@ def build_qemu_argv(
         cmd.extend(["-device", f"virtio-net-pci,netdev=net0,mac={guest_mac}"])
 
         # Extra drives. Each AHCI port holds exactly one drive on q35, so
-        # ISO entries with cdrom_bus="ide" are round-robined across
-        # ide.0..ide.5. Non-ISO extras (or Linux's None cdrom_bus) keep
-        # the legacy virtio-blk-pci wiring.
+        # ISO entries with cdrom_bus="ide" are placed on ide.0..ide.5 in
+        # order. Once those 6 ports are exhausted, additional ISOs fall
+        # back to virtio-blk-pci so the QEMU command line stays valid
+        # (Windows still sees them as block devices). Non-ISO extras and
+        # Linux (None cdrom_bus) keep the legacy virtio-blk-pci wiring.
         ide_port_index = 0
         for drive_id, drive_path in zip(
             extra_drive_ids, vm_info.config.extra_drives, strict=True
         ):
             is_iso = drive_path.suffix.lower() == ".iso"
-            if is_iso and platform_spec.cdrom_bus == "ide":
+            use_ide = (
+                is_iso
+                and platform_spec.cdrom_bus == "ide"
+                and ide_port_index < _Q35_AHCI_PORTS
+            )
+            if use_ide:
                 cmd.extend(
                     [
                         "-device",

--- a/src/smolvm/runtime/qemu_args.py
+++ b/src/smolvm/runtime/qemu_args.py
@@ -362,7 +362,9 @@ def build_qemu_argv(
         # ide.0..ide.5. Non-ISO extras (or Linux's None cdrom_bus) keep
         # the legacy virtio-blk-pci wiring.
         ide_port_index = 0
-        for drive_id, drive_path in zip(extra_drive_ids, vm_info.config.extra_drives):
+        for drive_id, drive_path in zip(
+            extra_drive_ids, vm_info.config.extra_drives, strict=True
+        ):
             is_iso = drive_path.suffix.lower() == ".iso"
             if is_iso and platform_spec.cdrom_bus == "ide":
                 cmd.extend(

--- a/src/smolvm/runtime/qemu_args.py
+++ b/src/smolvm/runtime/qemu_args.py
@@ -1,0 +1,387 @@
+# Copyright 2026 Celesto AI
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Pure command-line assembly for the QEMU backend.
+
+Splits the QEMU argv builder out of ``SmolVMManager._start_qemu`` so it can
+be unit-tested without spawning a real ``qemu-system-x86_64`` process. The
+builder is a pure function: it reads ``VMInfo`` plus a ``GuestPlatformSpec``
+and returns a ``list[str]`` argv. All side effects (spawning the process,
+opening log files, tracking PIDs) stay in ``_start_qemu``.
+
+For the Linux all-defaults spec (``_LINUX_SPEC``) this function produces
+output byte-identical to the pre-refactor ``_start_qemu``. The
+``GuestPlatformSpec`` fields exist to let later commits add Windows-specific
+fragments without disturbing the Linux path.
+"""
+
+from __future__ import annotations
+
+import platform
+from pathlib import Path
+
+from smolvm.exceptions import SmolVMError
+from smolvm.runtime.guest_platforms import GuestPlatformSpec
+from smolvm.runtime.qemu import QEMU_ROOT_NODE_NAME
+from smolvm.types import VMInfo
+
+# DNS server announced to the guest by QEMU's SLIRP stack. The default would
+# also work; we set it explicitly so the guest sees the same address whether
+# QEMU's compiled-in default ever changes upstream.
+QEMU_SLIRP_DNS = "10.0.2.3"
+
+
+# Candidate UEFI firmware locations for aarch64 QEMU firmware-boot.
+# Searched in order; the first existing file wins. macOS Homebrew ships
+# edk2-aarch64-code.fd under the qemu data dir; Debian/Ubuntu split it into
+# a separate qemu-efi-aarch64 package; RHEL uses AAVMF.
+_AARCH64_EDK2_FIRMWARE_CANDIDATES: tuple[str, ...] = (
+    "/opt/homebrew/share/qemu/edk2-aarch64-code.fd",
+    "/usr/local/share/qemu/edk2-aarch64-code.fd",
+    "/usr/share/qemu-efi-aarch64/QEMU_EFI.fd",
+    "/usr/share/AAVMF/AAVMF_CODE.fd",
+    "/usr/share/edk2/aarch64/QEMU_EFI.fd",
+    "/usr/share/edk2-armvirt/aarch64/QEMU_EFI.fd",
+)
+
+
+def _find_aarch64_uefi_firmware() -> Path | None:
+    """Return the first existing aarch64 UEFI firmware file, or ``None``."""
+    for candidate in _AARCH64_EDK2_FIRMWARE_CANDIDATES:
+        path = Path(candidate)
+        if path.is_file():
+            return path
+    return None
+
+
+def build_qemu_argv(
+    vm_info: VMInfo,
+    *,
+    qemu_bin: Path,
+    boot_args: str,
+    platform_spec: GuestPlatformSpec,
+    control_socket_path: Path | None = None,
+    firmware_vars_path: Path | None = None,
+    swtpm_socket: Path | None = None,
+    start_paused: bool = False,
+    root_node_name: str = QEMU_ROOT_NODE_NAME,
+    host_system: str | None = None,
+) -> list[str]:
+    """Build the ``qemu-system-*`` argv for *vm_info*.
+
+    Args:
+        vm_info: VM info with persisted configuration/network.
+        qemu_bin: Resolved path to the QEMU binary (caller looks this up
+            via ``_find_qemu_binary``). Its filename selects the arch path
+            (``qemu-system-aarch64`` vs ``qemu-system-x86_64``).
+        boot_args: Pre-resolved kernel command line (caller passes the
+            output of ``_resolve_boot_args``).
+        platform_spec: Per-guest-OS overrides. For Linux guests this is
+            ``_LINUX_SPEC`` and every field is at its default — the
+            returned argv is byte-identical to the pre-refactor builder.
+        control_socket_path: Optional QMP control socket path. When set,
+            ``-qmp unix:...,server=on,wait=off`` is appended.
+        firmware_vars_path: Per-VM OVMF NVRAM file path. Required when
+            ``platform_spec.firmware`` is set (Windows). The manager
+            materializes this file from
+            ``platform_spec.firmware.vars_template_path`` at create time
+            and the runtime adapter passes the per-VM path here.
+        swtpm_socket: Path to the per-VM swtpm Unix socket. Required when
+            ``platform_spec.requires_swtpm`` is True (Windows). The
+            adapter spawns swtpm before QEMU and passes its socket here.
+        start_paused: When True, append ``-S`` so QEMU boots into the
+            paused state. Used for snapshot restore.
+        root_node_name: QEMU block graph node name for the primary disk.
+        host_system: Override of ``platform.system()`` for testing. When
+            ``None`` (the default), the live host system is used.
+
+    Returns:
+        The argv list. No side effects — caller is responsible for
+        ``subprocess.Popen``.
+
+    Raises:
+        SmolVMError: When the VM has no reserved SSH host port; when
+            firmware boot is requested on aarch64 and no OVMF binary is
+            found on the host; or when the platform spec requires
+            firmware/swtpm and the caller didn't provide a per-VM path.
+    """
+    if vm_info.network is None or vm_info.network.ssh_host_port is None:
+        raise SmolVMError("QEMU backend requires a reserved ssh_host_port in VM network config")
+
+    # Defensive sanity check: if the platform spec forces a specific boot
+    # mode, the VMConfig must already match. The authoritative invariant
+    # lives on VMConfig._check_boot_mode_consistency — this assertion
+    # surfaces design-time bugs (a Windows VM somehow constructed with
+    # boot_mode='direct_kernel') as a clear runtime error.
+    if (
+        platform_spec.forced_boot_mode is not None
+        and vm_info.config.boot_mode != platform_spec.forced_boot_mode
+    ):
+        raise SmolVMError(
+            "VM boot_mode does not match platform spec",
+            {
+                "guest_os": platform_spec.guest_os.value,
+                "vmconfig_boot_mode": vm_info.config.boot_mode,
+                "platform_spec_forced": platform_spec.forced_boot_mode,
+            },
+        )
+
+    ssh_port = vm_info.network.ssh_host_port
+    guest_mac = vm_info.network.guest_mac.lower()
+
+    qemu_name = qemu_bin.name
+    system = host_system if host_system is not None else platform.system()
+
+    disk_format = "qcow2" if vm_info.config.rootfs_path.suffix == ".qcow2" else "raw"
+    root_drive_id = f"{root_node_name}-drive"
+    drive_arg = (
+        f"file={vm_info.config.rootfs_path},if=none,format={disk_format},"
+        f"id={root_drive_id},node-name={root_node_name}"
+    )
+    hostfwd_rules = [f"hostfwd=tcp:127.0.0.1:{ssh_port}-:22"]
+    for forward in vm_info.config.port_forwards:
+        hostfwd_rules.append(
+            f"hostfwd=tcp:{forward.host_address}:{forward.host_port}-:{forward.guest_port}"
+        )
+    netdev_arg = f"user,id=net0,dns={QEMU_SLIRP_DNS},{','.join(hostfwd_rules)}"
+
+    cmd: list[str] = [
+        str(qemu_bin),
+        "-smp",
+        str(vm_info.config.vcpu_count),
+        "-m",
+        str(vm_info.config.memory),
+    ]
+    # Boot mode: direct-kernel passes -kernel/-append (optionally -initrd);
+    # firmware mode lets QEMU boot the rootfs disk via default firmware
+    # (OVMF on aarch64, SeaBIOS on x86_64) — the guest kernel lives inside
+    # the rootfs image.
+    if vm_info.config.boot_mode == "direct_kernel":
+        cmd.extend(
+            [
+                "-kernel",
+                str(vm_info.config.kernel_path),
+                "-append",
+                boot_args,
+            ]
+        )
+    cmd.extend(
+        [
+            "-drive",
+            drive_arg,
+            "-netdev",
+            netdev_arg,
+            "-nographic",
+            "-no-reboot",
+        ]
+    )
+    if vm_info.config.boot_mode == "direct_kernel" and vm_info.config.initrd_path is not None:
+        cmd.extend(["-initrd", str(vm_info.config.initrd_path)])
+
+    extra_drive_ids: list[str] = []
+    for index, drive_path in enumerate(vm_info.config.extra_drives):
+        drive_id = f"extra{index}-drive"
+        node_name = f"extra{index}"
+        extra_drive_ids.append(drive_id)
+        drive_suffix = drive_path.suffix.lower()
+        drive_format = "qcow2" if drive_suffix == ".qcow2" else "raw"
+        readonly = ["readonly=on"] if drive_suffix == ".iso" else []
+        extra_drive_arg = ",".join(
+            [
+                f"file={drive_path}",
+                "if=none",
+                f"format={drive_format}",
+                *readonly,
+                f"id={drive_id}",
+                f"node-name={node_name}",
+            ]
+        )
+        cmd.extend(["-drive", extra_drive_arg])
+
+    # ── virtio-9p workspace mounts ──────────────────────────────
+    # Skipped entirely for guest OSes that can't mount 9p (e.g. Windows).
+    workspace_fsdev_ids: list[tuple[str, str]] = []
+    if not platform_spec.skip_workspace_mounts:
+        for index, ws in enumerate(vm_info.config.workspace_mounts):
+            tag = ws.resolved_tag(index)
+            fsdev_id = f"fsdev-{tag}"
+            workspace_fsdev_ids.append((fsdev_id, tag))
+            fsdev_opts = f"local,id={fsdev_id},path={ws.host_path},security_model=mapped-xattr"
+            if not ws.writable:
+                fsdev_opts += ",readonly=on"
+            cmd.extend(["-fsdev", fsdev_opts])
+
+    if control_socket_path is not None:
+        cmd.extend(
+            [
+                "-qmp",
+                f"unix:{control_socket_path},server=on,wait=off",
+            ]
+        )
+    if start_paused:
+        cmd.append("-S")
+
+    if "aarch64" in qemu_name:
+        # Pick a hardware accelerator. Without one, QEMU falls back to
+        # TCG (software emulation), which is 10-50x slower and routinely
+        # blows past the 30s wait_for_ssh budget on cloud-init boots.
+        # macOS → Hypervisor.framework; Linux → KVM (if /dev/kvm is
+        # missing the user couldn't run firecracker either, so requiring
+        # KVM here is consistent).
+        if system == "Darwin":
+            machine, cpu = "virt,accel=hvf", "host"
+        else:
+            machine, cpu = "virt,accel=kvm", "host"
+        cmd.extend(["-machine", machine, "-cpu", cpu])
+        if vm_info.config.boot_mode == "firmware":
+            firmware_path = _find_aarch64_uefi_firmware()
+            if firmware_path is None:
+                raise SmolVMError(
+                    "aarch64 firmware-boot requires UEFI firmware (edk2/AAVMF) "
+                    "but none was found. Searched: "
+                    f"{', '.join(_AARCH64_EDK2_FIRMWARE_CANDIDATES)}. "
+                    "On macOS run 'brew reinstall qemu'; on Debian/Ubuntu "
+                    "install 'qemu-efi-aarch64'."
+                )
+            cmd.extend(["-bios", str(firmware_path)])
+        # virtio-MMIO device ordering note: on `-machine virt`, kernel
+        # enumeration of virtio-mmio slots is the REVERSE of the order
+        # the `-device` flags appear on the command line. To make sure
+        # the rootdisk lands at /dev/vda (and not /dev/vdb behind the
+        # cloud-init seed), the rootdisk-block device must be the LAST
+        # virtio-blk-device added. Workspace fsdevs and the NIC must
+        # come before it too.
+        for drive_id in extra_drive_ids:
+            cmd.extend(["-device", f"virtio-blk-device,drive={drive_id}"])
+        for fsdev_id, tag in workspace_fsdev_ids:
+            cmd.extend(["-device", f"virtio-9p-device,fsdev={fsdev_id},mount_tag={tag}"])
+        cmd.extend(
+            [
+                "-device",
+                f"virtio-net-device,netdev=net0,mac={guest_mac}",
+                "-device",
+                f"virtio-blk-device,drive={root_drive_id}",
+            ]
+        )
+    else:
+        # See accel comment on the aarch64 branch above. Without
+        # accel=kvm on Linux, QEMU runs TCG and Ubuntu cloud-init blows
+        # past wait_for_ssh in seconds vs minutes.
+        if system == "Darwin":
+            machine_base, cpu_base = "q35,accel=hvf", "host"
+        else:
+            machine_base, cpu_base = "q35,accel=kvm", "host"
+        # Per-OS extras are comma-appended to the base. For _LINUX_SPEC
+        # both extra tuples are empty → byte-identical to the legacy form.
+        machine_str = ",".join((machine_base, *platform_spec.machine_extra_opts))
+        cpu_str = ",".join((cpu_base, *platform_spec.cpu_extra_flags))
+        cmd.extend(["-machine", machine_str, "-cpu", cpu_str])
+
+        # -global / -object entries from the spec. Linux: both empty.
+        for global_arg in platform_spec.extra_globals:
+            cmd.extend(["-global", global_arg])
+        for object_arg in platform_spec.extra_objects:
+            cmd.extend(["-object", object_arg])
+
+        # Firmware split-pflash (Windows). The CODE file is read-only and
+        # shared; the VARS file is per-VM (the manager materializes it
+        # from the spec's vars_template_path at create time).
+        if platform_spec.firmware is not None:
+            if firmware_vars_path is None:
+                raise SmolVMError(
+                    "Guest platform requires firmware split-pflash but no "
+                    "per-VM OVMF_VARS path was provided.",
+                    {"guest_os": platform_spec.guest_os.value},
+                )
+            cmd.extend(
+                [
+                    "-drive",
+                    (
+                        f"if=pflash,format=raw,unit=0,readonly=on,"
+                        f"file={platform_spec.firmware.code_path}"
+                    ),
+                    "-drive",
+                    f"if=pflash,format=raw,unit=1,file={firmware_vars_path}",
+                ]
+            )
+
+        # vTPM (Windows). The adapter starts swtpm before QEMU and passes
+        # its data-channel socket here; QEMU connects as a chardev client.
+        if platform_spec.requires_swtpm:
+            if swtpm_socket is None:
+                raise SmolVMError(
+                    "Guest platform requires swtpm but no socket path was "
+                    "provided.",
+                    {"guest_os": platform_spec.guest_os.value},
+                )
+            cmd.extend(
+                [
+                    "-chardev",
+                    f"socket,id=chrtpm,path={swtpm_socket}",
+                    "-tpmdev",
+                    "emulator,id=tpm0,chardev=chrtpm",
+                    "-device",
+                    f"{platform_spec.swtpm_device_model},tpmdev=tpm0",
+                ]
+            )
+
+        # Root disk topology. None (Linux default) keeps the historical
+        # virtio-blk-pci flat attachment. virtio-scsi-pci (Windows) emits
+        # a SCSI controller first, then a scsi-hd device bound to it —
+        # that's what the Windows vioscsi driver expects.
+        if platform_spec.root_disk_controller is None:
+            cmd.extend(["-device", f"virtio-blk-pci,drive={root_drive_id}"])
+        else:
+            cmd.extend(
+                [
+                    "-device",
+                    f"{platform_spec.root_disk_controller},id=scsi0",
+                    "-device",
+                    (
+                        f"{platform_spec.root_disk_device},"
+                        f"bus=scsi0.0,drive={root_drive_id}"
+                    ),
+                ]
+            )
+
+        cmd.extend(["-device", f"virtio-net-pci,netdev=net0,mac={guest_mac}"])
+
+        # Extra drives. Each AHCI port holds exactly one drive on q35, so
+        # ISO entries with cdrom_bus="ide" are round-robined across
+        # ide.0..ide.5. Non-ISO extras (or Linux's None cdrom_bus) keep
+        # the legacy virtio-blk-pci wiring.
+        ide_port_index = 0
+        for drive_id, drive_path in zip(extra_drive_ids, vm_info.config.extra_drives):
+            is_iso = drive_path.suffix.lower() == ".iso"
+            if is_iso and platform_spec.cdrom_bus == "ide":
+                cmd.extend(
+                    [
+                        "-device",
+                        f"ide-cd,bus=ide.{ide_port_index},drive={drive_id}",
+                    ]
+                )
+                ide_port_index += 1
+            else:
+                cmd.extend(["-device", f"virtio-blk-pci,drive={drive_id}"])
+
+        for fsdev_id, tag in workspace_fsdev_ids:
+            cmd.extend(["-device", f"virtio-9p-pci,fsdev={fsdev_id},mount_tag={tag}"])
+
+        # Trailing per-OS -device flags from the spec (e.g. qemu-xhci then
+        # usb-tablet for Windows). Emitted in declaration order so
+        # controllers always come before consumers.
+        for device_arg in platform_spec.extra_devices:
+            cmd.extend(["-device", device_arg])
+
+    return cmd

--- a/src/smolvm/types.py
+++ b/src/smolvm/types.py
@@ -382,9 +382,8 @@ class VMConfig(BaseModel):
             # boot manager; there is no direct-kernel path. The firmware-mode
             # invariants above then also pin backend='qemu' and kernel_path=None.
             raise ValueError(
-                "guest_os='windows' requires boot_mode='firmware' "
-                "(Windows boots via OVMF firmware reading the qcow2's UEFI "
-                "boot manager — no direct-kernel path)"
+                f"VM {self.vm_id!r}: guest_os='windows' requires "
+                "boot_mode='firmware' (Windows has no direct-kernel boot path)."
             )
         return self
 

--- a/src/smolvm/types.py
+++ b/src/smolvm/types.py
@@ -51,6 +51,7 @@ class GuestOS(str, Enum):
 
     ALPINE = "alpine"
     UBUNTU = "ubuntu"
+    WINDOWS = "windows"
 
 
 def _generate_vm_id() -> str:
@@ -320,6 +321,7 @@ class VMConfig(BaseModel):
     ]
     vcpu_count: Annotated[int, Field(ge=1, le=32)] = 2
     memory: Annotated[int, Field(ge=128, le=16384)] = 512
+    guest_os: GuestOS = GuestOS.ALPINE
     boot_mode: Literal["direct_kernel", "firmware"] = "direct_kernel"
     kernel_path: Path | None = None
     initrd_path: Path | None = None
@@ -375,6 +377,15 @@ class VMConfig(BaseModel):
         else:  # direct_kernel
             if self.kernel_path is None:
                 raise ValueError("boot_mode='direct_kernel' requires kernel_path to be set")
+        if self.guest_os is GuestOS.WINDOWS and self.boot_mode != "firmware":
+            # Windows always boots via OVMF firmware reading the qcow2's UEFI
+            # boot manager; there is no direct-kernel path. The firmware-mode
+            # invariants above then also pin backend='qemu' and kernel_path=None.
+            raise ValueError(
+                "guest_os='windows' requires boot_mode='firmware' "
+                "(Windows boots via OVMF firmware reading the qcow2's UEFI "
+                "boot manager — no direct-kernel path)"
+            )
         return self
 
     @field_validator("initrd_path")

--- a/src/smolvm/vm.py
+++ b/src/smolvm/vm.py
@@ -658,6 +658,16 @@ class SmolVMManager:
 
     def _ensure_snapshot_supported(self, vm_info: VMInfo) -> None:
         """Validate whether snapshot operations are supported for a VM."""
+        if vm_info.config.guest_os is GuestOS.WINDOWS:
+            # Snapshotting a Windows VM faithfully needs the qcow2, the OVMF
+            # NVRAM, AND the swtpm state captured atomically; that's a
+            # standalone design problem (multi-artifact snapshot atomicity)
+            # and not in Phase 1 scope.
+            raise SmolVMError(
+                "Snapshot and restore are not supported for Windows guests "
+                "in this release.",
+                {"vm_id": vm_info.vm_id},
+            )
         if vm_info.config.disk_mode != "isolated":
             raise SmolVMError("Snapshotting currently supports only isolated-disk VMs")
         if vm_info.config.extra_drives:
@@ -2014,6 +2024,31 @@ class SmolVMManager:
                     with suppress(Exception):
                         managed_disk.unlink()
                         logger.info("Removed isolated disk for VM %s: %s", vm_id, managed_disk)
+
+            # Per-VM firmware state (OVMF NVRAM + swtpm). Coupled to the
+            # disk lifecycle — kept iff retain_disk_on_delete is set so
+            # Secure Boot enrollment persists for a later VM with the
+            # same ID.
+            firmware_state = self.data_dir / "firmware" / vm_id
+            if firmware_state.exists():
+                retain = (
+                    vm_info is not None
+                    and vm_info.config.retain_disk_on_delete
+                )
+                if retain:
+                    logger.info(
+                        "Retaining per-VM firmware state for VM %s at %s",
+                        vm_id,
+                        firmware_state,
+                    )
+                else:
+                    with suppress(Exception):
+                        shutil.rmtree(firmware_state)
+                        logger.info(
+                            "Removed per-VM firmware state for VM %s: %s",
+                            vm_id,
+                            firmware_state,
+                        )
 
         except Exception as e:
             logger.warning("Error during cleanup for %s: %s", vm_id, e)

--- a/src/smolvm/vm.py
+++ b/src/smolvm/vm.py
@@ -53,10 +53,12 @@ from smolvm.runtime.backends import (
 )
 from smolvm.runtime.base import RuntimeContext, SnapshotCreateRequest, SnapshotRestoreRequest
 from smolvm.runtime.firecracker import FirecrackerRuntimeAdapter
+from smolvm.runtime.guest_platforms import get_guest_platform
 from smolvm.runtime.libkrun import LibkrunRuntimeAdapter
 from smolvm.runtime.qemu import QEMU_ROOT_NODE_NAME, QemuRuntimeAdapter
+from smolvm.runtime.qemu_args import build_qemu_argv
 from smolvm.storage import StateManagerProtocol, create_state_manager, ip_to_pool_index
-from smolvm.types import NetworkConfig, SnapshotInfo, VMConfig, VMInfo, VMState
+from smolvm.types import GuestOS, NetworkConfig, SnapshotInfo, VMConfig, VMInfo, VMState
 from smolvm.utils import RUNTIME_PRIVILEGE_SETUP_HINT, which
 
 logger = logging.getLogger(__name__)
@@ -127,30 +129,7 @@ def _qemu_install_hint() -> str:
     )
 QEMU_GATEWAY_IP = "10.0.2.2"
 QEMU_NETMASK = "255.255.255.0"
-QEMU_SLIRP_DNS = "10.0.2.3"
 SNAPSHOT_ID_PATTERN = re.compile(r"^[a-z0-9][a-z0-9_-]{0,62}[a-z0-9]$|^[a-z0-9]$")
-
-# Candidate UEFI firmware locations for aarch64 QEMU firmware-boot.
-# Searched in order; the first existing file wins. macOS Homebrew ships
-# edk2-aarch64-code.fd under the qemu data dir; Debian/Ubuntu split it into
-# a separate qemu-efi-aarch64 package; RHEL uses AAVMF.
-_AARCH64_EDK2_FIRMWARE_CANDIDATES: tuple[str, ...] = (
-    "/opt/homebrew/share/qemu/edk2-aarch64-code.fd",
-    "/usr/local/share/qemu/edk2-aarch64-code.fd",
-    "/usr/share/qemu-efi-aarch64/QEMU_EFI.fd",
-    "/usr/share/AAVMF/AAVMF_CODE.fd",
-    "/usr/share/edk2/aarch64/QEMU_EFI.fd",
-    "/usr/share/edk2-armvirt/aarch64/QEMU_EFI.fd",
-)
-
-
-def _find_aarch64_uefi_firmware() -> Path | None:
-    """Return the first existing aarch64 UEFI firmware file, or ``None``."""
-    for candidate in _AARCH64_EDK2_FIRMWARE_CANDIDATES:
-        path = Path(candidate)
-        if path.is_file():
-            return path
-    return None
 
 
 def _get_sudo_user_info() -> pwd.struct_passwd | None:
@@ -380,9 +359,12 @@ class SmolVMManager:
 
     def _runtime_context(self) -> RuntimeContext:
         """Build a shared adapter context from manager-owned helpers."""
+        firmware_dir = self.data_dir / "firmware"
+        firmware_dir.mkdir(parents=True, exist_ok=True)
         return RuntimeContext(
             data_dir=self.data_dir,
             socket_dir=self.socket_dir,
+            firmware_dir=firmware_dir,
             log_files=self._log_files,
             process_handles=self._process_handles,
             resolve_boot_args=self._resolve_boot_args,
@@ -575,6 +557,63 @@ class SmolVMManager:
             )
 
         return config.model_copy(update={"rootfs_path": instance_rootfs})
+
+    def _materialize_firmware(self, config: VMConfig) -> None:
+        """Create the per-VM OVMF NVRAM file for UEFI-firmware guests.
+
+        For Windows guests (the only Phase 1 firmware-required platform),
+        copies the system-wide ``OVMF_VARS.fd`` template to
+        ``data_dir/firmware/{vm_id}/OVMF_VARS.fd``. Subsequent VM starts
+        read and write the per-VM file directly — Secure Boot enrollment
+        and UEFI boot order persist across reboots.
+
+        No-op for Linux guests (no UEFI NVRAM needed). Idempotent: if
+        the per-VM file already exists, it is preserved as-is so prior
+        Secure Boot state isn't clobbered.
+        """
+        if config.guest_os is not GuestOS.WINDOWS:
+            return
+
+        # Resolving the spec also surfaces the macOS-host rejection and
+        # the missing-OVMF install hint at create time, rather than at
+        # start time when the user has already paid the cost of
+        # materializing the rootfs.
+        try:
+            spec = get_guest_platform(
+                config.guest_os,
+                host_system=platform.system(),
+                arch=platform.machine(),
+            )
+        except (NotImplementedError, ValueError) as exc:
+            raise SmolVMError(str(exc), {"vm_id": config.vm_id}) from exc
+
+        if spec.firmware is None:
+            return  # belt-and-braces; Windows spec always sets this
+
+        vm_firmware_dir = self.data_dir / "firmware" / config.vm_id
+        vm_firmware_dir.mkdir(parents=True, exist_ok=True)
+        target = vm_firmware_dir / "OVMF_VARS.fd"
+
+        if target.exists():
+            logger.info(
+                "Reusing per-VM OVMF NVRAM for VM %s at %s",
+                config.vm_id,
+                target,
+            )
+            return
+
+        template = spec.firmware.vars_template_path
+        logger.info(
+            "Materializing per-VM OVMF NVRAM for VM %s: %s -> %s",
+            config.vm_id,
+            template,
+            target,
+        )
+        shutil.copy2(template, target)
+        # NVRAM holds the UEFI variable store including any Secure Boot
+        # enrollment changes the guest makes. Lock down by-default to
+        # the SmolVM data-dir owner only.
+        target.chmod(0o600)
 
     def _managed_disk_for_vm(self, vm_info: VMInfo | None) -> Path | None:
         """Return the managed isolated disk path for a VM if applicable."""
@@ -872,6 +911,7 @@ class SmolVMManager:
             )
 
         effective_config = self._materialize_rootfs(effective_config)
+        self._materialize_firmware(effective_config)
 
         logger.info(
             "Creating VM: %s (backend=%s, disk_mode=%s)",
@@ -1564,8 +1604,15 @@ class SmolVMManager:
         control_socket_path: Path | None = None,
         start_paused: bool = False,
         root_node_name: str = QEMU_ROOT_NODE_NAME,
+        firmware_vars_path: Path | None = None,
+        swtpm_socket: Path | None = None,
     ) -> subprocess.Popen[bytes]:
         """Start a QEMU process for the qemu backend.
+
+        Thin shim: resolves the QEMU binary, the per-guest platform spec,
+        and pre-computes boot args, then delegates argv assembly to
+        :func:`smolvm.runtime.qemu_args.build_qemu_argv`. Spawning and
+        process-tracking stay here.
 
         Args:
             vm_info: VM info with persisted configuration/network.
@@ -1573,6 +1620,11 @@ class SmolVMManager:
             control_socket_path: Optional QMP control socket path.
             start_paused: Whether to start QEMU paused.
             root_node_name: QEMU block graph node name for the primary disk.
+            firmware_vars_path: Per-VM OVMF NVRAM path; required for
+                Windows guests. Passed in by the runtime adapter.
+            swtpm_socket: Per-VM swtpm data-channel socket path; required
+                for Windows guests. Spawned by the runtime adapter
+                before invoking this shim.
 
         Returns:
             The started QEMU process.
@@ -1584,169 +1636,24 @@ class SmolVMManager:
         if qemu_bin is None:
             raise SmolVMError(f"qemu-system binary is missing; {_qemu_install_hint()}")
 
-        if vm_info.network is None or vm_info.network.ssh_host_port is None:
-            raise SmolVMError("QEMU backend requires a reserved ssh_host_port in VM network config")
-
-        ssh_port = vm_info.network.ssh_host_port
-        guest_mac = vm_info.network.guest_mac.lower()
         boot_args = self._resolve_boot_args(vm_info)
-
-        qemu_name = qemu_bin.name
-        system = platform.system()
-
-        disk_format = "qcow2" if vm_info.config.rootfs_path.suffix == ".qcow2" else "raw"
-        root_drive_id = f"{root_node_name}-drive"
-        drive_arg = (
-            f"file={vm_info.config.rootfs_path},if=none,format={disk_format},"
-            f"id={root_drive_id},node-name={root_node_name}"
+        platform_spec = get_guest_platform(
+            vm_info.config.guest_os,
+            host_system=platform.system(),
+            arch=platform.machine(),
         )
-        hostfwd_rules = [f"hostfwd=tcp:127.0.0.1:{ssh_port}-:22"]
-        for forward in vm_info.config.port_forwards:
-            hostfwd_rules.append(
-                f"hostfwd=tcp:{forward.host_address}:{forward.host_port}-:{forward.guest_port}"
-            )
-        netdev_arg = f"user,id=net0,dns={QEMU_SLIRP_DNS},{','.join(hostfwd_rules)}"
 
-        cmd = [
-            str(qemu_bin),
-            "-smp",
-            str(vm_info.config.vcpu_count),
-            "-m",
-            str(vm_info.config.memory),
-        ]
-        # Boot mode: direct-kernel passes -kernel/-append (optionally -initrd);
-        # firmware mode lets QEMU boot the rootfs disk via default firmware
-        # (OVMF on aarch64, SeaBIOS on x86_64) — the guest kernel lives inside
-        # the rootfs image.
-        if vm_info.config.boot_mode == "direct_kernel":
-            cmd.extend(
-                [
-                    "-kernel",
-                    str(vm_info.config.kernel_path),
-                    "-append",
-                    boot_args,
-                ]
-            )
-        cmd.extend(
-            [
-                "-drive",
-                drive_arg,
-                "-netdev",
-                netdev_arg,
-                "-nographic",
-                "-no-reboot",
-            ]
+        cmd = build_qemu_argv(
+            vm_info,
+            qemu_bin=qemu_bin,
+            boot_args=boot_args,
+            platform_spec=platform_spec,
+            control_socket_path=control_socket_path,
+            firmware_vars_path=firmware_vars_path,
+            swtpm_socket=swtpm_socket,
+            start_paused=start_paused,
+            root_node_name=root_node_name,
         )
-        if vm_info.config.boot_mode == "direct_kernel" and vm_info.config.initrd_path is not None:
-            cmd.extend(["-initrd", str(vm_info.config.initrd_path)])
-
-        extra_drive_ids: list[str] = []
-        for index, drive_path in enumerate(vm_info.config.extra_drives):
-            drive_id = f"extra{index}-drive"
-            node_name = f"extra{index}"
-            extra_drive_ids.append(drive_id)
-            drive_suffix = drive_path.suffix.lower()
-            drive_format = "qcow2" if drive_suffix == ".qcow2" else "raw"
-            readonly = ["readonly=on"] if drive_suffix == ".iso" else []
-            extra_drive_arg = ",".join(
-                [
-                    f"file={drive_path}",
-                    "if=none",
-                    f"format={drive_format}",
-                    *readonly,
-                    f"id={drive_id}",
-                    f"node-name={node_name}",
-                ]
-            )
-            cmd.extend(["-drive", extra_drive_arg])
-
-        # ── virtio-9p workspace mounts ──────────────────────────────
-        workspace_fsdev_ids: list[tuple[str, str]] = []
-        for index, ws in enumerate(vm_info.config.workspace_mounts):
-            tag = ws.resolved_tag(index)
-            fsdev_id = f"fsdev-{tag}"
-            workspace_fsdev_ids.append((fsdev_id, tag))
-            fsdev_opts = f"local,id={fsdev_id},path={ws.host_path},security_model=mapped-xattr"
-            if not ws.writable:
-                fsdev_opts += ",readonly=on"
-            cmd.extend(["-fsdev", fsdev_opts])
-
-        if control_socket_path is not None:
-            cmd.extend(
-                [
-                    "-qmp",
-                    f"unix:{control_socket_path},server=on,wait=off",
-                ]
-            )
-        if start_paused:
-            cmd.append("-S")
-
-        if "aarch64" in qemu_name:
-            # Pick a hardware accelerator. Without one, QEMU falls back to
-            # TCG (software emulation), which is 10-50x slower and routinely
-            # blows past the 30s wait_for_ssh budget on cloud-init boots.
-            # macOS → Hypervisor.framework; Linux → KVM (if /dev/kvm is
-            # missing the user couldn't run firecracker either, so requiring
-            # KVM here is consistent).
-            if system == "Darwin":
-                machine, cpu = "virt,accel=hvf", "host"
-            else:
-                machine, cpu = "virt,accel=kvm", "host"
-            cmd.extend(["-machine", machine, "-cpu", cpu])
-            if vm_info.config.boot_mode == "firmware":
-                firmware_path = _find_aarch64_uefi_firmware()
-                if firmware_path is None:
-                    raise SmolVMError(
-                        "aarch64 firmware-boot requires UEFI firmware (edk2/AAVMF) "
-                        "but none was found. Searched: "
-                        f"{', '.join(_AARCH64_EDK2_FIRMWARE_CANDIDATES)}. "
-                        "On macOS run 'brew reinstall qemu'; on Debian/Ubuntu "
-                        "install 'qemu-efi-aarch64'."
-                    )
-                cmd.extend(["-bios", str(firmware_path)])
-            # virtio-MMIO device ordering note: on `-machine virt`, kernel
-            # enumeration of virtio-mmio slots is the REVERSE of the order
-            # the `-device` flags appear on the command line. To make sure
-            # the rootdisk lands at /dev/vda (and not /dev/vdb behind the
-            # cloud-init seed), the rootdisk-block device must be the LAST
-            # virtio-blk-device added. Workspace fsdevs and the NIC must
-            # come before it too.
-            for drive_id in extra_drive_ids:
-                cmd.extend(["-device", f"virtio-blk-device,drive={drive_id}"])
-            for fsdev_id, tag in workspace_fsdev_ids:
-                cmd.extend(["-device", f"virtio-9p-device,fsdev={fsdev_id},mount_tag={tag}"])
-            cmd.extend(
-                [
-                    "-device",
-                    f"virtio-net-device,netdev=net0,mac={guest_mac}",
-                    "-device",
-                    f"virtio-blk-device,drive={root_drive_id}",
-                ]
-            )
-        else:
-            # See accel comment on the aarch64 branch above. Without
-            # accel=kvm on Linux, QEMU runs TCG and Ubuntu cloud-init blows
-            # past wait_for_ssh in seconds vs minutes.
-            if system == "Darwin":
-                machine, cpu = "q35,accel=hvf", "host"
-            else:
-                machine, cpu = "q35,accel=kvm", "host"
-            cmd.extend(
-                [
-                    "-machine",
-                    machine,
-                    "-cpu",
-                    cpu,
-                    "-device",
-                    f"virtio-blk-pci,drive={root_drive_id}",
-                    "-device",
-                    f"virtio-net-pci,netdev=net0,mac={guest_mac}",
-                ]
-            )
-            for drive_id in extra_drive_ids:
-                cmd.extend(["-device", f"virtio-blk-pci,drive={drive_id}"])
-            for fsdev_id, tag in workspace_fsdev_ids:
-                cmd.extend(["-device", f"virtio-9p-pci,fsdev={fsdev_id},mount_tag={tag}"])
 
         logger.debug("Starting QEMU: %s", " ".join(cmd))
 
@@ -2129,6 +2036,8 @@ class SmolVMManager:
             effective_config = effective_config.model_copy(update={"backend": backend})
 
         effective_config = await self._async_materialize_rootfs(effective_config)
+        # Firmware materialization is a small file copy — synchronous is fine.
+        self._materialize_firmware(effective_config)
 
         logger.info(
             "Creating VM (async): %s (backend=%s, disk_mode=%s)",

--- a/src/smolvm/vm.py
+++ b/src/smolvm/vm.py
@@ -2468,5 +2468,29 @@ class SmolVMManager:
                         managed_disk.unlink()
                         logger.info("Removed isolated disk for VM %s: %s", vm_id, managed_disk)
 
+            # Per-VM firmware state (OVMF NVRAM + swtpm). Mirrors the sync
+            # _cleanup_resources path so async_delete() doesn't leave
+            # Windows-guest firmware behind.
+            firmware_state = self.data_dir / "firmware" / vm_id
+            if firmware_state.exists():
+                retain = (
+                    vm_info is not None
+                    and vm_info.config.retain_disk_on_delete
+                )
+                if retain:
+                    logger.info(
+                        "Retaining per-VM firmware state for VM %s at %s",
+                        vm_id,
+                        firmware_state,
+                    )
+                else:
+                    with suppress(Exception):
+                        shutil.rmtree(firmware_state)
+                        logger.info(
+                            "Removed per-VM firmware state for VM %s: %s",
+                            vm_id,
+                            firmware_state,
+                        )
+
         except Exception as e:
             logger.warning("Error during async cleanup for %s: %s", vm_id, e)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -864,16 +864,27 @@ class TestCliCreateImage:
         assert args.image == "s3://bucket/images/test/"
         assert args.os is None
 
-    def test_image_and_os_mutually_exclusive(
+    def test_image_and_os_parsed_together(self) -> None:
+        """--image and --os now both parse (Windows guests need both); the
+        facade rejects illegal combos at runtime with a clearer message."""
+        parser = build_parser()
+        args = parser.parse_args(
+            ["create", "--image", "s3://bucket/img/", "--os", "alpine"]
+        )
+        assert args.image == "s3://bucket/img/"
+        assert args.os == "alpine"
+
+    def test_s3_image_with_os_still_rejected_at_runtime(
         self,
         capsys: pytest.CaptureFixture[str],
     ) -> None:
-        """Argparse should reject --image and --os together."""
-        with pytest.raises(SystemExit) as exc_info:
-            main(["create", "--image", "s3://bucket/img/", "--os", "alpine"])
-
-        assert exc_info.value.code == 2
-        assert "not allowed" in capsys.readouterr().err
+        """S3 image + --os surfaces a one-sentence CLI error."""
+        ret = main(
+            ["create", "--image", "s3://bucket/img/", "--os", "alpine"]
+        )
+        assert ret == 1
+        err = capsys.readouterr().err
+        assert "--image (S3) and --os are mutually exclusive" in err
 
     def test_image_with_name_and_memory(self) -> None:
         """--image should work alongside --name, --memory, and --disk-size."""
@@ -914,6 +925,128 @@ class TestCliCreateImage:
         assert ret == 1
         err = capsys.readouterr().err
         assert "--disk-size is incompatible with --image" in err
+
+
+class TestCliCreateWindows:
+    """Tests for `smolvm create --os windows` routing."""
+
+    def test_windows_backend_explicit_firecracker_rejected(
+        self,
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        """`smolvm create --os windows --backend firecracker` fails cleanly."""
+        ret = main(
+            [
+                "create",
+                "--os",
+                "windows",
+                "--image",
+                "/tmp/win11.qcow2",
+                "--backend",
+                "firecracker",
+            ]
+        )
+        assert ret == 1
+        err = capsys.readouterr().err
+        assert "--os windows requires --backend qemu" in err
+        assert "firecracker" in err
+
+    def test_windows_backend_explicit_libkrun_rejected(
+        self,
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        """libkrun + Windows also fails with the same shape of error."""
+        ret = main(
+            [
+                "create",
+                "--os",
+                "windows",
+                "--image",
+                "/tmp/win11.qcow2",
+                "--backend",
+                "libkrun",
+            ]
+        )
+        assert ret == 1
+        err = capsys.readouterr().err
+        assert "--os windows requires --backend qemu" in err
+
+    def test_windows_without_image_surfaces_plain_english_error(
+        self,
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        """`smolvm create --os windows` (no --image) fires the facade error."""
+        ret = main(["create", "--os", "windows"])
+        assert ret == 1
+        err = capsys.readouterr().err
+        assert "Windows guests need a pre-installed disk image" in err
+
+    @patch("smolvm.facade._build_local_image_config")
+    @patch("smolvm.facade.SmolVM")
+    def test_windows_auto_selects_qemu_backend_and_routes_local_image(
+        self,
+        mock_vm_cls: MagicMock,
+        mock_build_local: MagicMock,
+        tmp_path: Path,
+    ) -> None:
+        """`--os windows --image PATH` auto-picks qemu and uses the local builder."""
+        disk = tmp_path / "win11.qcow2"
+        disk.touch()
+
+        config = MagicMock(vm_id="win-vm-1")
+        mock_build_local.return_value = (config, None)
+
+        vm = MagicMock()
+        vm.vm_id = "win-vm-1"
+        vm.info.config.backend = "qemu"
+        vm.info.network = MagicMock(spec=NetworkConfig)
+        vm.info.network.guest_ip = "10.0.2.15"
+        vm.info.network.ssh_host_port = 2222
+        mock_vm_cls.return_value = vm
+
+        ret = main(
+            [
+                "create",
+                "--name",
+                "win-vm-1",
+                "--os",
+                "windows",
+                "--image",
+                str(disk),
+                "--json",
+            ]
+        )
+        assert ret == 0
+        # The facade builder was called with the Windows-flavoured kwargs and
+        # the auto-picked qemu backend.
+        mock_build_local.assert_called_once_with(
+            image=str(disk),
+            os_input="windows",
+            backend="qemu",
+            memory=None,
+            ssh_key_path=None,
+            vm_name="win-vm-1",
+        )
+
+    def test_windows_with_explicit_backend_qemu_is_accepted(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        """`--os windows --backend qemu` parses without error (no auto-pick conflict)."""
+        parser = build_parser()
+        args = parser.parse_args(
+            [
+                "create",
+                "--os",
+                "windows",
+                "--image",
+                str(tmp_path / "win11.qcow2"),
+                "--backend",
+                "qemu",
+            ]
+        )
+        assert args.os == "windows"
+        assert args.backend == "qemu"
 
 
 class TestCliStop:

--- a/tests/test_facade.py
+++ b/tests/test_facade.py
@@ -26,7 +26,7 @@ from smolvm.exceptions import (
 )
 from smolvm.facade import SmolVM, _build_auto_config
 from smolvm.images.cloud_init import seed_cache_key
-from smolvm.types import VMConfig, VMState
+from smolvm.types import GuestOS, VMConfig, VMState
 
 
 @pytest.fixture
@@ -600,6 +600,148 @@ class TestVMImageParam:
             memory=1024,
             ssh_key_path=None,
         )
+
+
+class TestVMLocalImageParam:
+    """Tests for local-image (Windows POC) routing via the image= parameter."""
+
+    def test_is_local_image_truth_table(self) -> None:
+        """Detection should treat host paths and file:// URIs as local."""
+        from smolvm.facade import _is_local_image
+
+        # Locals
+        assert _is_local_image("/abs/path/to/disk.qcow2")
+        assert _is_local_image("~/win11-vm/disk.qcow2")
+        assert _is_local_image("relative/path/disk.qcow2")
+        assert _is_local_image("file:///abs/path/to/disk.qcow2")
+
+        # Remotes
+        assert not _is_local_image("s3://bucket/images/alpine/")
+        assert not _is_local_image("https://example.com/disk.qcow2")
+        assert not _is_local_image("http://example.com/disk.qcow2")
+
+    def test_windows_without_image_raises_plain_english(self) -> None:
+        """`os='windows'` with no image= must surface a plain-English error."""
+        with pytest.raises(ValueError, match="Windows guests need a pre-installed disk image"):
+            SmolVM(os="windows")
+
+    def test_windows_with_mounts_rejected(self, tmp_path: Path) -> None:
+        """Workspace mounts on Windows guests are Phase 2 scope."""
+        disk = tmp_path / "win11.qcow2"
+        disk.touch()
+        with pytest.raises(ValueError, match="mounts.* not yet supported for Windows"):
+            SmolVM(os="windows", image=str(disk), mounts=["/host/path"])
+
+    def test_windows_with_internet_settings_rejected(self, tmp_path: Path) -> None:
+        """Egress allowlist on Windows guests is Phase 2 scope."""
+        disk = tmp_path / "win11.qcow2"
+        disk.touch()
+        with pytest.raises(
+            ValueError, match="internet_settings.* not yet supported for Windows"
+        ):
+            SmolVM(
+                os="windows",
+                image=str(disk),
+                internet_settings={"allowed_domains": ["https://api.openai.com"]},
+            )
+
+    def test_s3_image_with_os_still_rejected(self) -> None:
+        """The image+os ban is preserved for S3 images (only relaxed for locals)."""
+        with pytest.raises(ValueError, match="mutually exclusive for S3 images"):
+            SmolVM(image="s3://bucket/images/alpine/", os="alpine")
+
+    def test_local_image_with_non_windows_os_rejected(self, tmp_path: Path) -> None:
+        """Local image with os='alpine' isn't supported in this release."""
+        disk = tmp_path / "rootfs.ext4"
+        disk.touch()
+        with pytest.raises(ValueError, match="only supported for os='windows'"):
+            SmolVM(image=str(disk), os="alpine")
+
+    def test_local_image_missing_file_raises(self, tmp_path: Path) -> None:
+        """A path that doesn't exist surfaces a plain-English error."""
+        with pytest.raises(ValueError, match="Local image not found"):
+            SmolVM(os="windows", image=str(tmp_path / "does-not-exist.qcow2"))
+
+    @patch("smolvm.facade.SmolVMManager")
+    @patch("smolvm.facade._build_local_image_config")
+    def test_local_windows_image_routes_to_local_builder(
+        self,
+        mock_build_local: MagicMock,
+        mock_sdk_cls: MagicMock,
+        tmp_path: Path,
+    ) -> None:
+        """Local image + os='windows' goes through _build_local_image_config."""
+        disk = tmp_path / "win11.qcow2"
+        disk.touch()
+
+        # Build a Windows VMConfig the dispatcher will then hand to the SDK.
+        config = VMConfig(
+            vm_id="vm-win",
+            rootfs_path=disk,
+            kernel_path=None,
+            backend="qemu",
+            guest_os=GuestOS.WINDOWS,
+            boot_mode="firmware",
+            disk_mode="shared",
+        )
+        mock_build_local.return_value = (config, str(tmp_path / "key"))
+
+        mock_sdk = MagicMock()
+        mock_sdk.create.return_value = MagicMock(vm_id="vm-win", status=VMState.CREATED)
+        mock_sdk_cls.return_value = mock_sdk
+
+        vm = SmolVM(os="windows", image=str(disk))
+
+        mock_build_local.assert_called_once()
+        call_kwargs = mock_build_local.call_args.kwargs
+        assert call_kwargs["image"] == str(disk)
+        assert call_kwargs["os_input"] == "windows"
+        assert vm.vm_id == "vm-win"
+
+    def test_build_local_image_config_produces_windows_vmconfig(
+        self, tmp_path: Path
+    ) -> None:
+        """_build_local_image_config returns a properly-shaped Windows VMConfig."""
+        from smolvm.facade import _build_local_image_config
+
+        disk = tmp_path / "win11.qcow2"
+        disk.write_bytes(b"fake qcow2")
+        key = tmp_path / "id_rsa"
+        key.touch()
+
+        config, ssh_key = _build_local_image_config(
+            image=str(disk),
+            os_input="windows",
+            backend=None,
+            memory=None,
+            ssh_key_path=str(key),
+        )
+
+        assert config.guest_os is GuestOS.WINDOWS
+        assert config.boot_mode == "firmware"
+        assert config.kernel_path is None
+        assert config.backend == "qemu"
+        assert config.disk_mode == "shared"
+        assert config.rootfs_path == disk
+        assert config.memory == 4096  # Windows default
+        assert ssh_key == str(key)
+
+    def test_build_local_image_config_rejects_non_qemu_backend(
+        self, tmp_path: Path
+    ) -> None:
+        """Firecracker + Windows = clear error before VMConfig validation."""
+        from smolvm.facade import _build_local_image_config
+
+        disk = tmp_path / "win11.qcow2"
+        disk.touch()
+        with pytest.raises(ValueError, match="only run on the QEMU backend"):
+            _build_local_image_config(
+                image=str(disk),
+                os_input="windows",
+                backend="firecracker",
+                memory=None,
+                ssh_key_path=None,
+            )
 
 
 class TestVMLifecycle:

--- a/tests/test_facade.py
+++ b/tests/test_facade.py
@@ -654,12 +654,12 @@ class TestVMLocalImageParam:
         """Local image with os='alpine' isn't supported in this release."""
         disk = tmp_path / "rootfs.ext4"
         disk.touch()
-        with pytest.raises(ValueError, match="only supported for os='windows'"):
+        with pytest.raises(ValueError, match="only support os='windows'"):
             SmolVM(image=str(disk), os="alpine")
 
     def test_local_image_missing_file_raises(self, tmp_path: Path) -> None:
         """A path that doesn't exist surfaces a plain-English error."""
-        with pytest.raises(ValueError, match="Local image not found"):
+        with pytest.raises(ValueError, match="does not exist"):
             SmolVM(os="windows", image=str(tmp_path / "does-not-exist.qcow2"))
 
     @patch("smolvm.facade.SmolVMManager")

--- a/tests/test_qemu_args.py
+++ b/tests/test_qemu_args.py
@@ -1,0 +1,195 @@
+# Copyright 2026 Celesto AI
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+
+"""Byte-identical-output tests for the pure QEMU argv builder.
+
+The builder ``build_qemu_argv`` was extracted from
+``SmolVMManager._start_qemu`` so it can be unit-tested without spawning
+QEMU. For the Linux all-defaults platform spec (``_LINUX_SPEC``) it must
+produce output byte-for-byte equivalent to the pre-refactor code path.
+The tests in this file lock that invariant: any change to the Linux argv
+shape must be intentional and explicitly captured here.
+"""
+
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from smolvm.exceptions import SmolVMError
+from smolvm.runtime.guest_platforms import (
+    _LINUX_SPEC,
+    FirmwareSpec,
+    _build_windows_spec,
+)
+from smolvm.runtime.qemu_args import build_qemu_argv
+from smolvm.types import GuestOS, NetworkConfig, VMConfig, VMInfo, VMState
+
+
+def _qemu_vm_info(tmp_path: Path, *, vm_id: str = "vm-test") -> VMInfo:
+    """A minimal Linux VMInfo wired for the QEMU backend."""
+    kernel = tmp_path / "vmlinux"
+    rootfs = tmp_path / "rootfs.ext4"
+    kernel.touch()
+    rootfs.touch()
+    return VMInfo(
+        vm_id=vm_id,
+        status=VMState.CREATED,
+        config=VMConfig(
+            vm_id=vm_id,
+            kernel_path=kernel,
+            rootfs_path=rootfs,
+            backend="qemu",
+            boot_args="console=ttyS0 reboot=k panic=1 init=/init",
+        ),
+        network=NetworkConfig(
+            guest_ip="10.0.2.15",
+            tap_device="qemu-user",
+            guest_mac="52:54:00:12:34:56",
+            ssh_host_port=2200,
+        ),
+    )
+
+
+def test_linux_x86_64_kvm_argv_byte_identical(tmp_path: Path) -> None:
+    """Linux x86_64 + KVM produces the legacy q35 argv exactly."""
+    vm_info = _qemu_vm_info(tmp_path)
+    cmd = build_qemu_argv(
+        vm_info,
+        qemu_bin=Path("/usr/bin/qemu-system-x86_64"),
+        boot_args=vm_info.config.boot_args,
+        platform_spec=_LINUX_SPEC,
+        host_system="Linux",
+    )
+
+    assert cmd == [
+        "/usr/bin/qemu-system-x86_64",
+        "-smp",
+        "2",
+        "-m",
+        "512",
+        "-kernel",
+        str(vm_info.config.kernel_path),
+        "-append",
+        "console=ttyS0 reboot=k panic=1 init=/init",
+        "-drive",
+        (
+            f"file={vm_info.config.rootfs_path},if=none,format=raw,"
+            "id=rootdisk0-drive,node-name=rootdisk0"
+        ),
+        "-netdev",
+        "user,id=net0,dns=10.0.2.3,hostfwd=tcp:127.0.0.1:2200-:22",
+        "-nographic",
+        "-no-reboot",
+        "-machine",
+        "q35,accel=kvm",
+        "-cpu",
+        "host",
+        "-device",
+        "virtio-blk-pci,drive=rootdisk0-drive",
+        "-device",
+        "virtio-net-pci,netdev=net0,mac=52:54:00:12:34:56",
+    ]
+
+
+def test_linux_x86_64_darwin_uses_hvf(tmp_path: Path) -> None:
+    """Darwin host swaps accel=kvm for accel=hvf; nothing else changes."""
+    vm_info = _qemu_vm_info(tmp_path)
+    cmd = build_qemu_argv(
+        vm_info,
+        qemu_bin=Path("/opt/homebrew/bin/qemu-system-x86_64"),
+        boot_args=vm_info.config.boot_args,
+        platform_spec=_LINUX_SPEC,
+        host_system="Darwin",
+    )
+
+    assert "-machine" in cmd
+    machine_arg = cmd[cmd.index("-machine") + 1]
+    assert machine_arg == "q35,accel=hvf"
+
+
+def test_linux_aarch64_kvm_orders_rootdisk_last(tmp_path: Path) -> None:
+    """aarch64 virt boots emit virtio-blk-device for root LAST (virtio-MMIO
+    reverse enumeration). Lock the exact ordering invariant."""
+    vm_info = _qemu_vm_info(tmp_path)
+    cmd = build_qemu_argv(
+        vm_info,
+        qemu_bin=Path("/opt/homebrew/bin/qemu-system-aarch64"),
+        boot_args=vm_info.config.boot_args,
+        platform_spec=_LINUX_SPEC,
+        host_system="Linux",
+    )
+
+    # Both -device pairs in order: NIC then root disk (root disk must be last).
+    device_pairs = [
+        (cmd[i + 1])
+        for i, tok in enumerate(cmd)
+        if tok == "-device"
+    ]
+    assert device_pairs == [
+        "virtio-net-device,netdev=net0,mac=52:54:00:12:34:56",
+        "virtio-blk-device,drive=rootdisk0-drive",
+    ]
+    machine_arg = cmd[cmd.index("-machine") + 1]
+    assert machine_arg == "virt,accel=kvm"
+
+
+def test_firmware_mode_aarch64_needs_uefi_firmware(tmp_path: Path) -> None:
+    """aarch64 firmware-boot raises a clear error when OVMF is absent."""
+    rootfs = tmp_path / "ubuntu.qcow2"
+    rootfs.touch()
+    config = VMConfig(
+        vm_id="vm-ubuntu",
+        kernel_path=None,
+        rootfs_path=rootfs,
+        backend="qemu",
+        boot_mode="firmware",
+        boot_args="",
+    )
+    vm_info = VMInfo(
+        vm_id="vm-ubuntu",
+        status=VMState.CREATED,
+        config=config,
+        network=NetworkConfig(
+            guest_ip="10.0.2.15",
+            tap_device="qemu-user",
+            guest_mac="52:54:00:12:34:56",
+            ssh_host_port=2201,
+        ),
+    )
+
+    with patch(
+        "smolvm.runtime.qemu_args._find_aarch64_uefi_firmware",
+        return_value=None,
+    ), pytest.raises(SmolVMError, match="aarch64 firmware-boot requires UEFI firmware"):
+        build_qemu_argv(
+            vm_info,
+            qemu_bin=Path("/usr/bin/qemu-system-aarch64"),
+            boot_args="",
+            platform_spec=_LINUX_SPEC,
+            host_system="Linux",
+        )
+
+
+def test_missing_ssh_host_port_raises(tmp_path: Path) -> None:
+    """The QEMU backend requires a reserved ssh_host_port."""
+    vm_info = _qemu_vm_info(tmp_path)
+    # Pydantic frozen model — swap the network for one without the port.
+    vm_info = vm_info.model_copy(
+        update={
+            "network": vm_info.network.model_copy(update={"ssh_host_port": None})
+        }
+    )
+    with pytest.raises(SmolVMError, match="ssh_host_port"):
+        build_qemu_argv(
+            vm_info,
+            qemu_bin=Path("/usr/bin/qemu-system-x86_64"),
+            boot_args=vm_info.config.boot_args,
+            platform_spec=_LINUX_SPEC,
+            host_system="Linux",
+        )

--- a/tests/test_qemu_args.py
+++ b/tests/test_qemu_args.py
@@ -193,3 +193,208 @@ def test_missing_ssh_host_port_raises(tmp_path: Path) -> None:
             platform_spec=_LINUX_SPEC,
             host_system="Linux",
         )
+
+
+# ───────────────────────── Windows guest tests ──────────────────────────
+
+
+def _windows_vm_info(tmp_path: Path, *, vm_id: str = "vm-win") -> VMInfo:
+    """A minimal Windows VMInfo wired for the QEMU backend."""
+    rootfs = tmp_path / "win11.qcow2"
+    rootfs.touch()
+    return VMInfo(
+        vm_id=vm_id,
+        status=VMState.CREATED,
+        config=VMConfig(
+            vm_id=vm_id,
+            kernel_path=None,
+            rootfs_path=rootfs,
+            backend="qemu",
+            guest_os=GuestOS.WINDOWS,
+            boot_mode="firmware",
+        ),
+        network=NetworkConfig(
+            guest_ip="10.0.2.15",
+            tap_device="qemu-user",
+            guest_mac="52:54:00:5d:00:01",
+            ssh_host_port=2201,
+        ),
+    )
+
+
+def _fake_windows_spec() -> object:
+    """Build a Windows GuestPlatformSpec with mocked OVMF discovery."""
+    fake = FirmwareSpec(
+        code_path=Path("/usr/share/OVMF/OVMF_CODE_4M.secboot.fd"),
+        vars_template_path=Path("/usr/share/OVMF/OVMF_VARS_4M.ms.fd"),
+    )
+    with patch(
+        "smolvm.runtime.guest_platforms._find_x86_64_ovmf",
+        return_value=fake,
+    ):
+        return _build_windows_spec(host_system="Linux", arch="x86_64")
+
+
+def test_build_windows_spec_raises_on_macos_host() -> None:
+    """Windows guests are Linux-host-only in this release."""
+    with pytest.raises(NotImplementedError, match="Linux hosts"):
+        _build_windows_spec(host_system="Darwin", arch="x86_64")
+
+
+def test_build_windows_spec_raises_on_arm_host() -> None:
+    """Windows-on-ARM is out of Phase 1 scope."""
+    with pytest.raises(NotImplementedError, match="aarch64|arm"):
+        _build_windows_spec(host_system="Linux", arch="aarch64")
+
+
+def test_build_windows_spec_raises_when_no_ovmf_found() -> None:
+    """Missing OVMF Secure Boot firmware raises a plain-English install hint."""
+    with patch(
+        "smolvm.runtime.guest_platforms._find_x86_64_ovmf",
+        return_value=None,
+    ), pytest.raises(ValueError, match="OVMF Secure Boot firmware"):
+        _build_windows_spec(host_system="Linux", arch="x86_64")
+
+
+def test_build_windows_spec_populates_expected_fields() -> None:
+    """The Windows spec carries every override the QEMU builder needs."""
+    spec = _fake_windows_spec()
+    assert spec.guest_os is GuestOS.WINDOWS
+    assert spec.name == "windows"
+    assert spec.forced_boot_mode == "firmware"
+    assert spec.skip_kernel_cmdline_injection is True
+    assert spec.skip_workspace_mounts is True
+    assert "smm=on" in spec.machine_extra_opts
+    assert "vmport=off" in spec.machine_extra_opts
+    assert "kernel-irqchip=on" in spec.machine_extra_opts
+    assert "hv_relaxed" in spec.cpu_extra_flags
+    assert "hv_vapic" in spec.cpu_extra_flags
+    assert "hv_spinlocks=0x1fff" in spec.cpu_extra_flags
+    assert spec.root_disk_controller == "virtio-scsi-pci"
+    assert spec.root_disk_device == "scsi-hd"
+    assert spec.cdrom_bus == "ide"
+    assert spec.firmware is not None
+    assert spec.requires_swtpm is True
+    assert spec.swtpm_device_model == "tpm-crb"
+    # Trailing -device entries: USB controller, then tablet binding to it.
+    assert spec.extra_devices == (
+        "qemu-xhci,id=xhci",
+        "usb-tablet,bus=xhci.0",
+    )
+
+
+def test_windows_argv_skips_kernel_and_emits_firmware_pflash(tmp_path: Path) -> None:
+    """No direct-kernel artefacts; OVMF split-pflash drives appear."""
+    spec = _fake_windows_spec()
+    vm_info = _windows_vm_info(tmp_path)
+    cmd = build_qemu_argv(
+        vm_info,
+        qemu_bin=Path("/usr/bin/qemu-system-x86_64"),
+        boot_args="",
+        platform_spec=spec,
+        firmware_vars_path=Path("/state/vm-win/OVMF_VARS.fd"),
+        swtpm_socket=Path("/state/vm-win/swtpm-sock"),
+        host_system="Linux",
+    )
+
+    # Windows is firmware-only — no direct-kernel artefacts.
+    assert "-kernel" not in cmd
+    assert "-append" not in cmd
+    assert "-initrd" not in cmd
+
+    # Both pflash drives (code = readonly, vars = writable).
+    drive_args = [cmd[i + 1] for i, tok in enumerate(cmd) if tok == "-drive"]
+    pflash_drives = [d for d in drive_args if "if=pflash" in d]
+    assert len(pflash_drives) == 2
+    code_drive, vars_drive = pflash_drives
+    assert "readonly=on" in code_drive
+    assert "OVMF_CODE_4M.secboot.fd" in code_drive
+    assert "readonly=on" not in vars_drive
+    assert "/state/vm-win/OVMF_VARS.fd" in vars_drive
+
+
+def test_windows_argv_emits_smm_machine_and_hyperv_cpu(tmp_path: Path) -> None:
+    """The machine sub-options and CPU flags Windows needs."""
+    spec = _fake_windows_spec()
+    cmd = build_qemu_argv(
+        _windows_vm_info(tmp_path),
+        qemu_bin=Path("/usr/bin/qemu-system-x86_64"),
+        boot_args="",
+        platform_spec=spec,
+        firmware_vars_path=Path("/state/OVMF_VARS.fd"),
+        swtpm_socket=Path("/state/swtpm-sock"),
+        host_system="Linux",
+    )
+
+    machine_arg = cmd[cmd.index("-machine") + 1]
+    for option in ("q35", "accel=kvm", "smm=on", "vmport=off", "kernel-irqchip=on"):
+        assert option in machine_arg, f"missing {option!r} in machine arg: {machine_arg!r}"
+
+    cpu_arg = cmd[cmd.index("-cpu") + 1]
+    for flag in ("host", "hv_relaxed", "hv_vapic", "hv_spinlocks=0x1fff"):
+        assert flag in cpu_arg, f"missing {flag!r} in cpu arg: {cpu_arg!r}"
+
+    global_args = [cmd[i + 1] for i, tok in enumerate(cmd) if tok == "-global"]
+    assert any("cfi.pflash01" in g for g in global_args)
+    assert any("ICH9-LPC.disable_s3=1" in g for g in global_args)
+
+
+def test_windows_argv_emits_virtio_scsi_root_and_tpm(tmp_path: Path) -> None:
+    """Root disk on virtio-scsi (with scsi-hd) and tpm-crb device."""
+    spec = _fake_windows_spec()
+    cmd = build_qemu_argv(
+        _windows_vm_info(tmp_path),
+        qemu_bin=Path("/usr/bin/qemu-system-x86_64"),
+        boot_args="",
+        platform_spec=spec,
+        firmware_vars_path=Path("/state/OVMF_VARS.fd"),
+        swtpm_socket=Path("/state/swtpm-sock"),
+        host_system="Linux",
+    )
+
+    device_args = [cmd[i + 1] for i, tok in enumerate(cmd) if tok == "-device"]
+    assert "virtio-scsi-pci,id=scsi0" in device_args
+    assert "scsi-hd,bus=scsi0.0,drive=rootdisk0-drive" in device_args
+    # NO legacy virtio-blk-pci attachment for the root disk.
+    assert not any(
+        d.startswith("virtio-blk-pci,drive=rootdisk0") for d in device_args
+    )
+    # USB topology: controller first, then tablet binding to it.
+    assert device_args.index("qemu-xhci,id=xhci") < device_args.index(
+        "usb-tablet,bus=xhci.0"
+    )
+    # TPM CRB device.
+    assert "tpm-crb,tpmdev=tpm0" in device_args
+    # And the chardev + tpmdev tokens.
+    assert "-tpmdev" in cmd
+    assert "-chardev" in cmd
+
+
+def test_windows_argv_missing_firmware_vars_path_raises(tmp_path: Path) -> None:
+    """Caller must provide a per-VM OVMF_VARS path when spec has firmware."""
+    spec = _fake_windows_spec()
+    with pytest.raises(SmolVMError, match="OVMF_VARS"):
+        build_qemu_argv(
+            _windows_vm_info(tmp_path),
+            qemu_bin=Path("/usr/bin/qemu-system-x86_64"),
+            boot_args="",
+            platform_spec=spec,
+            firmware_vars_path=None,
+            swtpm_socket=Path("/state/swtpm-sock"),
+            host_system="Linux",
+        )
+
+
+def test_windows_argv_missing_swtpm_socket_raises(tmp_path: Path) -> None:
+    """Caller must provide an swtpm socket when the spec requires TPM."""
+    spec = _fake_windows_spec()
+    with pytest.raises(SmolVMError, match="swtpm"):
+        build_qemu_argv(
+            _windows_vm_info(tmp_path),
+            qemu_bin=Path("/usr/bin/qemu-system-x86_64"),
+            boot_args="",
+            platform_spec=spec,
+            firmware_vars_path=Path("/state/OVMF_VARS.fd"),
+            swtpm_socket=None,
+            host_system="Linux",
+        )

--- a/tests/test_runtime_qemu.py
+++ b/tests/test_runtime_qemu.py
@@ -16,6 +16,7 @@ def _make_context() -> RuntimeContext:
     return RuntimeContext(
         data_dir=Path("/tmp/data"),
         socket_dir=Path("/tmp"),
+        firmware_dir=Path("/tmp/data/firmware"),
         log_files={},
         process_handles={},
         resolve_boot_args=lambda vm_info: vm_info.config.boot_args,

--- a/tests/test_snapshot_qemu.py
+++ b/tests/test_snapshot_qemu.py
@@ -22,7 +22,15 @@ import pytest
 
 from smolvm.exceptions import SmolVMError, VMNotFoundError
 from smolvm.runtime.qemu import QemuRuntimeAdapter
-from smolvm.types import SnapshotArtifacts, SnapshotInfo, VMConfig, VMState
+from smolvm.types import (
+    GuestOS,
+    NetworkConfig,
+    SnapshotArtifacts,
+    SnapshotInfo,
+    VMConfig,
+    VMInfo,
+    VMState,
+)
 from smolvm.vm import SmolVMManager
 
 
@@ -374,3 +382,33 @@ def test_delete_qemu_snapshot_rejects_active_restored_vm(
 
     with pytest.raises(SmolVMError, match="active"):
         qemu_smol_vm.delete_snapshot("snap-001")
+
+
+def test_snapshot_rejected_for_windows_guests(
+    qemu_smol_vm: SmolVMManager, tmp_path: Path
+) -> None:
+    """Windows snapshot/restore is locked out in Phase 1 with a clear message."""
+    rootfs = tmp_path / "win11.qcow2"
+    rootfs.touch()
+    config = VMConfig(
+        vm_id="vm-win-snap",
+        kernel_path=None,
+        rootfs_path=rootfs,
+        backend="qemu",
+        guest_os=GuestOS.WINDOWS,
+        boot_mode="firmware",
+        disk_mode="shared",
+    )
+    vm_info = VMInfo(
+        vm_id="vm-win-snap",
+        status=VMState.RUNNING,
+        config=config,
+        network=NetworkConfig(
+            guest_ip="10.0.2.15",
+            tap_device="qemu-user",
+            guest_mac="52:54:00:5d:00:01",
+            ssh_host_port=2202,
+        ),
+    )
+    with pytest.raises(SmolVMError, match="Windows guests"):
+        qemu_smol_vm._ensure_snapshot_supported(vm_info)

--- a/tests/test_swtpm_sidecar.py
+++ b/tests/test_swtpm_sidecar.py
@@ -1,0 +1,161 @@
+# Copyright 2026 Celesto AI
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+
+"""Unit tests for the per-VM swtpm sidecar used by Windows guests."""
+
+import subprocess
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from smolvm.exceptions import SmolVMError
+from smolvm.runtime.base import RuntimeContext
+from smolvm.runtime.qemu import _SwtpmSidecar
+
+
+def _make_context(firmware_dir: Path) -> RuntimeContext:
+    """A minimal runtime context where only is_process_running matters."""
+    return RuntimeContext(
+        data_dir=Path("/tmp/data"),
+        socket_dir=Path("/tmp"),
+        firmware_dir=firmware_dir,
+        log_files={},
+        process_handles={},
+        resolve_boot_args=lambda vm_info: vm_info.config.boot_args,
+        start_firecracker=MagicMock(),
+        start_qemu=MagicMock(),
+        unlink_socket=MagicMock(),
+        kill_process=MagicMock(),
+        wait_for_process=MagicMock(),
+        is_process_running=MagicMock(return_value=False),
+        find_qemu_binary=MagicMock(),
+    )
+
+
+def test_socket_path_under_per_vm_state_dir(tmp_path: Path) -> None:
+    """The data socket lives at firmware_dir/{vm_id}/swtpm/swtpm-sock."""
+    context = _make_context(tmp_path)
+    sidecar = _SwtpmSidecar(
+        vm_id="vm-win",
+        firmware_dir=tmp_path,
+        context=context,
+    )
+    assert sidecar.socket_path == tmp_path / "vm-win" / "swtpm" / "swtpm-sock"
+    assert sidecar.pidfile_path == tmp_path / "vm-win" / "swtpm" / "swtpm.pid"
+
+
+def test_start_raises_clear_error_when_swtpm_binary_missing(tmp_path: Path) -> None:
+    """Missing swtpm on PATH produces a plain-English install hint."""
+    context = _make_context(tmp_path)
+    sidecar = _SwtpmSidecar(
+        vm_id="vm-win",
+        firmware_dir=tmp_path,
+        context=context,
+    )
+    with patch("smolvm.runtime.qemu.which", return_value=None), pytest.raises(
+        SmolVMError, match="swtpm"
+    ):
+        sidecar.start()
+
+
+def test_start_spawns_swtpm_with_expected_arguments(tmp_path: Path) -> None:
+    """The swtpm invocation matches the documented daemon-socket form."""
+    context = _make_context(tmp_path)
+    sidecar = _SwtpmSidecar(
+        vm_id="vm-win",
+        firmware_dir=tmp_path,
+        context=context,
+    )
+
+    fake_pid = 99001
+
+    def fake_run(cmd: list[str], **_kwargs: object) -> subprocess.CompletedProcess[str]:
+        # swtpm in --daemon mode forks; simulate by writing the socket + pidfile.
+        sidecar.socket_path.touch()
+        sidecar.pidfile_path.write_text(f"{fake_pid}\n")
+        return subprocess.CompletedProcess(cmd, returncode=0, stdout="", stderr="")
+
+    with patch(
+        "smolvm.runtime.qemu.which",
+        return_value=Path("/usr/bin/swtpm"),
+    ), patch("smolvm.runtime.qemu.subprocess.run", side_effect=fake_run) as mock_run:
+        returned_pid = sidecar.start()
+
+    assert returned_pid == fake_pid
+    cmd = mock_run.call_args.args[0]
+    assert cmd[0] == "/usr/bin/swtpm"
+    assert "socket" in cmd
+    assert "--tpm2" in cmd
+    assert "--daemon" in cmd
+    # tpmstate dir, ctrl socket, pidfile all point under the per-VM state dir.
+    state_dir = tmp_path / "vm-win" / "swtpm"
+    assert f"dir={state_dir}" in cmd
+    assert f"type=unixio,path={state_dir / 'swtpm-sock'}" in cmd
+    assert f"file={state_dir / 'swtpm.pid'}" in cmd
+
+
+def test_start_raises_when_socket_never_appears(tmp_path: Path) -> None:
+    """If swtpm starts but never creates its socket, raise loudly."""
+    context = _make_context(tmp_path)
+    sidecar = _SwtpmSidecar(
+        vm_id="vm-win",
+        firmware_dir=tmp_path,
+        context=context,
+    )
+
+    def fake_run(cmd: list[str], **_kwargs: object) -> subprocess.CompletedProcess[str]:
+        return subprocess.CompletedProcess(cmd, returncode=0, stdout="", stderr="")
+
+    with patch(
+        "smolvm.runtime.qemu.which",
+        return_value=Path("/usr/bin/swtpm"),
+    ), patch("smolvm.runtime.qemu.subprocess.run", side_effect=fake_run), pytest.raises(
+        SmolVMError, match="socket never appeared"
+    ):
+        sidecar.start(timeout=0.2)
+
+
+def test_stop_sigterms_the_daemon_and_unlinks_files(tmp_path: Path) -> None:
+    """stop() reads the pidfile, SIGTERMs, then removes the socket + pidfile."""
+    context = _make_context(tmp_path)
+    sidecar = _SwtpmSidecar(
+        vm_id="vm-win",
+        firmware_dir=tmp_path,
+        context=context,
+    )
+
+    sidecar.socket_path.parent.mkdir(parents=True, exist_ok=True)
+    sidecar.socket_path.touch()
+    sidecar.pidfile_path.write_text("12345\n")
+
+    # First call: process is alive (signal sent). Subsequent polls: gone.
+    # Extra Falses cover the post-wait re-check that would SIGKILL if needed.
+    context.is_process_running.side_effect = [True, False, False, False]
+
+    with patch("smolvm.runtime.qemu.os.kill") as mock_kill:
+        sidecar.stop()
+
+    mock_kill.assert_called_once()
+    pid_arg, _signal_arg = mock_kill.call_args.args
+    assert pid_arg == 12345
+
+    assert not sidecar.socket_path.exists()
+    assert not sidecar.pidfile_path.exists()
+
+
+def test_stop_is_safe_when_pidfile_missing(tmp_path: Path) -> None:
+    """stop() must not raise when nothing is around to clean up."""
+    context = _make_context(tmp_path)
+    sidecar = _SwtpmSidecar(
+        vm_id="vm-win",
+        firmware_dir=tmp_path,
+        context=context,
+    )
+    # Don't create any files. stop() should be a clean no-op.
+    sidecar.stop()

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -356,6 +356,53 @@ class TestVMConfig:
                 disk_mode="snapshot",
             )
 
+    def test_windows_guest_requires_firmware_boot(self, tmp_path: Path) -> None:
+        """Windows guests must boot via OVMF firmware — no direct-kernel path."""
+        kernel = tmp_path / "vmlinux"
+        rootfs = tmp_path / "win11.qcow2"
+        kernel.touch()
+        rootfs.touch()
+
+        with pytest.raises(ValidationError, match="windows.*requires boot_mode='firmware'"):
+            VMConfig(
+                vm_id="vm-win",
+                kernel_path=kernel,
+                rootfs_path=rootfs,
+                backend="qemu",
+                guest_os=GuestOS.WINDOWS,
+                boot_mode="direct_kernel",
+            )
+
+    def test_windows_guest_with_firmware_boot_is_accepted(self, tmp_path: Path) -> None:
+        """Windows + firmware + qemu + no kernel = a valid config."""
+        rootfs = tmp_path / "win11.qcow2"
+        rootfs.touch()
+
+        config = VMConfig(
+            vm_id="vm-win",
+            kernel_path=None,
+            rootfs_path=rootfs,
+            backend="qemu",
+            guest_os=GuestOS.WINDOWS,
+            boot_mode="firmware",
+        )
+        assert config.guest_os is GuestOS.WINDOWS
+        assert config.boot_mode == "firmware"
+
+    def test_linux_default_guest_os_is_alpine(self, tmp_path: Path) -> None:
+        """Existing Linux callers that don't set guest_os get ALPINE by default."""
+        kernel = tmp_path / "vmlinux"
+        rootfs = tmp_path / "rootfs.ext4"
+        kernel.touch()
+        rootfs.touch()
+
+        config = VMConfig(
+            vm_id="vm-linux",
+            kernel_path=kernel,
+            rootfs_path=rootfs,
+        )
+        assert config.guest_os is GuestOS.ALPINE
+
 
 class TestVMState:
     """Tests for VMState enum."""

--- a/tests/test_vm_qemu.py
+++ b/tests/test_vm_qemu.py
@@ -188,6 +188,104 @@ def test_create_qemu_uses_managed_qcow2_disk(tmp_path: Path) -> None:
     assert expected_disk.read_text() == "managed-qcow2"
 
 
+def test_materialize_firmware_noop_for_linux_guests(tmp_path: Path) -> None:
+    """Linux guests don't need per-VM OVMF NVRAM — _materialize_firmware is a no-op."""
+    kernel = tmp_path / "vmlinux"
+    rootfs = tmp_path / "rootfs.ext4"
+    kernel.touch()
+    rootfs.touch()
+    config = VMConfig(
+        vm_id="vm-linux",
+        kernel_path=kernel,
+        rootfs_path=rootfs,
+        backend="qemu",
+    )
+
+    sdk = SmolVMManager(
+        data_dir=tmp_path / "data",
+        socket_dir=tmp_path / "sockets",
+        backend="qemu",
+    )
+    sdk._materialize_firmware(config)
+    # No firmware dir should be created for Linux VMs.
+    assert not (sdk.data_dir / "firmware" / "vm-linux").exists()
+
+
+def test_materialize_firmware_copies_ovmf_template_for_windows(tmp_path: Path) -> None:
+    """Windows guests get a per-VM OVMF_VARS.fd copied from the system template."""
+    from smolvm.runtime.guest_platforms import FirmwareSpec
+    from smolvm.types import GuestOS
+
+    rootfs = tmp_path / "win11.qcow2"
+    rootfs.touch()
+
+    # Fake the system OVMF template — both files have to exist for our copy.
+    template = tmp_path / "OVMF_VARS_4M.ms.fd"
+    template.write_bytes(b"fake-ovmf-vars-template")
+    code = tmp_path / "OVMF_CODE_4M.secboot.fd"
+    code.touch()
+    fake_spec_firmware = FirmwareSpec(code_path=code, vars_template_path=template)
+
+    config = VMConfig(
+        vm_id="vm-win",
+        kernel_path=None,
+        rootfs_path=rootfs,
+        backend="qemu",
+        guest_os=GuestOS.WINDOWS,
+        boot_mode="firmware",
+        disk_mode="shared",  # don't try to overlay a Windows qcow2
+    )
+
+    sdk = SmolVMManager(
+        data_dir=tmp_path / "data",
+        socket_dir=tmp_path / "sockets",
+        backend="qemu",
+    )
+    with patch(
+        "smolvm.runtime.guest_platforms._find_x86_64_ovmf",
+        return_value=fake_spec_firmware,
+    ), patch("smolvm.vm.platform.system", return_value="Linux"), patch(
+        "smolvm.vm.platform.machine", return_value="x86_64"
+    ):
+        sdk._materialize_firmware(config)
+
+    target = sdk.data_dir / "firmware" / "vm-win" / "OVMF_VARS.fd"
+    assert target.exists()
+    assert target.read_bytes() == b"fake-ovmf-vars-template"
+    # NVRAM is locked down (owner-only) by-default.
+    assert (target.stat().st_mode & 0o777) == 0o600
+
+
+def test_materialize_firmware_raises_with_install_hint_when_no_ovmf(tmp_path: Path) -> None:
+    """Missing OVMF gives a plain-English install hint at create time."""
+    from smolvm.types import GuestOS
+
+    rootfs = tmp_path / "win11.qcow2"
+    rootfs.touch()
+    config = VMConfig(
+        vm_id="vm-win-no-ovmf",
+        kernel_path=None,
+        rootfs_path=rootfs,
+        backend="qemu",
+        guest_os=GuestOS.WINDOWS,
+        boot_mode="firmware",
+        disk_mode="shared",
+    )
+
+    sdk = SmolVMManager(
+        data_dir=tmp_path / "data",
+        socket_dir=tmp_path / "sockets",
+        backend="qemu",
+    )
+    with patch(
+        "smolvm.runtime.guest_platforms._find_x86_64_ovmf",
+        return_value=None,
+    ), patch("smolvm.vm.platform.system", return_value="Linux"), patch(
+        "smolvm.vm.platform.machine", return_value="x86_64"
+    ), pytest.raises(SmolVMError, match="OVMF"):
+        sdk._materialize_firmware(config)
+
+
 def test_delete_qemu_retains_isolated_disk_when_enabled(tmp_path: Path) -> None:
     """retain_disk_on_delete should preserve managed qcow2 disks for QEMU VMs."""
     kernel = tmp_path / "vmlinux"


### PR DESCRIPTION
## Summary

Phase 1 of Windows-as-guest support for SmolVM. After this lands, a user can boot a pre-installed Windows 11 qcow2 via `SmolVM(os="windows", image=...)` on Linux hosts. SSH-into-Windows, the autounattend image build pipeline, and macOS host support are deliberate Phase 2/3 scope.

- **New `GuestPlatformSpec` abstraction** (`src/smolvm/runtime/guest_platforms.py`): frozen dataclass of QEMU command fragments, mirroring `BootProfileSpec`. Linux is the all-defaults instance; Windows carries q35+SMM+vmport=off, Hyper-V enlightenments, virtio-scsi root, IDE CD-ROMs, qemu-xhci+usb-tablet, OVMF split-pflash, and the tpm-crb sidecar requirement.
- **Pure `build_qemu_argv()`** (`src/smolvm/runtime/qemu_args.py`) extracted from the 200-line `_start_qemu` monolith — unit-testable without spawning QEMU. Snapshot tests lock byte-identical Linux argv pre/post-refactor.
- **`_SwtpmSidecar`** (private to `runtime/qemu.py`): per-VM swtpm process, spawned by `QemuRuntimeAdapter.start()` before QEMU, torn down after.
- **x86_64 OVMF discovery** probes the four distro install paths (Debian `_4M.secboot`, Fedora `.secboot`, Arch `.4m.fd`, Homebrew) and raises a plain-English install hint when missing.
- **`SmolVM(os="windows", image=...)`**: `image=` now accepts local paths and `file://` URIs alongside S3 URIs (relaxed for local images only). Windows guest + `mounts=` / `internet_settings=` / no `image=` → clear Phase-1-scope errors.
- **VMConfig invariants**: Windows ⇒ firmware boot ⇒ qemu backend ⇒ no kernel_path. Snapshot/restore rejected for Windows VMs (multi-artifact atomic snapshot is out of Phase 1 scope).
- **Per-VM firmware state** lives at `data_dir/firmware/{vm_id}/` (`OVMF_VARS.fd` + `swtpm/`), cleaned up on delete unless `retain_disk_on_delete=True`.

Design docs in `docs/deep-dive/windows-guest-qemu.md`. The deep-dive spells out every QEMU flag choice and links upstream sources.

29 new tests added; full suite 960 pass / 13 pre-existing skip / zero regressions. Verified end-to-end against \`~/win11-vm/disk-baseline.qcow2\` on Ubuntu 26.04: VM constructs, swtpm sidecar spawns, QEMU boots, clean stop reaps both processes and cleans up sockets/pidfiles.

## Test plan

- [x] \`pytest\` — 960 pass, 13 pre-existing skip, no regressions
- [x] \`ruff check\` — clean on all changed files
- [x] Byte-identical Linux argv invariant locked via snapshot tests
- [x] End-to-end: \`SmolVM(os="windows", image="~/win11-vm/disk-baseline.qcow2")\` boots Windows 11, swtpm sidecar tracked, clean stop verified
- [ ] Manual: try on a host *without* \`ovmf\` installed — confirm the install-hint error message reads cleanly
- [ ] Manual: try on macOS host — confirm the "Linux hosts only" rejection

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Windows guests: UEFI firmware boot with Secure Boot and TPM 2.0 emulation, per‑VM firmware state, and local file-based disk image support.
  * Improved cross-arch QEMU command-line generation and a managed software-TPM sidecar.

* **Behavior Changes / Restrictions**
  * Windows VMs must use firmware boot; snapshot creation for Windows guests is rejected.
  * Local Windows images require explicit OS selection and are restricted to the QEMU backend; some mounts/internet options are disallowed.

* **Documentation**
  * Detailed Windows-on-QEMU/KVM guide added.

* **Chores**
  * .gitignore updated to exclude working notes and ISO files.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/CelestoAI/SmolVM/pull/302?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->