### PR TITLE
Add bare-Ubuntu firecracker image + bake guest agent in CI

### DIFF
--- a/.github/workflows/build-published-images.yml
+++ b/.github/workflows/build-published-images.yml
@@ -288,15 +288,20 @@ jobs:
       fail-fast: false
       matrix:
         arch: [amd64, arm64]
-        preset: [codex, claude-code, hermes, pi]
+        # "ubuntu" is the bare base image (no preset install) — gives
+        # firecracker a raw-ext4 Ubuntu for `create --os ubuntu`.
+        preset: [codex, claude-code, hermes, pi, ubuntu]
         os: [ubuntu, alpine]
         # Phase 1 of the Alpine rollout (#264) excludes hermes — its
         # ``[all]`` extras pull manylinux2014 wheels that don't have
         # musllinux variants, so the install would fall back to slow
         # source builds with sometimes-broken results. Re-enable when
-        # we have a curated minimal extras set.
+        # we have a curated minimal extras set. The bare "ubuntu" image is
+        # Ubuntu-only — there's no bare-Alpine published image yet.
         exclude:
           - preset: hermes
+            os: alpine
+          - preset: ubuntu
             os: alpine
     runs-on: ${{ matrix.arch == 'arm64' && 'ubuntu-24.04-arm' || 'ubuntu-latest' }}
     timeout-minutes: 20

--- a/scripts/ci/build-preset.sh
+++ b/scripts/ci/build-preset.sh
@@ -19,7 +19,9 @@
 #
 # NOTE: openclaw uses its own builder (build_openclaw_rootfs) which bakes
 # in a custom init script, sidecars, and systemctl proxy. It's not layered
-# through this script. This script handles: codex, claude-code, hermes, pi.
+# through this script. This script handles: codex, claude-code, hermes, pi,
+# and the bare "ubuntu" image (no preset install — just the finalized base
+# rootfs, used for `create --os ubuntu` on firecracker).
 #
 # Runs in CI on a matching-arch runner. Requires: chroot, mount (loop).
 set -euo pipefail
@@ -164,6 +166,14 @@ case "$PRESET" in
     '
     ;;
 
+  ubuntu)
+    # Bare Ubuntu image: nothing to install on top of the base rootfs. The
+    # shared finalize below (install /init + bake the guest agent) is all it
+    # needs. Gives firecracker a raw-ext4 Ubuntu so `create --os ubuntu`
+    # works download-only (no qcow2, which firecracker can't read).
+    echo "==> Bare ubuntu image — no preset install."
+    ;;
+
   *)
     echo "Unknown preset: $PRESET"
     exit 1
@@ -175,6 +185,14 @@ esac
 # the launching user's pubkey into /root/.ssh/authorized_keys at boot.
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 install -m 0755 "$SCRIPT_DIR/preset-init.sh" "$MNT/init"
+
+# Bake the SmolVM guest agent (vsock control plane) into every published
+# image. preset-init.sh launches it before sshd (guarded on python3), so the
+# host can drive the guest over vsock. Mirrors the Python ImageBuilder, which
+# bakes the same file via the _GUEST_AGENT_* constants in
+# src/smolvm/images/builder.py — keep the guest path in sync with that.
+install -D -m 0755 "$SCRIPT_DIR/../../src/smolvm/guest_agent/agent.py" \
+  "$MNT/usr/local/bin/smolvm-guest-agent"
 
 # Restore (or remove) /etc/resolv.conf so the runner's DNS doesn't leak
 # into the published rootfs. The init script writes 8.8.8.8 / 8.8.4.4 at

--- a/scripts/ci/preset-init.sh
+++ b/scripts/ci/preset-init.sh
@@ -127,6 +127,16 @@ if [ -n "$AUTHKEY_B64" ]; then
     fi
 fi
 
+# ── Guest agent (vsock control plane) ────────────────────────
+# Started before sshd and independent of networking, so the host can drive
+# the guest over vsock the moment the kernel is up. Skipped silently if
+# python3 or the agent is missing (the host falls back to SSH in that case).
+# Mirrors _base_init_script() in src/smolvm/images/builder.py.
+if command -v python3 >/dev/null 2>&1 && [ -f /usr/local/bin/smolvm-guest-agent ]; then
+    python3 /usr/local/bin/smolvm-guest-agent >/var/log/smolvm-agent.log 2>&1 &
+    echo "SmolVM init: guest agent started (PID=$!)"
+fi
+
 /usr/sbin/sshd -e &
 
 echo "SmolVM init complete: IP=${GUEST_IP}, SSH listening on port 22"

--- a/src/smolvm/facade.py
+++ b/src/smolvm/facade.py
@@ -640,19 +640,25 @@ def _build_auto_config(
         # raw-ext4 rootfs + ELF kernel and boot it direct-kernel, exactly like
         # the alpine/published path below. The SSH key rides the kernel cmdline
         # (parsed by the image's /init), not a cloud-init seed.
-        from smolvm.exceptions import ImageError
-        from smolvm.images.published import Vmm, ensure_published_image
+        from smolvm.images.published import (
+            Vmm,
+            ensure_published_image,
+            is_preset_published,
+        )
 
         vmm: Vmm = "libkrun" if resolved_backend == BACKEND_LIBKRUN else "firecracker"
-        try:
-            local_image = ensure_published_image(
-                "ubuntu", to_published_arch(platform.machine()), vmm, "ubuntu"
-            )
-        except ImageError as exc:
+        arch = to_published_arch(platform.machine())
+        if not is_preset_published("ubuntu", arch, vmm, "ubuntu"):
+            # Manifest has no bare-Ubuntu row for this host yet — steer the user
+            # to the qemu path. A *published* image that then fails to download
+            # or verify raises ImageError from ensure_published_image below,
+            # which we deliberately let surface unchanged.
+            sandbox_name = vm_name or "<name>"
             raise SmolVMError(
-                "No bare-Ubuntu image is published for this backend yet; run "
-                "`--os ubuntu` with backend='qemu', or use `--os alpine`."
-            ) from exc
+                "No bare-Ubuntu image is published for this backend yet; "
+                f"run: smolvm create --name {sandbox_name} --os ubuntu --backend qemu"
+            )
+        local_image = ensure_published_image("ubuntu", arch, vmm, "ubuntu")
 
         kernel_profile = KernelBootProfile.MICROVM_DIRECT
         boot_args = get_boot_profile_spec(kernel_profile).base_boot_args_for_backend(

--- a/src/smolvm/facade.py
+++ b/src/smolvm/facade.py
@@ -635,7 +635,47 @@ def _build_auto_config(
         raise ValueError("disk_size_mib must be >= 64")
 
     if resolved_os is GuestOS.UBUNTU and resolved_backend != BACKEND_QEMU:
-        raise ValueError("ubuntu auto-config currently requires backend='qemu'")
+        # Firecracker / libkrun can't boot the Ubuntu cloud qcow2 (no qcow2
+        # support, no firmware/bootloader). Pull the published bare-Ubuntu
+        # raw-ext4 rootfs + ELF kernel and boot it direct-kernel, exactly like
+        # the alpine/published path below. The SSH key rides the kernel cmdline
+        # (parsed by the image's /init), not a cloud-init seed.
+        from smolvm.exceptions import ImageError
+        from smolvm.images.published import Vmm, ensure_published_image
+
+        vmm: Vmm = "libkrun" if resolved_backend == BACKEND_LIBKRUN else "firecracker"
+        try:
+            local_image = ensure_published_image(
+                "ubuntu", to_published_arch(platform.machine()), vmm, "ubuntu"
+            )
+        except ImageError as exc:
+            raise SmolVMError(
+                "No bare-Ubuntu image is published for this backend yet; run "
+                "`--os ubuntu` with backend='qemu', or use `--os alpine`."
+            ) from exc
+
+        kernel_profile = KernelBootProfile.MICROVM_DIRECT
+        boot_args = get_boot_profile_spec(kernel_profile).base_boot_args_for_backend(
+            resolved_backend,
+            platform.machine(),
+        )
+        resolved_vm_name = _resolve_vm_name(vm_name, prefix=name_prefix)
+        config = VMConfig(
+            vm_id=resolved_vm_name,
+            vcpu_count=1,
+            memory=resolved_memory,
+            kernel_path=local_image.kernel_path,
+            rootfs_path=local_image.rootfs_path,
+            boot_args=boot_args,
+            backend=resolved_backend,
+            ssh_public_key=public_key_value,
+        )
+        logger.info(
+            "Auto-configured VM: %s (os=ubuntu, backend=%s, source=published-bare-ubuntu)",
+            resolved_vm_name,
+            resolved_backend,
+        )
+        return config, resolved_ssh_key_path
 
     if resolved_os is GuestOS.UBUNTU:
         if resolved_disk_size_mib < default_disk_size_mib:

--- a/src/smolvm/images/published.py
+++ b/src/smolvm/images/published.py
@@ -44,7 +44,7 @@ from smolvm.exceptions import ImageError
 from smolvm.images.manager import ImageManager, ImageSource, LocalImage
 
 Arch = Literal["amd64", "arm64"]
-Preset = Literal["codex", "claude-code", "openclaw", "hermes", "pi"]
+Preset = Literal["codex", "claude-code", "openclaw", "hermes", "pi", "ubuntu"]
 # ``libkrun`` is reserved here for a future spike — manifest accepts the type
 # but the CLI never resolves a host to it until libkrun support is wired.
 Vmm = Literal["firecracker", "qemu", "libkrun"]
@@ -169,9 +169,7 @@ def _release_asset_url(preset: Preset, arch: Arch, suffix: str, os: Os = "ubuntu
     artifacts stay reachable. Alpine assets carry an explicit ``-alpine-``
     segment. ``scripts/ci/build-preset.sh`` mirrors this on the upload side.
     """
-    slug = (
-        f"{preset}-{arch}-{suffix}" if os == "ubuntu" else f"{preset}-{arch}-{os}-{suffix}"
-    )
+    slug = f"{preset}-{arch}-{suffix}" if os == "ubuntu" else f"{preset}-{arch}-{os}-{suffix}"
     return f"https://github.com/CelestoAI/SmolVM/releases/download/{IMAGES_RELEASE_TAG}/{slug}"
 
 
@@ -259,6 +257,12 @@ _HERMES_AMD64_ROOTFS_SHA = "cc8658943885f11c86b0616cf7b3351e8672608fa36e29de1577
 _HERMES_ARM64_ROOTFS_SHA = "fa965ae736f92af2ec32dbd8bbb747ee3702e3c265be0753a6d49f0f4439fcba"
 _PI_AMD64_ROOTFS_SHA = "a5b4833971d14e3f9623a816d2d724368b68537529bfb2e10ea02e74ee0d22be"
 _PI_ARM64_ROOTFS_SHA = "6d3aaa5379e70243b583f7c75e428aa84f0b5140483507d4e48855ea6da52e95"
+# Bare Ubuntu base image (no preset install). Fill these in — and uncomment the
+# ``_preset_rows("ubuntu", ...)`` call below — from the first Build Published
+# Images run that bakes the guest agent and publishes
+# ``ubuntu-<arch>-rootfs.ext4.zst`` under the (bumped) IMAGES_RELEASE_TAG.
+# _UBUNTU_AMD64_ROOTFS_SHA = "..."
+# _UBUNTU_ARM64_ROOTFS_SHA = "..."
 
 
 def _preset_rows(
@@ -294,6 +298,12 @@ MANIFEST: dict[ManifestKey, PublishedImage] = {
     **_preset_rows("claude-code", _CLAUDE_CODE_AMD64_ROOTFS_SHA, _CLAUDE_CODE_ARM64_ROOTFS_SHA),
     **_preset_rows("hermes", _HERMES_AMD64_ROOTFS_SHA, _HERMES_ARM64_ROOTFS_SHA),
     **_preset_rows("pi", _PI_AMD64_ROOTFS_SHA, _PI_ARM64_ROOTFS_SHA),
+    # Bare Ubuntu base image (raw-ext4, agent baked in) — enable once CI
+    # publishes ``ubuntu-<arch>-rootfs.ext4.zst`` and we have SHAs to pin.
+    # Powers ``create --os ubuntu`` on firecracker/libkrun (the qemu path
+    # keeps its qcow2 cloud image). Until pinned, that path raises a clear
+    # "not yet published" error.
+    # **_preset_rows("ubuntu", _UBUNTU_AMD64_ROOTFS_SHA, _UBUNTU_ARM64_ROOTFS_SHA),
     # Alpine rows — add once CI publishes ``<preset>-<arch>-alpine-rootfs.ext4.zst``
     # under :data:`IMAGES_RELEASE_TAG` and we have SHAs to pin against.
     # Until then, ``smolvm <preset> start --os alpine`` falls through to
@@ -469,9 +479,7 @@ def ensure_base_kernel(
     entry = catalog.get(arch)
     if entry is None:
         available = ", ".join(sorted(catalog)) or "(none)"
-        raise ImageError(
-            f"No base kernel registered for arch '{arch}' (available: {available})."
-        )
+        raise ImageError(f"No base kernel registered for arch '{arch}' (available: {available}).")
     manager = ImageManager(cache_dir=cache_dir)
     # Cache filename keeps the format suffix so the elf and image artifacts
     # don't collide for the same (version, arch). Same dir is fine — both

--- a/tests/test_facade.py
+++ b/tests/test_facade.py
@@ -244,10 +244,12 @@ class TestVMInit:
             _build_auto_config(os="ubuntu", backend="qemu", disk_size_mib=512)
 
     @patch("smolvm.images.published.ensure_published_image")
+    @patch("smolvm.images.published.is_preset_published", return_value=True)
     @patch("smolvm.utils.ensure_ssh_key")
     def test_autoconfigure_ubuntu_firecracker_uses_published_rootfs(
         self,
         mock_ensure_ssh_key: MagicMock,
+        _mock_is_published: MagicMock,
         mock_ensure_published: MagicMock,
         tmp_path: Path,
     ) -> None:
@@ -285,16 +287,19 @@ class TestVMInit:
         assert not config.extra_drives
 
     @patch("smolvm.images.published.ensure_published_image")
+    @patch("smolvm.images.published.is_preset_published", return_value=False)
     @patch("smolvm.utils.ensure_ssh_key")
     def test_autoconfigure_ubuntu_firecracker_unpublished_is_clear(
         self,
         mock_ensure_ssh_key: MagicMock,
+        _mock_is_published: MagicMock,
         mock_ensure_published: MagicMock,
         tmp_path: Path,
     ) -> None:
-        """Before the bare-Ubuntu image is pinned, the path fails with a clear,
-        actionable message rather than a raw lookup error."""
-        from smolvm.exceptions import ImageError, SmolVMError
+        """When no bare-Ubuntu row is published, fail with a single-line recovery
+        command that names the sandbox — without invoking the downloader, so
+        genuine download/integrity errors stay a separate signal."""
+        from smolvm.exceptions import SmolVMError
 
         priv = tmp_path / "id_ed25519"
         pub = tmp_path / "id_ed25519.pub"
@@ -302,8 +307,35 @@ class TestVMInit:
         pub.write_text("ssh-ed25519 AAAAExampleKey test@host\n")
         mock_ensure_ssh_key.return_value = (priv, pub)
 
-        mock_ensure_published.side_effect = ImageError("no manifest entry")
-        with pytest.raises(SmolVMError, match="No bare-Ubuntu image is published"):
+        with pytest.raises(
+            SmolVMError,
+            match="smolvm create --name myvm --os ubuntu --backend qemu",
+        ):
+            _build_auto_config(os="ubuntu", backend="firecracker", vm_name="myvm")
+        mock_ensure_published.assert_not_called()
+
+    @patch("smolvm.images.published.ensure_published_image")
+    @patch("smolvm.images.published.is_preset_published", return_value=True)
+    @patch("smolvm.utils.ensure_ssh_key")
+    def test_autoconfigure_ubuntu_firecracker_download_error_propagates(
+        self,
+        mock_ensure_ssh_key: MagicMock,
+        _mock_is_published: MagicMock,
+        mock_ensure_published: MagicMock,
+        tmp_path: Path,
+    ) -> None:
+        """A published-but-broken image (download / SHA-256 failure) surfaces as
+        the original ImageError, not the friendly 'not published' message."""
+        from smolvm.exceptions import ImageError
+
+        priv = tmp_path / "id_ed25519"
+        pub = tmp_path / "id_ed25519.pub"
+        priv.touch()
+        pub.write_text("ssh-ed25519 AAAAExampleKey test@host\n")
+        mock_ensure_ssh_key.return_value = (priv, pub)
+
+        mock_ensure_published.side_effect = ImageError("rootfs SHA-256 mismatch")
+        with pytest.raises(ImageError, match="SHA-256 mismatch"):
             _build_auto_config(os="ubuntu", backend="firecracker")
 
     def test_firmware_boot_vmconfig_rejects_non_qemu_backend(
@@ -691,14 +723,14 @@ class TestVMLocalImageParam:
         """Workspace mounts on Windows guests are Phase 2 scope."""
         disk = tmp_path / "win11.qcow2"
         disk.touch()
-        with pytest.raises(ValueError, match="mounts.* not yet supported for Windows"):
+        with pytest.raises(ValueError, match=r"mounts.* not yet supported for Windows"):
             SmolVM(os="windows", image=str(disk), mounts=["/host/path"])
 
     def test_windows_with_internet_settings_rejected(self, tmp_path: Path) -> None:
         """Egress allowlist on Windows guests is Phase 2 scope."""
         disk = tmp_path / "win11.qcow2"
         disk.touch()
-        with pytest.raises(ValueError, match="internet_settings.* not yet supported for Windows"):
+        with pytest.raises(ValueError, match=r"internet_settings.* not yet supported for Windows"):
             SmolVM(
                 os="windows",
                 image=str(disk),

--- a/tests/test_facade.py
+++ b/tests/test_facade.py
@@ -221,7 +221,6 @@ class TestVMInit:
         created_config = mock_sdk.create.call_args[0][0]
         assert created_config.ssh_public_key == pubkey_value
 
-
     @patch("smolvm.utils.ensure_ssh_key")
     def test_autoconfigure_ubuntu_rejects_undersized_disk(
         self,
@@ -243,6 +242,69 @@ class TestVMInit:
 
         with pytest.raises(ValueError, match="disk_size_mib >= 2048"):
             _build_auto_config(os="ubuntu", backend="qemu", disk_size_mib=512)
+
+    @patch("smolvm.images.published.ensure_published_image")
+    @patch("smolvm.utils.ensure_ssh_key")
+    def test_autoconfigure_ubuntu_firecracker_uses_published_rootfs(
+        self,
+        mock_ensure_ssh_key: MagicMock,
+        mock_ensure_published: MagicMock,
+        tmp_path: Path,
+    ) -> None:
+        """Ubuntu on firecracker pulls the published raw-ext4 image and boots
+        it direct-kernel (no qcow2, no cloud-init seed)."""
+        from smolvm.images.manager import LocalImage
+
+        priv = tmp_path / "id_ed25519"
+        pub = tmp_path / "id_ed25519.pub"
+        priv.touch()
+        pub.write_text("ssh-ed25519 AAAAExampleKey test@host\n")
+        mock_ensure_ssh_key.return_value = (priv, pub)
+
+        kernel = tmp_path / "vmlinux.bin"
+        rootfs = tmp_path / "rootfs.ext4"
+        kernel.touch()
+        rootfs.touch()
+        mock_ensure_published.return_value = LocalImage(
+            name="ubuntu-fc", kernel_path=kernel, rootfs_path=rootfs
+        )
+
+        config, _ = _build_auto_config(os="ubuntu", backend="firecracker")
+
+        # Resolved the bare-Ubuntu published image for the firecracker vmm.
+        preset, _arch, vmm, os_ = mock_ensure_published.call_args.args
+        assert (preset, vmm, os_) == ("ubuntu", "firecracker", "ubuntu")
+
+        # Raw-ext4 direct-kernel boot, SSH key via cmdline, no cloud-init seed.
+        assert config.backend == "firecracker"
+        assert config.rootfs_path == rootfs
+        assert config.kernel_path == kernel
+        assert config.boot_mode == "direct_kernel"
+        assert "init=/init" in config.boot_args
+        assert config.ssh_public_key == "ssh-ed25519 AAAAExampleKey test@host"
+        assert not config.extra_drives
+
+    @patch("smolvm.images.published.ensure_published_image")
+    @patch("smolvm.utils.ensure_ssh_key")
+    def test_autoconfigure_ubuntu_firecracker_unpublished_is_clear(
+        self,
+        mock_ensure_ssh_key: MagicMock,
+        mock_ensure_published: MagicMock,
+        tmp_path: Path,
+    ) -> None:
+        """Before the bare-Ubuntu image is pinned, the path fails with a clear,
+        actionable message rather than a raw lookup error."""
+        from smolvm.exceptions import ImageError, SmolVMError
+
+        priv = tmp_path / "id_ed25519"
+        pub = tmp_path / "id_ed25519.pub"
+        priv.touch()
+        pub.write_text("ssh-ed25519 AAAAExampleKey test@host\n")
+        mock_ensure_ssh_key.return_value = (priv, pub)
+
+        mock_ensure_published.side_effect = ImageError("no manifest entry")
+        with pytest.raises(SmolVMError, match="No bare-Ubuntu image is published"):
+            _build_auto_config(os="ubuntu", backend="firecracker")
 
     def test_firmware_boot_vmconfig_rejects_non_qemu_backend(
         self,
@@ -636,9 +698,7 @@ class TestVMLocalImageParam:
         """Egress allowlist on Windows guests is Phase 2 scope."""
         disk = tmp_path / "win11.qcow2"
         disk.touch()
-        with pytest.raises(
-            ValueError, match="internet_settings.* not yet supported for Windows"
-        ):
+        with pytest.raises(ValueError, match="internet_settings.* not yet supported for Windows"):
             SmolVM(
                 os="windows",
                 image=str(disk),
@@ -698,9 +758,7 @@ class TestVMLocalImageParam:
         assert call_kwargs["os_input"] == "windows"
         assert vm.vm_id == "vm-win"
 
-    def test_build_local_image_config_produces_windows_vmconfig(
-        self, tmp_path: Path
-    ) -> None:
+    def test_build_local_image_config_produces_windows_vmconfig(self, tmp_path: Path) -> None:
         """_build_local_image_config returns a properly-shaped Windows VMConfig."""
         from smolvm.facade import _build_local_image_config
 
@@ -729,9 +787,7 @@ class TestVMLocalImageParam:
         assert config.memory == 4096  # Windows default
         assert ssh_key == str(key)
 
-    def test_build_local_image_config_rejects_non_qemu_backend(
-        self, tmp_path: Path
-    ) -> None:
+    def test_build_local_image_config_rejects_non_qemu_backend(self, tmp_path: Path) -> None:
         """Firecracker + Windows = clear error before VMConfig validation."""
         from smolvm.facade import _build_local_image_config
 
@@ -952,8 +1008,7 @@ class TestVMUploadDownloadWindows:
         assert guest_path == "C:\\Users\\celesto\\hello.ps1"
 
         ssh.run.assert_called_once_with(
-            "New-Item -ItemType Directory -Force -Path "
-            "'C:\\Users\\celesto' | Out-Null",
+            "New-Item -ItemType Directory -Force -Path 'C:\\Users\\celesto' | Out-Null",
             timeout=30,
             shell="login",  # SSHClient wraps with powershell.exe -NoProfile -Command
         )

--- a/tests/test_guest_agent_image.py
+++ b/tests/test_guest_agent_image.py
@@ -23,6 +23,25 @@ import pytest
 from smolvm.images import builder as builder_mod
 from smolvm.images.builder import ImageBuilder
 
+_REPO_ROOT = Path(__file__).resolve().parents[1]
+
+
+def test_ci_preset_init_launches_guest_agent_before_sshd() -> None:
+    """The CI publish pipeline's /init must launch the agent before sshd,
+    mirroring the Python builder. These two init paths have to stay in sync —
+    PR #310 baked the agent only into the Python builder, which is why
+    published images shipped without it until this fix."""
+    script = (_REPO_ROOT / "scripts" / "ci" / "preset-init.sh").read_text()
+    assert "python3 /usr/local/bin/smolvm-guest-agent" in script
+    assert script.index("smolvm-guest-agent") < script.index("/usr/sbin/sshd")
+
+
+def test_ci_build_preset_bakes_guest_agent() -> None:
+    """build-preset.sh must copy the guest agent into every published rootfs."""
+    script = (_REPO_ROOT / "scripts" / "ci" / "build-preset.sh").read_text()
+    assert "src/smolvm/guest_agent/agent.py" in script
+    assert "/usr/local/bin/smolvm-guest-agent" in script
+
 
 def test_guest_agent_source_is_the_real_agent() -> None:
     source = builder_mod._guest_agent_source()

--- a/tests/test_published_images.py
+++ b/tests/test_published_images.py
@@ -33,6 +33,7 @@ from smolvm.images.published import (
     Preset,
     PublishedImage,
     _decompress_zstd,
+    _preset_rows,
     cache_name,
     ensure_base_kernel,
     ensure_published_image,
@@ -40,6 +41,23 @@ from smolvm.images.published import (
     lookup,
     to_image_source,
 )
+
+
+def test_ubuntu_rows_share_one_rootfs_across_vmms() -> None:
+    """The bare-Ubuntu image is one rootfs shared by firecracker/qemu/libkrun;
+    only the kernel format differs. Guards the shared-rootfs invariant the
+    `create --os ubuntu` firecracker path relies on."""
+    rows = _preset_rows("ubuntu", "a" * 64, "b" * 64)
+    fc = rows[("ubuntu", "amd64", "firecracker", "ubuntu")]
+    qemu = rows[("ubuntu", "amd64", "qemu", "ubuntu")]
+
+    # Same rootfs bytes + URL for both VMMs.
+    assert fc.rootfs_url == qemu.rootfs_url
+    assert fc.rootfs_sha256 == qemu.rootfs_sha256 == "a" * 64
+    assert fc.rootfs_url.endswith("ubuntu-amd64-rootfs.ext4.zst")
+    # Different kernel format: firecracker=elf, qemu=image.
+    assert fc.kernel_url.endswith(".elf")
+    assert qemu.kernel_url.endswith(".image")
 
 
 @pytest.fixture


### PR DESCRIPTION
## What & why

`smolvm create --os ubuntu` fails on the **firecracker** backend with
`ubuntu auto-config currently requires backend='qemu'`. The bare-Ubuntu
auto-config only ships a **qcow2 cloud image**, which firecracker can't read —
it needs a **raw ext4** rootfs + an **ELF** kernel (direct-kernel boot). Since
Linux defaults to firecracker, the common `create --os ubuntu` just errors.

While fixing this we found a second gap: the **CI publish pipeline**
(`scripts/ci/*`) is a *separate* build from the Python `ImageBuilder` and was
never updated by #310 to bake/launch the vsock **guest agent**. So published
preset images (codex/claude-code/hermes/pi) ship **without** the agent — only
`openclaw` (Python builder) had it. Verified live: a published `pi` image booted
on firecracker reported the agent absent.

## Changes

- **CI agent baking** — `scripts/ci/build-preset.sh` copies the guest agent into
  every published rootfs; `scripts/ci/preset-init.sh` launches it before sshd
  (mirrors `_base_init_script` in `builder.py`). Alpine base already has python3.
- **Bare-Ubuntu image** — a no-install `ubuntu` pseudo-preset in `build-preset.sh`
  + the workflow matrix publishes `ubuntu-<arch>-rootfs.ext4.zst`.
- **Manifest** — `"ubuntu"` added to the `Preset` literal; `_preset_rows("ubuntu", …)`
  staged **commented** until the post-fix rebuild pins SHAs (same convention as
  the alpine rows).
- **Facade** — firecracker/libkrun + ubuntu now pulls the published raw-ext4 image
  and boots direct-kernel (SSH key via cmdline); qemu keeps its qcow2 path. Clear
  "not yet published" error until the image is pinned.
- **Tests** — firecracker-ubuntu resolution + unpinned error, shared rootfs across
  VMMs, and CI scripts bake + launch the agent.

## Testing

- Full suite: **1130 passed, 13 skipped**. Changed files pass `ruff check` + `format`.
- Verified the firecracker+ubuntu path reaches the published-image flow (no longer
  the old guard) and returns the actionable message while the image is unpinned.

## Follow-up (operational, after merge)

1. Re-run **Build Published Images** on this ref (agent baking + the new `ubuntu`
   rootfs) — re-bake `images-v0.0.16` with `force_overwrite=true` or a fresh tag.
   The existing `images-v0.0.16` draft predates the agent fix; discard it.
2. Uncomment `_preset_rows("ubuntu", …)`, fill all rootfs SHAs (incl. `ubuntu-<arch>`),
   bump `IMAGES_RELEASE_TAG`.
3. Smoke-test + publish the draft. Then `create --os ubuntu` works on firecracker
   download-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a bare Ubuntu preset image option alongside existing presets
  * Guest agent is baked into published images and started on boot for improved management
  * Ubuntu auto-configuration now supports Firecracker and libkrun backends (not just QEMU)
  * SSH public-key injection enabled for direct access to Ubuntu images

* **Tests**
  * Added CI tests verifying guest-agent inclusion and startup
  * Added tests ensuring Ubuntu preset consistency across backends

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/CelestoAI/SmolVM/pull/312?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->