### PR TITLE
Add vsock host↔guest control channel (QEMU first, SSH fallback)

### DIFF
--- a/src/smolvm/cli/main.py
+++ b/src/smolvm/cli/main.py
@@ -2182,7 +2182,10 @@ def _run_start_with_published_image(args: argparse.Namespace, preset: object) ->
         return _emit_cli_error(
             "start",
             2,
-            ValueError(f"Preset {_preset.name!r} has no boot_args configured for vmm {vmm!r}."),
+            ValueError(
+                f"Preset {_preset.name!r} isn't available as a prebuilt image "
+                "for this platform yet."
+            ),
             json_output=args.json,
         )
 

--- a/src/smolvm/cli/main.py
+++ b/src/smolvm/cli/main.py
@@ -356,6 +356,19 @@ def _add_ssh_auth_args(command_parser: argparse.ArgumentParser) -> None:
     )
 
 
+def _add_comm_channel_arg(command_parser: argparse.ArgumentParser) -> None:
+    """Add the host↔guest control-channel selector to a command parser."""
+    command_parser.add_argument(
+        "--comm-channel",
+        choices=["ssh", "vsock"],
+        default=None,
+        help=(
+            "Host-to-guest control channel for this command (default: auto — "
+            "vsock when the guest agent answers on a QEMU/Linux host, else SSH)."
+        ),
+    )
+
+
 def _add_boot_timeout_arg(command_parser: argparse.ArgumentParser) -> None:
     """Add a shared boot/SSH readiness timeout flag."""
     command_parser.add_argument(
@@ -974,6 +987,7 @@ def build_parser() -> argparse.ArgumentParser:
         help="Emit machine-readable JSON output.",
     )
     _add_ssh_auth_args(file_upload)
+    _add_comm_channel_arg(file_upload)
 
     file_download = file_sub.add_parser(
         "download",
@@ -1001,6 +1015,7 @@ def build_parser() -> argparse.ArgumentParser:
         help="Emit machine-readable JSON output.",
     )
     _add_ssh_auth_args(file_download)
+    _add_comm_channel_arg(file_download)
 
     # ── windows: image-building helpers ────────────────────────────
     windows_parser = subparsers.add_parser(
@@ -1255,6 +1270,7 @@ def build_parser() -> argparse.ArgumentParser:
         help="Emit machine-readable JSON output.",
     )
     _add_ssh_auth_args(env_set)
+    _add_comm_channel_arg(env_set)
 
     env_unset = env_sub.add_parser(
         "unset",
@@ -1273,6 +1289,7 @@ def build_parser() -> argparse.ArgumentParser:
         help="Emit machine-readable JSON output.",
     )
     _add_ssh_auth_args(env_unset)
+    _add_comm_channel_arg(env_unset)
 
     env_list = env_sub.add_parser(
         "list",
@@ -1290,6 +1307,7 @@ def build_parser() -> argparse.ArgumentParser:
         help="Emit machine-readable JSON output.",
     )
     _add_ssh_auth_args(env_list)
+    _add_comm_channel_arg(env_list)
 
     return parser
 
@@ -1870,11 +1888,7 @@ def _run_create(args: argparse.Namespace) -> int:
 
         # CLI default: roomier disk for ubuntu so package installs
         # and apt cache don't fill the rootfs on a basic `smolvm create`.
-        if (
-            not use_s3_image
-            and args.disk_size_mib is None
-            and resolved_guest_os is GuestOS.UBUNTU
-        ):
+        if not use_s3_image and args.disk_size_mib is None and resolved_guest_os is GuestOS.UBUNTU:
             args.disk_size_mib = 4096
 
         if use_local_image:
@@ -2123,10 +2137,7 @@ def _vmm_for_host() -> Vmm:
         return "firecracker"
     if system == "Darwin":
         return "qemu"
-    raise RuntimeError(
-        f"Unsupported host OS for published images: {system!r}."
-    )
-
+    raise RuntimeError(f"Unsupported host OS for published images: {system!r}.")
 
 
 def _host_arch_for_published() -> Arch:
@@ -2136,9 +2147,7 @@ def _host_arch_for_published() -> Arch:
         return "arm64"
     if machine in {"x86_64", "amd64"}:
         return "amd64"
-    raise RuntimeError(
-        f"Unsupported host architecture for published images: {machine!r}."
-    )
+    raise RuntimeError(f"Unsupported host architecture for published images: {machine!r}.")
 
 
 def _run_start_with_published_image(args: argparse.Namespace, preset: object) -> int:
@@ -2173,10 +2182,7 @@ def _run_start_with_published_image(args: argparse.Namespace, preset: object) ->
         return _emit_cli_error(
             "start",
             2,
-            ValueError(
-                f"Preset {_preset.name!r} has no boot_args configured for "
-                f"vmm {vmm!r}."
-            ),
+            ValueError(f"Preset {_preset.name!r} has no boot_args configured for vmm {vmm!r}."),
             json_output=args.json,
         )
 
@@ -2933,6 +2939,7 @@ def _run_env(args: argparse.Namespace) -> int:
             args.vm_id,
             ssh_user=args.ssh_user,
             ssh_key_path=args.ssh_key,
+            comm_channel=args.comm_channel,
         )
 
         if args.env_action == "set":
@@ -3063,6 +3070,7 @@ def _run_file(args: argparse.Namespace) -> int:
             args.vm_id,
             ssh_user=args.ssh_user,
             ssh_key_path=args.ssh_key,
+            comm_channel=args.comm_channel,
         )
 
         if args.file_action == "upload":
@@ -3308,8 +3316,7 @@ def _run_windows(args: argparse.Namespace) -> int:
         return _run_windows_build_image(args)
     # No verb supplied — print the windows subparser help.
     print(
-        "smolvm windows: choose a subcommand "
-        "(e.g. `smolvm windows build-image --help`).",
+        "smolvm windows: choose a subcommand (e.g. `smolvm windows build-image --help`).",
         file=sys.stderr,
     )
     return 2
@@ -3355,7 +3362,7 @@ def _run_windows_build_image(args: argparse.Namespace) -> int:
                 f"Boot it with:\n"
                 f"  [bold]smolvm create --os windows --image {output}[/bold]\n"
                 f"or in Python:\n"
-                f"  [bold]SmolVM(os=\"windows\", image=\"{output}\", "
+                f'  [bold]SmolVM(os="windows", image="{output}", '
                 f'ssh_user="{args.username}", ssh_password="<hidden>")[/bold]',
                 title="Windows image ready",
                 border_style="green",

--- a/src/smolvm/comm/__init__.py
+++ b/src/smolvm/comm/__init__.py
@@ -1,0 +1,45 @@
+# Copyright 2026 Celesto AI
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Host↔guest control-plane transports.
+
+SmolVM drives a guest from the host to run commands, transfer files, and
+probe readiness. :class:`~smolvm.comm.base.CommChannel` is the small interface
+every consumer relies on; it has two implementations:
+
+- :class:`~smolvm.ssh.SSHClient` — SSH/paramiko (the default, works everywhere).
+- :class:`~smolvm.comm.vsock_channel.VsockChannel` — a guest agent reached over
+  ``AF_VSOCK`` (QEMU on Linux first), which works before the guest network or
+  sshd is up.
+"""
+
+from __future__ import annotations
+
+from smolvm.comm.base import CommChannel, CommChannelKind, ShellMode
+from smolvm.comm.select import (
+    ChannelResolution,
+    host_supports_vsock,
+    resolve_comm_channel,
+)
+from smolvm.comm.vsock_channel import VsockChannel
+
+__all__ = [
+    "ChannelResolution",
+    "CommChannel",
+    "CommChannelKind",
+    "ShellMode",
+    "VsockChannel",
+    "host_supports_vsock",
+    "resolve_comm_channel",
+]

--- a/src/smolvm/comm/base.py
+++ b/src/smolvm/comm/base.py
@@ -1,0 +1,81 @@
+# Copyright 2026 Celesto AI
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""The host↔guest transport interface shared by SSH and vsock.
+
+``CommChannel`` is the least-common-denominator surface every caller already
+uses: run a command, push/pull a file, wait until the guest answers, and
+close. :class:`~smolvm.ssh.SSHClient` satisfies it structurally (it predates
+this protocol), and :class:`~smolvm.comm.vsock_channel.VsockChannel`
+implements it explicitly. Keeping the interface this narrow means env-var
+injection (``smolvm.env``) and preset credential copying
+(``smolvm.presets``) work over either transport with no code change — they
+only ever call :meth:`run` and :meth:`put_file`.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Literal, Protocol, runtime_checkable
+
+from smolvm.types import CommandResult
+
+CommChannelKind = Literal["ssh", "vsock"]
+"""Which transport a VM uses for its control plane."""
+
+ShellMode = Literal["login", "raw"]
+"""``login`` wraps the command in the guest login shell; ``raw`` runs it
+verbatim. Mirrors :data:`smolvm.ssh.ShellMode`."""
+
+
+@runtime_checkable
+class CommChannel(Protocol):
+    """Host-side handle for driving a single guest.
+
+    Implementations keep their own connection state and (re)connect lazily,
+    so a channel can be constructed before the guest is reachable and used
+    once :meth:`wait_ready` returns.
+    """
+
+    kind: CommChannelKind
+
+    def run(
+        self,
+        command: str,
+        timeout: int = 30,
+        shell: ShellMode = "login",
+    ) -> CommandResult:
+        """Execute *command* on the guest and return its result."""
+        ...
+
+    def put_file(self, local_path: str | Path, remote_path: str) -> None:
+        """Upload a local file to *remote_path* in the guest."""
+        ...
+
+    def get_file(self, remote_path: str, local_path: str | Path) -> Path:
+        """Download *remote_path* from the guest to *local_path*."""
+        ...
+
+    def wait_ready(self, timeout: float = 60.0, interval: float = 0.1) -> None:
+        """Block until the guest answers, or raise on timeout."""
+        ...
+
+    def close(self) -> None:
+        """Release any connection held by the channel."""
+        ...
+
+    @property
+    def connected(self) -> bool:
+        """Whether the channel currently holds a live connection."""
+        ...

--- a/src/smolvm/comm/protocol.py
+++ b/src/smolvm/comm/protocol.py
@@ -1,0 +1,122 @@
+# Copyright 2026 Celesto AI
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Wire protocol for the SmolVM guest-agent vsock control channel.
+
+Every frame is a 1-byte type tag, a ``u32`` big-endian payload length, and
+that many payload bytes. Control frames carry UTF-8 JSON; stream and file
+frames carry raw bytes, so command output and large files never pay base64
+overhead.
+
+This module is the host-side authority for the format. The guest agent
+(``smolvm/guest_agent/agent.py``) ships as a standalone, dependency-free file
+into the guest image — where the ``smolvm`` package is not installed — and
+embeds a byte-compatible copy of the framing below. ``tests/test_guest_agent.py``
+drives the agent with these host functions over a socketpair to prove the two
+ends interoperate, so the duplication can't drift silently.
+
+Each request occupies its own connection: the host opens a connection, sends
+one request frame, consumes the response (which may stream many frames), and
+closes. vsock connect is cheap and the agent is unauthenticated, so there is
+no handshake to amortize — one request per connection keeps the stream
+impossible to desync.
+
+Request/response shapes (``op`` selects the operation, ``v`` the protocol
+version):
+
+- ``ping``  → ``{"ok": true, "op": "pong", "agent_version": str, "proto": int}``
+- ``run``   ``{"cmd": str, "shell": "login"|"raw", "timeout": int|null, "env": {}}``
+  → interleaved ``STDOUT``/``STDERR`` frames, terminated by a control frame
+  ``{"op": "exit", "exit_code": int}`` or ``{"op": "timeout", "timeout": float}``.
+- ``put_file`` ``{"path": str, "mode": int|null, "size": int}`` followed by
+  exactly ``size`` bytes in ``DATA`` frames → ``{"ok": bool, "error"?: str}``.
+- ``get_file`` ``{"path": str}`` → ``{"ok": true, "mode": int, "size": int}``
+  then ``DATA`` frames terminated by ``EOF`` (or ``{"ok": false, "error": str}``).
+"""
+
+from __future__ import annotations
+
+import json
+import struct
+from typing import Any
+
+PROTOCOL_VERSION = 1
+"""Bumped on incompatible wire changes; carried as ``v`` on every request."""
+
+SMOLVM_AGENT_PORT = 1024
+"""Guest vsock port the agent listens on (host dials the same fixed port)."""
+
+CHUNK_SIZE = 64 * 1024
+"""Bytes per streamed output/file frame."""
+
+_MAX_FRAME = 16 * 1024 * 1024
+"""Hard cap on a single frame payload, to bound memory on a hostile peer."""
+
+# Frame type tags.
+FRAME_JSON = 1
+"""A UTF-8 JSON control object."""
+FRAME_STDOUT = 2
+"""A raw chunk of a command's standard output."""
+FRAME_STDERR = 3
+"""A raw chunk of a command's standard error."""
+FRAME_DATA = 4
+"""A raw chunk of file content."""
+FRAME_EOF = 5
+"""End-of-stream marker (empty payload)."""
+
+_HEADER = struct.Struct(">BI")  # 1-byte type tag + u32 big-endian length
+
+
+def recv_exact(sock: Any, n: int) -> bytes:
+    """Read exactly *n* bytes from *sock*, raising if the peer closes early."""
+    if n == 0:
+        return b""
+    buf = bytearray()
+    while len(buf) < n:
+        chunk = sock.recv(n - len(buf))
+        if not chunk:
+            raise ConnectionError("connection closed mid-frame")
+        buf.extend(chunk)
+    return bytes(buf)
+
+
+def send_frame(sock: Any, frame_type: int, payload: bytes = b"") -> None:
+    """Send a single framed message."""
+    if len(payload) > _MAX_FRAME:
+        raise ValueError(f"frame payload too large: {len(payload)} bytes")
+    sock.sendall(_HEADER.pack(frame_type, len(payload)) + payload)
+
+
+def recv_frame(sock: Any) -> tuple[int, bytes]:
+    """Receive a single framed message as ``(frame_type, payload)``."""
+    frame_type, length = _HEADER.unpack(recv_exact(sock, _HEADER.size))
+    if length > _MAX_FRAME:
+        raise ValueError(f"frame payload too large: {length} bytes")
+    return frame_type, recv_exact(sock, length)
+
+
+def send_json(sock: Any, obj: dict[str, Any]) -> None:
+    """Send a JSON control frame."""
+    send_frame(sock, FRAME_JSON, json.dumps(obj).encode("utf-8"))
+
+
+def recv_json(sock: Any) -> dict[str, Any]:
+    """Receive a JSON control frame, rejecting any other frame type."""
+    frame_type, payload = recv_frame(sock)
+    if frame_type != FRAME_JSON:
+        raise ValueError(f"expected JSON control frame, got frame type {frame_type}")
+    obj = json.loads(payload.decode("utf-8"))
+    if not isinstance(obj, dict):
+        raise ValueError("control frame is not a JSON object")
+    return obj

--- a/src/smolvm/comm/select.py
+++ b/src/smolvm/comm/select.py
@@ -120,10 +120,8 @@ def resolve_comm_channel(
             )
         if not host_vsock_supported:
             raise SmolVMError(
-                "This host can't provide a vsock device: it needs Linux with the "
-                "vhost_vsock module loaded (run 'sudo modprobe vhost_vsock'). "
-                "Use the SSH channel (comm_channel='ssh') instead — for example "
-                "on macOS, where QEMU has no vsock support."
+                "This host can't provide vsock (needs Linux with vhost_vsock loaded "
+                "via 'sudo modprobe vhost_vsock'); use comm_channel='ssh' instead."
             )
         # Explicit request: use vsock, never silently downgrade to SSH.
         return ChannelResolution(kind="vsock", allow_fallback=False)

--- a/src/smolvm/comm/select.py
+++ b/src/smolvm/comm/select.py
@@ -1,0 +1,135 @@
+# Copyright 2026 Celesto AI
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Decide which control channel a VM should use.
+
+Two layers cooperate:
+
+1. ``resolve_comm_channel`` (here) is the *static* decision: given the user's
+   request, the VM config, the backend, the guest OS, and whether the host can
+   do vsock, it returns the channel to attempt first and whether falling back
+   to SSH is allowed. It raises a plain-English error when the user explicitly
+   asked for vsock somewhere it can't work.
+2. The facade then does the *runtime* probe: when vsock is the choice it pings
+   the guest agent; on success it uses vsock, and — only when fallback is
+   allowed (auto-selection, not an explicit request) — it drops to SSH if the
+   agent doesn't answer.
+
+vsock currently requires the **QEMU backend on a Linux host** (native
+``vhost-vsock-pci`` needs ``/dev/vhost-vsock``). Windows guests and other
+backends always use SSH for now.
+"""
+
+from __future__ import annotations
+
+import platform
+from dataclasses import dataclass
+from pathlib import Path
+
+from smolvm.comm.base import CommChannelKind
+from smolvm.exceptions import SmolVMError
+from smolvm.runtime.backends import BACKEND_QEMU
+from smolvm.types import GuestOS
+
+_VHOST_VSOCK_DEV = Path("/dev/vhost-vsock")
+
+
+def host_supports_vsock() -> bool:
+    """Whether this host can provide a QEMU vsock device.
+
+    True only on Linux with the ``vhost_vsock`` driver loaded (its device node
+    present). macOS/HVF has no equivalent, so this returns False there.
+    """
+    return platform.system() == "Linux" and _VHOST_VSOCK_DEV.exists()
+
+
+@dataclass(frozen=True)
+class ChannelResolution:
+    """Outcome of channel selection.
+
+    Attributes:
+        kind: The channel to use (or attempt first).
+        allow_fallback: When ``kind == "vsock"``, whether the facade may fall
+            back to SSH if the guest agent does not answer. True only for
+            auto-selection; an explicit ``comm_channel="vsock"`` never silently
+            downgrades.
+    """
+
+    kind: CommChannelKind
+    allow_fallback: bool
+
+
+def resolve_comm_channel(
+    *,
+    requested: CommChannelKind | None,
+    config_channel: CommChannelKind | None,
+    backend: str | None,
+    guest_os: GuestOS | str | None,
+    host_vsock_supported: bool | None = None,
+) -> ChannelResolution:
+    """Resolve the control channel for a VM.
+
+    Args:
+        requested: Explicit ``comm_channel`` kwarg from the caller (highest
+            precedence).
+        config_channel: ``VMConfig.comm_channel`` persisted on the VM.
+        backend: Resolved runtime backend (``"qemu"``/``"firecracker"``/...).
+        guest_os: The guest operating system.
+        host_vsock_supported: Override for :func:`host_supports_vsock`
+            (injected in tests). Defaults to probing the host.
+
+    Returns:
+        A :class:`ChannelResolution`.
+
+    Raises:
+        SmolVMError: If vsock was explicitly requested but cannot work here.
+    """
+    if host_vsock_supported is None:
+        host_vsock_supported = host_supports_vsock()
+
+    is_windows = guest_os == GuestOS.WINDOWS or guest_os == "windows"
+    is_qemu = backend == BACKEND_QEMU
+    vsock_possible = is_qemu and not is_windows and host_vsock_supported
+
+    effective = requested if requested is not None else config_channel
+
+    if effective == "ssh":
+        return ChannelResolution(kind="ssh", allow_fallback=False)
+
+    if effective == "vsock":
+        if is_windows:
+            raise SmolVMError(
+                "vsock is not available for Windows guests; use the SSH channel "
+                "(comm_channel='ssh') instead."
+            )
+        if not is_qemu:
+            raise SmolVMError(
+                "vsock is only supported on the QEMU backend in this release; "
+                "use the SSH channel (comm_channel='ssh') instead."
+            )
+        if not host_vsock_supported:
+            raise SmolVMError(
+                "This host can't provide a vsock device: it needs Linux with the "
+                "vhost_vsock module loaded (run 'sudo modprobe vhost_vsock'). "
+                "Use the SSH channel (comm_channel='ssh') instead — for example "
+                "on macOS, where QEMU has no vsock support."
+            )
+        # Explicit request: use vsock, never silently downgrade to SSH.
+        return ChannelResolution(kind="vsock", allow_fallback=False)
+
+    # Auto: prefer vsock where it can work, but fall back to SSH if the agent
+    # isn't reachable (e.g. an older image without the agent baked in).
+    if vsock_possible:
+        return ChannelResolution(kind="vsock", allow_fallback=True)
+    return ChannelResolution(kind="ssh", allow_fallback=False)

--- a/src/smolvm/comm/vsock_channel.py
+++ b/src/smolvm/comm/vsock_channel.py
@@ -1,0 +1,319 @@
+# Copyright 2026 Celesto AI
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Host-side vsock transport — talks to the guest agent over ``AF_VSOCK``.
+
+:class:`VsockChannel` implements :class:`~smolvm.comm.base.CommChannel` by
+speaking :mod:`smolvm.comm.protocol` to the agent baked into the guest image.
+It opens a fresh connection per request (one request per connection — vsock
+connect is cheap and the agent is unauthenticated, so there is no handshake to
+amortize), which keeps the stream impossible to desync.
+
+Two ways to reach the guest:
+
+- :meth:`from_cid` — host ``AF_VSOCK`` connect to ``(guest_cid, port)``. This is
+  the native QEMU ``vhost-vsock-pci`` path and is **Linux-only** (the host
+  needs ``/dev/vhost-vsock``).
+- :meth:`from_uds` — connect to a host Unix socket and issue the Firecracker
+  ``CONNECT <port>`` handshake. Used by Firecracker and (later) the macOS
+  libkrun proxy; works cross-platform.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import socket
+import stat
+import time
+from pathlib import Path
+
+from smolvm.comm import protocol
+from smolvm.comm.base import CommChannelKind, ShellMode
+from smolvm.exceptions import OperationTimeoutError, SmolVMError
+from smolvm.types import CommandResult
+
+logger = logging.getLogger(__name__)
+
+
+class VsockChannel:
+    """Drive a guest over its vsock control agent.
+
+    Construct via :meth:`from_cid` or :meth:`from_uds`; the direct constructor
+    takes exactly one of *guest_cid* or *uds_path*.
+    """
+
+    kind: CommChannelKind = "vsock"
+
+    def __init__(
+        self,
+        *,
+        guest_cid: int | None = None,
+        uds_path: str | Path | None = None,
+        agent_port: int = protocol.SMOLVM_AGENT_PORT,
+        connect_timeout: int = 10,
+    ) -> None:
+        if (guest_cid is None) == (uds_path is None):
+            raise ValueError("provide exactly one of guest_cid or uds_path")
+        if connect_timeout < 1:
+            raise ValueError("connect_timeout must be >= 1")
+        self.guest_cid = guest_cid
+        self.uds_path = str(uds_path) if uds_path is not None else None
+        self.agent_port = agent_port
+        self.connect_timeout = connect_timeout
+        self._ready = False
+
+    @classmethod
+    def from_cid(
+        cls,
+        guest_cid: int,
+        *,
+        agent_port: int = protocol.SMOLVM_AGENT_PORT,
+        connect_timeout: int = 10,
+    ) -> VsockChannel:
+        """Reach the guest via host ``AF_VSOCK`` (native QEMU on Linux)."""
+        return cls(guest_cid=guest_cid, agent_port=agent_port, connect_timeout=connect_timeout)
+
+    @classmethod
+    def from_uds(
+        cls,
+        uds_path: str | Path,
+        *,
+        agent_port: int = protocol.SMOLVM_AGENT_PORT,
+        connect_timeout: int = 10,
+    ) -> VsockChannel:
+        """Reach the guest via a host Unix socket (Firecracker / libkrun)."""
+        return cls(uds_path=uds_path, agent_port=agent_port, connect_timeout=connect_timeout)
+
+    # ── Connection ──────────────────────────────────────────────
+
+    def _open(self) -> socket.socket:
+        """Open a connection to the guest agent, ready for framed I/O."""
+        if self.uds_path is not None:
+            return self._open_uds()
+        return self._open_vsock()
+
+    def _open_vsock(self) -> socket.socket:
+        if not hasattr(socket, "AF_VSOCK"):
+            raise SmolVMError(
+                "vsock is not available on this host (no AF_VSOCK). "
+                "Use the SSH channel, or run on a Linux host with vhost_vsock loaded."
+            )
+        sock = socket.socket(socket.AF_VSOCK, socket.SOCK_STREAM)
+        sock.settimeout(float(self.connect_timeout))
+        try:
+            sock.connect((self.guest_cid, self.agent_port))
+        except OSError:
+            sock.close()
+            raise
+        return sock
+
+    def _open_uds(self) -> socket.socket:
+        sock = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+        sock.settimeout(float(self.connect_timeout))
+        try:
+            sock.connect(self.uds_path)
+            # Firecracker-style host->guest handshake: ask to be connected to
+            # the agent's vsock port, then expect an "OK <n>" acknowledgement.
+            sock.sendall(f"CONNECT {self.agent_port}\n".encode())
+            ack = self._read_line(sock)
+            if not ack.startswith("OK"):
+                raise SmolVMError(f"vsock CONNECT handshake failed: {ack!r}")
+        except OSError:
+            sock.close()
+            raise
+        return sock
+
+    @staticmethod
+    def _read_line(sock: socket.socket) -> str:
+        """Read a single ``\\n``-terminated line (for the CONNECT handshake)."""
+        buf = bytearray()
+        while not buf.endswith(b"\n"):
+            byte = sock.recv(1)
+            if not byte:
+                break
+            buf.extend(byte)
+        return buf.decode("utf-8", errors="replace").strip()
+
+    # ── CommChannel interface ───────────────────────────────────
+
+    def run(
+        self,
+        command: str,
+        timeout: int = 30,
+        shell: ShellMode = "login",
+    ) -> CommandResult:
+        if not command or not command.strip():
+            raise ValueError("command cannot be empty")
+        if timeout < 1:
+            raise ValueError("timeout must be >= 1")
+
+        stdout = bytearray()
+        stderr = bytearray()
+        sock = self._open()
+        try:
+            # Read deadline a little beyond the command timeout, so the agent's
+            # own timeout fires first and we still receive its report.
+            sock.settimeout(float(timeout) + float(self.connect_timeout))
+            protocol.send_json(
+                sock,
+                {
+                    "v": protocol.PROTOCOL_VERSION,
+                    "op": "run",
+                    "cmd": command,
+                    "shell": shell,
+                    "timeout": timeout,
+                },
+            )
+            while True:
+                frame_type, payload = protocol.recv_frame(sock)
+                if frame_type == protocol.FRAME_STDOUT:
+                    stdout.extend(payload)
+                elif frame_type == protocol.FRAME_STDERR:
+                    stderr.extend(payload)
+                elif frame_type == protocol.FRAME_JSON:
+                    msg = json.loads(payload.decode("utf-8"))
+                    return self._finish_run(command, timeout, msg, stdout, stderr)
+                else:  # pragma: no cover - defensive
+                    raise SmolVMError(f"unexpected frame type {frame_type} during run")
+        except TimeoutError as exc:
+            raise OperationTimeoutError(f"vsock run: {command}", timeout) from exc
+        finally:
+            sock.close()
+
+    def _finish_run(
+        self,
+        command: str,
+        timeout: int,
+        msg: dict,
+        stdout: bytearray,
+        stderr: bytearray,
+    ) -> CommandResult:
+        op = msg.get("op")
+        if op == "exit":
+            return CommandResult(
+                exit_code=int(msg["exit_code"]),
+                stdout=bytes(stdout).decode("utf-8", errors="replace"),
+                stderr=bytes(stderr).decode("utf-8", errors="replace"),
+            )
+        if op == "timeout":
+            raise OperationTimeoutError(f"vsock run: {command}", timeout)
+        raise SmolVMError(f"guest agent error during run: {msg.get('error', msg)}")
+
+    def put_file(self, local_path: str | Path, remote_path: str) -> None:
+        if not remote_path:
+            raise ValueError("remote_path cannot be empty")
+        source = Path(local_path)
+        if not source.exists():
+            raise ValueError(f"local_path does not exist: {source}")
+
+        data = source.read_bytes()
+        mode = stat.S_IMODE(source.stat().st_mode)
+        sock = self._open()
+        try:
+            protocol.send_json(
+                sock,
+                {
+                    "v": protocol.PROTOCOL_VERSION,
+                    "op": "put_file",
+                    "path": remote_path,
+                    "mode": mode,
+                    "size": len(data),
+                },
+            )
+            for start in range(0, len(data), protocol.CHUNK_SIZE):
+                chunk = data[start : start + protocol.CHUNK_SIZE]
+                protocol.send_frame(sock, protocol.FRAME_DATA, chunk)
+            protocol.send_frame(sock, protocol.FRAME_EOF)
+            resp = protocol.recv_json(sock)
+            if not resp.get("ok"):
+                raise SmolVMError(
+                    f"Failed to upload file to guest '{remote_path}': {resp.get('error')}"
+                )
+        finally:
+            sock.close()
+
+    def get_file(self, remote_path: str, local_path: str | Path) -> Path:
+        if not remote_path:
+            raise ValueError("remote_path cannot be empty")
+        destination = Path(local_path)
+        destination.parent.mkdir(parents=True, exist_ok=True)
+
+        sock = self._open()
+        try:
+            protocol.send_json(
+                sock,
+                {"v": protocol.PROTOCOL_VERSION, "op": "get_file", "path": remote_path},
+            )
+            header = protocol.recv_json(sock)
+            if not header.get("ok"):
+                raise SmolVMError(
+                    f"Failed to download guest file '{remote_path}': {header.get('error')}"
+                )
+            mode = header.get("mode")
+            with open(destination, "wb") as handle:  # noqa: SIM115 - within try for cleanup
+                while True:
+                    frame_type, payload = protocol.recv_frame(sock)
+                    if frame_type == protocol.FRAME_EOF:
+                        break
+                    if frame_type != protocol.FRAME_DATA:  # pragma: no cover - defensive
+                        raise SmolVMError(f"unexpected frame type {frame_type} during download")
+                    handle.write(payload)
+            if mode is not None:
+                os.chmod(destination, int(mode))
+        finally:
+            sock.close()
+        return destination
+
+    def wait_ready(self, timeout: float = 60.0, interval: float = 0.1) -> None:
+        if timeout <= 0:
+            raise ValueError("timeout must be > 0")
+        deadline = time.monotonic() + timeout
+        last_error = ""
+        target = self.uds_path if self.uds_path is not None else f"cid={self.guest_cid}"
+        logger.info("Waiting for guest agent on vsock %s (timeout=%.0fs)", target, timeout)
+
+        while time.monotonic() < deadline:
+            try:
+                sock = self._open()
+                try:
+                    protocol.send_json(sock, {"v": protocol.PROTOCOL_VERSION, "op": "ping"})
+                    resp = protocol.recv_json(sock)
+                finally:
+                    sock.close()
+                if resp.get("ok"):
+                    self._ready = True
+                    logger.info("Guest agent is ready on vsock %s", target)
+                    return
+                last_error = str(resp.get("error", resp))
+            except (OSError, SmolVMError, ValueError) as exc:
+                last_error = str(exc)
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                break
+            time.sleep(min(interval, remaining))
+
+        raise OperationTimeoutError(
+            f"wait_ready(vsock {target}): last error: {last_error}", timeout
+        )
+
+    def close(self) -> None:
+        """No persistent connection is held; present for interface parity."""
+        self._ready = False
+
+    @property
+    def connected(self) -> bool:
+        """Whether the agent has answered at least once since the last reset."""
+        return self._ready

--- a/src/smolvm/env.py
+++ b/src/smolvm/env.py
@@ -28,8 +28,8 @@ import logging
 import re
 import shlex
 
+from smolvm.comm.base import CommChannel
 from smolvm.exceptions import SmolVMError
-from smolvm.ssh import SSHClient
 
 logger = logging.getLogger(__name__)
 
@@ -83,7 +83,7 @@ def build_env_script(env_vars: dict[str, str]) -> str:
 
 
 def inject_env_vars(
-    ssh: SSHClient,
+    ssh: CommChannel,
     env_vars: dict[str, str],
     *,
     merge: bool = True,
@@ -133,7 +133,7 @@ def inject_env_vars(
     return keys
 
 
-def _atomic_write(ssh: SSHClient, content: str) -> "CommandResult":  # noqa: F821
+def _atomic_write(ssh: CommChannel, content: str) -> "CommandResult":  # noqa: F821
     """Write *content* to the env file atomically inside the guest.
 
     Uses **base64 transport** to avoid any shell-interpretation of the
@@ -155,7 +155,7 @@ def _atomic_write(ssh: SSHClient, content: str) -> "CommandResult":  # noqa: F82
     return ssh.run(cmd, timeout=10)
 
 
-def read_env_vars(ssh: SSHClient) -> dict[str, str]:
+def read_env_vars(ssh: CommChannel) -> dict[str, str]:
     """Read current SmolVM-managed environment variables from the guest.
 
     Parses ``/etc/profile.d/smolvm_env.sh`` for ``export KEY=VALUE``
@@ -201,7 +201,7 @@ def read_env_vars(ssh: SSHClient) -> dict[str, str]:
     return env_vars
 
 
-def remove_env_vars(ssh: SSHClient, keys: list[str]) -> dict[str, str]:
+def remove_env_vars(ssh: CommChannel, keys: list[str]) -> dict[str, str]:
     """Remove environment variables from the guest.
 
     Reads the current file, removes the specified keys, and rewrites

--- a/src/smolvm/facade.py
+++ b/src/smolvm/facade.py
@@ -2043,6 +2043,21 @@ class SmolVM:
         if self._ssh_ready:
             return self
 
+        # Honor the resolved control channel: try vsock before SSH so an
+        # explicit comm_channel="vsock" never silently downgrades on the async
+        # path (mirrors the sync _wait_for_ssh dispatch).
+        resolution = self._resolve_channel()
+        if resolution.kind == "vsock":
+            probe = timeout
+            if resolution.allow_fallback:
+                probe = min(timeout, _VSOCK_AUTO_PROBE_TIMEOUT)
+            if await asyncio.to_thread(self._try_vsock_ready, probe):
+                return self
+            if not resolution.allow_fallback:
+                raise OperationTimeoutError(
+                    "wait_for_ready: the guest vsock agent did not respond", timeout
+                )
+
         network = self._info.network
         if network is None:
             raise SmolVMError("VM has no network", {"vm_id": self._vm_id})

--- a/src/smolvm/facade.py
+++ b/src/smolvm/facade.py
@@ -45,6 +45,9 @@ from typing import Any, Literal
 from urllib.parse import urlparse
 
 from smolvm._naming import generate_sandbox_name
+from smolvm.comm import VsockChannel
+from smolvm.comm.base import CommChannelKind
+from smolvm.comm.select import ChannelResolution, resolve_comm_channel
 from smolvm.env import inject_env_vars, read_env_vars, remove_env_vars
 from smolvm.env_windows import (
     inject_env_vars as inject_env_vars_windows,
@@ -90,6 +93,11 @@ from smolvm.vm import SmolVMManager
 logger = logging.getLogger(__name__)
 
 _DEFAULT_RUN_READY_TIMEOUT = 30.0
+
+# When auto-selecting the channel, how long to wait for the vsock agent before
+# falling back to SSH. Kept short: the agent comes up early in boot, so if it
+# hasn't answered by now the image probably lacks it and SSH is the real path.
+_VSOCK_AUTO_PROBE_TIMEOUT = 8.0
 _LOCAL_FORWARD_PROBE_TIMEOUT = 2.0
 _LOCAL_FORWARD_PROBE_INTERVAL = 0.2
 _LOCAL_TUNNEL_START_TIMEOUT = 10.0
@@ -849,12 +857,16 @@ class SmolVM:
         ssh_user: str = "root",
         ssh_key_path: str | None = None,
         ssh_password: str | None = None,
+        comm_channel: CommChannelKind | None = None,
         internet_settings: InternetSettings | dict[str, Any] | None = None,
         mounts: list[str] | None = None,
         writable_mounts: bool = False,
     ) -> None:
         if config is not None and vm_id is not None:
             raise ValueError("Provide either config or vm_id, not both.")
+
+        if comm_channel is not None and comm_channel not in ("ssh", "vsock"):
+            raise ValueError(f"comm_channel must be 'ssh' or 'vsock', got {comm_channel!r}")
 
         if image is not None and (config is not None or vm_id is not None):
             raise ValueError("image cannot be combined with config or vm_id.")
@@ -982,6 +994,7 @@ class SmolVM:
         self._ssh_user = ssh_user
         self._ssh_key_path = ssh_key_path
         self._ssh_password = ssh_password
+        self._comm_channel_request: CommChannelKind | None = comm_channel
         self._default_ssh_key_path: str | None = None
 
         sdk_kwargs: dict[str, Any] = {}
@@ -991,6 +1004,12 @@ class SmolVM:
             sdk_kwargs["socket_dir"] = socket_dir
         if backend is not None:
             sdk_kwargs["backend"] = backend
+
+        # Record the channel preference on the config so create() can reserve a
+        # vsock CID and wire the device before boot. Covers both an explicit
+        # config and one built from image=.
+        if config is not None and comm_channel is not None:
+            config = config.model_copy(update={"comm_channel": comm_channel})
 
         if config is not None:
             self._sdk = SmolVMManager(**sdk_kwargs)
@@ -1024,6 +1043,7 @@ class SmolVM:
         ssh_user: str = "root",
         ssh_key_path: str | None = None,
         ssh_password: str | None = None,
+        comm_channel: CommChannelKind | None = None,
     ) -> SmolVM:
         """Reconnect to an existing VM by ID.
 
@@ -1053,6 +1073,7 @@ class SmolVM:
             ssh_user=ssh_user,
             ssh_key_path=ssh_key_path,
             ssh_password=ssh_password,
+            comm_channel=comm_channel,
         )
 
     @classmethod
@@ -1178,9 +1199,7 @@ class SmolVM:
                     key_path=self._ssh_key_path,
                 )
                 self._ssh_ready = True
-            injector = (
-                inject_env_vars_windows if self._is_windows_guest() else inject_env_vars
-            )
+            injector = inject_env_vars_windows if self._is_windows_guest() else inject_env_vars
             injected = injector(self._ssh, env_vars)
             logger.info(
                 "VM %s: injected %d env var(s): %s",
@@ -1458,10 +1477,7 @@ class SmolVM:
                     # — no escape gymnastics.
                     ps_parent = _windows_path_for_powershell(parent)
                     safe_parent = ps_parent.replace("'", "''")
-                    cmd = (
-                        f"New-Item -ItemType Directory -Force -Path "
-                        f"'{safe_parent}' | Out-Null"
-                    )
+                    cmd = f"New-Item -ItemType Directory -Force -Path '{safe_parent}' | Out-Null"
                     result = ssh.run(cmd, timeout=30, shell="login")
                     if result.exit_code != 0:
                         stderr = result.stderr.strip()
@@ -1531,9 +1547,7 @@ class SmolVM:
             # Strip trailing separator (either kind) then take the basename.
             guest_name = guest_path.rstrip("/\\").rsplit("\\", 1)[-1].rsplit("/", 1)[-1]
             if not guest_name:
-                raise ValueError(
-                    f"Cannot derive a filename from the sandbox path: {guest_path!r}."
-                )
+                raise ValueError(f"Cannot derive a filename from the sandbox path: {guest_path!r}.")
             destination = destination / guest_name
 
         parent = destination.parent
@@ -1951,9 +1965,7 @@ class SmolVM:
                     key_path=self._ssh_key_path,
                 )
                 self._ssh_ready = True
-            injector = (
-                inject_env_vars_windows if self._is_windows_guest() else inject_env_vars
-            )
+            injector = inject_env_vars_windows if self._is_windows_guest() else inject_env_vars
             await asyncio.to_thread(injector, self._ssh, env_vars)
 
         # Mount workspace directories after boot if configured.
@@ -2009,13 +2021,16 @@ class SmolVM:
                 {"vm_id": self._vm_id},
             )
         if not self.can_run_commands():
-            raise CommandExecutionUnavailableError(self._vm_id, {"vm_id": self._vm_id})
+            raise CommandExecutionUnavailableError(
+                vm_id=self._vm_id,
+                reason="VM config does not advertise a command-capable boot path.",
+                remediation=self._command_exec_remediation(),
+            )
 
-        self._ensure_ssh()
-        assert self._ssh is not None
-        return await asyncio.to_thread(
-            self._ssh.run, command, timeout=timeout, login_shell=(shell == "login")
-        )
+        # Resolve and connect the channel (vsock or SSH) off the event loop,
+        # then run the command. Both transports are synchronous.
+        channel = await asyncio.to_thread(self._ensure_ssh_for_operation, action="run a command")
+        return await asyncio.to_thread(channel.run, command, timeout=timeout, shell=shell)
 
     async def async_wait_for_ssh(self, timeout: float = 60.0) -> SmolVM:
         """Async version of :meth:`wait_for_ssh`.
@@ -2564,11 +2579,68 @@ modprobe 9pnet_virtio""".strip()
 
         return False
 
+    def _resolve_channel(self) -> ChannelResolution:
+        """Resolve which control channel this VM should use."""
+        config = self._info.config
+        return resolve_comm_channel(
+            requested=self._comm_channel_request,
+            config_channel=getattr(config, "comm_channel", None),
+            backend=getattr(config, "backend", None),
+            guest_os=getattr(config, "guest_os", None),
+        )
+
+    def _try_vsock_ready(self, timeout: float) -> bool:
+        """Probe the guest vsock agent; on success cache the channel.
+
+        Returns True if the agent answered within *timeout*. Requires a
+        reserved CID (``config.vsock``) — without one (e.g. a VM created
+        before vsock was enabled) vsock can't be used.
+        """
+        self._refresh_info()
+        vsock = getattr(self._info.config, "vsock", None)
+        if vsock is None:
+            return False
+        channel = VsockChannel.from_cid(vsock.guest_cid)
+        try:
+            channel.wait_ready(timeout=timeout)
+        except (OperationTimeoutError, SmolVMError, OSError):
+            return False
+        self._ssh = channel  # type: ignore[assignment]  # CommChannel duck-types
+        self._ssh_ready = True
+        return True
+
     def _wait_for_ssh(self, timeout: float) -> None:
+        """Wait until the resolved control channel is ready.
+
+        Named ``_wait_for_ssh`` for back-compat; it now dispatches to vsock
+        when that's the resolved channel, falling back to SSH only when the
+        selection was automatic (never for an explicit ``comm_channel='vsock'``).
+        """
+        resolution = self._resolve_channel()
+        if resolution.kind == "vsock":
+            deadline = time.monotonic() + timeout
+            probe = timeout
+            if resolution.allow_fallback:
+                probe = min(timeout, _VSOCK_AUTO_PROBE_TIMEOUT)
+            if self._try_vsock_ready(probe):
+                return
+            if not resolution.allow_fallback:
+                raise OperationTimeoutError(
+                    "wait_for_ready: the guest vsock agent did not respond", timeout
+                )
+            logger.info("VM %s: vsock agent not reachable, falling back to SSH", self._vm_id)
+            self._wait_for_ssh_over_network(max(1.0, deadline - time.monotonic()))
+            return
+        self._wait_for_ssh_over_network(timeout)
+
+    def _wait_for_ssh_over_network(self, timeout: float) -> None:
         """Wait for SSH across available network endpoints."""
         endpoints = self._ssh_endpoints()
 
         # Prefer the already selected client first, then try remaining candidates.
+        # self._ssh is only ever an SSHClient here: _try_vsock_ready assigns the
+        # vsock channel solely on success, after which _wait_for_ssh returns
+        # before reaching this network path.
         ordered_endpoints = endpoints
         if self._ssh is not None:
             current = (self._ssh.host, self._ssh.port)

--- a/src/smolvm/guest_agent/__init__.py
+++ b/src/smolvm/guest_agent/__init__.py
@@ -1,0 +1,21 @@
+# Copyright 2026 Celesto AI
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""The SmolVM guest agent.
+
+``agent.py`` is a self-contained, stdlib-only program copied verbatim into the
+guest image and launched by ``/init``. It is intentionally free of any
+``smolvm`` imports so it runs in a guest that has no SmolVM package installed.
+The host speaks to it via :mod:`smolvm.comm.protocol`.
+"""

--- a/src/smolvm/guest_agent/agent.py
+++ b/src/smolvm/guest_agent/agent.py
@@ -1,0 +1,380 @@
+#!/usr/bin/env python3
+# Copyright 2026 Celesto AI
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""SmolVM guest agent — host↔guest control plane over AF_VSOCK.
+
+Runs as a background process inside the guest, started by ``/init`` before
+sshd, so the host can run commands, transfer files, and probe readiness
+without the guest network or sshd being up.
+
+This file is **standalone and stdlib-only**: it is copied verbatim into the
+guest image (where the ``smolvm`` package is not installed), so it must not
+import anything from ``smolvm``. It embeds a byte-compatible copy of the
+framing in ``smolvm/comm/protocol.py``; ``tests/test_guest_agent.py`` drives
+this module with the host-side protocol helpers over a socketpair to prove the
+two ends stay in sync.
+
+Security: like SSH-into-your-own-sandbox, anyone who can open the guest's
+vsock port gets to run commands as the agent's user. The guest is a disposable
+sandbox the host owns, so this matches SmolVM's existing trust model — but the
+channel must never be exposed beyond the host.
+"""
+
+from __future__ import annotations
+
+import argparse
+import contextlib
+import json
+import os
+import selectors
+import signal
+import socket
+import stat
+import struct
+import sys
+import tempfile
+import threading
+from typing import Any
+
+# ── Wire protocol (kept byte-compatible with smolvm/comm/protocol.py) ──────
+
+PROTOCOL_VERSION = 1
+SMOLVM_AGENT_PORT = 1024
+CHUNK_SIZE = 64 * 1024
+_MAX_FRAME = 16 * 1024 * 1024
+
+FRAME_JSON = 1
+FRAME_STDOUT = 2
+FRAME_STDERR = 3
+FRAME_DATA = 4
+FRAME_EOF = 5
+
+_HEADER = struct.Struct(">BI")
+
+AGENT_VERSION = "1.0"
+
+# VMADDR_CID_ANY is 0xFFFFFFFF; expose a fallback for older Pythons that lack
+# the named constant even though AF_VSOCK itself is available.
+_VMADDR_CID_ANY = getattr(socket, "VMADDR_CID_ANY", 0xFFFFFFFF)
+
+
+def recv_exact(sock: Any, n: int) -> bytes:
+    if n == 0:
+        return b""
+    buf = bytearray()
+    while len(buf) < n:
+        chunk = sock.recv(n - len(buf))
+        if not chunk:
+            raise ConnectionError("connection closed mid-frame")
+        buf.extend(chunk)
+    return bytes(buf)
+
+
+def send_frame(sock: Any, frame_type: int, payload: bytes = b"") -> None:
+    if len(payload) > _MAX_FRAME:
+        raise ValueError(f"frame payload too large: {len(payload)} bytes")
+    sock.sendall(_HEADER.pack(frame_type, len(payload)) + payload)
+
+
+def recv_frame(sock: Any) -> tuple[int, bytes]:
+    frame_type, length = _HEADER.unpack(recv_exact(sock, _HEADER.size))
+    if length > _MAX_FRAME:
+        raise ValueError(f"frame payload too large: {length} bytes")
+    return frame_type, recv_exact(sock, length)
+
+
+def send_json(sock: Any, obj: dict[str, Any]) -> None:
+    send_frame(sock, FRAME_JSON, json.dumps(obj).encode("utf-8"))
+
+
+def recv_json(sock: Any) -> dict[str, Any]:
+    frame_type, payload = recv_frame(sock)
+    if frame_type != FRAME_JSON:
+        raise ValueError(f"expected JSON control frame, got frame type {frame_type}")
+    obj = json.loads(payload.decode("utf-8"))
+    if not isinstance(obj, dict):
+        raise ValueError("control frame is not a JSON object")
+    return obj
+
+
+# ── Request handlers ───────────────────────────────────────────────────────
+
+
+def _build_argv(command: str, shell: str) -> list[str]:
+    """Build the argv for a command, mirroring SSHClient's POSIX wrapping.
+
+    ``login`` runs the command through a login shell (``$SHELL -lc``) so it
+    sees ``/etc/profile`` and the injected ``/etc/profile.d/smolvm_env.sh``,
+    matching SSH behavior. ``raw`` runs it with no login semantics.
+    """
+    if shell == "raw":
+        return ["/bin/sh", "-c", command]
+    shell_bin = os.environ.get("SHELL") or "/bin/sh"
+    return [shell_bin, "-lc", command]
+
+
+def _kill_process_group(proc: Any) -> None:
+    """SIGKILL the child's process group and reap it."""
+    with contextlib.suppress(ProcessLookupError, PermissionError, OSError):
+        os.killpg(os.getpgid(proc.pid), signal.SIGKILL)
+    with contextlib.suppress(Exception):
+        proc.wait(timeout=5)
+
+
+def handle_ping(conn: Any, req: dict[str, Any]) -> None:
+    send_json(
+        conn,
+        {
+            "ok": True,
+            "op": "pong",
+            "agent_version": AGENT_VERSION,
+            "proto": PROTOCOL_VERSION,
+        },
+    )
+
+
+def handle_run(conn: Any, req: dict[str, Any]) -> None:
+    import subprocess
+    import time
+
+    command = req.get("cmd")
+    if not command:
+        send_json(conn, {"ok": False, "op": "error", "error": "missing 'cmd'"})
+        return
+    shell = req.get("shell", "login")
+    timeout = req.get("timeout")
+    env = dict(os.environ)
+    for key, value in (req.get("env") or {}).items():
+        env[str(key)] = str(value)
+
+    try:
+        proc = subprocess.Popen(  # noqa: S603 - intentional command execution in sandbox
+            _build_argv(command, shell),
+            stdin=subprocess.DEVNULL,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            env=env,
+            start_new_session=True,  # own process group, so timeout can killpg
+        )
+    except OSError as exc:
+        send_json(conn, {"ok": False, "op": "error", "error": f"spawn failed: {exc}"})
+        return
+
+    deadline = None if not timeout else time.monotonic() + float(timeout)
+    sel = selectors.DefaultSelector()
+    sel.register(proc.stdout, selectors.EVENT_READ, FRAME_STDOUT)
+    sel.register(proc.stderr, selectors.EVENT_READ, FRAME_STDERR)
+    open_streams = 2
+    timed_out = False
+    try:
+        while open_streams > 0:
+            sel_timeout = None
+            if deadline is not None:
+                remaining = deadline - time.monotonic()
+                if remaining <= 0:
+                    timed_out = True
+                    break
+                sel_timeout = remaining
+            for key, _mask in sel.select(timeout=sel_timeout):
+                chunk = os.read(key.fileobj.fileno(), CHUNK_SIZE)
+                if not chunk:
+                    sel.unregister(key.fileobj)
+                    open_streams -= 1
+                    continue
+                send_frame(conn, key.data, chunk)
+    finally:
+        sel.close()
+
+    if timed_out:
+        _kill_process_group(proc)
+        send_json(conn, {"ok": True, "op": "timeout", "timeout": float(timeout)})
+        return
+
+    exit_code = proc.wait()
+    send_json(conn, {"ok": True, "op": "exit", "exit_code": exit_code})
+
+
+def handle_put_file(conn: Any, req: dict[str, Any]) -> None:
+    path = req.get("path")
+    size = int(req.get("size", 0))
+    mode = req.get("mode")
+
+    error: str | None = None
+    tmp_path: str | None = None
+    handle = None
+    if not path:
+        error = "missing 'path'"
+    else:
+        target = os.path.abspath(path)
+        parent = os.path.dirname(target) or "/"
+        try:
+            tmp_fd, tmp_path = tempfile.mkstemp(dir=parent, prefix=".smolvm-put-")
+            handle = os.fdopen(tmp_fd, "wb")
+        except OSError as exc:
+            error = f"cannot create file: {exc}"
+
+    # Always drain exactly `size` payload bytes so the stream stays framed even
+    # when the write target is unwritable; discard them if we have no file.
+    received = 0
+    try:
+        while received < size:
+            frame_type, payload = recv_frame(conn)
+            if frame_type == FRAME_EOF:
+                break
+            if frame_type != FRAME_DATA:
+                error = error or f"unexpected frame type {frame_type} during upload"
+                break
+            received += len(payload)
+            if handle is not None and error is None:
+                try:
+                    handle.write(payload)
+                except OSError as exc:
+                    error = str(exc)
+    finally:
+        if handle is not None:
+            handle.close()
+
+    if error is None and tmp_path is not None:
+        try:
+            if mode is not None:
+                os.chmod(tmp_path, int(mode))
+            os.replace(tmp_path, os.path.abspath(path))
+        except OSError as exc:
+            error = str(exc)
+
+    if error is not None and tmp_path is not None:
+        with contextlib.suppress(OSError):
+            os.unlink(tmp_path)
+
+    send_json(conn, {"ok": error is None} if error is None else {"ok": False, "error": error})
+
+
+def handle_get_file(conn: Any, req: dict[str, Any]) -> None:
+    path = req.get("path")
+    if not path:
+        send_json(conn, {"ok": False, "error": "missing 'path'"})
+        return
+    try:
+        info = os.stat(path)
+    except OSError as exc:
+        send_json(conn, {"ok": False, "error": str(exc)})
+        return
+    if not stat.S_ISREG(info.st_mode):
+        send_json(conn, {"ok": False, "error": "not a regular file"})
+        return
+    # Open in its own try so an open error is reported BEFORE the header
+    # frame; once the header is sent we're committed to streaming, so a later
+    # error can't be reported without desyncing the protocol.
+    try:
+        handle = open(path, "rb")  # noqa: SIM115 - closed via `with` below
+    except OSError as exc:
+        send_json(conn, {"ok": False, "error": str(exc)})
+        return
+
+    send_json(conn, {"ok": True, "mode": stat.S_IMODE(info.st_mode), "size": info.st_size})
+    with handle:
+        while True:
+            chunk = handle.read(CHUNK_SIZE)
+            if not chunk:
+                break
+            send_frame(conn, FRAME_DATA, chunk)
+    send_frame(conn, FRAME_EOF)
+
+
+_HANDLERS = {
+    "ping": handle_ping,
+    "run": handle_run,
+    "put_file": handle_put_file,
+    "get_file": handle_get_file,
+}
+
+
+def handle_connection(conn: Any) -> None:
+    """Serve a single request on *conn* (one request per connection)."""
+    try:
+        req = recv_json(conn)
+    except (ConnectionError, ValueError, OSError, json.JSONDecodeError):
+        return
+
+    version = req.get("v")
+    if version not in (None, PROTOCOL_VERSION):
+        with contextlib.suppress(OSError):
+            send_json(conn, {"ok": False, "error": f"unsupported protocol version {version}"})
+        return
+
+    handler = _HANDLERS.get(req.get("op"))
+    if handler is None:
+        with contextlib.suppress(OSError):
+            send_json(conn, {"ok": False, "error": f"unknown op {req.get('op')!r}"})
+        return
+
+    try:
+        handler(conn, req)
+    except (ConnectionError, OSError):
+        pass  # peer hung up mid-response; nothing actionable
+    except Exception as exc:  # noqa: BLE001 - last-resort error report to the host
+        with contextlib.suppress(OSError):
+            send_json(conn, {"ok": False, "error": f"agent error: {exc}"})
+
+
+# ── AF_VSOCK server ──────────────────────────────────────────────────────────
+
+
+def _serve_one(conn: Any, sem: threading.Semaphore) -> None:
+    try:
+        handle_connection(conn)
+    finally:
+        with contextlib.suppress(OSError):
+            conn.close()
+        sem.release()
+
+
+def serve(port: int = SMOLVM_AGENT_PORT, max_workers: int = 64) -> None:
+    """Listen on ``AF_VSOCK`` and serve requests until killed."""
+    if not hasattr(socket, "AF_VSOCK"):
+        raise RuntimeError("this platform has no AF_VSOCK support")
+
+    server = socket.socket(socket.AF_VSOCK, socket.SOCK_STREAM)
+    server.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+    server.bind((_VMADDR_CID_ANY, port))
+    server.listen(128)
+    sys.stderr.write(f"smolvm-guest-agent listening on vsock port {port}\n")
+    sys.stderr.flush()
+
+    sem = threading.Semaphore(max_workers)
+    while True:
+        conn, _peer = server.accept()
+        sem.acquire()
+        threading.Thread(target=_serve_one, args=(conn, sem), daemon=True).start()
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="SmolVM guest agent (vsock).")
+    parser.add_argument(
+        "--port",
+        type=int,
+        default=int(os.environ.get("SMOLVM_AGENT_PORT", SMOLVM_AGENT_PORT)),
+        help="vsock port to listen on",
+    )
+    args = parser.parse_args(argv)
+    try:
+        serve(port=args.port)
+    except KeyboardInterrupt:
+        return 0
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/smolvm/guest_agent/agent.py
+++ b/src/smolvm/guest_agent/agent.py
@@ -194,6 +194,12 @@ def handle_run(conn: Any, req: dict[str, Any]) -> None:
                     open_streams -= 1
                     continue
                 send_frame(conn, key.data, chunk)
+    except Exception:
+        # Peer dropped (or a read/send failed) mid-stream: kill and reap the
+        # child so it isn't left running and unreaped in the guest, then let
+        # handle_connection swallow the (connection) error as usual.
+        _kill_process_group(proc)
+        raise
     finally:
         sel.close()
 

--- a/src/smolvm/images/builder.py
+++ b/src/smolvm/images/builder.py
@@ -51,6 +51,19 @@ OPENCLAW_BOOT_ARGS = "reboot=k panic=1 pci=off init=/init 8250.nr_uarts=0"
 
 LOOPFS_HELPER_PATH = Path("/usr/local/libexec/smolvm-loopfs-helper")
 
+# The SmolVM guest agent (vsock control plane). It is baked into every image
+# built here and launched by /init. ``_GUEST_AGENT_SOURCE_PATH`` points at the
+# checked-in agent module; it ships into the build context as
+# ``_GUEST_AGENT_BUILD_FILE`` and lands in the guest at ``_GUEST_AGENT_GUEST_PATH``.
+_GUEST_AGENT_SOURCE_PATH = Path(__file__).resolve().parents[1] / "guest_agent" / "agent.py"
+_GUEST_AGENT_BUILD_FILE = "smolvm-guest-agent"
+_GUEST_AGENT_GUEST_PATH = "/usr/local/bin/smolvm-guest-agent"
+
+
+def _guest_agent_source() -> str:
+    """Return the guest agent source baked into every built image."""
+    return _GUEST_AGENT_SOURCE_PATH.read_text()
+
 
 class ImageBuilder:
     """Builds custom VM images with SSH pre-configured.
@@ -202,12 +215,14 @@ FROM alpine:3.19
 
 ARG SSH_PASSWORD
 
-# Install SSH and networking utilities
+# Install SSH and networking utilities. python3 powers the SmolVM guest
+# agent (vsock control plane); the agent is stdlib-only, so no pip deps.
 RUN apk add --no-cache \\
     openssh \\
     iproute2 \\
     curl \\
-    bash
+    bash \\
+    python3
 
 # Configure SSH. Host keys are generated at first boot in /init, not here,
 # so each VM gets a unique SSH identity — required for safely sharing images.
@@ -424,6 +439,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \\
     curl \\
     bash \\
     ca-certificates \\
+    python3 \\
     && rm -rf /var/lib/apt/lists/*
 
 # Host keys generated at first boot in /init so each VM has unique identity.
@@ -1242,6 +1258,20 @@ fi
 hostname {custom_hostname}
 log_ts "net-ready"
 
+# ── Guest agent (vsock control plane) ───────────────────────
+# Started before sshd and independent of networking, so the host can
+# drive the guest over vsock the moment the kernel is up. Skipped
+# silently if the image has no python3 or the agent wasn't baked in —
+# the host falls back to SSH in that case.
+log_ts "guest-agent-start"
+if command -v python3 >/dev/null 2>&1 && [ -f /usr/local/bin/smolvm-guest-agent ]; then
+    python3 /usr/local/bin/smolvm-guest-agent >/var/log/smolvm-agent.log 2>&1 &
+    echo "SmolVM init: guest agent started (PID=$!)"
+else
+    echo "SmolVM init: guest agent not started (python3 or agent missing)"
+fi
+log_ts "guest-agent-started"
+
 # ── SSH ──────────────────────────────────────────────────────
 log_ts "ssh-hostkey-check-start"
 if ! ls /etc/ssh/ssh_host_*_key >/dev/null 2>&1; then
@@ -1417,6 +1447,9 @@ echo "Device-approver running with PID=${DEVICE_APPROVER_PID}"
             **fingerprint_data,
             "_dockerfile_sha256": hashlib.sha256(dockerfile_content.encode()).hexdigest(),
             "_init_script_sha256": hashlib.sha256(init_script.encode()).hexdigest(),
+            # The guest agent is injected into every image by _do_build, so an
+            # edit to it must invalidate all cached images.
+            "_guest_agent_sha256": hashlib.sha256(_guest_agent_source().encode()).hexdigest(),
         }
 
     def _check_fingerprint(self, image_dir: Path, data: dict[str, typing.Any]) -> bool:
@@ -1614,12 +1647,27 @@ echo "Device-approver running with PID=${DEVICE_APPROVER_PID}"
         """Execute the Docker build and image conversion."""
         docker_tag = f"smolvm-{name}"
 
+        # Bake the guest agent into every image. Centralized here so all five
+        # build_* recipes inherit it without each repeating the COPY; /init
+        # launches it (guarded on python3), and the host reaches it over vsock.
+        # Appended after the recipe's own COPY lines — order is irrelevant for
+        # an independent file drop. Its content hash is in the fingerprint via
+        # _fingerprint_with_content, so edits still trigger a rebuild even
+        # though this COPY text is constant.
+        dockerfile_content = (
+            dockerfile_content
+            + "\n# SmolVM guest agent (vsock control plane)\n"
+            + f"COPY {_GUEST_AGENT_BUILD_FILE} {_GUEST_AGENT_GUEST_PATH}\n"
+            + f"RUN chmod +x {_GUEST_AGENT_GUEST_PATH}\n"
+        )
+
         with tempfile.TemporaryDirectory() as tmp_dir:
             tmp_path = Path(tmp_dir)
 
             # Write Dockerfile and init script
             (tmp_path / "Dockerfile").write_text(dockerfile_content)
             (tmp_path / "init").write_text(init_script)
+            (tmp_path / _GUEST_AGENT_BUILD_FILE).write_text(_guest_agent_source())
             if extra_files:
                 for filename, content in extra_files.items():
                     (tmp_path / filename).write_text(content)

--- a/src/smolvm/presets/_install.py
+++ b/src/smolvm/presets/_install.py
@@ -34,8 +34,8 @@ from smolvm.exceptions import SmolVMError
 from smolvm.presets._git import GIT_HOST_CONFIGS, register_workspace_safe_directories
 
 if TYPE_CHECKING:
+    from smolvm.comm.base import CommChannel
     from smolvm.presets._types import Preset
-    from smolvm.ssh import SSHClient
 
 
 logger = logging.getLogger(__name__)
@@ -58,7 +58,7 @@ def collect_host_env(preset: Preset) -> dict[str, str]:
 
 
 def apply_preset(
-    ssh: SSHClient,
+    ssh: CommChannel,
     preset: Preset,
     *,
     on_progress: Callable[[str], None] | None = None,
@@ -157,7 +157,7 @@ def apply_preset(
 
 
 def _run_install_phase(
-    ssh: SSHClient,
+    ssh: CommChannel,
     preset: Preset,
     script: str,
     install_timeout: int,
@@ -184,7 +184,7 @@ def _run_install_phase(
 
 
 def _copy_to_guest(
-    ssh: SSHClient, local: Path, guest_path: str, *, file_mode: int | None = None
+    ssh: CommChannel, local: Path, guest_path: str, *, file_mode: int | None = None
 ) -> None:
     """Copy a host file or directory tree to *guest_path* inside the VM.
 
@@ -204,7 +204,7 @@ def _copy_to_guest(
 
 
 def _copy_file(
-    ssh: SSHClient, local: Path, guest_path: str, *, file_mode: int | None = None
+    ssh: CommChannel, local: Path, guest_path: str, *, file_mode: int | None = None
 ) -> None:
     """Upload a single host file to *guest_path* via SFTP, mkdir parent first.
 
@@ -233,7 +233,7 @@ def _copy_file(
             )
 
 
-def _copy_dir(ssh: SSHClient, local: Path, guest_path: str) -> None:
+def _copy_dir(ssh: CommChannel, local: Path, guest_path: str) -> None:
     """Tar a host directory tree and untar it into *guest_path* on the guest.
 
     Strips ownership (uid/gid/uname/gname) on every TarInfo so the guest
@@ -331,7 +331,7 @@ def _extract_keychain_secret(service: str, *, account: str | None = None) -> str
     return value
 
 
-def _write_secret_to_guest(ssh: SSHClient, content: str, guest_path: str, file_mode: int) -> None:
+def _write_secret_to_guest(ssh: CommChannel, content: str, guest_path: str, file_mode: int) -> None:
     """Stage *content* in a 0o600 host tempfile, SFTP it, then chmod on the guest."""
     parent = _posix_dirname(guest_path)
     if parent:

--- a/src/smolvm/runtime/qemu_args.py
+++ b/src/smolvm/runtime/qemu_args.py
@@ -326,8 +326,7 @@ def build_qemu_argv(
         if platform_spec.requires_swtpm:
             if swtpm_socket is None:
                 raise SmolVMError(
-                    "Guest platform requires swtpm but no socket path was "
-                    "provided.",
+                    "Guest platform requires swtpm but no socket path was provided.",
                     {"guest_os": platform_spec.guest_os.value},
                 )
             cmd.extend(
@@ -353,10 +352,7 @@ def build_qemu_argv(
                     "-device",
                     f"{platform_spec.root_disk_controller},id=scsi0",
                     "-device",
-                    (
-                        f"{platform_spec.root_disk_device},"
-                        f"bus=scsi0.0,drive={root_drive_id}"
-                    ),
+                    (f"{platform_spec.root_disk_device},bus=scsi0.0,drive={root_drive_id}"),
                 ]
             )
 
@@ -369,14 +365,10 @@ def build_qemu_argv(
         # (Windows still sees them as block devices). Non-ISO extras and
         # Linux (None cdrom_bus) keep the legacy virtio-blk-pci wiring.
         ide_port_index = 0
-        for drive_id, drive_path in zip(
-            extra_drive_ids, vm_info.config.extra_drives, strict=True
-        ):
+        for drive_id, drive_path in zip(extra_drive_ids, vm_info.config.extra_drives, strict=True):
             is_iso = drive_path.suffix.lower() == ".iso"
             use_ide = (
-                is_iso
-                and platform_spec.cdrom_bus == "ide"
-                and ide_port_index < _Q35_AHCI_PORTS
+                is_iso and platform_spec.cdrom_bus == "ide" and ide_port_index < _Q35_AHCI_PORTS
             )
             if use_ide:
                 cmd.extend(
@@ -397,5 +389,14 @@ def build_qemu_argv(
         # controllers always come before consumers.
         for device_arg in platform_spec.extra_devices:
             cmd.extend(["-device", device_arg])
+
+    # vsock control-plane device. The guest agent listens on this CID and the
+    # host VsockChannel connects to it. Native vhost-vsock needs the host's
+    # /dev/vhost-vsock, which only exists on Linux — macOS/HVF has no
+    # equivalent, so we emit nothing there and the host stays on SSH. The
+    # device variant differs by machine type (PCI for q35, MMIO for virt).
+    if vm_info.config.vsock is not None and system == "Linux":
+        vsock_device = "vhost-vsock-device" if "aarch64" in qemu_name else "vhost-vsock-pci"
+        cmd.extend(["-device", f"{vsock_device},guest-cid={vm_info.config.vsock.guest_cid}"])
 
     return cmd

--- a/src/smolvm/ssh.py
+++ b/src/smolvm/ssh.py
@@ -123,6 +123,9 @@ class SSHClient:
             ``shell="raw"`` bypasses the wrap entirely.
     """
 
+    #: Transport tag for the :class:`~smolvm.comm.base.CommChannel` interface.
+    kind: str = "ssh"
+
     def __init__(
         self,
         host: str,
@@ -455,3 +458,11 @@ class SSHClient:
             f"wait_for_ssh({self.host}:{self.port}): last error: {last_error}",
             timeout,
         )
+
+    def wait_ready(self, timeout: float = 60.0, interval: float = 0.1) -> None:
+        """Block until the guest is reachable (:class:`CommChannel` alias).
+
+        Delegates to :meth:`wait_for_ssh`; for the SSH transport "ready"
+        means sshd is answering. See :class:`smolvm.comm.base.CommChannel`.
+        """
+        self.wait_for_ssh(timeout=timeout, interval=interval)

--- a/src/smolvm/storage/_base.py
+++ b/src/smolvm/storage/_base.py
@@ -45,6 +45,12 @@ IP_POOL_END = 65534  # 172.16.255.254
 SSH_PORT_START = 2200
 SSH_PORT_END = 67499
 
+# vsock guest-CID pool. CIDs 0/1/2 are reserved (hypervisor/local/host), so
+# allocation starts at 3. The upper bound is well within the 32-bit CID space
+# and gives ample headroom for concurrent VMs.
+VSOCK_CID_START = 3
+VSOCK_CID_END = 1_000_000
+
 
 def pool_index_to_ip(index: int) -> str:
     """Convert a pool index to an IP in the ``172.16.0.0/16`` range."""

--- a/src/smolvm/storage/_postgres.py
+++ b/src/smolvm/storage/_postgres.py
@@ -505,8 +505,8 @@ class PostgresStateManager:
     def reserve_vsock_cid(self, vm_id: str, guest_cid: int | None = None) -> int:
         if not vm_id:
             raise ValueError("vm_id cannot be empty")
-        if guest_cid is not None and guest_cid < VSOCK_CID_START:
-            raise ValueError(f"guest_cid must be >= {VSOCK_CID_START}")
+        if guest_cid is not None and not (VSOCK_CID_START <= guest_cid <= VSOCK_CID_END):
+            raise ValueError(f"guest_cid must be between {VSOCK_CID_START} and {VSOCK_CID_END}")
 
         now = now_iso()
 

--- a/src/smolvm/storage/_postgres.py
+++ b/src/smolvm/storage/_postgres.py
@@ -40,6 +40,8 @@ from smolvm.storage._base import (
     IP_POOL_START,
     SSH_PORT_END,
     SSH_PORT_START,
+    VSOCK_CID_END,
+    VSOCK_CID_START,
     browser_session_info_from_row,
     now_iso,
     pool_index_to_ip,
@@ -62,6 +64,7 @@ logger = logging.getLogger(__name__)
 # Advisory lock keys (arbitrary constants, must be unique per lock type)
 _ADVISORY_LOCK_IP = 1
 _ADVISORY_LOCK_SSH = 2
+_ADVISORY_LOCK_VSOCK = 3
 
 
 def _require_psycopg() -> None:
@@ -140,6 +143,15 @@ class PostgresStateManager:
                 CREATE INDEX IF NOT EXISTS idx_ssh_forwards_host_port
                     ON ssh_forwards(host_port);
 
+                CREATE TABLE IF NOT EXISTS vsock_cids (
+                    vm_id TEXT PRIMARY KEY,
+                    guest_cid BIGINT NOT NULL UNIQUE,
+                    created_at TEXT NOT NULL,
+                    FOREIGN KEY (vm_id) REFERENCES vms(id) ON DELETE CASCADE
+                );
+
+                CREATE INDEX IF NOT EXISTS idx_vsock_cids_vm_id ON vsock_cids(vm_id);
+
                 CREATE TABLE IF NOT EXISTS browser_sessions (
                     session_id TEXT PRIMARY KEY,
                     vm_id TEXT NOT NULL UNIQUE,
@@ -190,9 +202,7 @@ class PostgresStateManager:
         now = now_iso()
 
         with self._pool.connection() as conn:
-            row = conn.execute(
-                "SELECT id FROM vms WHERE id = %s", (config.vm_id,)
-            ).fetchone()
+            row = conn.execute("SELECT id FROM vms WHERE id = %s", (config.vm_id,)).fetchone()
             if row:
                 raise VMAlreadyExistsError(config.vm_id)
 
@@ -235,6 +245,7 @@ class PostgresStateManager:
         vm_id: str,
         *,
         status: VMState | None = None,
+        config: VMConfig | None = None,
         network: NetworkConfig | None = None,
         pid: int | None = None,
         control_socket_path: Path | None = None,
@@ -247,9 +258,7 @@ class PostgresStateManager:
         now = now_iso()
 
         with self._pool.connection() as conn:
-            existing = conn.execute(
-                "SELECT id FROM vms WHERE id = %s", (vm_id,)
-            ).fetchone()
+            existing = conn.execute("SELECT id FROM vms WHERE id = %s", (vm_id,)).fetchone()
             if not existing:
                 raise VMNotFoundError(vm_id)
 
@@ -259,6 +268,9 @@ class PostgresStateManager:
             if status is not None:
                 updates.append("status = %s")
                 params.append(status.value)
+            if config is not None:
+                updates.append("config = %s")
+                params.append(config.model_dump_json())
             if network is not None:
                 updates.append("network = %s")
                 params.append(network.model_dump_json())
@@ -285,9 +297,7 @@ class PostgresStateManager:
             raise ValueError("vm_id cannot be empty")
 
         with self._pool.connection() as conn:
-            existing = conn.execute(
-                "SELECT id FROM vms WHERE id = %s", (vm_id,)
-            ).fetchone()
+            existing = conn.execute("SELECT id FROM vms WHERE id = %s", (vm_id,)).fetchone()
             if not existing:
                 raise VMNotFoundError(vm_id)
             conn.execute("DELETE FROM vms WHERE id = %s", (vm_id,))
@@ -489,6 +499,74 @@ class PostgresStateManager:
             logger.info("Released SSH host port for VM: %s", vm_id)
 
     # ------------------------------------------------------------------
+    # vsock CID allocation (advisory lock)
+    # ------------------------------------------------------------------
+
+    def reserve_vsock_cid(self, vm_id: str, guest_cid: int | None = None) -> int:
+        if not vm_id:
+            raise ValueError("vm_id cannot be empty")
+        if guest_cid is not None and guest_cid < VSOCK_CID_START:
+            raise ValueError(f"guest_cid must be >= {VSOCK_CID_START}")
+
+        now = now_iso()
+
+        with self._pool.connection() as conn:
+            conn.execute("SELECT pg_advisory_xact_lock(%s)", (_ADVISORY_LOCK_VSOCK,))
+
+            existing = conn.execute(
+                "SELECT guest_cid FROM vsock_cids WHERE vm_id = %s", (vm_id,)
+            ).fetchone()
+            if existing:
+                existing_cid = int(existing["guest_cid"])
+                if guest_cid is not None and existing_cid != guest_cid:
+                    raise NetworkError(
+                        f"VM {vm_id} already has vsock CID {existing_cid}, "
+                        f"cannot reserve {guest_cid}"
+                    )
+                return existing_cid
+
+            allocated = conn.execute("SELECT guest_cid FROM vsock_cids").fetchall()
+            allocated_set = {int(row["guest_cid"]) for row in allocated}
+
+            candidate_cids = (
+                [guest_cid] if guest_cid is not None else range(VSOCK_CID_START, VSOCK_CID_END + 1)
+            )
+            for candidate_cid in candidate_cids:
+                if candidate_cid in allocated_set:
+                    continue
+                conn.execute(
+                    "INSERT INTO vsock_cids (vm_id, guest_cid, created_at) VALUES (%s, %s, %s)",
+                    (vm_id, candidate_cid, now),
+                )
+                logger.info("Reserved vsock CID %d for VM %s", candidate_cid, vm_id)
+                return candidate_cid
+
+        if guest_cid is not None:
+            raise NetworkError(f"Requested vsock CID {guest_cid} is not available")
+        raise NetworkError("No vsock CIDs available in pool")
+
+    def get_vsock_cid(self, vm_id: str) -> int | None:
+        if not vm_id:
+            raise ValueError("vm_id cannot be empty")
+
+        with self._pool.connection() as conn:
+            row = conn.execute(
+                "SELECT guest_cid FROM vsock_cids WHERE vm_id = %s", (vm_id,)
+            ).fetchone()
+
+        if row:
+            return int(row["guest_cid"])
+        return None
+
+    def release_vsock_cid(self, vm_id: str) -> None:
+        if not vm_id:
+            raise ValueError("vm_id cannot be empty")
+
+        with self._pool.connection() as conn:
+            conn.execute("DELETE FROM vsock_cids WHERE vm_id = %s", (vm_id,))
+            logger.info("Released vsock CID for VM: %s", vm_id)
+
+    # ------------------------------------------------------------------
     # Snapshots
     # ------------------------------------------------------------------
 
@@ -580,9 +658,7 @@ class PostgresStateManager:
             raise ValueError("snapshot_id cannot be empty")
 
         with self._pool.connection() as conn:
-            result = conn.execute(
-                "DELETE FROM snapshots WHERE snapshot_id = %s", (snapshot_id,)
-            )
+            result = conn.execute("DELETE FROM snapshots WHERE snapshot_id = %s", (snapshot_id,))
             if result.rowcount == 0:
                 raise SnapshotNotFoundError(snapshot_id)
 
@@ -749,9 +825,7 @@ class PostgresStateManager:
                     (status.value,),
                 ).fetchall()
             else:
-                rows = conn.execute(
-                    "SELECT * FROM browser_sessions ORDER BY created_at"
-                ).fetchall()
+                rows = conn.execute("SELECT * FROM browser_sessions ORDER BY created_at").fetchall()
 
         return [browser_session_info_from_row(row) for row in rows]
 

--- a/src/smolvm/storage/_protocol.py
+++ b/src/smolvm/storage/_protocol.py
@@ -62,6 +62,7 @@ class StateManagerProtocol(Protocol):
         vm_id: str,
         *,
         status: VMState | None = None,
+        config: VMConfig | None = None,
         network: NetworkConfig | None = None,
         pid: int | None = None,
         control_socket_path: Path | None = None,
@@ -116,6 +117,19 @@ class StateManagerProtocol(Protocol):
         pass
 
     # ------------------------------------------------------------------
+    # vsock CID allocation
+    # ------------------------------------------------------------------
+
+    def reserve_vsock_cid(self, vm_id: str, guest_cid: int | None = None) -> int:
+        pass
+
+    def get_vsock_cid(self, vm_id: str) -> int | None:
+        pass
+
+    def release_vsock_cid(self, vm_id: str) -> None:
+        pass
+
+    # ------------------------------------------------------------------
     # Snapshots
     # ------------------------------------------------------------------
 
@@ -128,9 +142,7 @@ class StateManagerProtocol(Protocol):
     def list_snapshots(self, vm_id: str | None = None) -> list[SnapshotInfo]:
         pass
 
-    def mark_snapshot_restored(
-        self, snapshot_id: str, restored_vm_id: str
-    ) -> SnapshotInfo:
+    def mark_snapshot_restored(self, snapshot_id: str, restored_vm_id: str) -> SnapshotInfo:
         pass
 
     def delete_snapshot(self, snapshot_id: str) -> None:

--- a/src/smolvm/storage/_sqlite.py
+++ b/src/smolvm/storage/_sqlite.py
@@ -507,8 +507,8 @@ class SQLiteStateManager:
         """
         if not vm_id:
             raise ValueError("vm_id cannot be empty")
-        if guest_cid is not None and guest_cid < VSOCK_CID_START:
-            raise ValueError(f"guest_cid must be >= {VSOCK_CID_START}")
+        if guest_cid is not None and not (VSOCK_CID_START <= guest_cid <= VSOCK_CID_END):
+            raise ValueError(f"guest_cid must be between {VSOCK_CID_START} and {VSOCK_CID_END}")
 
         now = now_iso()
 

--- a/src/smolvm/storage/_sqlite.py
+++ b/src/smolvm/storage/_sqlite.py
@@ -41,6 +41,8 @@ from smolvm.storage._base import (
     IP_POOL_START,
     SSH_PORT_END,
     SSH_PORT_START,
+    VSOCK_CID_END,
+    VSOCK_CID_START,
     browser_session_info_from_row,
     now_iso,
     pool_index_to_ip,
@@ -134,6 +136,15 @@ class SQLiteStateManager:
                 CREATE INDEX IF NOT EXISTS idx_ssh_forwards_vm_id ON ssh_forwards(vm_id);
                 CREATE INDEX IF NOT EXISTS idx_ssh_forwards_host_port
                     ON ssh_forwards(host_port);
+
+                CREATE TABLE IF NOT EXISTS vsock_cids (
+                    vm_id TEXT PRIMARY KEY,
+                    guest_cid INTEGER NOT NULL UNIQUE,
+                    created_at TEXT NOT NULL,
+                    FOREIGN KEY (vm_id) REFERENCES vms(id) ON DELETE CASCADE
+                );
+
+                CREATE INDEX IF NOT EXISTS idx_vsock_cids_vm_id ON vsock_cids(vm_id);
 
                 CREATE TABLE IF NOT EXISTS browser_sessions (
                     session_id TEXT PRIMARY KEY,
@@ -235,6 +246,7 @@ class SQLiteStateManager:
         vm_id: str,
         *,
         status: VMState | None = None,
+        config: VMConfig | None = None,
         network: NetworkConfig | None = None,
         pid: int | None = None,
         control_socket_path: Path | None = None,
@@ -257,6 +269,9 @@ class SQLiteStateManager:
             if status is not None:
                 updates.append("status = ?")
                 params.append(status.value)
+            if config is not None:
+                updates.append("config = ?")
+                params.append(config.model_dump_json())
             if network is not None:
                 updates.append("network = ?")
                 params.append(network.model_dump_json())
@@ -335,9 +350,7 @@ class SQLiteStateManager:
         now = now_iso()
 
         with self._get_connection(exclusive=True) as conn:
-            existing = conn.execute(
-                "SELECT ip FROM ip_leases WHERE vm_id = ?", (vm_id,)
-            ).fetchone()
+            existing = conn.execute("SELECT ip FROM ip_leases WHERE vm_id = ?", (vm_id,)).fetchone()
             if existing:
                 existing_ip = str(existing["ip"])
                 if requested_ip and existing_ip != requested_ip:
@@ -482,6 +495,79 @@ class SQLiteStateManager:
                 logger.info("Released SSH host port for VM: %s", vm_id)
 
     # ------------------------------------------------------------------
+    # vsock CID allocation
+    # ------------------------------------------------------------------
+
+    def reserve_vsock_cid(self, vm_id: str, guest_cid: int | None = None) -> int:
+        """Reserve a unique guest vsock CID for *vm_id* (idempotent).
+
+        Mirrors :meth:`reserve_ssh_port`: returns the existing CID if the VM
+        already has one, otherwise allocates the lowest free CID in the pool
+        (or *guest_cid* if explicitly requested, e.g. on snapshot restore).
+        """
+        if not vm_id:
+            raise ValueError("vm_id cannot be empty")
+        if guest_cid is not None and guest_cid < VSOCK_CID_START:
+            raise ValueError(f"guest_cid must be >= {VSOCK_CID_START}")
+
+        now = now_iso()
+
+        with self._get_connection(exclusive=True) as conn:
+            existing = conn.execute(
+                "SELECT guest_cid FROM vsock_cids WHERE vm_id = ?", (vm_id,)
+            ).fetchone()
+            if existing:
+                existing_cid = int(existing["guest_cid"])
+                if guest_cid is not None and existing_cid != guest_cid:
+                    raise NetworkError(
+                        f"VM {vm_id} already has vsock CID {existing_cid}, "
+                        f"cannot reserve {guest_cid}"
+                    )
+                return existing_cid
+
+            allocated = conn.execute("SELECT guest_cid FROM vsock_cids").fetchall()
+            allocated_set = {int(row["guest_cid"]) for row in allocated}
+
+            candidate_cids = (
+                [guest_cid] if guest_cid is not None else range(VSOCK_CID_START, VSOCK_CID_END + 1)
+            )
+            for candidate_cid in candidate_cids:
+                if candidate_cid in allocated_set:
+                    continue
+                conn.execute(
+                    "INSERT INTO vsock_cids (vm_id, guest_cid, created_at) VALUES (?, ?, ?)",
+                    (vm_id, candidate_cid, now),
+                )
+                logger.info("Reserved vsock CID %d for VM %s", candidate_cid, vm_id)
+                return candidate_cid
+
+        if guest_cid is not None:
+            raise NetworkError(f"Requested vsock CID {guest_cid} is not available")
+        raise NetworkError("No vsock CIDs available in pool")
+
+    def get_vsock_cid(self, vm_id: str) -> int | None:
+        if not vm_id:
+            raise ValueError("vm_id cannot be empty")
+
+        with self._get_connection() as conn:
+            row = conn.execute(
+                "SELECT guest_cid FROM vsock_cids WHERE vm_id = ?", (vm_id,)
+            ).fetchone()
+
+        if row:
+            return int(row["guest_cid"])
+        return None
+
+    def release_vsock_cid(self, vm_id: str) -> None:
+        if not vm_id:
+            raise ValueError("vm_id cannot be empty")
+
+        with self._get_connection(exclusive=True) as conn:
+            result = conn.execute("DELETE FROM vsock_cids WHERE vm_id = ?", (vm_id,))
+            if result.rowcount > 0:
+                logger.info("Released vsock CID for VM: %s", vm_id)
+
+    # ------------------------------------------------------------------
     # Snapshots
     # ------------------------------------------------------------------
 
@@ -573,9 +659,7 @@ class SQLiteStateManager:
             raise ValueError("snapshot_id cannot be empty")
 
         with self._get_connection(exclusive=True) as conn:
-            result = conn.execute(
-                "DELETE FROM snapshots WHERE snapshot_id = ?", (snapshot_id,)
-            )
+            result = conn.execute("DELETE FROM snapshots WHERE snapshot_id = ?", (snapshot_id,))
             if result.rowcount == 0:
                 raise SnapshotNotFoundError(snapshot_id)
 
@@ -742,9 +826,7 @@ class SQLiteStateManager:
                     (status.value,),
                 ).fetchall()
             else:
-                rows = conn.execute(
-                    "SELECT * FROM browser_sessions ORDER BY created_at"
-                ).fetchall()
+                rows = conn.execute("SELECT * FROM browser_sessions ORDER BY created_at").fetchall()
 
         return [browser_session_info_from_row(row) for row in rows]
 

--- a/src/smolvm/types.py
+++ b/src/smolvm/types.py
@@ -304,6 +304,10 @@ class VMConfig(BaseModel):
         env_vars: Environment variables to inject into the guest
             after boot via SSH. Keys must be valid shell identifiers.
         port_forwards: Optional host TCP forwards configured at VM launch.
+        comm_channel: Host↔guest control transport (``"ssh"`` or ``"vsock"``).
+            ``None`` means auto-select at runtime (vsock when the guest agent
+            answers on a supported backend, else SSH). See
+            :func:`smolvm.comm.select.resolve_comm_channel`.
         ssh_public_key: Optional OpenSSH public key (one-line ``authorized_keys``
             format) to install in the guest's ``/root/.ssh/authorized_keys`` at
             first boot. Passed via the kernel command line as
@@ -336,6 +340,7 @@ class VMConfig(BaseModel):
     network_rate_limit_mbps: Annotated[int, Field(ge=1)] | None = None
     port_forwards: list[PortForwardConfig] = []
     vsock: VsockConfig | None = None
+    comm_channel: Literal["ssh", "vsock"] | None = None
     internet_settings: InternetSettings | None = None
     workspace_mounts: list[WorkspaceMount] = []
     ssh_public_key: str | None = None

--- a/src/smolvm/vm.py
+++ b/src/smolvm/vm.py
@@ -37,6 +37,7 @@ from pathlib import Path
 from typing import Any, TextIO
 from uuid import uuid4
 
+from smolvm.comm.select import resolve_comm_channel
 from smolvm.exceptions import (
     SmolVMError,
     SnapshotAlreadyExistsError,
@@ -58,7 +59,15 @@ from smolvm.runtime.libkrun import LibkrunRuntimeAdapter
 from smolvm.runtime.qemu import QEMU_ROOT_NODE_NAME, QemuRuntimeAdapter
 from smolvm.runtime.qemu_args import build_qemu_argv
 from smolvm.storage import StateManagerProtocol, create_state_manager, ip_to_pool_index
-from smolvm.types import GuestOS, NetworkConfig, SnapshotInfo, VMConfig, VMInfo, VMState
+from smolvm.types import (
+    GuestOS,
+    NetworkConfig,
+    SnapshotInfo,
+    VMConfig,
+    VMInfo,
+    VMState,
+    VsockConfig,
+)
 from smolvm.utils import RUNTIME_PRIVILEGE_SETUP_HINT, which
 
 logger = logging.getLogger(__name__)
@@ -127,6 +136,8 @@ def _qemu_install_hint() -> str:
         "Install QEMU for this operating system, then make sure qemu-system-x86_64 "
         "or qemu-system-aarch64 is on PATH."
     )
+
+
 QEMU_GATEWAY_IP = "10.0.2.2"
 QEMU_NETMASK = "255.255.255.0"
 SNAPSHOT_ID_PATTERN = re.compile(r"^[a-z0-9][a-z0-9_-]{0,62}[a-z0-9]$|^[a-z0-9]$")
@@ -672,8 +683,7 @@ class SmolVMManager:
             # standalone design problem (multi-artifact snapshot atomicity)
             # and not in Phase 1 scope.
             raise SmolVMError(
-                "Snapshot and restore are not supported for Windows guests "
-                "in this release.",
+                "Snapshot and restore are not supported for Windows guests in this release.",
                 {"vm_id": vm_info.vm_id},
             )
         if vm_info.config.disk_mode != "isolated":
@@ -894,6 +904,29 @@ class SmolVMManager:
 
         return errors
 
+    def _maybe_enable_vsock(self, config: VMConfig, backend: str, vm_info: VMInfo) -> VMInfo:
+        """Reserve a vsock CID and persist ``config.vsock`` when the VM should
+        use the vsock control channel.
+
+        No-op unless the resolved channel is vsock (QEMU on a Linux host with
+        ``/dev/vhost-vsock``). The CID is reserved after the VM row exists (the
+        ``vsock_cids`` foreign key requires it) and written back to the config
+        so ``build_qemu_argv`` wires the ``vhost-vsock`` device at boot.
+        Returns the possibly-updated :class:`VMInfo`.
+        """
+        resolution = resolve_comm_channel(
+            requested=None,
+            config_channel=config.comm_channel,
+            backend=backend,
+            guest_os=config.guest_os,
+        )
+        if resolution.kind != "vsock":
+            return vm_info
+        cid = self.state.reserve_vsock_cid(config.vm_id)
+        updated = config.model_copy(update={"vsock": VsockConfig(guest_cid=cid)})
+        logger.info("VM %s will use vsock control channel (CID %d)", config.vm_id, cid)
+        return self.state.update_vm(config.vm_id, config=updated)
+
     def create(self, config: VMConfig) -> VMInfo:
         """Create a new microVM.
 
@@ -965,6 +998,7 @@ class SmolVMManager:
                     ssh_host_port=ssh_host_port,
                 )
                 vm_info = self.state.update_vm(effective_config.vm_id, network=network_config)
+                vm_info = self._maybe_enable_vsock(effective_config, backend, vm_info)
                 logger.info(
                     "VM created: %s (backend=%s, ssh localhost:%d)",
                     effective_config.vm_id,
@@ -2098,10 +2132,7 @@ class SmolVMManager:
             # same ID.
             firmware_state = self.data_dir / "firmware" / vm_id
             if firmware_state.exists():
-                retain = (
-                    vm_info is not None
-                    and vm_info.config.retain_disk_on_delete
-                )
+                retain = vm_info is not None and vm_info.config.retain_disk_on_delete
                 if retain:
                     logger.info(
                         "Retaining per-VM firmware state for VM %s at %s",
@@ -2174,6 +2205,7 @@ class SmolVMManager:
                     ssh_host_port=ssh_host_port,
                 )
                 vm_info = self.state.update_vm(effective_config.vm_id, network=network_config)
+                vm_info = self._maybe_enable_vsock(effective_config, backend, vm_info)
                 return vm_info
 
             # Firecracker networking (async)
@@ -2540,10 +2572,7 @@ class SmolVMManager:
             # Windows-guest firmware behind.
             firmware_state = self.data_dir / "firmware" / vm_id
             if firmware_state.exists():
-                retain = (
-                    vm_info is not None
-                    and vm_info.config.retain_disk_on_delete
-                )
+                retain = vm_info is not None and vm_info.config.retain_disk_on_delete
                 if retain:
                     logger.info(
                         "Retaining per-VM firmware state for VM %s at %s",

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -151,6 +151,7 @@ class TestCliEnv:
             "vm001",
             ssh_user="root",
             ssh_key_path=None,
+            comm_channel=None,
         )
         vm.set_env_vars.assert_called_once_with({"FOO": "bar"})
         vm.close.assert_called_once()
@@ -324,6 +325,7 @@ class TestCliEnv:
             "vm001",
             ssh_user="custom-user",
             ssh_key_path="/custom/key",
+            comm_channel=None,
         )
 
     def test_vm_lookup_failure_prints_error(
@@ -383,6 +385,7 @@ class TestCliFile:
             "vm001",
             ssh_user="root",
             ssh_key_path=None,
+            comm_channel=None,
         )
         vm.upload_file.assert_called_once_with(
             str(source),
@@ -472,6 +475,7 @@ class TestCliFile:
             "vm001",
             ssh_user="root",
             ssh_key_path=None,
+            comm_channel=None,
         )
         vm.download_file.assert_called_once_with(
             "/tmp/note.txt",

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -157,6 +157,26 @@ class TestCliEnv:
         vm.close.assert_called_once()
         assert "Set 1 env var(s)" in capsys.readouterr().out
 
+    @pytest.mark.parametrize("channel", ["ssh", "vsock"])
+    def test_env_set_passes_comm_channel(
+        self,
+        mock_vm_cls: MagicMock,
+        channel: str,
+    ) -> None:
+        """`--comm-channel` is forwarded to SmolVM.from_id."""
+        vm = self._setup_vm(mock_vm_cls)
+        vm.set_env_vars.return_value = ["FOO"]
+
+        ret = main(["env", "set", "vm001", "FOO=bar", "--comm-channel", channel])
+
+        assert ret == 0
+        mock_vm_cls.from_id.assert_called_once_with(
+            "vm001",
+            ssh_user="root",
+            ssh_key_path=None,
+            comm_channel=channel,
+        )
+
     def test_env_set_multiple(
         self,
         mock_vm_cls: MagicMock,
@@ -395,6 +415,30 @@ class TestCliFile:
         vm.close.assert_called_once()
         assert "Uploaded" in capsys.readouterr().out
 
+    @pytest.mark.parametrize("channel", ["ssh", "vsock"])
+    def test_file_upload_passes_comm_channel(
+        self,
+        mock_vm_cls: MagicMock,
+        tmp_path: Path,
+        channel: str,
+    ) -> None:
+        """`--comm-channel` is forwarded to SmolVM.from_id."""
+        source = tmp_path / "note.txt"
+        source.write_text("hello")
+        vm = MagicMock()
+        vm.upload_file.return_value = "/tmp/note.txt"
+        mock_vm_cls.from_id.return_value = vm
+
+        ret = main(["file", "upload", "vm001", str(source), "/tmp/", "--comm-channel", channel])
+
+        assert ret == 0
+        mock_vm_cls.from_id.assert_called_once_with(
+            "vm001",
+            ssh_user="root",
+            ssh_key_path=None,
+            comm_channel=channel,
+        )
+
     def test_file_upload_json(
         self,
         mock_vm_cls: MagicMock,
@@ -497,9 +541,7 @@ class TestCliFile:
         vm.download_file.return_value = str(destination)
         mock_vm_cls.from_id.return_value = vm
 
-        ret = main(
-            ["file", "download", "vm001", "/tmp/note.txt", str(tmp_path) + "/", "--json"]
-        )
+        ret = main(["file", "download", "vm001", "/tmp/note.txt", str(tmp_path) + "/", "--json"])
 
         assert ret == 0
         payload = json.loads(capsys.readouterr().out)
@@ -872,9 +914,7 @@ class TestCliCreateImage:
         """--image and --os now both parse (Windows guests need both); the
         facade rejects illegal combos at runtime with a clearer message."""
         parser = build_parser()
-        args = parser.parse_args(
-            ["create", "--image", "s3://bucket/img/", "--os", "alpine"]
-        )
+        args = parser.parse_args(["create", "--image", "s3://bucket/img/", "--os", "alpine"])
         assert args.image == "s3://bucket/img/"
         assert args.os == "alpine"
 
@@ -883,9 +923,7 @@ class TestCliCreateImage:
         capsys: pytest.CaptureFixture[str],
     ) -> None:
         """S3 image + --os surfaces a one-sentence CLI error."""
-        ret = main(
-            ["create", "--image", "s3://bucket/img/", "--os", "alpine"]
-        )
+        ret = main(["create", "--image", "s3://bucket/img/", "--os", "alpine"])
         assert ret == 1
         err = capsys.readouterr().err
         assert "--image (S3) and --os are mutually exclusive" in err
@@ -1157,8 +1195,8 @@ class TestCliWindowsBuildImage:
         out_text = capsys.readouterr().out
         assert "Windows image ready" in out_text
         # Password is never leaked in the success panel.
-        assert "ssh_password=\"<hidden>\"" in out_text
-        assert "ssh_password=\"smolvm\"" not in out_text
+        assert 'ssh_password="<hidden>"' in out_text
+        assert 'ssh_password="smolvm"' not in out_text
 
     @patch("smolvm.windows.WindowsImageBuilder")
     def test_build_image_json_mode_emits_envelope(
@@ -3431,7 +3469,7 @@ class TestPublishedImageLaunchPath:
         envelope = json.loads(capsys.readouterr().out)
         assert ret == 2
         assert envelope["exit_code"] == 2
-        assert "no boot_args" in envelope["error"]["message"]
+        assert "isn't available as a prebuilt image" in envelope["error"]["message"]
 
     @pytest.mark.parametrize(
         "system,machine,expected_arch,expected_vmm,expected_backend",

--- a/tests/test_comm.py
+++ b/tests/test_comm.py
@@ -1,0 +1,31 @@
+# Copyright 2026 Celesto AI
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for the host↔guest transport abstraction."""
+
+from smolvm.comm import CommChannel
+from smolvm.ssh import SSHClient
+
+
+class TestCommChannelProtocol:
+    def test_sshclient_satisfies_commchannel(self) -> None:
+        client = SSHClient(host="127.0.0.1")
+        assert isinstance(client, CommChannel)
+        assert client.kind == "ssh"
+
+    def test_sshclient_has_wait_ready_alias(self) -> None:
+        client = SSHClient(host="127.0.0.1")
+        # wait_ready delegates to wait_for_ssh; both must be callable.
+        assert callable(client.wait_ready)
+        assert callable(client.wait_for_ssh)

--- a/tests/test_comm_select.py
+++ b/tests/test_comm_select.py
@@ -1,0 +1,87 @@
+# Copyright 2026 Celesto AI
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for comm-channel resolution."""
+
+import pytest
+
+from smolvm.comm.select import resolve_comm_channel
+from smolvm.exceptions import SmolVMError
+from smolvm.runtime.backends import BACKEND_FIRECRACKER, BACKEND_QEMU
+from smolvm.types import GuestOS
+
+
+def _resolve(**overrides):
+    base = {
+        "requested": None,
+        "config_channel": None,
+        "backend": BACKEND_QEMU,
+        "guest_os": GuestOS.ALPINE,
+        "host_vsock_supported": True,
+    }
+    base.update(overrides)
+    return resolve_comm_channel(**base)
+
+
+class TestAuto:
+    def test_auto_picks_vsock_with_fallback_on_linux_qemu(self) -> None:
+        res = _resolve()
+        assert res.kind == "vsock"
+        assert res.allow_fallback is True
+
+    def test_auto_falls_back_to_ssh_without_host_vsock(self) -> None:
+        res = _resolve(host_vsock_supported=False)
+        assert res.kind == "ssh"
+        assert res.allow_fallback is False
+
+    def test_auto_uses_ssh_on_non_qemu_backend(self) -> None:
+        res = _resolve(backend=BACKEND_FIRECRACKER)
+        assert res.kind == "ssh"
+
+    def test_auto_uses_ssh_for_windows(self) -> None:
+        res = _resolve(guest_os=GuestOS.WINDOWS, backend=BACKEND_QEMU)
+        assert res.kind == "ssh"
+
+
+class TestExplicit:
+    def test_explicit_ssh(self) -> None:
+        res = _resolve(requested="ssh")
+        assert res.kind == "ssh"
+        assert res.allow_fallback is False
+
+    def test_explicit_vsock_no_fallback(self) -> None:
+        res = _resolve(requested="vsock")
+        assert res.kind == "vsock"
+        assert res.allow_fallback is False
+
+    def test_explicit_vsock_on_macos_raises(self) -> None:
+        with pytest.raises(SmolVMError, match="vhost_vsock"):
+            _resolve(requested="vsock", host_vsock_supported=False)
+
+    def test_explicit_vsock_on_non_qemu_raises(self) -> None:
+        with pytest.raises(SmolVMError, match="QEMU"):
+            _resolve(requested="vsock", backend=BACKEND_FIRECRACKER)
+
+    def test_explicit_vsock_on_windows_raises(self) -> None:
+        with pytest.raises(SmolVMError, match="Windows"):
+            _resolve(requested="vsock", guest_os=GuestOS.WINDOWS)
+
+    def test_request_overrides_config(self) -> None:
+        # Explicit ssh beats a vsock preference stored on the config.
+        res = _resolve(requested="ssh", config_channel="vsock")
+        assert res.kind == "ssh"
+
+    def test_config_channel_used_when_no_request(self) -> None:
+        res = _resolve(requested=None, config_channel="ssh")
+        assert res.kind == "ssh"

--- a/tests/test_facade_vsock.py
+++ b/tests/test_facade_vsock.py
@@ -1,0 +1,100 @@
+# Copyright 2026 Celesto AI
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Facade-level tests for the vsock control-channel seam.
+
+These build a SmolVM via ``__new__`` (bypassing the SDK/create path) and drive
+``_wait_for_ssh`` directly, so they validate channel resolution + dispatch
+without booting a VM.
+"""
+
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+from smolvm.comm.vsock_channel import VsockChannel
+from smolvm.exceptions import OperationTimeoutError
+from smolvm.facade import SmolVM
+from smolvm.types import GuestOS, VMConfig, VMInfo, VMState, VsockConfig
+
+
+def _vsock_vm(tmp_path: Path, *, comm_channel: str | None, request: str | None) -> SmolVM:
+    kernel = tmp_path / "vmlinux"
+    rootfs = tmp_path / "rootfs.ext4"
+    kernel.touch()
+    rootfs.touch()
+    config = VMConfig(
+        vm_id="vm1",
+        kernel_path=kernel,
+        rootfs_path=rootfs,
+        backend="qemu",
+        guest_os=GuestOS.ALPINE,
+        boot_args="console=ttyS0 reboot=k panic=1 init=/init",
+        comm_channel=comm_channel,
+        vsock=VsockConfig(guest_cid=5),
+    )
+    info = VMInfo(vm_id="vm1", status=VMState.RUNNING, config=config)
+
+    vm = SmolVM.__new__(SmolVM)
+    vm._comm_channel_request = request
+    vm._vm_id = "vm1"
+    vm._ssh = None
+    vm._ssh_ready = False
+    vm._info = info
+    vm._sdk = MagicMock()
+    vm._sdk.get.return_value = info
+    return vm
+
+
+def test_wait_for_ssh_uses_vsock_when_agent_answers(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setattr("smolvm.comm.select.host_supports_vsock", lambda: True)
+    monkeypatch.setattr(VsockChannel, "wait_ready", lambda self, timeout=60.0, interval=0.1: None)
+
+    vm = _vsock_vm(tmp_path, comm_channel="vsock", request=None)
+    vm._wait_for_ssh(timeout=5)
+
+    assert vm._ssh_ready is True
+    assert isinstance(vm._ssh, VsockChannel)
+    assert vm._ssh.guest_cid == 5
+
+
+def test_explicit_vsock_does_not_fall_back_to_ssh(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setattr("smolvm.comm.select.host_supports_vsock", lambda: True)
+
+    def _fail(self, timeout=60.0, interval=0.1):
+        raise OperationTimeoutError("vsock", timeout)
+
+    monkeypatch.setattr(VsockChannel, "wait_ready", _fail)
+
+    # request="vsock" → explicit, allow_fallback=False
+    vm = _vsock_vm(tmp_path, comm_channel="vsock", request="vsock")
+    with pytest.raises(OperationTimeoutError):
+        vm._wait_for_ssh(timeout=1)
+    assert vm._ssh_ready is False
+
+
+def test_resolve_channel_reads_config_and_request(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setattr("smolvm.comm.select.host_supports_vsock", lambda: True)
+    vm = _vsock_vm(tmp_path, comm_channel=None, request=None)
+    # auto on linux+qemu → vsock with fallback allowed
+    res = vm._resolve_channel()
+    assert res.kind == "vsock"
+    assert res.allow_fallback is True

--- a/tests/test_guest_agent.py
+++ b/tests/test_guest_agent.py
@@ -1,0 +1,256 @@
+# Copyright 2026 Celesto AI
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for the guest agent and the vsock wire protocol.
+
+The agent (``smolvm.guest_agent.agent``) ships into the guest as a standalone
+file and embeds its own copy of the framing in ``smolvm.comm.protocol``. These
+tests drive the agent's per-connection handler over an ``AF_UNIX`` socketpair
+using the *host-side* protocol helpers, so any drift between the two framings
+is caught immediately — without needing a real VM or AF_VSOCK.
+"""
+
+import os
+import socket
+import threading
+
+import pytest
+
+from smolvm.comm import protocol
+from smolvm.guest_agent import agent
+
+
+def _serve_once(guest_sock: socket.socket) -> threading.Thread:
+    """Run the agent's handler for one request on a background thread."""
+
+    def _target() -> None:
+        try:
+            agent.handle_connection(guest_sock)
+        finally:
+            guest_sock.close()
+
+    thread = threading.Thread(target=_target, daemon=True)
+    thread.start()
+    return thread
+
+
+def _read_run_response(host_sock: socket.socket) -> tuple[dict, bytes, bytes]:
+    """Collect a ``run`` response: stream frames until the terminal JSON."""
+    stdout = bytearray()
+    stderr = bytearray()
+    while True:
+        frame_type, payload = protocol.recv_frame(host_sock)
+        if frame_type == protocol.FRAME_JSON:
+            import json
+
+            return json.loads(payload.decode()), bytes(stdout), bytes(stderr)
+        if frame_type == protocol.FRAME_STDOUT:
+            stdout.extend(payload)
+        elif frame_type == protocol.FRAME_STDERR:
+            stderr.extend(payload)
+        else:  # pragma: no cover - defensive
+            raise AssertionError(f"unexpected frame type {frame_type}")
+
+
+class TestFramingParity:
+    """The agent must embed the exact same wire constants as the host."""
+
+    def test_constants_match(self) -> None:
+        assert agent.PROTOCOL_VERSION == protocol.PROTOCOL_VERSION
+        assert agent.SMOLVM_AGENT_PORT == protocol.SMOLVM_AGENT_PORT
+        assert agent.CHUNK_SIZE == protocol.CHUNK_SIZE
+        assert agent.FRAME_JSON == protocol.FRAME_JSON
+        assert agent.FRAME_STDOUT == protocol.FRAME_STDOUT
+        assert agent.FRAME_STDERR == protocol.FRAME_STDERR
+        assert agent.FRAME_DATA == protocol.FRAME_DATA
+        assert agent.FRAME_EOF == protocol.FRAME_EOF
+
+    def test_frame_roundtrip_over_socketpair(self) -> None:
+        a, b = socket.socketpair()
+        with a, b:
+            protocol.send_frame(a, protocol.FRAME_DATA, b"hello world")
+            frame_type, payload = protocol.recv_frame(b)
+        assert frame_type == protocol.FRAME_DATA
+        assert payload == b"hello world"
+
+    def test_recv_exact_raises_on_short_read(self) -> None:
+        a, b = socket.socketpair()
+        with b:
+            a.sendall(b"abc")
+            a.close()
+            with pytest.raises(ConnectionError):
+                protocol.recv_exact(b, 8)
+
+
+class TestPing:
+    def test_ping_returns_pong(self) -> None:
+        host, guest = socket.socketpair()
+        with host:
+            thread = _serve_once(guest)
+            protocol.send_json(host, {"v": protocol.PROTOCOL_VERSION, "op": "ping"})
+            resp = protocol.recv_json(host)
+            thread.join(timeout=5)
+        assert resp["ok"] is True
+        assert resp["op"] == "pong"
+        assert resp["proto"] == protocol.PROTOCOL_VERSION
+        assert "agent_version" in resp
+
+
+class TestRun:
+    def test_run_raw_captures_stdout_and_exit(self) -> None:
+        host, guest = socket.socketpair()
+        with host:
+            thread = _serve_once(guest)
+            protocol.send_json(
+                host,
+                {"op": "run", "cmd": "printf 'hi there'", "shell": "raw", "timeout": 10},
+            )
+            terminal, stdout, stderr = _read_run_response(host)
+            thread.join(timeout=5)
+        assert terminal["op"] == "exit"
+        assert terminal["exit_code"] == 0
+        assert stdout == b"hi there"
+        assert stderr == b""
+
+    def test_run_reports_stderr_and_nonzero_exit(self) -> None:
+        host, guest = socket.socketpair()
+        with host:
+            thread = _serve_once(guest)
+            protocol.send_json(
+                host,
+                {"op": "run", "cmd": "echo oops 1>&2; exit 3", "shell": "raw", "timeout": 10},
+            )
+            terminal, stdout, stderr = _read_run_response(host)
+            thread.join(timeout=5)
+        assert terminal["exit_code"] == 3
+        assert stderr.strip() == b"oops"
+
+    def test_run_login_shell(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        # Force a quiet POSIX shell so login-shell profile noise doesn't
+        # pollute stdout on dev machines whose $SHELL is zsh/bash.
+        monkeypatch.setenv("SHELL", "/bin/sh")
+        host, guest = socket.socketpair()
+        with host:
+            thread = _serve_once(guest)
+            protocol.send_json(
+                host,
+                {"op": "run", "cmd": "printf done", "shell": "login", "timeout": 10},
+            )
+            terminal, stdout, _ = _read_run_response(host)
+            thread.join(timeout=5)
+        assert terminal["exit_code"] == 0
+        assert b"done" in stdout
+
+    def test_run_timeout_kills_and_reports(self) -> None:
+        host, guest = socket.socketpair()
+        with host:
+            thread = _serve_once(guest)
+            protocol.send_json(
+                host,
+                {"op": "run", "cmd": "sleep 10", "shell": "raw", "timeout": 1},
+            )
+            terminal, _, _ = _read_run_response(host)
+            thread.join(timeout=10)
+        assert terminal["op"] == "timeout"
+
+
+class TestFileTransfer:
+    def test_put_file_preserves_mode(self, tmp_path) -> None:
+        target = tmp_path / "id_ed25519"
+        payload = b"-----BEGIN OPENSSH PRIVATE KEY-----\nsecret\n"
+        host, guest = socket.socketpair()
+        with host:
+            thread = _serve_once(guest)
+            protocol.send_json(
+                host,
+                {"op": "put_file", "path": str(target), "mode": 0o600, "size": len(payload)},
+            )
+            protocol.send_frame(host, protocol.FRAME_DATA, payload)
+            resp = protocol.recv_json(host)
+            thread.join(timeout=5)
+        assert resp["ok"] is True
+        assert target.read_bytes() == payload
+        assert (target.stat().st_mode & 0o777) == 0o600
+
+    def test_put_file_into_missing_dir_fails_cleanly(self, tmp_path) -> None:
+        target = tmp_path / "nope" / "file.txt"
+        payload = b"data"
+        host, guest = socket.socketpair()
+        with host:
+            thread = _serve_once(guest)
+            protocol.send_json(
+                host,
+                {"op": "put_file", "path": str(target), "mode": None, "size": len(payload)},
+            )
+            # Bytes must still be drained even though the write target is bad.
+            protocol.send_frame(host, protocol.FRAME_DATA, payload)
+            resp = protocol.recv_json(host)
+            thread.join(timeout=5)
+        assert resp["ok"] is False
+        assert "error" in resp
+
+    def test_get_file_streams_bytes_and_mode(self, tmp_path) -> None:
+        source = tmp_path / "blob.bin"
+        payload = os.urandom(200_000)  # spans multiple CHUNK_SIZE frames
+        source.write_bytes(payload)
+        os.chmod(source, 0o640)
+
+        host, guest = socket.socketpair()
+        received = bytearray()
+        with host:
+            thread = _serve_once(guest)
+            protocol.send_json(host, {"op": "get_file", "path": str(source)})
+            header = protocol.recv_json(host)
+            while True:
+                frame_type, chunk = protocol.recv_frame(host)
+                if frame_type == protocol.FRAME_EOF:
+                    break
+                assert frame_type == protocol.FRAME_DATA
+                received.extend(chunk)
+            thread.join(timeout=5)
+        assert header["ok"] is True
+        assert header["size"] == len(payload)
+        assert header["mode"] == 0o640
+        assert bytes(received) == payload
+
+    def test_get_missing_file_returns_error(self, tmp_path) -> None:
+        host, guest = socket.socketpair()
+        with host:
+            thread = _serve_once(guest)
+            protocol.send_json(host, {"op": "get_file", "path": str(tmp_path / "absent")})
+            resp = protocol.recv_json(host)
+            thread.join(timeout=5)
+        assert resp["ok"] is False
+
+
+class TestProtocolErrors:
+    def test_unknown_op(self) -> None:
+        host, guest = socket.socketpair()
+        with host:
+            thread = _serve_once(guest)
+            protocol.send_json(host, {"op": "frobnicate"})
+            resp = protocol.recv_json(host)
+            thread.join(timeout=5)
+        assert resp["ok"] is False
+        assert "unknown op" in resp["error"]
+
+    def test_version_mismatch_rejected(self) -> None:
+        host, guest = socket.socketpair()
+        with host:
+            thread = _serve_once(guest)
+            protocol.send_json(host, {"v": 999, "op": "ping"})
+            resp = protocol.recv_json(host)
+            thread.join(timeout=5)
+        assert resp["ok"] is False
+        assert "version" in resp["error"]

--- a/tests/test_guest_agent_image.py
+++ b/tests/test_guest_agent_image.py
@@ -1,0 +1,136 @@
+# Copyright 2026 Celesto AI
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests that the guest agent is baked into and launched by built images."""
+
+import subprocess
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from smolvm.images import builder as builder_mod
+from smolvm.images.builder import ImageBuilder
+
+
+def test_guest_agent_source_is_the_real_agent() -> None:
+    source = builder_mod._guest_agent_source()
+    assert "AF_VSOCK" in source
+    assert "smolvm-guest-agent listening" in source
+
+
+def test_base_init_script_launches_guest_agent_before_sshd() -> None:
+    script = ImageBuilder()._default_init_script()
+    assert "python3 /usr/local/bin/smolvm-guest-agent" in script
+    # The agent must start before sshd so the channel is up independent of it.
+    assert script.index("smolvm-guest-agent") < script.index("/usr/sbin/sshd")
+
+
+def test_fingerprint_tracks_guest_agent(tmp_path: Path) -> None:
+    builder = ImageBuilder(cache_dir=tmp_path)
+    fp = builder._fingerprint_with_content({"x": 1}, "FROM alpine", "init")
+    assert "_guest_agent_sha256" in fp
+
+
+@pytest.mark.parametrize(
+    ("method_name", "expected_base"),
+    [("build_alpine_ssh", "alpine"), ("build_debian_ssh_key", "debian")],
+)
+def test_base_images_install_python3_for_agent(
+    method_name: str, expected_base: str, tmp_path: Path
+) -> None:
+    """Alpine/Debian base images must ship python3 so the agent can run."""
+    builder = ImageBuilder(cache_dir=tmp_path / "images")
+    captured: dict[str, str] = {}
+
+    def _capture(
+        name: str,
+        dockerfile_content: str,
+        init_script: str,
+        image_dir: Path,
+        kernel_path: Path,
+        rootfs_path: Path,
+        rootfs_size_mb: int,
+        **kwargs: object,
+    ) -> None:
+        captured["dockerfile"] = dockerfile_content
+        kernel_path.touch()
+        rootfs_path.touch()
+
+    with (
+        patch.object(ImageBuilder, "check_docker", return_value=True),
+        patch.object(ImageBuilder, "_resolve_public_key", return_value="ssh-ed25519 AAAA u@t"),
+        patch.object(
+            ImageBuilder, "_resolve_kernel_url", return_value="https://example.invalid/vmlinux"
+        ),
+        patch.object(ImageBuilder, "_do_build", side_effect=_capture),
+    ):
+        getattr(builder, method_name)("ssh-ed25519 AAAA u@t")
+
+    assert expected_base in captured["dockerfile"]
+    assert "python3" in captured["dockerfile"]
+
+
+@patch("smolvm.images.builder.subprocess.run")
+@patch("smolvm.images.builder.run_command")
+def test_do_build_bakes_agent_into_context(
+    mock_run_command: MagicMock, mock_subprocess_run: MagicMock, tmp_path: Path
+) -> None:
+    """_do_build must drop the agent file into the build context and COPY it."""
+    builder = ImageBuilder(cache_dir=tmp_path / "images")
+    captured: dict[str, object] = {}
+
+    def _subprocess_side_effect(
+        cmd: list[str], *args: object, **kwargs: object
+    ) -> subprocess.CompletedProcess[str]:
+        if cmd[:2] == ["docker", "build"]:
+            context = Path(cmd[-1])
+            captured["dockerfile"] = (context / "Dockerfile").read_text()
+            agent_file = context / builder_mod._GUEST_AGENT_BUILD_FILE
+            captured["agent_present"] = agent_file.exists()
+            captured["agent_text"] = agent_file.read_text() if agent_file.exists() else ""
+        if cmd[:2] == ["docker", "create"]:
+            return subprocess.CompletedProcess(cmd, 0, stdout="container-id\n", stderr="")
+        return subprocess.CompletedProcess(cmd, 0, stdout="", stderr="")
+
+    mock_subprocess_run.side_effect = _subprocess_side_effect
+
+    image_dir = tmp_path / "image"
+    image_dir.mkdir()
+
+    with (
+        patch.object(
+            ImageBuilder,
+            "_loopfs_helper_path",
+            return_value=Path("/usr/local/libexec/smolvm-loopfs-helper"),
+        ),
+        patch.object(ImageBuilder, "_create_ext4_with_loopfs"),
+        patch.object(ImageBuilder, "_download_kernel"),
+    ):
+        builder._do_build(
+            name="demo",
+            dockerfile_content="FROM scratch\n",
+            init_script="#!/bin/sh\n",
+            image_dir=image_dir,
+            kernel_path=image_dir / "vmlinux.bin",
+            rootfs_path=image_dir / "rootfs.ext4",
+            rootfs_size_mb=8,
+        )
+
+    assert (
+        f"COPY {builder_mod._GUEST_AGENT_BUILD_FILE} {builder_mod._GUEST_AGENT_GUEST_PATH}"
+        in (captured["dockerfile"])
+    )
+    assert captured["agent_present"] is True
+    assert "AF_VSOCK" in captured["agent_text"]

--- a/tests/test_qemu_args.py
+++ b/tests/test_qemu_args.py
@@ -28,7 +28,7 @@ from smolvm.runtime.guest_platforms import (
     _build_windows_spec,
 )
 from smolvm.runtime.qemu_args import build_qemu_argv
-from smolvm.types import GuestOS, NetworkConfig, VMConfig, VMInfo, VMState
+from smolvm.types import GuestOS, NetworkConfig, VMConfig, VMInfo, VMState, VsockConfig
 
 
 def _qemu_vm_info(tmp_path: Path, *, vm_id: str = "vm-test") -> VMInfo:
@@ -97,6 +97,61 @@ def test_linux_x86_64_kvm_argv_byte_identical(tmp_path: Path) -> None:
     ]
 
 
+def _with_vsock(vm_info: VMInfo, guest_cid: int = 42) -> VMInfo:
+    config = vm_info.config.model_copy(update={"vsock": VsockConfig(guest_cid=guest_cid)})
+    return vm_info.model_copy(update={"config": config})
+
+
+def test_vsock_device_emitted_on_linux_x86(tmp_path: Path) -> None:
+    vm_info = _with_vsock(_qemu_vm_info(tmp_path))
+    cmd = build_qemu_argv(
+        vm_info,
+        qemu_bin=Path("/usr/bin/qemu-system-x86_64"),
+        boot_args=vm_info.config.boot_args,
+        platform_spec=_LINUX_SPEC,
+        host_system="Linux",
+    )
+    assert "-device" in cmd
+    assert "vhost-vsock-pci,guest-cid=42" in cmd
+
+
+def test_vsock_device_uses_mmio_variant_on_aarch64(tmp_path: Path) -> None:
+    vm_info = _with_vsock(_qemu_vm_info(tmp_path))
+    cmd = build_qemu_argv(
+        vm_info,
+        qemu_bin=Path("/usr/bin/qemu-system-aarch64"),
+        boot_args=vm_info.config.boot_args,
+        platform_spec=_LINUX_SPEC,
+        host_system="Linux",
+    )
+    assert "vhost-vsock-device,guest-cid=42" in cmd
+    assert "vhost-vsock-pci,guest-cid=42" not in cmd
+
+
+def test_vsock_device_omitted_on_darwin(tmp_path: Path) -> None:
+    vm_info = _with_vsock(_qemu_vm_info(tmp_path))
+    cmd = build_qemu_argv(
+        vm_info,
+        qemu_bin=Path("/usr/bin/qemu-system-x86_64"),
+        boot_args=vm_info.config.boot_args,
+        platform_spec=_LINUX_SPEC,
+        host_system="Darwin",
+    )
+    assert not any("vhost-vsock" in arg for arg in cmd)
+
+
+def test_no_vsock_device_when_config_has_none(tmp_path: Path) -> None:
+    vm_info = _qemu_vm_info(tmp_path)
+    cmd = build_qemu_argv(
+        vm_info,
+        qemu_bin=Path("/usr/bin/qemu-system-x86_64"),
+        boot_args=vm_info.config.boot_args,
+        platform_spec=_LINUX_SPEC,
+        host_system="Linux",
+    )
+    assert not any("vhost-vsock" in arg for arg in cmd)
+
+
 def test_linux_x86_64_darwin_uses_hvf(tmp_path: Path) -> None:
     """Darwin host swaps accel=kvm for accel=hvf; nothing else changes."""
     vm_info = _qemu_vm_info(tmp_path)
@@ -126,11 +181,7 @@ def test_linux_aarch64_kvm_orders_rootdisk_last(tmp_path: Path) -> None:
     )
 
     # Both -device pairs in order: NIC then root disk (root disk must be last).
-    device_pairs = [
-        (cmd[i + 1])
-        for i, tok in enumerate(cmd)
-        if tok == "-device"
-    ]
+    device_pairs = [(cmd[i + 1]) for i, tok in enumerate(cmd) if tok == "-device"]
     assert device_pairs == [
         "virtio-net-device,netdev=net0,mac=52:54:00:12:34:56",
         "virtio-blk-device,drive=rootdisk0-drive",
@@ -163,10 +214,13 @@ def test_firmware_mode_aarch64_needs_uefi_firmware(tmp_path: Path) -> None:
         ),
     )
 
-    with patch(
-        "smolvm.runtime.qemu_args._find_aarch64_uefi_firmware",
-        return_value=None,
-    ), pytest.raises(SmolVMError, match="aarch64 firmware-boot requires UEFI firmware"):
+    with (
+        patch(
+            "smolvm.runtime.qemu_args._find_aarch64_uefi_firmware",
+            return_value=None,
+        ),
+        pytest.raises(SmolVMError, match="aarch64 firmware-boot requires UEFI firmware"),
+    ):
         build_qemu_argv(
             vm_info,
             qemu_bin=Path("/usr/bin/qemu-system-aarch64"),
@@ -181,9 +235,7 @@ def test_missing_ssh_host_port_raises(tmp_path: Path) -> None:
     vm_info = _qemu_vm_info(tmp_path)
     # Pydantic frozen model — swap the network for one without the port.
     vm_info = vm_info.model_copy(
-        update={
-            "network": vm_info.network.model_copy(update={"ssh_host_port": None})
-        }
+        update={"network": vm_info.network.model_copy(update={"ssh_host_port": None})}
     )
     with pytest.raises(SmolVMError, match="ssh_host_port"):
         build_qemu_argv(
@@ -249,10 +301,13 @@ def test_build_windows_spec_raises_on_arm_host() -> None:
 
 def test_build_windows_spec_raises_when_no_ovmf_found() -> None:
     """Missing OVMF Secure Boot firmware raises a plain-English install hint."""
-    with patch(
-        "smolvm.runtime.guest_platforms._find_x86_64_ovmf",
-        return_value=None,
-    ), pytest.raises(ValueError, match="OVMF Secure Boot firmware"):
+    with (
+        patch(
+            "smolvm.runtime.guest_platforms._find_x86_64_ovmf",
+            return_value=None,
+        ),
+        pytest.raises(ValueError, match="OVMF Secure Boot firmware"),
+    ):
         _build_windows_spec(host_system="Linux", arch="x86_64")
 
 
@@ -356,13 +411,9 @@ def test_windows_argv_emits_virtio_scsi_root_and_tpm(tmp_path: Path) -> None:
     assert "virtio-scsi-pci,id=scsi0" in device_args
     assert "scsi-hd,bus=scsi0.0,drive=rootdisk0-drive" in device_args
     # NO legacy virtio-blk-pci attachment for the root disk.
-    assert not any(
-        d.startswith("virtio-blk-pci,drive=rootdisk0") for d in device_args
-    )
+    assert not any(d.startswith("virtio-blk-pci,drive=rootdisk0") for d in device_args)
     # USB topology: controller first, then tablet binding to it.
-    assert device_args.index("qemu-xhci,id=xhci") < device_args.index(
-        "usb-tablet,bus=xhci.0"
-    )
+    assert device_args.index("qemu-xhci,id=xhci") < device_args.index("usb-tablet,bus=xhci.0")
     # TPM CRB device.
     assert "tpm-crb,tpmdev=tpm0" in device_args
     # And the chardev + tpmdev tokens.

--- a/tests/test_vsock_channel.py
+++ b/tests/test_vsock_channel.py
@@ -1,0 +1,167 @@
+# Copyright 2026 Celesto AI
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for the host-side VsockChannel.
+
+The channel's transport (AF_VSOCK / UDS) is exercised by pointing ``_open`` at
+a socketpair whose far end is served by the real guest agent, so these tests
+validate the full host↔agent round-trip without a VM.
+"""
+
+import socket
+import threading
+
+import pytest
+
+from smolvm.comm import CommChannel
+from smolvm.comm.vsock_channel import VsockChannel
+from smolvm.exceptions import OperationTimeoutError, SmolVMError
+from smolvm.guest_agent import agent
+
+
+def _agent_backed_open():
+    """A ``_open`` replacement: each call is served by one agent handler."""
+
+    def _open() -> socket.socket:
+        host, guest = socket.socketpair()
+
+        def _serve() -> None:
+            try:
+                agent.handle_connection(guest)
+            finally:
+                guest.close()
+
+        threading.Thread(target=_serve, daemon=True).start()
+        return host
+
+    return _open
+
+
+class TestConstruction:
+    def test_satisfies_commchannel(self) -> None:
+        assert isinstance(VsockChannel.from_cid(3), CommChannel)
+        assert VsockChannel.from_cid(3).kind == "vsock"
+
+    def test_requires_exactly_one_target(self) -> None:
+        with pytest.raises(ValueError):
+            VsockChannel()
+        with pytest.raises(ValueError):
+            VsockChannel(guest_cid=3, uds_path="/tmp/x.sock")
+
+
+class TestRun:
+    def test_run_raw_captures_output(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        ch = VsockChannel.from_cid(3)
+        monkeypatch.setattr(ch, "_open", _agent_backed_open())
+        result = ch.run("printf 'hi there'", shell="raw")
+        assert result.exit_code == 0
+        assert result.stdout == "hi there"
+        assert result.ok
+
+    def test_run_nonzero_exit_and_stderr(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        ch = VsockChannel.from_cid(3)
+        monkeypatch.setattr(ch, "_open", _agent_backed_open())
+        result = ch.run("echo bad 1>&2; exit 7", shell="raw")
+        assert result.exit_code == 7
+        assert result.stderr.strip() == "bad"
+
+    def test_run_timeout_raises(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        ch = VsockChannel.from_cid(3)
+        monkeypatch.setattr(ch, "_open", _agent_backed_open())
+        with pytest.raises(OperationTimeoutError):
+            ch.run("sleep 10", shell="raw", timeout=1)
+
+    def test_run_rejects_empty(self) -> None:
+        ch = VsockChannel.from_cid(3)
+        with pytest.raises(ValueError):
+            ch.run("   ")
+
+
+class TestFileTransfer:
+    def test_put_then_get_roundtrip_preserves_mode(
+        self, tmp_path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        local = tmp_path / "key"
+        local.write_bytes(b"secret-key-bytes")
+        local.chmod(0o600)
+        remote = tmp_path / "guest_copy"
+
+        ch = VsockChannel.from_cid(3)
+        monkeypatch.setattr(ch, "_open", _agent_backed_open())
+        ch.put_file(local, str(remote))
+        assert remote.read_bytes() == b"secret-key-bytes"
+        assert (remote.stat().st_mode & 0o777) == 0o600
+
+        back = tmp_path / "downloaded"
+        ch.get_file(str(remote), back)
+        assert back.read_bytes() == b"secret-key-bytes"
+        assert (back.stat().st_mode & 0o777) == 0o600
+
+    def test_get_missing_file_raises(self, tmp_path, monkeypatch: pytest.MonkeyPatch) -> None:
+        ch = VsockChannel.from_cid(3)
+        monkeypatch.setattr(ch, "_open", _agent_backed_open())
+        with pytest.raises(SmolVMError):
+            ch.get_file(str(tmp_path / "absent"), tmp_path / "out")
+
+
+class TestReadiness:
+    def test_wait_ready_succeeds(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        ch = VsockChannel.from_cid(3)
+        monkeypatch.setattr(ch, "_open", _agent_backed_open())
+        ch.wait_ready(timeout=5)
+        assert ch.connected
+
+    def test_wait_ready_times_out_when_unreachable(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        ch = VsockChannel.from_cid(3)
+
+        def _always_fail() -> socket.socket:
+            raise OSError("connection refused")
+
+        monkeypatch.setattr(ch, "_open", _always_fail)
+        with pytest.raises(OperationTimeoutError):
+            ch.wait_ready(timeout=0.3, interval=0.05)
+        assert not ch.connected
+
+
+class TestUdsTransport:
+    """Exercise the real UDS path + Firecracker-style CONNECT handshake."""
+
+    def test_from_uds_handshake_then_ping(self, tmp_path) -> None:
+        uds = str(tmp_path / "vsock.sock")
+        server = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+        server.bind(uds)
+        server.listen(1)
+
+        def _serve() -> None:
+            conn, _ = server.accept()
+            line = b""
+            while not line.endswith(b"\n"):
+                chunk = conn.recv(1)
+                if not chunk:
+                    break
+                line += chunk
+            assert line.startswith(b"CONNECT")
+            conn.sendall(b"OK 1234\n")
+            agent.handle_connection(conn)
+            conn.close()
+
+        thread = threading.Thread(target=_serve, daemon=True)
+        thread.start()
+        try:
+            ch = VsockChannel.from_uds(uds)
+            ch.wait_ready(timeout=5)
+            assert ch.connected
+        finally:
+            server.close()
+            thread.join(timeout=5)

--- a/tests/test_vsock_cid_storage.py
+++ b/tests/test_vsock_cid_storage.py
@@ -1,0 +1,87 @@
+# Copyright 2026 Celesto AI
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for per-VM vsock CID allocation (mirrors the SSH-port pool)."""
+
+from pathlib import Path
+
+import pytest
+
+from smolvm.storage import StateManager
+from smolvm.storage._base import VSOCK_CID_START
+from smolvm.types import GuestOS, VMConfig
+
+
+def _make_config(tmp_path: Path, vm_id: str) -> VMConfig:
+    rootfs = tmp_path / f"{vm_id}.ext4"
+    rootfs.write_bytes(b"rootfs")
+    kernel = tmp_path / f"{vm_id}.bin"
+    kernel.write_bytes(b"kernel")
+    return VMConfig(
+        vm_id=vm_id,
+        kernel_path=kernel,
+        rootfs_path=rootfs,
+        guest_os=GuestOS.ALPINE,
+    )
+
+
+@pytest.fixture
+def state(tmp_path: Path) -> StateManager:
+    return StateManager(tmp_path / "state.db")
+
+
+def test_reserve_vsock_cid_starts_at_pool_start(state: StateManager, tmp_path: Path) -> None:
+    state.create_vm(_make_config(tmp_path, "vm-a"))
+    cid = state.reserve_vsock_cid("vm-a")
+    assert cid == VSOCK_CID_START
+    assert state.get_vsock_cid("vm-a") == VSOCK_CID_START
+
+
+def test_reserve_is_idempotent(state: StateManager, tmp_path: Path) -> None:
+    state.create_vm(_make_config(tmp_path, "vm-a"))
+    first = state.reserve_vsock_cid("vm-a")
+    second = state.reserve_vsock_cid("vm-a")
+    assert first == second
+
+
+def test_distinct_vms_get_distinct_cids(state: StateManager, tmp_path: Path) -> None:
+    state.create_vm(_make_config(tmp_path, "vm-a"))
+    state.create_vm(_make_config(tmp_path, "vm-b"))
+    cid_a = state.reserve_vsock_cid("vm-a")
+    cid_b = state.reserve_vsock_cid("vm-b")
+    assert cid_a != cid_b
+
+
+def test_release_frees_cid_for_reuse(state: StateManager, tmp_path: Path) -> None:
+    state.create_vm(_make_config(tmp_path, "vm-a"))
+    cid = state.reserve_vsock_cid("vm-a")
+    state.release_vsock_cid("vm-a")
+    assert state.get_vsock_cid("vm-a") is None
+
+    state.create_vm(_make_config(tmp_path, "vm-b"))
+    assert state.reserve_vsock_cid("vm-b") == cid
+
+
+def test_explicit_cid_request_for_restore(state: StateManager, tmp_path: Path) -> None:
+    state.create_vm(_make_config(tmp_path, "vm-a"))
+    cid = state.reserve_vsock_cid("vm-a", guest_cid=42)
+    assert cid == 42
+    assert state.get_vsock_cid("vm-a") == 42
+
+
+def test_delete_vm_cascades_cid(state: StateManager, tmp_path: Path) -> None:
+    state.create_vm(_make_config(tmp_path, "vm-a"))
+    state.reserve_vsock_cid("vm-a")
+    state.delete_vm("vm-a")
+    assert state.get_vsock_cid("vm-a") is None


### PR DESCRIPTION
## What & why

Today SmolVM drives every guest over **SSH** — which on QEMU means slirp networking + a host port-forward, so the control plane depends on the guest network coming up, cloud-init/sshd restarting, and a TCP banner probe before the first command.

This adds a **vsock control channel**: a tiny guest agent reachable over `AF_VSOCK`, up seconds after the kernel boots (before sshd), independent of networking. It's faster, works before/without the network, and removes a class of boot-race flakiness. Selected via `SmolVM(comm_channel="vsock"|"ssh")` on **SDK and CLI**, starting with the **QEMU backend**; default is **auto** (vsock when the agent answers on a QEMU/Linux host, else SSH).

## How it works

- **`comm/`** — `CommChannel` protocol (`run`/`put_file`/`get_file`/`wait_ready`/`close`); `SSHClient` now satisfies it. Length-prefixed JSON+binary wire protocol. `VsockChannel` host client (native `AF_VSOCK` by CID for QEMU/Linux; UDS + Firecracker-style `CONNECT` handshake for Firecracker/libkrun). `resolve_comm_channel` picks the transport.
- **`guest_agent/agent.py`** — stdlib-only `AF_VSOCK` server: threaded, login/raw command exec with streamed stdout/stderr + exit code and timeout (process-group kill), file transfer with **mode preservation**. Baked into every built image and launched from `/init` **before sshd** (added `python3` to the alpine/debian base images).
- **QEMU** — emits `vhost-vsock-pci` / `vhost-vsock-device` (Linux-only, arch-aware). A unique guest CID is reserved per VM (`vsock_cids` table, sqlite + postgres) and `config.vsock` is persisted before boot.
- **Facade** — `comm_channel` kwarg on `__init__`/`from_id`; readiness dispatches to vsock with SSH fallback (never silent for an explicit `comm_channel="vsock"`). Also fixes a latent `async_run` bug (called an undefined `_ensure_ssh()` and passed a non-existent `login_shell=` kwarg).
- **CLI** — `--comm-channel {ssh,vsock}` on `smolvm file upload/download` and `smolvm env set/unset/list`. `smolvm ssh` stays real SSH (interactive PTY).

## Scope / platform notes

- **macOS** keeps using SSH automatically — QEMU has no `vhost-vsock` there (needs Linux `/dev/vhost-vsock`). No regression, no new dependency.
- **`expose_local`** stays on the SSH tunnel (data-plane, not control-plane).
- Follow-ups (out of scope): republish images so downloaded images carry the agent (locally-built images already work); macOS-native vsock via libkrun; vsock-proxied `expose_local`; a Windows guest agent.

## Testing

- **1121 passed, 13 skipped** (full suite); all changed files pass `ruff check` + `ruff format`.
- New tests: protocol/agent round-trip over a socketpair, `VsockChannel` end-to-end against the real agent, channel resolution matrix, CID allocation, QEMU device wiring, image baking, and the facade seam.
- A true end-to-end VM run needs a Linux host with `vhost_vsock` loaded + a locally-built image; not run on the macOS dev box.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * New CLI flag to pick the VM control channel (ssh or vsock) for file and env commands.
  * Built-in guest agent and image changes that enable direct vsock control as an alternative to SSH.
  * Automatic channel selection with sensible fallback behavior.

* **Bug Fixes**
  * Clarified and simplified several startup and error messages.

* **Tests**
  * Added broad tests for channel selection, guest-agent protocol, vsock transport, and CID allocation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->