### PR TITLE
Phase 2: vm.run() and vm.upload_file() work on Windows guests

### DIFF
--- a/src/smolvm/facade.py
+++ b/src/smolvm/facade.py
@@ -337,6 +337,27 @@ def _windows_guest_parent_dir(path: str) -> str:
     return parent
 
 
+def _windows_path_for_powershell(path: str) -> str:
+    """Convert any accepted Windows path form into one PowerShell will parse.
+
+    Paramiko/SFTP accepts the leading-slash SFTP form (``/C:/Users/foo``),
+    the bare drive-letter forward-slash form (``C:/Users/foo``), and the
+    Windows-native backslash form (``C:\\Users\\foo``) interchangeably.
+    PowerShell's path parser, however, treats a leading ``/`` as a
+    drive-relative path from the current PSDrive root and chokes on
+    ``/C:/...``. This helper strips the leading slash (if any) and
+    normalises separators to backslashes so the result is always a
+    native Windows path PowerShell can consume.
+
+    Input shapes handled:
+      - ``/C:/Users/foo`` -> ``C:\\Users\\foo``
+      - ``C:/Users/foo``  -> ``C:\\Users\\foo``
+      - ``C:\\Users\\foo`` -> ``C:\\Users\\foo`` (unchanged)
+    """
+    stripped = path.lstrip("/")
+    return stripped.replace("/", "\\")
+
+
 def _build_auto_config_image_name(
     guest_os: GuestOS,
     *,
@@ -769,8 +790,12 @@ class SmolVM:
             ``~/.smolvm/keys/id_ed25519`` when needed.
         ssh_password: Optional SSH password (paramiko password auth).
             Used when the guest has password-only SSH (e.g. a Windows
-            POC qcow2). Ignored when *ssh_key_path* is also set —
-            paramiko prefers key auth.
+            POC qcow2). **Takes precedence over** *ssh_key_path*: when
+            ``ssh_password`` is set, ``ssh_key_path`` is ignored and
+            password auth is used. (paramiko silently prefers
+            ``key_filename`` over ``password`` if both are passed —
+            SmolVM clears the key path internally so the password is
+            actually tried.)
         internet_settings: Network access controls. Accepts an
             :class:`~smolvm.types.InternetSettings` instance or a dict
             (e.g. ``{"allowed_domains": ["https://example.com/"]}``).
@@ -1398,9 +1423,13 @@ class SmolVM:
                 if parent:
                     # PowerShell's New-Item -Force creates intermediate
                     # directories and succeeds silently if the path already
-                    # exists. Single-quoted Path lets PowerShell treat the
-                    # backslashes literally — no escape gymnastics.
-                    safe_parent = parent.replace("'", "''")
+                    # exists. Normalise to a native Windows path because
+                    # PowerShell's path parser rejects SFTP-style leading
+                    # slashes (``/C:/foo`` -> ``C:\\foo``). Single-quoted
+                    # Path lets PowerShell treat the backslashes literally
+                    # — no escape gymnastics.
+                    ps_parent = _windows_path_for_powershell(parent)
+                    safe_parent = ps_parent.replace("'", "''")
                     cmd = (
                         f"New-Item -ItemType Directory -Force -Path "
                         f"'{safe_parent}' | Out-Null"
@@ -2018,13 +2047,18 @@ class SmolVM:
                 ssh_timeout = min(remaining, timeout / len(attempts))
                 while time.monotonic() - start_time < ssh_timeout:
                     try:
+                        # Use the factory so Windows guests get powershell
+                        # shell_kind and ssh_password is honored — direct
+                        # SSHClient construction here was a silent regression
+                        # against the sync wait_for_ssh path. Tight
+                        # connect_timeout (2s) keeps the polling loop
+                        # iterating quickly within the per-endpoint budget.
                         ssh = await asyncio.to_thread(
-                            SSHClient,
+                            self._new_ssh_client,
                             host=host,
                             port=port,
-                            user=self._ssh_user,
                             key_path=key_path,
-                            connect_timeout=2.0,
+                            connect_timeout=2,
                         )
                         self._ssh = ssh
                         self._ssh_ready = True
@@ -2308,6 +2342,7 @@ modprobe 9pnet_virtio""".strip()
         host: str,
         port: int = 22,
         key_path: str | None = None,
+        connect_timeout: int = 10,
     ) -> SSHClient:
         """Construct an SSHClient with this VM's auth + shell flavor.
 
@@ -2321,6 +2356,10 @@ modprobe 9pnet_virtio""".strip()
         ``key_filename`` over ``password`` and would silently ignore the
         password if both were passed, which leaves Windows POC users
         wondering why their password never gets tried.
+
+        ``connect_timeout`` defaults to 10s for one-shot operations; the
+        async wait_for_ssh polling loop passes a tighter value so each
+        in-loop retry fails fast.
         """
         if self._ssh_password is not None:
             effective_key_path: str | None = None
@@ -2332,6 +2371,7 @@ modprobe 9pnet_virtio""".strip()
             port=port,
             key_path=effective_key_path,
             password=self._ssh_password,
+            connect_timeout=connect_timeout,
             shell_kind=self._guest_shell_kind(),
         )
 

--- a/src/smolvm/facade.py
+++ b/src/smolvm/facade.py
@@ -65,7 +65,7 @@ from smolvm.runtime.boot_profiles import (
     normalize_arch,
     to_published_arch,
 )
-from smolvm.ssh import SSHClient
+from smolvm.ssh import ShellKind, SSHClient
 from smolvm.types import (
     CommandResult,
     GuestOS,
@@ -300,6 +300,43 @@ def _guest_parent_dir(path: str) -> str:
     return parent or "/"
 
 
+def _is_windows_guest_path(path: str) -> bool:
+    """Return True if *path* looks like a Windows-style guest path.
+
+    Accepts the three forms OpenSSH-Win32 SFTP normalizes:
+    ``C:\\...`` (Windows-native), ``C:/...`` (forward-slash mix), and
+    ``/C:/...`` (SFTP/cygwin-style POSIX prefix). POSIX paths (``/foo``)
+    are still POSIX — only paths with a drive-letter colon qualify.
+    """
+    if len(path) >= 3 and path[1] == ":" and path[2] in ("\\", "/") and path[0].isalpha():
+        return True
+    # /C:/... — leading slash + drive letter, e.g. "/C:/Users/foo".
+    return (
+        len(path) >= 4
+        and path[0] == "/"
+        and path[2] == ":"
+        and path[3] in ("\\", "/")
+        and path[1].isalpha()
+    )
+
+
+def _windows_guest_parent_dir(path: str) -> str:
+    """Return the parent directory of a Windows-style guest path.
+
+    Uses :mod:`ntpath` so we handle ``\\``, ``/``, and mixed separators
+    the same way Windows itself does.
+    """
+    import ntpath
+
+    normalized = path.rstrip("\\/")
+    if not normalized:
+        return ""
+    parent = ntpath.dirname(normalized)
+    # ntpath.dirname("C:\\foo") -> "C:\\", but ntpath.dirname("C:foo") -> "C:".
+    # Either form is fine to pass to PowerShell's New-Item -Path.
+    return parent
+
+
 def _build_auto_config_image_name(
     guest_os: GuestOS,
     *,
@@ -408,7 +445,12 @@ def _build_local_image_config(
         backend=BACKEND_QEMU,
         boot_mode="firmware",
         boot_args="",  # ignored in firmware mode
-        ssh_capable=False,  # Phase 1: SSH-into-Windows is Phase 2
+        # Phase 2: the contract for the Windows path is that the user's
+        # qcow2 has OpenSSH server set up. Declaring ssh_capable=True
+        # lets vm.run() / vm.upload_file() / wait_for_ssh() work; if
+        # the user's image doesn't actually have sshd, those calls fail
+        # at connect-time with a clear paramiko auth/connection error.
+        ssh_capable=True,
         disk_mode="shared",  # Phase 1: no overlay cloning for Windows qcow2s
     )
     logger.info(
@@ -719,10 +761,16 @@ class SmolVM:
         os: Guest OS for auto-config mode (``"alpine"`` or ``"ubuntu"``).
         memory: Guest memory in MiB for auto-config mode (``SmolVM()`` only).
         disk_size: Root filesystem size in MiB for auto-config mode (``SmolVM()`` only).
-        ssh_user: SSH user for :meth:`run` (default ``root``).
+        ssh_user: SSH user for :meth:`run` (default ``root``; pass the
+            Windows local-admin username for Windows guests, e.g.
+            ``"Administrator"`` or whatever you baked into the qcow2).
         ssh_key_path: Optional SSH private key path. If omitted,
             SmolVM first tries default SSH auth, then falls back to
             ``~/.smolvm/keys/id_ed25519`` when needed.
+        ssh_password: Optional SSH password (paramiko password auth).
+            Used when the guest has password-only SSH (e.g. a Windows
+            POC qcow2). Ignored when *ssh_key_path* is also set —
+            paramiko prefers key auth.
         internet_settings: Network access controls. Accepts an
             :class:`~smolvm.types.InternetSettings` instance or a dict
             (e.g. ``{"allowed_domains": ["https://example.com/"]}``).
@@ -757,6 +805,7 @@ class SmolVM:
         disk_size: int | None = None,
         ssh_user: str = "root",
         ssh_key_path: str | None = None,
+        ssh_password: str | None = None,
         internet_settings: InternetSettings | dict[str, Any] | None = None,
         mounts: list[str] | None = None,
         writable_mounts: bool = False,
@@ -887,8 +936,24 @@ class SmolVM:
                 "WorkspaceMount(writable=True) on config.workspace_mounts."
             )
 
+        # Phase 2: Windows guests can't take env_vars yet (Linux POSIX
+        # /etc/profile.d injection doesn't apply). Phase 3 will add
+        # setx-based injection. Reject upfront with a clear sentence so
+        # the failure happens before we spin up swtpm + QEMU.
+        if (
+            config is not None
+            and config.guest_os is GuestOS.WINDOWS
+            and config.env_vars
+        ):
+            raise ValueError(
+                "Environment variable injection (env_vars=) is not yet "
+                "supported for Windows guests; drop env_vars from your "
+                "VMConfig (Phase 3 will add setx-based injection)."
+            )
+
         self._ssh_user = ssh_user
         self._ssh_key_path = ssh_key_path
+        self._ssh_password = ssh_password
         self._default_ssh_key_path: str | None = None
 
         sdk_kwargs: dict[str, Any] = {}
@@ -930,6 +995,7 @@ class SmolVM:
         backend: str | None = None,
         ssh_user: str = "root",
         ssh_key_path: str | None = None,
+        ssh_password: str | None = None,
     ) -> SmolVM:
         """Reconnect to an existing VM by ID.
 
@@ -942,6 +1008,8 @@ class SmolVM:
             ssh_key_path: Optional SSH private key path. If omitted,
                 SmolVM first tries default SSH auth, then falls back to
                 ``~/.smolvm/keys/id_ed25519`` when needed.
+            ssh_password: Optional SSH password (for Windows guests with
+                password-auth qcow2s).
 
         Returns:
             A :class:`SmolVM` instance bound to the existing VM.
@@ -956,6 +1024,7 @@ class SmolVM:
             backend=backend,
             ssh_user=ssh_user,
             ssh_key_path=ssh_key_path,
+            ssh_password=ssh_password,
         )
 
     @classmethod
@@ -1076,9 +1145,8 @@ class SmolVM:
                 )
             self.wait_for_ssh(timeout=boot_timeout, on_progress=on_progress)
             if self._ssh is None:
-                self._ssh = SSHClient(
+                self._ssh = self._new_ssh_client(
                     host=self._info.network.guest_ip,
-                    user=self._ssh_user,
                     key_path=self._ssh_key_path,
                 )
                 self._ssh_ready = True
@@ -1101,9 +1169,8 @@ class SmolVM:
             if not self._ssh_ready:
                 self.wait_for_ssh(timeout=boot_timeout, on_progress=on_progress)
             if self._ssh is None:
-                self._ssh = SSHClient(
+                self._ssh = self._new_ssh_client(
                     host=self._info.network.guest_ip,
-                    user=self._ssh_user,
                     key_path=self._ssh_key_path,
                 )
                 self._ssh_ready = True
@@ -1308,27 +1375,57 @@ class SmolVM:
             )
         if not guest_path:
             raise ValueError("Destination path in the sandbox cannot be empty.")
-        if not guest_path.startswith("/"):
+        is_windows_path = _is_windows_guest_path(guest_path)
+        if not guest_path.startswith("/") and not is_windows_path:
             raise ValueError(
                 f"Destination path in the sandbox must be absolute "
-                f"(start with '/'): {guest_path!r}."
+                f"(start with '/', or a Windows drive-letter path like "
+                f"'C:\\\\Users\\\\foo'): {guest_path!r}."
             )
 
         destination = guest_path
-        if destination.endswith("/"):
-            destination = f"{destination}{source.name}"
+        # Strip a trailing slash/backslash and append the local filename when
+        # the destination names a directory. Path style (POSIX vs Windows)
+        # determines which separator to add back.
+        if destination.endswith("/") or destination.endswith("\\"):
+            sep = "\\" if destination.endswith("\\") else "/"
+            destination = f"{destination.rstrip(chr(92) + '/')}{sep}{source.name}"
 
         ssh = self._ensure_ssh_for_file_transfer()
         if make_dirs:
-            parent = _guest_parent_dir(destination)
-            if parent:
-                result = ssh.run(f"mkdir -p -- {shlex.quote(parent)}", timeout=30, shell="raw")
-                if result.exit_code != 0:
-                    stderr = result.stderr.strip()
-                    raise SmolVMError(
-                        f"Could not create directory {parent!r} in the sandbox: {stderr}",
-                        {"vm_id": self._vm_id, "guest_path": destination},
+            if is_windows_path:
+                parent = _windows_guest_parent_dir(destination)
+                if parent:
+                    # PowerShell's New-Item -Force creates intermediate
+                    # directories and succeeds silently if the path already
+                    # exists. Single-quoted Path lets PowerShell treat the
+                    # backslashes literally — no escape gymnastics.
+                    safe_parent = parent.replace("'", "''")
+                    cmd = (
+                        f"New-Item -ItemType Directory -Force -Path "
+                        f"'{safe_parent}' | Out-Null"
                     )
+                    result = ssh.run(cmd, timeout=30, shell="login")
+                    if result.exit_code != 0:
+                        stderr = result.stderr.strip()
+                        raise SmolVMError(
+                            f"Could not create directory {parent!r} in the sandbox: {stderr}",
+                            {"vm_id": self._vm_id, "guest_path": destination},
+                        )
+            else:
+                parent = _guest_parent_dir(destination)
+                if parent:
+                    result = ssh.run(
+                        f"mkdir -p -- {shlex.quote(parent)}",
+                        timeout=30,
+                        shell="raw",
+                    )
+                    if result.exit_code != 0:
+                        stderr = result.stderr.strip()
+                        raise SmolVMError(
+                            f"Could not create directory {parent!r} in the sandbox: {stderr}",
+                            {"vm_id": self._vm_id, "guest_path": destination},
+                        )
         ssh.put_file(source, destination)
         return destination
 
@@ -1363,17 +1460,19 @@ class SmolVM:
         """
         if not guest_path:
             raise ValueError("Source path in the sandbox cannot be empty.")
-        if not guest_path.startswith("/"):
+        if not guest_path.startswith("/") and not _is_windows_guest_path(guest_path):
             raise ValueError(
                 f"Source path in the sandbox must be absolute "
-                f"(start with '/'): {guest_path!r}."
+                f"(start with '/', or a Windows drive-letter path like "
+                f"'C:\\\\Users\\\\foo'): {guest_path!r}."
             )
 
         raw_local = str(local_path)
         destination = Path(local_path).expanduser()
         treat_as_dir = raw_local.endswith("/") or destination.is_dir()
         if treat_as_dir:
-            guest_name = guest_path.rstrip("/").rsplit("/", 1)[-1]
+            # Strip trailing separator (either kind) then take the basename.
+            guest_name = guest_path.rstrip("/\\").rsplit("\\", 1)[-1].rsplit("/", 1)[-1]
             if not guest_name:
                 raise ValueError(
                     f"Cannot derive a filename from the sandbox path: {guest_path!r}."
@@ -1790,9 +1889,8 @@ class SmolVM:
                 )
             await self.async_wait_for_ssh(timeout=boot_timeout)
             if self._ssh is None:
-                self._ssh = SSHClient(
+                self._ssh = self._new_ssh_client(
                     host=self._info.network.guest_ip,
-                    user=self._ssh_user,
                     key_path=self._ssh_key_path,
                 )
                 self._ssh_ready = True
@@ -1808,9 +1906,8 @@ class SmolVM:
             if not self._ssh_ready:
                 await self.async_wait_for_ssh(timeout=boot_timeout)
             if self._ssh is None:
-                self._ssh = SSHClient(
+                self._ssh = self._new_ssh_client(
                     host=self._info.network.guest_ip,
-                    user=self._ssh_user,
                     key_path=self._ssh_key_path,
                 )
                 self._ssh_ready = True
@@ -2195,6 +2292,49 @@ modprobe 9pnet_virtio""".strip()
         if hasattr(self, "_probed_endpoint"):
             self._probed_endpoint = None
 
+    def _guest_shell_kind(self) -> ShellKind:
+        """Pick the SSHClient login-shell flavor for this guest OS.
+
+        Windows guests get ``powershell``; everything else gets the POSIX
+        ``sh`` wrap (byte-identical to the pre-Phase-2 behavior).
+        """
+        if self._info.config.guest_os is GuestOS.WINDOWS:
+            return "powershell"
+        return "sh"
+
+    def _new_ssh_client(
+        self,
+        *,
+        host: str,
+        port: int = 22,
+        key_path: str | None = None,
+    ) -> SSHClient:
+        """Construct an SSHClient with this VM's auth + shell flavor.
+
+        Single source of truth for SSH-client construction so password
+        auth, key auth, and shell-kind dispatch stay consistent across
+        the five call sites (sync/async start, env injection, workspace
+        mounts, candidate probing).
+
+        When ``self._ssh_password`` is set, it takes precedence over any
+        per-call ``key_path``: paramiko's ``connect()`` prefers
+        ``key_filename`` over ``password`` and would silently ignore the
+        password if both were passed, which leaves Windows POC users
+        wondering why their password never gets tried.
+        """
+        if self._ssh_password is not None:
+            effective_key_path: str | None = None
+        else:
+            effective_key_path = key_path
+        return SSHClient(
+            host=host,
+            user=self._ssh_user,
+            port=port,
+            key_path=effective_key_path,
+            password=self._ssh_password,
+            shell_kind=self._guest_shell_kind(),
+        )
+
     def _ensure_ssh_for_file_transfer(self) -> SSHClient:
         """Return a ready SSH client for file transfer operations."""
         return self._ensure_ssh_for_operation(action="transfer files")
@@ -2329,9 +2469,8 @@ modprobe 9pnet_virtio""".strip()
                 or client.port != port
                 or client.key_path != key_path
             ):
-                client = SSHClient(
+                client = self._new_ssh_client(
                     host=host,
-                    user=self._ssh_user,
                     port=port,
                     key_path=key_path,
                 )

--- a/src/smolvm/ssh.py
+++ b/src/smolvm/ssh.py
@@ -20,6 +20,7 @@ to guest VMs.  A single TCP connection is established on first use (or during
 eliminating the ~170ms overhead of forking a new ``ssh`` process per call.
 """
 
+import base64
 import logging
 import shlex
 import socket
@@ -61,6 +62,29 @@ logger = logging.getLogger(__name__)
 logging.getLogger("paramiko.transport").setLevel(logging.CRITICAL)
 
 ShellMode = Literal["login", "raw"]
+ShellKind = Literal["sh", "powershell", "cmd"]
+"""Guest-side login-shell wrap. ``sh`` is the POSIX default
+(``$SHELL -lc <quoted>``); ``powershell`` wraps for Windows OpenSSH using
+``powershell.exe -NoProfile -EncodedCommand``; ``cmd`` uses ``cmd.exe /c``.
+The ``shell="raw"`` mode on :meth:`SSHClient.run` bypasses the wrap
+entirely for any kind."""
+
+
+def _pwsh_encoded_command(command: str) -> str:
+    """Return a ``powershell.exe -NoProfile -EncodedCommand <b64>`` wrap.
+
+    The ``-EncodedCommand`` option takes a base64-encoded UTF-16LE
+    PowerShell script and sidesteps both ``cmd.exe`` and ``powershell.exe``
+    quoting entirely — the command bytes survive intact regardless of what
+    Windows OpenSSH does with the SSH exec request (it forwards through
+    cmd.exe by default, which would otherwise mangle backtick-escaped
+    quotes). This is the documented Microsoft recipe for "pass arbitrary
+    PowerShell over a wire transport."
+
+    See: https://learn.microsoft.com/en-us/powershell/module/microsoft.powershell.core/about/about_powershell_exe
+    """
+    encoded = base64.b64encode(command.encode("utf-16-le")).decode("ascii")
+    return f"powershell.exe -NoProfile -EncodedCommand {encoded}"
 
 
 class SSHClient:
@@ -76,6 +100,12 @@ class SSHClient:
         key_path: Optional path to an SSH private key file.
         password: Optional password for authentication.
         connect_timeout: Seconds to wait for the TCP connection.
+        shell_kind: Login-shell flavor for the guest. ``sh`` (default) wraps
+            with ``$SHELL -lc``; ``powershell`` wraps with
+            ``powershell.exe -NoProfile -Command`` (Windows guests);
+            ``cmd`` wraps with ``cmd.exe /c``. Only consulted when
+            :meth:`run` is called with ``shell="login"`` (the default);
+            ``shell="raw"`` bypasses the wrap entirely.
     """
 
     def __init__(
@@ -86,6 +116,7 @@ class SSHClient:
         key_path: str | None = None,
         password: str | None = None,
         connect_timeout: int = 10,
+        shell_kind: ShellKind = "sh",
     ) -> None:
         if not host:
             raise ValueError("host cannot be empty")
@@ -102,6 +133,7 @@ class SSHClient:
         self.key_path = key_path
         self.password = password
         self.connect_timeout = connect_timeout
+        self.shell_kind: ShellKind = shell_kind
 
         self._client: paramiko.SSHClient | None = None
 
@@ -224,9 +256,21 @@ class SSHClient:
 
     # ── Command execution ───────────────────────────────────────
 
-    @staticmethod
-    def _wrap_login_shell_command(command: str) -> str:
-        """Wrap a command so it runs inside a login shell."""
+    def _wrap_login_shell_command(self, command: str) -> str:
+        """Wrap a command so it runs inside the guest's login shell.
+
+        Dispatches on :attr:`shell_kind`. The POSIX ``sh`` form preserves
+        the legacy ``$SHELL -lc <quoted>`` shape byte-for-byte; the
+        ``powershell`` form base64-encodes the command via
+        ``-EncodedCommand`` so it survives cmd.exe + PowerShell quoting
+        (Windows OpenSSH routes through cmd.exe by default); ``cmd``
+        uses ``cmd.exe /c`` (caller is responsible for cmd.exe quoting).
+        """
+        if self.shell_kind == "powershell":
+            return _pwsh_encoded_command(command)
+        if self.shell_kind == "cmd":
+            return f'cmd.exe /c "{command}"'
+        # POSIX sh — legacy default, unchanged.
         quoted_command = shlex.quote(command)
         return f'SHELL_BIN="${{SHELL:-/bin/sh}}"; exec "$SHELL_BIN" -lc {quoted_command}'
 

--- a/src/smolvm/ssh.py
+++ b/src/smolvm/ssh.py
@@ -87,6 +87,21 @@ def _pwsh_encoded_command(command: str) -> str:
     return f"powershell.exe -NoProfile -EncodedCommand {encoded}"
 
 
+def _cmd_wrap(command: str) -> str:
+    """Wrap *command* for ``cmd.exe /s /c "..."``.
+
+    ``/s`` makes cmd's quote-handling deterministic: with ``cmd /s /c
+    "<...>"``, the *outer* double quotes are stripped and everything
+    between them is passed through to the command processor. We escape
+    embedded ``"`` by doubling them (cmd's in-quote escape). Shell
+    metacharacters (``& | < > ^ ( )``) need no extra escaping because
+    they are not interpreted inside double-quoted strings.
+
+    Reference: https://learn.microsoft.com/en-us/windows-server/administration/windows-commands/cmd
+    """
+    return f'cmd.exe /s /c "{command.replace(chr(34), chr(34) * 2)}"'
+
+
 class SSHClient:
     """Execute commands on a microVM guest via SSH.
 
@@ -264,12 +279,13 @@ class SSHClient:
         ``powershell`` form base64-encodes the command via
         ``-EncodedCommand`` so it survives cmd.exe + PowerShell quoting
         (Windows OpenSSH routes through cmd.exe by default); ``cmd``
-        uses ``cmd.exe /c`` (caller is responsible for cmd.exe quoting).
+        uses ``cmd.exe /s /c "<doubled-quoted>"`` so embedded ``"`` and
+        shell metacharacters are safe.
         """
         if self.shell_kind == "powershell":
             return _pwsh_encoded_command(command)
         if self.shell_kind == "cmd":
-            return f'cmd.exe /c "{command}"'
+            return _cmd_wrap(command)
         # POSIX sh — legacy default, unchanged.
         quoted_command = shlex.quote(command)
         return f'SHELL_BIN="${{SHELL:-/bin/sh}}"; exec "$SHELL_BIN" -lc {quoted_command}'

--- a/tests/test_facade.py
+++ b/tests/test_facade.py
@@ -876,6 +876,28 @@ class TestWindowsGuestPathHelpers:
 
         assert _windows_guest_parent_dir(path) == expected
 
+    @pytest.mark.parametrize(
+        ("path", "expected"),
+        [
+            # SFTP-style leading slash is stripped; forward slashes normalized.
+            ("/C:/Users/foo", "C:\\Users\\foo"),
+            ("/c:/users/bar", "c:\\users\\bar"),
+            # Bare drive-letter forward-slash form normalizes too.
+            ("C:/Users/foo", "C:\\Users\\foo"),
+            # Native Windows path is unchanged.
+            ("C:\\Users\\foo", "C:\\Users\\foo"),
+            # Mixed separators normalize to all-backslash.
+            ("C:\\Users/foo\\bar", "C:\\Users\\foo\\bar"),
+        ],
+    )
+    def test_windows_path_for_powershell(self, path: str, expected: str) -> None:
+        """The PowerShell-bound form must never start with ``/`` (PSH chokes)."""
+        from smolvm.facade import _windows_path_for_powershell
+
+        assert _windows_path_for_powershell(path) == expected
+        # And every form is safe to embed as a PowerShell -Path argument.
+        assert not _windows_path_for_powershell(path).startswith("/")
+
 
 class TestVMUploadDownloadWindows:
     """Tests for Windows-guest upload/download path acceptance + mkdir."""

--- a/tests/test_facade.py
+++ b/tests/test_facade.py
@@ -744,6 +744,299 @@ class TestVMLocalImageParam:
             )
 
 
+class TestVMSSHClientHelper:
+    """Tests for SmolVM._new_ssh_client (single source of SSH-client truth)."""
+
+    @patch("smolvm.facade.SmolVMManager")
+    def test_helper_uses_sh_shell_kind_for_linux_guests(
+        self,
+        mock_sdk_cls: MagicMock,
+        sample_config: VMConfig,
+    ) -> None:
+        """Linux guests (default) get shell_kind='sh' — byte-identical legacy."""
+        info = MagicMock()
+        info.vm_id = sample_config.vm_id
+        info.config = sample_config  # default guest_os=ALPINE
+        info.network = MagicMock()
+        mock_sdk = MagicMock()
+        mock_sdk.create.return_value = info
+        mock_sdk_cls.return_value = mock_sdk
+
+        vm = SmolVM(sample_config, ssh_user="root", ssh_key_path="/k")
+        # key_path is per-call (the SSH wait loop tries different keys),
+        # NOT pulled from self._ssh_key_path inside the helper.
+        client = vm._new_ssh_client(host="10.0.2.15", key_path="/k")
+
+        assert client.shell_kind == "sh"
+        assert client.user == "root"
+        assert client.key_path == "/k"
+        assert client.password is None
+
+    @patch("smolvm.facade.SmolVMManager")
+    def test_helper_uses_powershell_for_windows_guests(
+        self,
+        mock_sdk_cls: MagicMock,
+        tmp_path: Path,
+    ) -> None:
+        """Windows guests get shell_kind='powershell' automatically."""
+        disk = tmp_path / "win11.qcow2"
+        disk.touch()
+
+        info = MagicMock()
+        info.vm_id = "vm-win"
+        # Use a real VMConfig so guest_os is the real enum.
+        info.config = VMConfig(
+            vm_id="vm-win",
+            rootfs_path=disk,
+            kernel_path=None,
+            backend="qemu",
+            guest_os=GuestOS.WINDOWS,
+            boot_mode="firmware",
+            disk_mode="shared",
+        )
+        info.network = MagicMock()
+        mock_sdk = MagicMock()
+        mock_sdk.create.return_value = info
+        mock_sdk_cls.return_value = mock_sdk
+
+        # Construct via the same local-image path that real Windows users hit.
+        vm = SmolVM(
+            os="windows",
+            image=str(disk),
+            ssh_user="celesto",
+            ssh_password="celesto",
+        )
+        client = vm._new_ssh_client(host="127.0.0.1", port=2222)
+
+        assert client.shell_kind == "powershell"
+        assert client.user == "celesto"
+        assert client.password == "celesto"
+        assert client.port == 2222
+
+    @patch("smolvm.facade.SmolVMManager")
+    def test_ssh_password_threads_to_client(
+        self,
+        mock_sdk_cls: MagicMock,
+        sample_config: VMConfig,
+    ) -> None:
+        """ssh_password= kwarg surfaces on every SSHClient the facade builds."""
+        info = MagicMock()
+        info.vm_id = sample_config.vm_id
+        info.config = sample_config
+        info.network = MagicMock()
+        mock_sdk = MagicMock()
+        mock_sdk.create.return_value = info
+        mock_sdk_cls.return_value = mock_sdk
+
+        vm = SmolVM(sample_config, ssh_password="secret-pw")
+        client = vm._new_ssh_client(host="10.0.2.15")
+        assert client.password == "secret-pw"
+
+
+class TestWindowsGuestPathHelpers:
+    """Tests for the Windows-path helpers used by upload_file/download_file."""
+
+    @pytest.mark.parametrize(
+        ("path", "is_windows"),
+        [
+            ("/etc/foo", False),
+            ("/", False),
+            ("/usr/local/bin/x", False),
+            ("C:\\Users\\foo", True),
+            ("c:\\users\\foo", True),
+            ("D:\\data", True),
+            ("C:/Users/foo", True),
+            ("/C:/Users/foo", True),
+            ("/c:/users/foo", True),
+            # Not Windows: no drive letter, no trailing separator.
+            ("C:foo", False),  # missing separator
+            ("CC:\\foo", False),  # not a single drive letter
+            ("relative/path", False),
+            ("", False),
+        ],
+    )
+    def test_is_windows_guest_path_truth_table(self, path: str, is_windows: bool) -> None:
+        from smolvm.facade import _is_windows_guest_path
+
+        assert _is_windows_guest_path(path) is is_windows
+
+    @pytest.mark.parametrize(
+        ("path", "expected"),
+        [
+            ("C:\\Users\\foo\\file.txt", "C:\\Users\\foo"),
+            ("C:/Users/foo/file.txt", "C:/Users/foo"),
+            ("/C:/Users/foo/file.txt", "/C:/Users/foo"),
+            ("C:\\foo", "C:\\"),
+            # Mixed separators stay as-is in the parent.
+            ("C:\\Users/foo\\file", "C:\\Users/foo"),
+        ],
+    )
+    def test_windows_guest_parent_dir(self, path: str, expected: str) -> None:
+        from smolvm.facade import _windows_guest_parent_dir
+
+        assert _windows_guest_parent_dir(path) == expected
+
+
+class TestVMUploadDownloadWindows:
+    """Tests for Windows-guest upload/download path acceptance + mkdir."""
+
+    @patch("smolvm.facade.SmolVMManager")
+    def test_upload_accepts_windows_path_and_uses_powershell_mkdir(
+        self,
+        mock_sdk_cls: MagicMock,
+        tmp_path: Path,
+    ) -> None:
+        """C:\\... paths land via SFTP after a PowerShell New-Item parent."""
+        disk = tmp_path / "win11.qcow2"
+        disk.touch()
+        source = tmp_path / "hello.ps1"
+        source.write_text("Write-Host hi")
+
+        running_info = MagicMock(vm_id="vm-win", status=VMState.RUNNING)
+        running_info.config = VMConfig(
+            vm_id="vm-win",
+            rootfs_path=disk,
+            kernel_path=None,
+            backend="qemu",
+            guest_os=GuestOS.WINDOWS,
+            boot_mode="firmware",
+            disk_mode="shared",
+            ssh_capable=True,
+        )
+        running_info.network.guest_ip = "127.0.0.1"
+        running_info.network.ssh_host_port = 2222
+
+        mock_sdk = MagicMock()
+        mock_sdk.create.return_value = running_info
+        mock_sdk.get.return_value = running_info
+        mock_sdk_cls.return_value = mock_sdk
+
+        ssh = MagicMock()
+        ssh.run.return_value = MagicMock(exit_code=0, stderr="")
+
+        vm = SmolVM(
+            os="windows",
+            image=str(disk),
+            ssh_user="celesto",
+            ssh_password="celesto",
+        )
+        vm._ssh = ssh
+        vm._ssh_ready = True
+
+        guest_path = vm.upload_file(source, "C:\\Users\\celesto\\hello.ps1")
+        assert guest_path == "C:\\Users\\celesto\\hello.ps1"
+
+        ssh.run.assert_called_once_with(
+            "New-Item -ItemType Directory -Force -Path "
+            "'C:\\Users\\celesto' | Out-Null",
+            timeout=30,
+            shell="login",  # SSHClient wraps with powershell.exe -NoProfile -Command
+        )
+        ssh.put_file.assert_called_once_with(source, "C:\\Users\\celesto\\hello.ps1")
+
+    @patch("smolvm.facade.SmolVMManager")
+    def test_upload_rejects_relative_path_on_windows_too(
+        self,
+        mock_sdk_cls: MagicMock,
+        tmp_path: Path,
+    ) -> None:
+        """Relative paths are still rejected on Windows guests."""
+        disk = tmp_path / "win11.qcow2"
+        disk.touch()
+        source = tmp_path / "hello.ps1"
+        source.write_text("x")
+
+        running_info = MagicMock(vm_id="vm-win", status=VMState.RUNNING)
+        running_info.config = VMConfig(
+            vm_id="vm-win",
+            rootfs_path=disk,
+            kernel_path=None,
+            backend="qemu",
+            guest_os=GuestOS.WINDOWS,
+            boot_mode="firmware",
+            disk_mode="shared",
+            ssh_capable=True,
+        )
+        running_info.network = MagicMock()
+        mock_sdk = MagicMock()
+        mock_sdk.create.return_value = running_info
+        mock_sdk.get.return_value = running_info
+        mock_sdk_cls.return_value = mock_sdk
+
+        vm = SmolVM(
+            os="windows",
+            image=str(disk),
+            ssh_user="celesto",
+            ssh_password="celesto",
+        )
+        with pytest.raises(ValueError, match="absolute"):
+            vm.upload_file(source, "relative/path.txt")
+
+    @patch("smolvm.facade.SmolVMManager")
+    def test_download_accepts_windows_path(
+        self,
+        mock_sdk_cls: MagicMock,
+        tmp_path: Path,
+    ) -> None:
+        """Windows guest_path on download_file passes the path validator."""
+        disk = tmp_path / "win11.qcow2"
+        disk.touch()
+        local_target = tmp_path / "out.txt"
+
+        running_info = MagicMock(vm_id="vm-win", status=VMState.RUNNING)
+        running_info.config = VMConfig(
+            vm_id="vm-win",
+            rootfs_path=disk,
+            kernel_path=None,
+            backend="qemu",
+            guest_os=GuestOS.WINDOWS,
+            boot_mode="firmware",
+            disk_mode="shared",
+            ssh_capable=True,
+        )
+        running_info.network = MagicMock()
+        mock_sdk = MagicMock()
+        mock_sdk.create.return_value = running_info
+        mock_sdk.get.return_value = running_info
+        mock_sdk_cls.return_value = mock_sdk
+
+        ssh = MagicMock()
+
+        vm = SmolVM(
+            os="windows",
+            image=str(disk),
+            ssh_user="celesto",
+            ssh_password="celesto",
+        )
+        vm._ssh = ssh
+        vm._ssh_ready = True
+
+        result = vm.download_file("C:\\Users\\celesto\\hello.txt", local_target)
+        assert result == str(local_target)
+        ssh.get_file.assert_called_once_with("C:\\Users\\celesto\\hello.txt", local_target)
+
+
+class TestVMWindowsEnvVarsRejection:
+    """Phase 2 explicit rejection of env_vars= on Windows VMConfigs."""
+
+    def test_env_vars_on_windows_vmconfig_rejected_at_init(self, tmp_path: Path) -> None:
+        """SmolVM(config=...) with Windows+env_vars fails fast with plain English."""
+        disk = tmp_path / "win11.qcow2"
+        disk.touch()
+        config = VMConfig(
+            vm_id="vm-win",
+            rootfs_path=disk,
+            kernel_path=None,
+            backend="qemu",
+            guest_os=GuestOS.WINDOWS,
+            boot_mode="firmware",
+            disk_mode="shared",
+            env_vars={"FOO": "bar"},
+        )
+        with pytest.raises(ValueError, match="env_vars.*not yet supported for Windows"):
+            SmolVM(config)
+
+
 class TestVMLifecycle:
     """Tests for VM lifecycle operations."""
 

--- a/tests/test_ssh.py
+++ b/tests/test_ssh.py
@@ -14,13 +14,12 @@
 
 """Tests for SmolVM SSH module."""
 
+import base64
 import logging
 import socket
 from unittest.mock import MagicMock, patch
 
 import pytest
-
-import base64
 
 from smolvm.exceptions import OperationTimeoutError, SmolVMError
 from smolvm.ssh import SSHClient, _pwsh_encoded_command
@@ -307,11 +306,27 @@ class TestSSHClientShellKind:
         )
         assert base64.b64decode(encoded).decode("utf-16-le") == tricky
 
-    def test_cmd_wrap(self) -> None:
-        """cmd.exe wrap uses ``/c`` with double-quoted command."""
+    def test_cmd_wrap_uses_slash_s_and_doubled_quotes(self) -> None:
+        """cmd.exe wrap uses ``/s /c "..."`` with embedded ``"`` doubled."""
         client = SSHClient("10.0.2.15", shell_kind="cmd")
-        wrapped = client._wrap_login_shell_command("dir C:\\Users")
-        assert wrapped == 'cmd.exe /c "dir C:\\Users"'
+        # No embedded quotes — clean wrap.
+        assert (
+            client._wrap_login_shell_command("dir C:\\Users")
+            == 'cmd.exe /s /c "dir C:\\Users"'
+        )
+        # Embedded quotes get doubled (cmd's in-quote escape).
+        assert (
+            client._wrap_login_shell_command('echo "hi"')
+            == 'cmd.exe /s /c "echo ""hi"""'
+        )
+
+    def test_cmd_wrap_metacharacters_safe_inside_quotes(self) -> None:
+        """Shell metacharacters survive because they're inside the outer quotes."""
+        client = SSHClient("10.0.2.15", shell_kind="cmd")
+        tricky = "echo hi & echo bye | findstr hi"
+        wrapped = client._wrap_login_shell_command(tricky)
+        # The whole command is inside the outer "..." — & and | are literal.
+        assert wrapped == f'cmd.exe /s /c "{tricky}"'
 
     def test_raw_shell_mode_bypasses_wrap_regardless_of_kind(self) -> None:
         """``shell="raw"`` is the explicit escape hatch for any kind."""

--- a/tests/test_ssh.py
+++ b/tests/test_ssh.py
@@ -20,8 +20,10 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
+import base64
+
 from smolvm.exceptions import OperationTimeoutError, SmolVMError
-from smolvm.ssh import SSHClient
+from smolvm.ssh import SSHClient, _pwsh_encoded_command
 from smolvm.types import CommandResult
 
 
@@ -261,3 +263,92 @@ class TestSSHClientWaitForSSH:
         client = SSHClient("172.16.0.2")
         with pytest.raises(ValueError, match="timeout must be"):
             client.wait_for_ssh(timeout=0)
+
+
+class TestSSHClientShellKind:
+    """Tests for the per-guest-OS login-shell wrapping."""
+
+    def test_default_shell_kind_is_sh(self) -> None:
+        """Constructing without shell_kind keeps the POSIX default."""
+        client = SSHClient("172.16.0.2")
+        assert client.shell_kind == "sh"
+
+    def test_sh_wrap_is_byte_identical_to_legacy(self) -> None:
+        """The POSIX wrap shape must not drift — locks zero-regression."""
+        client = SSHClient("172.16.0.2", shell_kind="sh")
+        wrapped = client._wrap_login_shell_command("echo hello world")
+        assert wrapped == (
+            'SHELL_BIN="${SHELL:-/bin/sh}"; exec "$SHELL_BIN" -lc '
+            "'echo hello world'"
+        )
+
+    def test_powershell_wrap_uses_encoded_command(self) -> None:
+        """PowerShell wrap base64-encodes the command via -EncodedCommand.
+
+        Round-trip the b64 back to UTF-16LE bytes and verify the original
+        command bytes survived intact. -EncodedCommand sidesteps cmd.exe
+        and PowerShell quoting both — critical because Windows OpenSSH
+        routes commands through cmd.exe by default.
+        """
+        client = SSHClient("10.0.2.15", shell_kind="powershell")
+        wrapped = client._wrap_login_shell_command("echo hi")
+        prefix = "powershell.exe -NoProfile -EncodedCommand "
+        assert wrapped.startswith(prefix)
+        encoded = wrapped[len(prefix) :]
+        assert base64.b64decode(encoded).decode("utf-16-le") == "echo hi"
+
+    def test_powershell_wrap_survives_quotes_and_backticks(self) -> None:
+        """The encoded form trivially preserves quotes, backticks, $, etc."""
+        client = SSHClient("10.0.2.15", shell_kind="powershell")
+        tricky = 'Write-Output "hi `now $env:USERNAME"'
+        wrapped = client._wrap_login_shell_command(tricky)
+        encoded = wrapped.removeprefix(
+            "powershell.exe -NoProfile -EncodedCommand "
+        )
+        assert base64.b64decode(encoded).decode("utf-16-le") == tricky
+
+    def test_cmd_wrap(self) -> None:
+        """cmd.exe wrap uses ``/c`` with double-quoted command."""
+        client = SSHClient("10.0.2.15", shell_kind="cmd")
+        wrapped = client._wrap_login_shell_command("dir C:\\Users")
+        assert wrapped == 'cmd.exe /c "dir C:\\Users"'
+
+    def test_raw_shell_mode_bypasses_wrap_regardless_of_kind(self) -> None:
+        """``shell="raw"`` is the explicit escape hatch for any kind."""
+        client = SSHClient("10.0.2.15", shell_kind="powershell")
+        prepared = client._prepare_remote_command("echo raw", shell="raw")
+        assert prepared == "echo raw"
+
+
+class TestPwshEncodedCommand:
+    """Direct tests for the PowerShell -EncodedCommand wrapper."""
+
+    @pytest.mark.parametrize(
+        "raw",
+        [
+            "echo hi",
+            'Write-Output "hi"',
+            'with `backtick',
+            "$env:USERNAME",
+            "line1\nline2",
+            'New-Item -ItemType Directory -Force -Path "C:\\Users\\foo"',
+            # Unicode survives UTF-16LE round-trip.
+            "echo héllo 🐍",
+        ],
+    )
+    def test_round_trip(self, raw: str) -> None:
+        """Decoded base64 matches the original command byte-for-byte."""
+        wrapped = _pwsh_encoded_command(raw)
+        prefix = "powershell.exe -NoProfile -EncodedCommand "
+        assert wrapped.startswith(prefix)
+        encoded = wrapped[len(prefix) :]
+        assert base64.b64decode(encoded).decode("utf-16-le") == raw
+
+    def test_no_shell_metacharacters_in_wrapped_form(self) -> None:
+        """The wrapped form is plain ASCII (no quotes, $, backticks)."""
+        wrapped = _pwsh_encoded_command('echo "hi" `now $env:X')
+        # Base64 alphabet is [A-Za-z0-9+/=]. No quotes, no $, no backticks.
+        encoded = wrapped.removeprefix(
+            "powershell.exe -NoProfile -EncodedCommand "
+        )
+        assert all(c not in encoded for c in '"`$')


### PR DESCRIPTION
## Summary

Phase 2 of Windows-guest support. After Phase 1 (#302) you could **boot** a Windows 11 qcow2 — but `vm.run("powershell …")` crashed because `SSHClient` wrapped every command in `bash -lc`. This adds the guest-OS-aware plumbing so the SmolVM SDK actually drives a Windows guest end-to-end:

```python
vm = SmolVM(
    os="windows",
    image="~/win11-vm/disk-baseline.qcow2",
    ssh_user="celesto",
    ssh_password="celesto",
)
vm.start(); vm.wait_for_ssh()
result = vm.run("Write-Output 'hello from windows'")
vm.upload_file("./hello.ps1", "C:\\Users\\celesto\\hello.ps1")
```

- **`SSHClient` gains `shell_kind`** (`"sh" | "powershell" | "cmd"`). PowerShell uses `-NoProfile -EncodedCommand <base64>` instead of `-Command "<escaped>"` — survives the cmd.exe layer that Windows OpenSSH routes through, which silently mangles backtick-escaped quotes. POSIX `sh` path is byte-identical to pre-refactor (snapshot test locks it).
- **`SmolVM(ssh_password=...)`** exposes the password-auth path paramiko already supported. Plumbed through `from_id()` too. When set, key auth is suppressed so paramiko doesn't silently prefer keys.
- **Single `_new_ssh_client()` helper** replaces the five SSHClient call sites so password + shell_kind stay consistent across sync/async start, env injection, workspace mounts, and the candidate-probe loop.
- **`upload_file` / `download_file` accept Windows paths** (`C:\...`, `c:/...`, `/C:/...`). Parent-dir creation switches to PowerShell `New-Item -ItemType Directory -Force` for Windows guests; POSIX `mkdir -p` for Linux unchanged.
- **Reject `env_vars=` on Windows VMConfigs** at construction time with a one-sentence Phase-3-deferral error.
- **Flip Phase 1's `ssh_capable=False` placeholder to True** on the Windows local-image path. Contract: the user's qcow2 has sshd; if not, `vm.run()` fails with a clear paramiko auth error.

44 new tests; full suite **1004 pass / 13 pre-existing skip / no regressions**. End-to-end verified against the real Windows 11 baseline qcow2: 8-second SSH ready, PowerShell cmdlet round-trip, SFTP upload + `type` readback all clean.

## Test plan

- [x] `pytest` — 1004 pass, 13 pre-existing skip
- [x] `ruff check` — clean on all changed files (pre-existing warnings in untouched code unchanged)
- [x] Linux byte-identical SSH wrap invariant locked via snapshot test (`test_sh_wrap_is_byte_identical_to_legacy`)
- [x] End-to-end on Ubuntu 26.04 with a real Windows 11 qcow2:
  - `vm.run("Write-Output 'hello from windows'")` → exit 0, stdout `'hello from windows\r\n'`
  - `vm.run("(Get-Item C:\\Windows).Name")` → exit 0, stdout `'Windows\r\n'` (real PowerShell cmdlet)
  - `vm.upload_file("./hello.txt", "C:\\Users\\celesto\\hello.txt")` → readback via `type` matches
  - Clean `vm.stop()` reaps QEMU + swtpm
- [ ] Manual: try with a Windows qcow2 that *doesn't* have OpenSSH installed — confirm `vm.wait_for_ssh()` fails with a clear paramiko error (not silently)

## Out of scope (Phase 3)

- Overlay cloning for Windows qcow2s (today's `disk_mode="shared"` mutates the baseline across runs).
- Env var injection on Windows (setx / registry).
- Workspace mounts.
- Presets.
- macOS host.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * SSH password authentication option (takes precedence over key auth when set)
  * SSH capability enabled for Windows VMs; login-shell selection now supports PowerShell and CMD in addition to POSIX sh
  * File upload/download accept and normalize Windows-style guest paths (drive-letter and POSIX-like forms)

* **Behavior Changes / Bug Fixes**
  * Initialization now rejects Windows VM configs that include environment-variable injection (fails early)

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/CelestoAI/SmolVM/pull/303?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->