### PR TITLE
Keep /tmp on root disk

### DIFF
--- a/kernel/microvm/config.fragment
+++ b/kernel/microvm/config.fragment
@@ -29,7 +29,7 @@ CONFIG_VIRTIO_BALLOON=y                 # why: memory pressure feedback to host
 # ── Filesystems built in (no initrd) ─────────────────────────────────
 CONFIG_EXT4_FS=y                # why: rootfs is ext4
 CONFIG_ISO9660_FS=y             # why: cloud-init NoCloud seed disk is an iso9660 image
-CONFIG_TMPFS=y                  # why: /tmp + tmpfs root for /init bootstrap
+CONFIG_TMPFS=y                  # why: tmpfs-backed /run during /init bootstrap
 CONFIG_DEVTMPFS=y               # why: /dev populated by kernel at mount
 CONFIG_DEVTMPFS_MOUNT=y         # why: auto-mount /dev at boot
 

--- a/scripts/ci/preset-init.sh
+++ b/scripts/ci/preset-init.sh
@@ -41,11 +41,14 @@ mount -t devtmpfs dev /dev 2>/dev/null   # may already be mounted
 mkdir -p /dev/pts
 mount -t devpts devpts /dev/pts
 mount -t tmpfs tmpfs /run
-mount -t tmpfs tmpfs /tmp
+# Keep /tmp on the root disk, not tmpfs. Package managers use /tmp for
+# temporary writes, and a memory-sized tmpfs can fill up even when the disk
+# still has plenty of space.
 
 echo 0 > /proc/sys/kernel/ctrl-alt-del
 mount -o remount,rw /
-mkdir -p /run/sshd /var/log
+mkdir -p /run/sshd /var/log /tmp
+chmod 1777 /tmp
 
 # ── Networking ───────────────────────────────────────────────
 # Format: ip=<guest_ip>::<gateway>:<netmask>::eth0:off (kernel ip= param)

--- a/src/smolvm/images/builder.py
+++ b/src/smolvm/images/builder.py
@@ -1164,7 +1164,9 @@ mount -t devtmpfs dev /dev 2>/dev/null  # may already be mounted
 mkdir -p /dev/pts
 mount -t devpts devpts /dev/pts
 mount -t tmpfs tmpfs /run
-mount -t tmpfs tmpfs /tmp
+# Keep /tmp on the root disk, not tmpfs. Package managers use /tmp for
+# temporary writes, and a memory-sized tmpfs can fill up even when the disk
+# still has plenty of space.
 
 log_ts "mounts-ready"
 
@@ -1175,7 +1177,8 @@ echo 0 > /proc/sys/kernel/ctrl-alt-del
 mount -o remount,rw /
 
 # Create required directories
-mkdir -p /run/sshd /var/log
+mkdir -p /run/sshd /var/log /tmp
+chmod 1777 /tmp
 
 log_ts "root-ready"
 

--- a/tests/test_build.py
+++ b/tests/test_build.py
@@ -59,6 +59,24 @@ def test_preset_init_script_uses_cmdline_netmask_and_gateway_dns() -> None:
     assert 'ip addr add "${GUEST_IP}/24"' not in script
 
 
+def test_base_init_script_keeps_tmp_on_root_disk() -> None:
+    script = ImageBuilder()._default_init_script()
+
+    assert "mount -t tmpfs tmpfs /run" in script
+    assert "mount -t tmpfs tmpfs /tmp" not in script
+    assert "mkdir -p /run/sshd /var/log /tmp" in script
+    assert "chmod 1777 /tmp" in script
+
+
+def test_preset_init_script_keeps_tmp_on_root_disk() -> None:
+    script = Path("scripts/ci/preset-init.sh").read_text()
+
+    assert "mount -t tmpfs tmpfs /run" in script
+    assert "mount -t tmpfs tmpfs /tmp" not in script
+    assert "mkdir -p /run/sshd /var/log /tmp" in script
+    assert "chmod 1777 /tmp" in script
+
+
 class TestDockerDiagnostics:
     """Tests for Docker availability diagnostics."""
 


### PR DESCRIPTION
Stops mounting /tmp as tmpfs so package managers and build tools are not limited by guest memory. Keeps /run as tmpfs for runtime state and ensures /tmp has sticky 1777 permissions.\n\nTests:\n- uv run pytest tests/test_build.py\n- uv run ruff check tests/test_build.py src/smolvm/images/builder.py

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * `/tmp` now persists on the root disk instead of mounting as a temporary in-memory filesystem.
  * Updated initialization scripts and directory permission handling accordingly.

* **Tests**
  * Added validation tests for `/tmp` persistence behavior across initialization scripts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->