### PR TITLE
Phase 3a: per-sandbox overlay disk for Windows guests

### DIFF
--- a/src/smolvm/facade.py
+++ b/src/smolvm/facade.py
@@ -407,10 +407,14 @@ def _build_local_image_config(
     supported on this path; Linux users still go through auto-config
     or S3.
 
-    The qcow2 is used **shared** (no per-VM overlay clone), so concurrent
-    ``SmolVM(image=...)`` calls against the same baseline corrupt each
-    other. Document loudly when surfacing this path. Phase 2 introduces
-    qcow2 overlay cloning for Windows base images.
+    Each sandbox gets a thin per-VM qcow2 overlay stacked on top of the
+    user's baseline (``disk_mode="isolated"``), so concurrent
+    ``SmolVM(image=...)`` calls don't collide on the write lock and the
+    baseline itself stays read-only and uncorrupted. The overlay lives
+    under ``data_dir/disks/{vm_id}.qcow2`` and is created near-instantly
+    via ``qemu-img create -b``. Power users who need writes to land in
+    the baseline (e.g., a one-off image-baking workflow) can construct
+    a ``VMConfig`` directly with ``disk_mode="shared"``.
     """
     if os_input is None:
         raise ValueError(
@@ -472,7 +476,12 @@ def _build_local_image_config(
         # the user's image doesn't actually have sshd, those calls fail
         # at connect-time with a clear paramiko auth/connection error.
         ssh_capable=True,
-        disk_mode="shared",  # Phase 1: no overlay cloning for Windows qcow2s
+        # Per-VM qcow2 overlay on top of the user's baseline. The same
+        # _materialize_rootfs path Linux Alpine/Ubuntu use; the baseline
+        # stays read-only so multiple Windows sandboxes can run in
+        # parallel from the same image without colliding on the write
+        # lock, and a crashed sandbox doesn't dirty the original.
+        disk_mode="isolated",
     )
     logger.info(
         "Configured Windows VM from local image: %s (image=%s)",

--- a/tests/test_facade.py
+++ b/tests/test_facade.py
@@ -721,7 +721,10 @@ class TestVMLocalImageParam:
         assert config.boot_mode == "firmware"
         assert config.kernel_path is None
         assert config.backend == "qemu"
-        assert config.disk_mode == "shared"
+        # Phase 3a: Windows now uses isolated (per-VM qcow2 overlay) so
+        # concurrent SmolVM(image=SAME) calls don't collide on the disk
+        # write lock and the baseline stays untouched.
+        assert config.disk_mode == "isolated"
         assert config.rootfs_path == disk
         assert config.memory == 4096  # Windows default
         assert ssh_key == str(key)

--- a/tests/test_vm_qemu.py
+++ b/tests/test_vm_qemu.py
@@ -286,6 +286,116 @@ def test_materialize_firmware_raises_with_install_hint_when_no_ovmf(tmp_path: Pa
         sdk._materialize_firmware(config)
 
 
+def test_windows_local_image_uses_per_vm_overlay_disk(tmp_path: Path) -> None:
+    """Windows VMs get a per-VM overlay, baseline qcow2 stays untouched."""
+    from smolvm.runtime.guest_platforms import FirmwareSpec
+    from smolvm.types import GuestOS
+
+    baseline = tmp_path / "win11-baseline.qcow2"
+    baseline.write_bytes(b"baseline-bytes")
+    baseline_mtime = baseline.stat().st_mtime_ns
+
+    code = tmp_path / "OVMF_CODE.fd"
+    code.touch()
+    template = tmp_path / "OVMF_VARS.fd"
+    template.write_bytes(b"vars-template")
+    fake_firmware = FirmwareSpec(code_path=code, vars_template_path=template)
+
+    config = VMConfig(
+        vm_id="vm-win-iso",
+        kernel_path=None,
+        rootfs_path=baseline,
+        backend="qemu",
+        guest_os=GuestOS.WINDOWS,
+        boot_mode="firmware",
+        disk_mode="isolated",  # Phase 3a: new default for Windows local-image
+    )
+
+    sdk = SmolVMManager(
+        data_dir=tmp_path / "data",
+        socket_dir=tmp_path / "sockets",
+        backend="qemu",
+    )
+    with (
+        patch(
+            "smolvm.runtime.guest_platforms._find_x86_64_ovmf",
+            return_value=fake_firmware,
+        ),
+        patch("smolvm.vm.platform.system", return_value="Linux"),
+        patch("smolvm.vm.platform.machine", return_value="x86_64"),
+        patch.object(SmolVMManager, "_create_qemu_overlay_disk") as mock_overlay,
+    ):
+        mock_overlay.side_effect = lambda source, target: target.write_text("overlay-bytes")
+        vm_info = sdk.create(config)
+
+    expected_overlay = sdk.data_dir / "disks" / "vm-win-iso.qcow2"
+    # The VM now points at its own overlay, NOT the user's baseline.
+    assert vm_info.config.rootfs_path == expected_overlay
+    assert expected_overlay.read_text() == "overlay-bytes"
+    # The user's baseline file is byte-identical AND mtime-identical —
+    # nothing wrote to it, so two SmolVMs in parallel can share it safely.
+    assert baseline.read_bytes() == b"baseline-bytes"
+    assert baseline.stat().st_mtime_ns == baseline_mtime
+    # The overlay was created with the baseline as the backing file.
+    source_arg, target_arg = mock_overlay.call_args.args
+    assert source_arg == baseline
+    assert target_arg == expected_overlay
+
+
+def test_two_windows_vms_from_same_baseline_get_distinct_overlays(
+    tmp_path: Path,
+) -> None:
+    """Concurrent Windows sandboxes from the same image use separate overlays."""
+    from smolvm.runtime.guest_platforms import FirmwareSpec
+    from smolvm.types import GuestOS
+
+    baseline = tmp_path / "win11-baseline.qcow2"
+    baseline.write_bytes(b"baseline-bytes")
+
+    code = tmp_path / "OVMF_CODE.fd"
+    code.touch()
+    template = tmp_path / "OVMF_VARS.fd"
+    template.write_bytes(b"vars-template")
+    fake_firmware = FirmwareSpec(code_path=code, vars_template_path=template)
+
+    def _windows_config(vm_id: str) -> VMConfig:
+        return VMConfig(
+            vm_id=vm_id,
+            kernel_path=None,
+            rootfs_path=baseline,
+            backend="qemu",
+            guest_os=GuestOS.WINDOWS,
+            boot_mode="firmware",
+            disk_mode="isolated",
+        )
+
+    sdk = SmolVMManager(
+        data_dir=tmp_path / "data",
+        socket_dir=tmp_path / "sockets",
+        backend="qemu",
+    )
+    with (
+        patch(
+            "smolvm.runtime.guest_platforms._find_x86_64_ovmf",
+            return_value=fake_firmware,
+        ),
+        patch("smolvm.vm.platform.system", return_value="Linux"),
+        patch("smolvm.vm.platform.machine", return_value="x86_64"),
+        patch.object(SmolVMManager, "_create_qemu_overlay_disk") as mock_overlay,
+    ):
+        mock_overlay.side_effect = lambda source, target: target.write_text(target.name)
+        vm_alpha = sdk.create(_windows_config("vm-win-alpha"))
+        vm_beta = sdk.create(_windows_config("vm-win-beta"))
+
+    # Distinct per-VM overlays.
+    assert vm_alpha.config.rootfs_path != vm_beta.config.rootfs_path
+    assert vm_alpha.config.rootfs_path.name == "vm-win-alpha.qcow2"
+    assert vm_beta.config.rootfs_path.name == "vm-win-beta.qcow2"
+    # Both overlays share the same backing file (the user's baseline).
+    backing_paths = [call.args[0] for call in mock_overlay.call_args_list]
+    assert backing_paths == [baseline, baseline]
+
+
 def test_delete_qemu_retains_isolated_disk_when_enabled(tmp_path: Path) -> None:
     """retain_disk_on_delete should preserve managed qcow2 disks for QEMU VMs."""
     kernel = tmp_path / "vmlinux"


### PR DESCRIPTION
## Summary

Phase 1 shipped `SmolVM(os="windows", image=...)` with `disk_mode="shared"` — every Windows VM wrote directly to the user's baseline qcow2. **Two sandboxes from the same image couldn't run in parallel** (disk-lock conflict), and any crashed sandbox left the baseline dirty. We hit this concretely during Phase 2 e2e testing — needed to keep restoring the baseline between runs.

This flips the Windows local-image path to `disk_mode="isolated"`. The existing `_materialize_rootfs` / `_create_qemu_overlay_disk` infrastructure (already used by Alpine/Ubuntu) creates a thin per-VM qcow2 overlay backed by the user's baseline. **The baseline stays read-only across VM lifecycles**; overlays live under `data_dir/disks/{vm_id}.qcow2` and are reaped on `vm.delete()` unless `retain_disk_on_delete` is set.

One-line behavior flip — no new infrastructure. The docstring and tests catch up.

## What changes for users

- `SmolVM(os="windows", image="~/win11-vm/baseline.qcow2")` is now safe to call concurrently from multiple processes. Each gets its own scratch overlay.
- Crashes / Ctrl-C no longer corrupt the baseline.
- Power users who specifically *want* writes to land in the baseline (e.g. a one-shot image-baking workflow) can still construct a `VMConfig` directly with `disk_mode="shared"`.

## Test plan

- [x] `pytest` — 1013 pass / 13 pre-existing skip / no regressions
- [x] `ruff check` clean on changed files
- [x] Unit tests assert the VM's `rootfs_path` points at the overlay (not the baseline), the overlay is created with the baseline as its backing file, and the baseline mtime is unchanged across `create()`.
- [x] Unit test confirms two VMs with different `vm_id` but the same baseline get distinct overlays both backed by the same image.
- [x] **End-to-end against a real Windows 11 qcow2**: full boot → wait_for_ssh → vm.run() → clean stop → baseline file is byte-identical (size + mtime + first-4K bytes all unchanged):
  ```
  size before/after:   68,730,224,640 / 68,730,224,640
  mtime before/after:  1779786328905318035 / 1779786328905318035
  first-4k bytes equal: True
  ```

## Out of scope

- Env var injection on Windows (Phase 3b).
- Automated Windows install / `smolvm windows build-image` (Phase 3c).
- Snapshot/restore for Windows VMs (still rejected — atomic multi-artifact snapshot is its own design problem).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Windows local-image VMs now use per-VM disk isolation instead of shared baselines, preventing concurrent corruption and ensuring baseline integrity.

* **Tests**
  * Expanded test coverage for Windows local-image VM behavior with isolated disk mode, including validation of concurrent VM creation and baseline immutability.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/CelestoAI/SmolVM/pull/304?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->