### PR TITLE
Detect crashed VMs in list/pause/resume/ssh; confirm cleanup

### DIFF
--- a/src/smolvm/cli/cleanup.py
+++ b/src/smolvm/cli/cleanup.py
@@ -97,6 +97,12 @@ def add_cleanup_args(parser: argparse.ArgumentParser) -> None:
         help="Show what would be cleaned up without actually deleting.",
     )
     parser.add_argument(
+        "--force",
+        "-f",
+        action="store_true",
+        help="Skip the confirmation prompt and delete all VMs.",
+    )
+    parser.add_argument(
         "--json",
         action="store_true",
         help="Emit machine-readable JSON output.",
@@ -290,10 +296,57 @@ def run_delete(
 # ---------------------------------------------------------------------------
 
 
+def _confirm_cleanup(
+    target_ids: list[str],
+    *,
+    force: bool,
+    json_output: bool,
+) -> int | None:
+    """Confirm the destructive cleanup with the user.
+
+    Returns ``None`` to proceed, or an exit code to return from
+    ``run_cleanup``. A clean user abort at the prompt returns ``0``;
+    refusing to run unattended (``--json`` without ``--force``, or no TTY)
+    returns ``1``.
+    """
+    if force:
+        return None
+
+    if json_output:
+        render_error(
+            "Refusing to delete VMs without --force in --json mode. Pass --force to confirm."
+        )
+        return 1
+
+    if not sys.stdin.isatty():
+        render_error(
+            "Refusing to delete VMs without a confirmation prompt. Pass --force to confirm."
+        )
+        return 1
+
+    console = console_stdout()
+    console.print(
+        f"This will permanently delete [bold]{len(target_ids)}[/bold] VM(s): "
+        f"{', '.join(target_ids)}"
+    )
+    console.print("[yellow]This action cannot be undone.[/yellow]")
+    try:
+        console.print("Continue? \\[y/N] ", end="")
+        answer = input("").strip().lower()
+    except (EOFError, KeyboardInterrupt):
+        console.print("\nAborted.")
+        return 0
+    if answer not in {"y", "yes"}:
+        console.print("Aborted.")
+        return 0
+    return None
+
+
 def run_cleanup(
     *,
     dry_run: bool = False,
     json_output: bool = False,
+    force: bool = False,
 ) -> int:
     """Delete all VMs."""
     warn_not_root = sys.platform == "linux" and os.geteuid() != 0
@@ -306,6 +359,10 @@ def run_cleanup(
 
             deleted: list[str] = []
             failed: list[DeleteFailure] = []
+            if not dry_run and target_ids:
+                abort_code = _confirm_cleanup(target_ids, force=force, json_output=json_output)
+                if abort_code is not None:
+                    return abort_code
             if not dry_run:
                 deleted, failed = _delete_vms_concurrent(sdk, target_ids)
 
@@ -354,4 +411,5 @@ def main(argv: Sequence[str] | None = None) -> int:
     return run_cleanup(
         dry_run=args.dry_run,
         json_output=args.json,
+        force=args.force,
     )

--- a/src/smolvm/cli/cleanup.py
+++ b/src/smolvm/cli/cleanup.py
@@ -313,8 +313,17 @@ def _confirm_cleanup(
         return None
 
     if json_output:
-        render_error(
-            "Refusing to delete VMs without --force in --json mode. Pass --force to confirm."
+        emit_json(
+            "cleanup",
+            1,
+            data=None,
+            error={
+                "message": (
+                    "Refusing to delete VMs without --force in --json mode. "
+                    "Pass --force to confirm."
+                ),
+                "type": "refused",
+            },
         )
         return 1
 

--- a/src/smolvm/cli/main.py
+++ b/src/smolvm/cli/main.py
@@ -1471,6 +1471,12 @@ def _run_list(*, include_all: bool, status_filter: str | None, json_output: bool
             effective_status = status_filter or (None if include_all else VMState.RUNNING.value)
             state = VMState(effective_status) if effective_status else None
             vms = sdk.list_vms(status=state)
+            # Cheap per-row liveness check: a VM marked RUNNING/PAUSED whose
+            # QEMU process is gone gets demoted to ERROR right here, so the
+            # rendered table reflects reality instead of a stale DB row.
+            vms = [sdk.refresh_status(vm) for vm in vms]
+            if state is not None:
+                vms = [vm for vm in vms if vm.status == state]
             rows = _vm_rows(vms)
             data: ListPayload = {
                 "filters": {
@@ -3102,6 +3108,25 @@ def _run_file(args: argparse.Namespace) -> int:
             vm.close()
 
 
+def _hint_if_vm_crashed(vm: object) -> None:
+    """Print a clearer error if a non-zero ssh exit was caused by a dead VM.
+
+    ssh's own "Connection refused" is unhelpful when the real cause is that
+    the underlying QEMU process is gone but the DB still says ``running``.
+    Surface the recovery command without changing the ssh exit code.
+    """
+    from smolvm.facade import SmolVM
+    from smolvm.vm import _crashed_message
+
+    _vm: SmolVM = vm  # type: ignore[assignment]
+    try:
+        refreshed = _vm._sdk.refresh_status(_vm._info)
+    except Exception:
+        return
+    if refreshed.status == VMState.ERROR:
+        render_error(_crashed_message(_vm.vm_id))
+
+
 def _run_ssh(args: argparse.Namespace) -> int:
     """Handle ``smolvm ssh``."""
     from smolvm.facade import SmolVM
@@ -3133,8 +3158,12 @@ def _run_ssh(args: argparse.Namespace) -> int:
         else:
             # VM is already running — connect directly without probing.
             completed = subprocess.run(vm._ssh_direct_command(), check=False)
+            if completed.returncode != 0:
+                _hint_if_vm_crashed(vm)
             return completed.returncode
         completed = subprocess.run(vm._ssh_attach_command(), check=False)
+        if completed.returncode != 0:
+            _hint_if_vm_crashed(vm)
         return completed.returncode
     except FileNotFoundError:
         return _emit_cli_error(
@@ -3534,6 +3563,7 @@ def main(argv: Sequence[str] | None = None) -> int:
         return run_cleanup(
             dry_run=args.dry_run,
             json_output=args.json,
+            force=args.force,
         )
 
     if args.command == "prune":

--- a/src/smolvm/vm.py
+++ b/src/smolvm/vm.py
@@ -211,6 +211,14 @@ def resolve_data_dir(data_dir: Path | None = None) -> Path:
     )
 
 
+def _crashed_message(vm_id: str) -> str:
+    """User-facing message for a VM whose process is gone."""
+    return (
+        f"VM '{vm_id}' is not running — its process has exited. "
+        f"Run 'smolvm delete {vm_id}' to clear it."
+    )
+
+
 class SmolVMManager:
     """Low-level manager class for orchestrating sandbox VMs.
 
@@ -1146,12 +1154,13 @@ class SmolVMManager:
         vm_info = self.state.get_vm(vm_id)
 
         if vm_info.status != VMState.RUNNING:
-            raise SmolVMError(
-                f"Cannot pause VM in state '{vm_info.status.value}'",
-                {"vm_id": vm_id, "current_status": vm_info.status.value},
-            )
+            self._raise_crashed_or_state_error(vm_info, action="pause")
 
-        self._runtime_adapter_for_vm(vm_info).pause(vm_info)
+        try:
+            self._runtime_adapter_for_vm(vm_info).pause(vm_info)
+        except Exception:
+            self._raise_if_crashed(vm_info)
+            raise
         return self.state.update_vm(vm_id, status=VMState.PAUSED)
 
     def resume(self, vm_id: str) -> VMInfo:
@@ -1162,13 +1171,45 @@ class SmolVMManager:
         vm_info = self.state.get_vm(vm_id)
 
         if vm_info.status != VMState.PAUSED:
-            raise SmolVMError(
-                f"Cannot resume VM in state '{vm_info.status.value}'",
-                {"vm_id": vm_id, "current_status": vm_info.status.value},
-            )
+            self._raise_crashed_or_state_error(vm_info, action="resume")
 
-        self._runtime_adapter_for_vm(vm_info).resume(vm_info)
+        try:
+            self._runtime_adapter_for_vm(vm_info).resume(vm_info)
+        except Exception:
+            self._raise_if_crashed(vm_info)
+            raise
         return self.state.update_vm(vm_id, status=VMState.RUNNING)
+
+    def _raise_crashed_or_state_error(self, vm_info: VMInfo, *, action: str) -> None:
+        """Raise the state error, replacing it with a 'crashed' message if stale.
+
+        A VM whose DB row says RUNNING/PAUSED but whose process is gone shows
+        up here as a state-guard failure (e.g. resume rejecting a "running"
+        VM). Translate that into an actionable crash message instead of the
+        misleading "Cannot resume VM in state 'running'".
+        """
+        refreshed = self.refresh_status(vm_info)
+        if refreshed.status == VMState.ERROR and vm_info.status in (
+            VMState.RUNNING,
+            VMState.PAUSED,
+        ):
+            raise SmolVMError(
+                _crashed_message(vm_info.vm_id),
+                {"vm_id": vm_info.vm_id, "current_status": refreshed.status.value},
+            )
+        raise SmolVMError(
+            f"Cannot {action} VM in state '{vm_info.status.value}'",
+            {"vm_id": vm_info.vm_id, "current_status": vm_info.status.value},
+        )
+
+    def _raise_if_crashed(self, vm_info: VMInfo) -> None:
+        """Re-raise as a crash error if the VM's process is gone, otherwise no-op."""
+        refreshed = self.refresh_status(vm_info)
+        if refreshed.status == VMState.ERROR:
+            raise SmolVMError(
+                _crashed_message(vm_info.vm_id),
+                {"vm_id": vm_info.vm_id, "current_status": refreshed.status.value},
+            ) from None
 
     def create_snapshot(
         self,
@@ -1538,6 +1579,24 @@ class SmolVMManager:
     def list_snapshots(self, vm_id: str | None = None) -> list[SnapshotInfo]:
         """List snapshots, optionally filtered by source VM ID."""
         return self.state.list_snapshots(vm_id=vm_id)
+
+    def refresh_status(self, vm_info: VMInfo) -> VMInfo:
+        """Detect a dead VM process and demote the DB row to ERROR.
+
+        Cheap per-row liveness check (one ``os.kill(pid, 0)`` syscall) for
+        callers that already have a ``VMInfo`` in hand and don't want the
+        full reconcile sweep. Returns ``vm_info`` unchanged if the VM is
+        not in a status that should track a process, or if the process is
+        still alive.
+        """
+        if vm_info.status not in (VMState.RUNNING, VMState.PAUSED):
+            return vm_info
+        if vm_info.pid is None:
+            return vm_info
+        if self._is_process_running(vm_info.pid):
+            return vm_info
+        logger.warning("VM %s pid %d is gone; marking ERROR.", vm_info.vm_id, vm_info.pid)
+        return self.state.update_vm(vm_info.vm_id, status=VMState.ERROR, clear_pid=True)
 
     def reconcile(self) -> list[str]:
         """Reconcile state with actual system state.

--- a/src/smolvm/vm.py
+++ b/src/smolvm/vm.py
@@ -214,8 +214,8 @@ def resolve_data_dir(data_dir: Path | None = None) -> Path:
 def _crashed_message(vm_id: str) -> str:
     """User-facing message for a VM whose process is gone."""
     return (
-        f"VM '{vm_id}' is not running — its process has exited. "
-        f"Run 'smolvm delete {vm_id}' to clear it."
+        f"VM '{vm_id}' is not running — its process has exited; "
+        f"run 'smolvm delete {vm_id}' to clear it."
     )
 
 
@@ -1197,8 +1197,16 @@ class SmolVMManager:
                 _crashed_message(vm_info.vm_id),
                 {"vm_id": vm_info.vm_id, "current_status": refreshed.status.value},
             )
+        # State-appropriate recovery: STOPPED/CREATED → start, ERROR → delete.
+        # PAUSED/RUNNING (already in a compatible state) needs no recovery —
+        # the status string itself is the explanation.
+        recovery = ""
+        if vm_info.status == VMState.ERROR:
+            recovery = f"; run 'smolvm delete {vm_info.vm_id}' to clear it"
+        elif vm_info.status in (VMState.STOPPED, VMState.CREATED):
+            recovery = f"; run 'smolvm start {vm_info.vm_id}' to start it"
         raise SmolVMError(
-            f"Cannot {action} VM in state '{vm_info.status.value}'",
+            f"Cannot {action} VM in state '{vm_info.status.value}'{recovery}.",
             {"vm_id": vm_info.vm_id, "current_status": vm_info.status.value},
         )
 

--- a/tests/test_cleanup.py
+++ b/tests/test_cleanup.py
@@ -256,7 +256,7 @@ class TestCleanup:
         mock_sdk_cls: MagicMock,
         capsys: pytest.CaptureFixture,
     ) -> None:
-        """JSON mode without --force should refuse to delete."""
+        """JSON mode without --force should refuse to delete and emit a JSON envelope."""
         sdk = mock_sdk_cls
         sdk.reconcile.return_value = []
         sdk.list_vms.return_value = [_make_vm("vm-abc123")]
@@ -265,6 +265,12 @@ class TestCleanup:
 
         assert ret == 1
         sdk.delete.assert_not_called()
+        payload = json.loads(capsys.readouterr().out)
+        assert isinstance(payload, dict)
+        assert payload["ok"] is False
+        assert payload["command"] == "cleanup"
+        assert payload["exit_code"] == 1
+        assert "force" in payload["error"]["message"].lower()
 
     @patch("smolvm.cli.cleanup.os.geteuid", return_value=0)
     @patch("smolvm.cli.cleanup.sys.stdin")

--- a/tests/test_cleanup.py
+++ b/tests/test_cleanup.py
@@ -194,7 +194,7 @@ class TestCleanup:
         sdk.reconcile.return_value = []
         sdk.list_vms.return_value = [_make_vm("vm-abc123"), _make_vm("vm-def456")]
 
-        ret = run_cleanup()
+        ret = run_cleanup(force=True)
 
         assert ret == 0
         assert sdk.delete.call_count == 2
@@ -217,7 +217,7 @@ class TestCleanup:
 
         sdk.delete.side_effect = _delete
 
-        ret = run_cleanup()
+        ret = run_cleanup(force=True)
 
         assert ret == 1
         out = capsys.readouterr().out
@@ -238,7 +238,7 @@ class TestCleanup:
         sdk.reconcile.return_value = ["vm-stale"]
         sdk.list_vms.return_value = [_make_vm("vm-stale"), _make_vm("vm-other")]
 
-        ret = run_cleanup(json_output=True)
+        ret = run_cleanup(json_output=True, force=True)
 
         assert ret == 0
         payload = json.loads(capsys.readouterr().out)
@@ -249,10 +249,99 @@ class TestCleanup:
         assert payload["data"]["reconciled_stale_ids"] == ["vm-stale"]
         assert payload["data"]["summary"]["failed_count"] == 0
 
+    @patch("smolvm.cli.cleanup.os.geteuid", return_value=0)
+    def test_run_cleanup_json_requires_force(
+        self,
+        _: MagicMock,
+        mock_sdk_cls: MagicMock,
+        capsys: pytest.CaptureFixture,
+    ) -> None:
+        """JSON mode without --force should refuse to delete."""
+        sdk = mock_sdk_cls
+        sdk.reconcile.return_value = []
+        sdk.list_vms.return_value = [_make_vm("vm-abc123")]
+
+        ret = run_cleanup(json_output=True)
+
+        assert ret == 1
+        sdk.delete.assert_not_called()
+
+    @patch("smolvm.cli.cleanup.os.geteuid", return_value=0)
+    @patch("smolvm.cli.cleanup.sys.stdin")
+    def test_run_cleanup_non_tty_requires_force(
+        self,
+        mock_stdin: MagicMock,
+        _: MagicMock,
+        mock_sdk_cls: MagicMock,
+        capsys: pytest.CaptureFixture,
+    ) -> None:
+        """Non-TTY callers must pass --force; we won't silently delete."""
+        mock_stdin.isatty.return_value = False
+        sdk = mock_sdk_cls
+        sdk.reconcile.return_value = []
+        sdk.list_vms.return_value = [_make_vm("vm-abc123")]
+
+        ret = run_cleanup()
+
+        assert ret == 1
+        sdk.delete.assert_not_called()
+
+    @patch("smolvm.cli.cleanup.os.geteuid", return_value=0)
+    @patch("smolvm.cli.cleanup.sys.stdin")
+    @patch("smolvm.cli.cleanup.input", create=True)
+    def test_run_cleanup_prompt_yes(
+        self,
+        mock_input: MagicMock,
+        mock_stdin: MagicMock,
+        _: MagicMock,
+        mock_sdk_cls: MagicMock,
+        capsys: pytest.CaptureFixture,
+    ) -> None:
+        """TTY prompt with 'y' proceeds with deletion."""
+        mock_stdin.isatty.return_value = True
+        mock_input.return_value = "y"
+        sdk = mock_sdk_cls
+        sdk.reconcile.return_value = []
+        sdk.list_vms.return_value = [_make_vm("vm-abc123")]
+
+        ret = run_cleanup()
+
+        assert ret == 0
+        sdk.delete.assert_called_once_with("vm-abc123")
+
+    @patch("smolvm.cli.cleanup.os.geteuid", return_value=0)
+    @patch("smolvm.cli.cleanup.sys.stdin")
+    @patch("smolvm.cli.cleanup.input", create=True)
+    def test_run_cleanup_prompt_no(
+        self,
+        mock_input: MagicMock,
+        mock_stdin: MagicMock,
+        _: MagicMock,
+        mock_sdk_cls: MagicMock,
+        capsys: pytest.CaptureFixture,
+    ) -> None:
+        """TTY prompt with empty/'n' aborts."""
+        mock_stdin.isatty.return_value = True
+        mock_input.return_value = ""
+        sdk = mock_sdk_cls
+        sdk.reconcile.return_value = []
+        sdk.list_vms.return_value = [_make_vm("vm-abc123")]
+
+        ret = run_cleanup()
+
+        assert ret == 0
+        sdk.delete.assert_not_called()
+        assert "Aborted" in capsys.readouterr().out
+
     def test_cleanup_parser_includes_json(self) -> None:
         """The standalone cleanup parser should expose `--json`."""
         args = build_parser().parse_args(["--json"])
         assert args.json is True
+
+    def test_cleanup_parser_includes_force(self) -> None:
+        """The standalone cleanup parser should expose `--force`."""
+        args = build_parser().parse_args(["--force"])
+        assert args.force is True
 
     @patch("smolvm.cli.main.run_cleanup", return_value=0)
     def test_cli_cleanup_forwards_json(self, mock_run_cleanup: MagicMock) -> None:
@@ -263,6 +352,7 @@ class TestCleanup:
         mock_run_cleanup.assert_called_once_with(
             dry_run=False,
             json_output=True,
+            force=False,
         )
 
     @patch("smolvm.cli.cleanup.run_cleanup", return_value=0)
@@ -274,4 +364,5 @@ class TestCleanup:
         mock_run_cleanup.assert_called_once_with(
             dry_run=False,
             json_output=True,
+            force=False,
         )

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -2205,6 +2205,9 @@ class TestCliList:
         with patch("smolvm.vm.SmolVMManager") as m:
             m.return_value.__enter__.return_value = m.return_value
             m.return_value.__exit__.side_effect = lambda *args: m.return_value.close()
+            # `_run_list` now calls `sdk.refresh_status(vm)` on every row.
+            # Default to a pass-through so the mock VMInfo objects survive.
+            m.return_value.refresh_status.side_effect = lambda vm: vm
             yield m
 
     def test_list_empty(
@@ -2273,7 +2276,7 @@ class TestCliList:
         capsys: pytest.CaptureFixture,
     ) -> None:
         """`smolvm list` should show '-' for a missing PID."""
-        vms = [_make_vm_info("vm-abc123", VMState.CREATED, "", None, None)]
+        vms = [_make_vm_info("vm-abc123", VMState.RUNNING, "", None, None)]
         vms[0].network = None
         mock_sdk_cls.return_value.list_vms.return_value = vms
 
@@ -2282,7 +2285,7 @@ class TestCliList:
         assert ret == 0
         out = capsys.readouterr().out
         assert "vm-abc123" in out
-        assert "created" in out
+        assert "running" in out
         mock_sdk_cls.return_value.list_vms.assert_called_once_with(status=VMState.RUNNING)
         assert "PID" in out
         assert "-" in out

--- a/tests/test_vm.py
+++ b/tests/test_vm.py
@@ -866,6 +866,120 @@ class TestProcessLifecycle:
         assert process.pid not in smol_vm._process_handles
 
 
+def _info(config: VMConfig, status: VMState, pid: int | None = None) -> VMInfo:
+    """Build a VMInfo with a real VMConfig (pydantic strict-validates)."""
+    return VMInfo(vm_id=config.vm_id, status=status, config=config, pid=pid)
+
+
+class TestRefreshStatus:
+    """Tests for the cheap per-row liveness check used by ``smolvm list``."""
+
+    def test_running_with_live_pid_unchanged(
+        self, smol_vm: SmolVMManager, sample_config: VMConfig
+    ) -> None:
+        vm_info = _info(sample_config, VMState.RUNNING, pid=12345)
+        with patch.object(smol_vm, "_is_process_running", return_value=True):
+            result = smol_vm.refresh_status(vm_info)
+        assert result is vm_info
+
+    def test_running_with_dead_pid_demoted_to_error(
+        self, smol_vm: SmolVMManager, sample_config: VMConfig
+    ) -> None:
+        vm_info = _info(sample_config, VMState.RUNNING, pid=99999)
+        updated = _info(sample_config, VMState.ERROR, pid=None)
+        with (
+            patch.object(smol_vm, "_is_process_running", return_value=False),
+            patch.object(smol_vm.state, "update_vm", return_value=updated) as mock_update,
+        ):
+            result = smol_vm.refresh_status(vm_info)
+        assert result.status == VMState.ERROR
+        mock_update.assert_called_once_with(
+            sample_config.vm_id, status=VMState.ERROR, clear_pid=True
+        )
+
+    def test_paused_with_dead_pid_demoted_to_error(
+        self, smol_vm: SmolVMManager, sample_config: VMConfig
+    ) -> None:
+        vm_info = _info(sample_config, VMState.PAUSED, pid=99999)
+        updated = _info(sample_config, VMState.ERROR, pid=None)
+        with (
+            patch.object(smol_vm, "_is_process_running", return_value=False),
+            patch.object(smol_vm.state, "update_vm", return_value=updated),
+        ):
+            result = smol_vm.refresh_status(vm_info)
+        assert result.status == VMState.ERROR
+
+    def test_stopped_not_touched(self, smol_vm: SmolVMManager, sample_config: VMConfig) -> None:
+        vm_info = _info(sample_config, VMState.STOPPED, pid=None)
+        with (
+            patch.object(smol_vm, "_is_process_running") as mock_check,
+            patch.object(smol_vm.state, "update_vm") as mock_update,
+        ):
+            result = smol_vm.refresh_status(vm_info)
+        assert result is vm_info
+        mock_check.assert_not_called()
+        mock_update.assert_not_called()
+
+    def test_running_without_pid_not_touched(
+        self, smol_vm: SmolVMManager, sample_config: VMConfig
+    ) -> None:
+        vm_info = _info(sample_config, VMState.RUNNING, pid=None)
+        with (
+            patch.object(smol_vm, "_is_process_running") as mock_check,
+            patch.object(smol_vm.state, "update_vm") as mock_update,
+        ):
+            result = smol_vm.refresh_status(vm_info)
+        assert result is vm_info
+        mock_check.assert_not_called()
+        mock_update.assert_not_called()
+
+
+class TestCrashedVMDetection:
+    """Tests that pause/resume surface a useful error when the VM has crashed."""
+
+    def test_resume_reports_crash_when_status_stale_running(
+        self, smol_vm: SmolVMManager, sample_config: VMConfig
+    ) -> None:
+        """DB says RUNNING but PID is dead: resume should raise 'crashed', not 'Cannot resume'."""
+        vm_info = _info(sample_config, VMState.RUNNING, pid=99999)
+        crashed = _info(sample_config, VMState.ERROR, pid=None)
+        with (
+            patch.object(smol_vm.state, "get_vm", return_value=vm_info),
+            patch.object(smol_vm, "_is_process_running", return_value=False),
+            patch.object(smol_vm.state, "update_vm", return_value=crashed),
+            pytest.raises(SmolVMError, match="is not running"),
+        ):
+            smol_vm.resume(sample_config.vm_id)
+
+    def test_resume_original_error_when_status_genuinely_wrong(
+        self, smol_vm: SmolVMManager, sample_config: VMConfig
+    ) -> None:
+        """DB says STOPPED: resume should raise the original 'Cannot resume' error."""
+        vm_info = _info(sample_config, VMState.STOPPED, pid=None)
+        with (
+            patch.object(smol_vm.state, "get_vm", return_value=vm_info),
+            pytest.raises(SmolVMError, match="Cannot resume VM in state 'stopped'"),
+        ):
+            smol_vm.resume(sample_config.vm_id)
+
+    def test_pause_reports_crash_when_runtime_pause_fails_with_dead_pid(
+        self, smol_vm: SmolVMManager, sample_config: VMConfig
+    ) -> None:
+        """pause's QMP call fails: if PID is dead, surface a crash message."""
+        vm_info = _info(sample_config, VMState.RUNNING, pid=99999)
+        crashed = _info(sample_config, VMState.ERROR, pid=None)
+        mock_adapter = MagicMock()
+        mock_adapter.pause.side_effect = SmolVMError("Timed out waiting for QMP socket")
+        with (
+            patch.object(smol_vm.state, "get_vm", return_value=vm_info),
+            patch.object(smol_vm, "_runtime_adapter_for_vm", return_value=mock_adapter),
+            patch.object(smol_vm, "_is_process_running", return_value=False),
+            patch.object(smol_vm.state, "update_vm", return_value=crashed),
+            pytest.raises(SmolVMError, match="is not running"),
+        ):
+            smol_vm.pause(sample_config.vm_id)
+
+
 class TestResolveBootArgs:
     """Tests for boot-args resolution, including SSH-key cmdline injection.
 


### PR DESCRIPTION
## Summary

`smolvm list` trusted the SQLite state DB blindly, so a VM whose QEMU process had died still showed up as `running`. Every follow-up command then failed for a different misleading reason (`ssh` got "connection refused", `resume` said "Cannot resume VM in state 'running'", `pause` timed out on the QMP socket). This PR detects the stale state and surfaces an actionable error, and adds a confirmation prompt to `smolvm cleanup` since it's irreversible.

- **Cheap PID check in `list`** — new `SmolVMManager.refresh_status(vm_info)` does a single `os.kill(pid, 0)` syscall and demotes a stale `running`/`paused` row to `ERROR`. `_run_list` runs every row through it before rendering and re-applies the status filter so demoted rows drop out of the default `running` view.
- **Crash detection on `pause` / `resume` / `ssh`** — these check the PID only when something goes wrong (state-guard rejection, QMP timeout, non-zero ssh exit). When the underlying process is gone, the misleading error is replaced with: *"VM 'X' is not running — its process has exited. Run 'smolvm delete X' to clear it."* The ssh exit code is preserved.
- **`smolvm cleanup` confirmation + `--force`** — lists the targeted VMs and prompts before deleting. `--force` / `-f` skips the prompt. Without `--force`, non-TTY callers and `--json` mode refuse to delete rather than silently destroying data; declining at the prompt exits cleanly (0).

## Test plan

- [x] `uv run pytest tests/test_vm.py tests/test_cleanup.py tests/test_cli.py` — 227 passed
- [x] `uv run pytest` — full suite, 1064 passed / 13 skipped
- [x] `uv run ruff check` and `uv run ruff format --check` on touched files (no new findings)
- [ ] Manual: reproduce the original bug (kill QEMU PID, then run `smolvm list`, `smolvm ssh`, `smolvm pause`, `smolvm resume`) and verify each surfaces the new crash message
- [ ] Manual: `smolvm cleanup` (interactive prompt), `smolvm cleanup --force`, `smolvm cleanup --json` (refuses without `--force`), `smolvm cleanup --json --force` (deletes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `--force` to `smolvm cleanup` to skip interactive confirmation; cleanup now refuses to run in JSON mode or when stdin is non‑TTY unless forced.
  * CLI forwards the force flag; `smolvm list` performs a lightweight status refresh for accurate filtering.

* **Bug Fixes**
  * Improved crash detection with clearer VM "not running" errors for pause/resume and SSH failure cases.

* **Tests**
  * Updated and added tests covering force behavior, JSON/non‑TTY refusal, status refresh, and crash handling.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/CelestoAI/SmolVM/pull/309?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->