### PR TITLE
Add space-saving diff snapshots via --snapshot-type (QEMU + Firecracker)

### DIFF
--- a/docs/deep-dive/filesystem-and-disk-images.md
+++ b/docs/deep-dive/filesystem-and-disk-images.md
@@ -72,6 +72,15 @@ Firecracker attaches them as `data_drive`, `data_drive_1`, etc. QEMU uses additi
 | **Memory file** | `mem.bin` | included in QEMU snapshot |
 | **Disk file** | `disk.ext4` | `disk.qcow2` |
 
+### Snapshot types: full vs diff
+
+When you create a snapshot you can choose how much of the disk to store with `--snapshot-type` (CLI) or `snapshot_type=` (SDK):
+
+- **`full`** (default): a complete, self-contained copy of the disk. It restores on its own even if the original base image is gone — the safest, most portable choice, and the right default for everyday use.
+- **`diff`**: stores only what changed since the shared base image, so it takes far less space. On QEMU the snapshot keeps the thin qcow2 overlay; on Firecracker the disk is cloned with a copy-on-write reflink on filesystems that support it (btrfs, XFS, ZFS, APFS), falling back to a full copy elsewhere. The trade-off: a diff snapshot needs its base image to still be present to restore. Best for production systems that take many snapshots and keep their base images in place.
+
+On Firecracker the VM state and memory files are always captured in full; `diff` only changes how the disk is stored.
+
 ---
 
 ## Built-in Images

--- a/src/smolvm/cli/main.py
+++ b/src/smolvm/cli/main.py
@@ -48,7 +48,7 @@ from smolvm.cli.cleanup import add_cleanup_args, add_delete_args, run_cleanup, r
 from smolvm.cli.output import console_stdout, emit_json, render_empty, render_error, status_style
 from smolvm.cli.version_check import maybe_print_update_notice
 from smolvm.host.doctor import run_doctor
-from smolvm.types import BrowserSessionState, GuestOS, VMState
+from smolvm.types import BrowserSessionState, GuestOS, SnapshotType, VMState
 
 if TYPE_CHECKING:
     from smolvm.images.published import Arch, Vmm
@@ -193,6 +193,7 @@ class SnapshotRow(TypedDict):
     snapshot_id: str
     vm_id: str
     backend: str
+    snapshot_type: str
     restored: bool
     restored_vm_id: str | None
     created_at: str
@@ -888,6 +889,17 @@ def build_parser() -> argparse.ArgumentParser:
         "--snapshot-id",
         default=None,
         help="Custom snapshot name (default: auto-generated).",
+    )
+    snapshot_create.add_argument(
+        "--snapshot-type",
+        choices=[t.value for t in SnapshotType],
+        default=SnapshotType.FULL.value,
+        help=(
+            "How much disk to store. 'full' (default) is a self-contained copy "
+            "that always restores on its own. 'diff' stores only what changed "
+            "since the base image to save space, but needs that base image to "
+            "stay present."
+        ),
     )
     snapshot_create.add_argument(
         "--resume-source",
@@ -2582,6 +2594,7 @@ def _snapshot_row(snapshot: SnapshotInfo) -> SnapshotRow:
         "snapshot_id": snapshot.snapshot_id,
         "vm_id": snapshot.vm_id,
         "backend": snapshot.backend,
+        "snapshot_type": snapshot.snapshot_type.value,
         "restored": snapshot.restored,
         "restored_vm_id": snapshot.restored_vm_id,
         "created_at": snapshot.created_at.isoformat(),
@@ -2603,6 +2616,7 @@ def _render_snapshot_list(rows: list[SnapshotRow]) -> None:
     table.add_column("Snapshot")
     table.add_column("VM")
     table.add_column("Backend")
+    table.add_column("Type")
     table.add_column("Restored")
     table.add_column("Restored VM")
     for row in rows:
@@ -2610,6 +2624,7 @@ def _render_snapshot_list(rows: list[SnapshotRow]) -> None:
             row["snapshot_id"],
             row["vm_id"],
             row["backend"],
+            row["snapshot_type"],
             "yes" if row["restored"] else "no",
             row["restored_vm_id"] or "-",
         )
@@ -2784,6 +2799,7 @@ def _run_snapshot(args: argparse.Namespace) -> int:
             vm = SmolVM.from_id(args.vm_id)
             snapshot = vm.snapshot(
                 snapshot_id=args.snapshot_id,
+                snapshot_type=args.snapshot_type,
                 resume_source=args.resume_source,
             )
             row = _snapshot_row(snapshot)

--- a/src/smolvm/facade.py
+++ b/src/smolvm/facade.py
@@ -1323,10 +1323,17 @@ class SmolVM:
                 changed since the base image to save space.
             resume_source: Keep this VM running after the snapshot is taken.
         """
+        try:
+            resolved_snapshot_type = SnapshotType(snapshot_type)
+        except ValueError as exc:
+            allowed = ", ".join(repr(t.value) for t in SnapshotType)
+            raise ValueError(
+                f"snapshot_type must be one of {allowed}; got {snapshot_type!r}"
+            ) from exc
         snapshot_info = self._sdk.create_snapshot(
             self._vm_id,
             snapshot_id=snapshot_id,
-            snapshot_type=SnapshotType(snapshot_type),
+            snapshot_type=resolved_snapshot_type,
             resume_source=resume_source,
         )
         self._refresh_info()

--- a/src/smolvm/facade.py
+++ b/src/smolvm/facade.py
@@ -83,6 +83,7 @@ from smolvm.types import (
     GuestOS,
     InternetSettings,
     SnapshotInfo,
+    SnapshotType,
     VMConfig,
     VMInfo,
     VMState,
@@ -1310,12 +1311,22 @@ class SmolVM:
         self,
         snapshot_id: str | None = None,
         *,
+        snapshot_type: SnapshotType | str = SnapshotType.FULL,
         resume_source: bool = False,
     ) -> SnapshotInfo:
-        """Create a snapshot for the VM."""
+        """Create a snapshot for the VM.
+
+        Args:
+            snapshot_id: Optional custom snapshot name.
+            snapshot_type: ``"full"`` (default) for a self-contained copy that
+                always restores on its own, or ``"diff"`` to store only what
+                changed since the base image to save space.
+            resume_source: Keep this VM running after the snapshot is taken.
+        """
         snapshot_info = self._sdk.create_snapshot(
             self._vm_id,
             snapshot_id=snapshot_id,
+            snapshot_type=SnapshotType(snapshot_type),
             resume_source=resume_source,
         )
         self._refresh_info()

--- a/src/smolvm/runtime/base.py
+++ b/src/smolvm/runtime/base.py
@@ -22,7 +22,7 @@ from dataclasses import dataclass, field
 from pathlib import Path
 from typing import TYPE_CHECKING, Protocol, TextIO
 
-from smolvm.types import SnapshotArtifacts, SnapshotInfo, VMInfo, VMState
+from smolvm.types import SnapshotArtifacts, SnapshotInfo, SnapshotType, VMInfo, VMState
 
 if TYPE_CHECKING:
     from collections.abc import Awaitable, Callable
@@ -48,6 +48,7 @@ class SnapshotCreateRequest:
     managed_disk_path: Path
     resume_source: bool
     original_status: VMState
+    snapshot_type: SnapshotType = SnapshotType.FULL
 
 
 @dataclass(slots=True, frozen=True)

--- a/src/smolvm/runtime/firecracker.py
+++ b/src/smolvm/runtime/firecracker.py
@@ -34,7 +34,8 @@ from smolvm.runtime.base import (
     SnapshotCreateResult,
     SnapshotRestoreRequest,
 )
-from smolvm.types import SnapshotArtifacts, VMInfo, VMState
+from smolvm.types import SnapshotArtifacts, SnapshotType, VMInfo, VMState
+from smolvm.utils import copy_with_reflink
 
 logger = logging.getLogger(__name__)
 
@@ -59,7 +60,9 @@ class FirecrackerRuntimeAdapter(RuntimeAdapter):
             process = self._context.start_firecracker(control_socket_path, log_path)
             client = FirecrackerClient(control_socket_path)
             client.wait_for_socket(timeout=boot_timeout)
-            client.set_boot_source(vm_info.config.kernel_path, self._context.resolve_boot_args(vm_info))
+            client.set_boot_source(
+                vm_info.config.kernel_path, self._context.resolve_boot_args(vm_info)
+            )
             client.set_machine_config(vm_info.config.vcpu_count, vm_info.config.memory)
             client.add_drive(
                 "rootfs",
@@ -163,7 +166,14 @@ class FirecrackerRuntimeAdapter(RuntimeAdapter):
             client.close()
 
     def create_snapshot(self, request: SnapshotCreateRequest) -> SnapshotCreateResult:
-        """Create a Firecracker full snapshot and copy the managed disk."""
+        """Create a Firecracker snapshot and copy the managed disk.
+
+        The Firecracker VM state and guest memory are always captured in full
+        so the snapshot restores on its own. ``snapshot_type=DIFF`` only
+        changes how the disk is copied: a copy-on-write reflink clone that
+        shares unchanged blocks with the source on CoW filesystems, instead of
+        a full byte-for-byte copy.
+        """
         vm_info = request.vm_info
         client = self._require_client(vm_info)
         try:
@@ -175,7 +185,10 @@ class FirecrackerRuntimeAdapter(RuntimeAdapter):
                 client.pause_vm()
 
             client.create_snapshot(state_path, memory_path, snapshot_type="Full")
-            shutil.copy2(request.managed_disk_path, disk_path)
+            if request.snapshot_type == SnapshotType.DIFF:
+                copy_with_reflink(request.managed_disk_path, disk_path)
+            else:
+                shutil.copy2(request.managed_disk_path, disk_path)
             return SnapshotCreateResult(
                 artifacts=SnapshotArtifacts(
                     state_path=state_path,

--- a/src/smolvm/runtime/qemu.py
+++ b/src/smolvm/runtime/qemu.py
@@ -17,6 +17,7 @@
 from __future__ import annotations
 
 import asyncio
+import json
 import logging
 import os
 import platform
@@ -40,7 +41,7 @@ from smolvm.runtime.base import (
     SnapshotRestoreRequest,
 )
 from smolvm.runtime.guest_platforms import GuestPlatformSpec, get_guest_platform
-from smolvm.types import GuestOS, SnapshotArtifacts, VMInfo, VMState
+from smolvm.types import GuestOS, SnapshotArtifacts, SnapshotType, VMInfo, VMState
 from smolvm.utils import which
 
 logger = logging.getLogger(__name__)
@@ -170,10 +171,7 @@ class _SwtpmSidecar:
                 with suppress(ProcessLookupError, OSError):
                     os.kill(pid, signal.SIGTERM)
                 deadline = time.time() + 5.0
-                while (
-                    time.time() < deadline
-                    and self._context.is_process_running(pid)
-                ):
+                while time.time() < deadline and self._context.is_process_running(pid):
                     time.sleep(0.05)
                 if self._context.is_process_running(pid):
                     with suppress(ProcessLookupError, OSError):
@@ -335,7 +333,10 @@ class QemuRuntimeAdapter(RuntimeAdapter):
                 snapshot_saved = True
 
                 disk_path = request.snapshot_root / "disk.qcow2"
-                self._copy_disk_standalone(request.managed_disk_path, disk_path)
+                if request.snapshot_type == SnapshotType.DIFF:
+                    self._copy_disk_overlay(request.managed_disk_path, disk_path)
+                else:
+                    self._copy_disk_standalone(request.managed_disk_path, disk_path)
 
                 delete_job_id = f"snapshot-delete-{request.snapshot_id}"
                 client.snapshot_delete(delete_job_id, request.snapshot_id, [QEMU_ROOT_NODE_NAME])
@@ -375,6 +376,16 @@ class QemuRuntimeAdapter(RuntimeAdapter):
 
         request.managed_disk_path.parent.mkdir(parents=True, exist_ok=True)
         shutil.copy2(snapshot.artifacts.disk_path, request.managed_disk_path)
+
+        if snapshot.snapshot_type == SnapshotType.DIFF:
+            backing = self._qcow2_backing_file(request.managed_disk_path)
+            if backing is not None and not backing.exists():
+                raise SmolVMError(
+                    "This space-saving snapshot needs its original base image, "
+                    f"which is missing: '{backing}'. Restore that file, or take a "
+                    "full snapshot next time with '--snapshot-type full'.",
+                    {"snapshot_id": snapshot.snapshot_id, "backing_file": str(backing)},
+                )
 
         control_socket_path = self._control_socket_path(snapshot.vm_id)
         if control_socket_path.exists():
@@ -476,9 +487,7 @@ class QemuRuntimeAdapter(RuntimeAdapter):
                 text=True,
                 check=False,
             )
-            has_backing = (
-                info_result.returncode == 0 and "backing-filename" in info_result.stdout
-            )
+            has_backing = info_result.returncode == 0 and "backing-filename" in info_result.stdout
 
             if has_backing:
                 logger.info(
@@ -509,6 +518,81 @@ class QemuRuntimeAdapter(RuntimeAdapter):
                 )
 
         shutil.copy2(source, dest)
+
+    @staticmethod
+    def _qcow2_backing_file(disk: Path) -> Path | None:
+        """Return the absolute backing-file path of a qcow2 disk, if any.
+
+        Returns ``None`` when the disk has no backing file or when its layout
+        cannot be read (e.g. ``qemu-img`` is unavailable).
+        """
+        qemu_img = which("qemu-img")
+        if qemu_img is None:
+            return None
+        info = subprocess.run(
+            [str(qemu_img), "info", "--output=json", str(disk)],
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        if info.returncode != 0:
+            return None
+        try:
+            data = json.loads(info.stdout)
+        except (ValueError, TypeError):
+            return None
+        backing = data.get("full-backing-filename") or data.get("backing-filename")
+        return Path(backing) if backing else None
+
+    @staticmethod
+    def _copy_disk_overlay(source: Path, dest: Path) -> None:
+        """Copy a qcow2 overlay for a diff snapshot, keeping its backing chain.
+
+        Unlike :meth:`_copy_disk_standalone`, this preserves the thin overlay's
+        link to the shared base image, so the snapshot stores only the clusters
+        that changed since the base — much smaller, at the cost of depending on
+        the base image still being present at restore time. The copy keeps any
+        QEMU internal VM-state snapshot the overlay carries.
+
+        When the source has no backing file there is nothing to diff against,
+        so this falls back to a self-contained copy.
+        """
+        backing = QemuRuntimeAdapter._qcow2_backing_file(source)
+        if backing is None:
+            logger.info(
+                "qcow2 has no backing file; writing a full snapshot instead of diff: %s",
+                source,
+            )
+            QemuRuntimeAdapter._copy_disk_standalone(source, dest)
+            return
+
+        shutil.copy2(source, dest)
+
+        # Re-point the copied overlay at the base by absolute path so it
+        # resolves from the snapshot directory regardless of the cwd.
+        qemu_img = which("qemu-img")
+        if qemu_img is None:
+            return
+        rebase = subprocess.run(
+            [
+                str(qemu_img),
+                "rebase",
+                "-u",
+                "-b",
+                str(backing.resolve()),
+                "-F",
+                "qcow2" if backing.suffix == ".qcow2" else "raw",
+                str(dest),
+            ],
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        if rebase.returncode != 0:
+            logger.warning(
+                "qemu-img rebase failed for diff snapshot; backing path left as-is: %s",
+                rebase.stderr.strip(),
+            )
 
     def _client(self, control_socket_path: Path | None, timeout: float = 5.0) -> QMPClient:
         """Connect a QMP client for a runtime control socket."""

--- a/src/smolvm/runtime/qemu.py
+++ b/src/smolvm/runtime/qemu.py
@@ -382,8 +382,9 @@ class QemuRuntimeAdapter(RuntimeAdapter):
             if backing is not None and not backing.exists():
                 raise SmolVMError(
                     "This space-saving snapshot needs its original base image, "
-                    f"which is missing: '{backing}'. Restore that file, or take a "
-                    "full snapshot next time with '--snapshot-type full'.",
+                    f"which is missing: '{backing}'. Restore that file and run "
+                    f"'smolvm snapshot restore {snapshot.snapshot_id}' again, or take "
+                    "a full snapshot next time with '--snapshot-type full'.",
                     {"snapshot_id": snapshot.snapshot_id, "backing_file": str(backing)},
                 )
 

--- a/src/smolvm/runtime/qemu.py
+++ b/src/smolvm/runtime/qemu.py
@@ -545,6 +545,37 @@ class QemuRuntimeAdapter(RuntimeAdapter):
         return Path(backing) if backing else None
 
     @staticmethod
+    def _qcow2_disk_format(disk: Path) -> str | None:
+        """Return the image format qemu-img reports for *disk*, or ``None``.
+
+        Used to pass an accurate ``-F`` (backing format) to ``qemu-img rebase``
+        instead of guessing from the file extension. Returns ``None`` — letting
+        the caller fall back to the extension heuristic — when qemu-img is
+        unavailable, errors, or omits the field.
+        """
+        qemu_img = which("qemu-img")
+        if qemu_img is None:
+            return None
+        info = subprocess.run(
+            [str(qemu_img), "info", "--output=json", str(disk)],
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        if info.returncode != 0:
+            logger.warning(
+                "qemu-img info failed for backing file %s; guessing its format "
+                "from the extension instead: %s",
+                disk,
+                info.stderr.strip(),
+            )
+            return None
+        try:
+            return json.loads(info.stdout).get("format")
+        except (ValueError, TypeError):
+            return None
+
+    @staticmethod
     def _copy_disk_overlay(source: Path, dest: Path) -> None:
         """Copy a qcow2 overlay for a diff snapshot, keeping its backing chain.
 
@@ -573,6 +604,9 @@ class QemuRuntimeAdapter(RuntimeAdapter):
         qemu_img = which("qemu-img")
         if qemu_img is None:
             return
+        backing_fmt = QemuRuntimeAdapter._qcow2_disk_format(backing) or (
+            "qcow2" if backing.suffix == ".qcow2" else "raw"
+        )
         rebase = subprocess.run(
             [
                 str(qemu_img),
@@ -581,7 +615,7 @@ class QemuRuntimeAdapter(RuntimeAdapter):
                 "-b",
                 str(backing.resolve()),
                 "-F",
-                "qcow2" if backing.suffix == ".qcow2" else "raw",
+                backing_fmt,
                 str(dest),
             ],
             capture_output=True,

--- a/src/smolvm/storage/_base.py
+++ b/src/smolvm/storage/_base.py
@@ -26,6 +26,7 @@ from smolvm.types import (
     NetworkConfig,
     SnapshotArtifacts,
     SnapshotInfo,
+    SnapshotType,
     VMConfig,
 )
 
@@ -86,6 +87,13 @@ def snapshot_info_from_row(row: Any) -> SnapshotInfo:
             memory_path=Path(row["mem_file_path"]) if row["mem_file_path"] else None,
             disk_path=Path(row["disk_path"]),
         )
+    # ``snapshot_type`` is a newer column; rows predating it (or fakes built in
+    # tests) may not carry it, so default to a full snapshot.
+    try:
+        raw_snapshot_type = row["snapshot_type"]
+    except (KeyError, IndexError):
+        raw_snapshot_type = None
+    snapshot_type = SnapshotType(raw_snapshot_type) if raw_snapshot_type else SnapshotType.FULL
     return SnapshotInfo(
         snapshot_id=row["snapshot_id"],
         vm_id=row["vm_id"],
@@ -94,6 +102,7 @@ def snapshot_info_from_row(row: Any) -> SnapshotInfo:
         vm_config=vm_config_from_json(row["vm_config"]),
         network_config=NetworkConfig.model_validate_json(row["network_config"]),
         created_at=datetime.fromisoformat(row["created_at"]),
+        snapshot_type=snapshot_type,
         restored=bool(row["restored"]),
         restored_vm_id=row["restored_vm_id"],
     )

--- a/src/smolvm/storage/_base.py
+++ b/src/smolvm/storage/_base.py
@@ -93,7 +93,11 @@ def snapshot_info_from_row(row: Any) -> SnapshotInfo:
         raw_snapshot_type = row["snapshot_type"]
     except (KeyError, IndexError):
         raw_snapshot_type = None
-    snapshot_type = SnapshotType(raw_snapshot_type) if raw_snapshot_type else SnapshotType.FULL
+    try:
+        snapshot_type = SnapshotType(raw_snapshot_type) if raw_snapshot_type else SnapshotType.FULL
+    except ValueError:
+        # Unknown value persisted by a newer/other writer — treat as full.
+        snapshot_type = SnapshotType.FULL
     return SnapshotInfo(
         snapshot_id=row["snapshot_id"],
         vm_id=row["vm_id"],

--- a/src/smolvm/storage/_postgres.py
+++ b/src/smolvm/storage/_postgres.py
@@ -183,11 +183,14 @@ class PostgresStateManager:
                     vm_config TEXT NOT NULL,
                     network_config TEXT NOT NULL,
                     created_at TEXT NOT NULL,
+                    snapshot_type TEXT,
                     restored BOOLEAN DEFAULT FALSE,
                     restored_vm_id TEXT
                 );
 
                 CREATE INDEX IF NOT EXISTS idx_snapshots_vm_id ON snapshots(vm_id);
+
+                ALTER TABLE snapshots ADD COLUMN IF NOT EXISTS snapshot_type TEXT;
                 """
             )
 
@@ -587,9 +590,9 @@ class PostgresStateManager:
                 INSERT INTO snapshots (
                     snapshot_id, vm_id, snapshot_path, mem_file_path, disk_path,
                     backend, artifacts, vm_config, network_config,
-                    created_at, restored, restored_vm_id
+                    created_at, snapshot_type, restored, restored_vm_id
                 )
-                VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s)
+                VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s)
                 """,
                 (
                     info.snapshot_id,
@@ -602,6 +605,7 @@ class PostgresStateManager:
                     info.vm_config.model_dump_json(),
                     info.network_config.model_dump_json(),
                     info.created_at.isoformat(),
+                    info.snapshot_type.value,
                     info.restored,
                     info.restored_vm_id,
                 ),

--- a/src/smolvm/storage/_sqlite.py
+++ b/src/smolvm/storage/_sqlite.py
@@ -177,6 +177,7 @@ class SQLiteStateManager:
                     vm_config TEXT NOT NULL,
                     network_config TEXT NOT NULL,
                     created_at TEXT NOT NULL,
+                    snapshot_type TEXT,
                     restored INTEGER DEFAULT 0,
                     restored_vm_id TEXT
                 );
@@ -191,6 +192,8 @@ class SQLiteStateManager:
                 conn.execute("ALTER TABLE snapshots ADD COLUMN backend TEXT")
             if "artifacts" not in snapshot_columns:
                 conn.execute("ALTER TABLE snapshots ADD COLUMN artifacts TEXT")
+            if "snapshot_type" not in snapshot_columns:
+                conn.execute("ALTER TABLE snapshots ADD COLUMN snapshot_type TEXT")
 
     # ------------------------------------------------------------------
     # VM operations
@@ -588,9 +591,9 @@ class SQLiteStateManager:
                 INSERT INTO snapshots (
                     snapshot_id, vm_id, snapshot_path, mem_file_path, disk_path,
                     backend, artifacts, vm_config, network_config,
-                    created_at, restored, restored_vm_id
+                    created_at, snapshot_type, restored, restored_vm_id
                 )
-                VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
                 """,
                 (
                     info.snapshot_id,
@@ -603,6 +606,7 @@ class SQLiteStateManager:
                     info.vm_config.model_dump_json(),
                     info.network_config.model_dump_json(),
                     info.created_at.isoformat(),
+                    info.snapshot_type.value,
                     int(info.restored),
                     info.restored_vm_id,
                 ),

--- a/src/smolvm/types.py
+++ b/src/smolvm/types.py
@@ -54,6 +54,19 @@ class GuestOS(str, Enum):
     WINDOWS = "windows"
 
 
+class SnapshotType(str, Enum):
+    """How much of a VM's disk a snapshot stores.
+
+    ``FULL`` (the default) writes a complete, self-contained copy of the
+    disk, so the snapshot can be restored on its own. ``DIFF`` stores only
+    the data that changed since the shared base image, which is much smaller
+    but means the snapshot depends on that base image still being present.
+    """
+
+    FULL = "full"
+    DIFF = "diff"
+
+
 def _generate_vm_id() -> str:
     """Generate a VM identifier compatible with VMConfig validation."""
     return generate_sandbox_name()
@@ -653,6 +666,7 @@ class SnapshotInfo(BaseModel):
     vm_config: VMConfig
     network_config: NetworkConfig
     created_at: datetime
+    snapshot_type: SnapshotType = SnapshotType.FULL
     restored: bool = False
     restored_vm_id: str | None = None
 

--- a/src/smolvm/utils.py
+++ b/src/smolvm/utils.py
@@ -58,14 +58,16 @@ def copy_with_reflink(source_path: Path, target_path: Path) -> None:
         text=True,
         check=False,
     )
-    if result.returncode != 0:
-        logger.debug(
-            "cp --reflink failed for %s -> %s; falling back to a regular copy: %s",
-            source_path,
-            target_path,
-            (result.stderr or "").strip(),
-        )
-        shutil.copy2(source_path, target_path)
+    if result.returncode == 0:
+        logger.debug("Copied %s -> %s via cp --reflink=auto", source_path, target_path)
+        return
+    logger.debug(
+        "cp --reflink failed for %s -> %s; falling back to a regular copy: %s",
+        source_path,
+        target_path,
+        (result.stderr or "").strip(),
+    )
+    shutil.copy2(source_path, target_path)
 
 
 def run_command(

--- a/src/smolvm/utils.py
+++ b/src/smolvm/utils.py
@@ -26,10 +26,7 @@ from smolvm.exceptions import SmolVMError
 
 logger = logging.getLogger(__name__)
 
-RUNTIME_PRIVILEGE_SETUP_HINT = (
-    "Configure non-interactive runtime privileges once:\n"
-    "  smolvm setup"
-)
+RUNTIME_PRIVILEGE_SETUP_HINT = "Configure non-interactive runtime privileges once:\n  smolvm setup"
 
 
 def _is_sudo_non_interactive_error(stderr: str) -> bool:
@@ -43,6 +40,26 @@ def _is_sudo_non_interactive_error(stderr: str) -> bool:
         "may not run sudo",
     )
     return any(pattern in text for pattern in patterns)
+
+
+def copy_with_reflink(source_path: Path, target_path: Path) -> None:
+    """Copy a file using a copy-on-write reflink when the filesystem allows it.
+
+    On CoW filesystems (btrfs, XFS with reflinks, ZFS, APFS) the new file
+    shares its blocks with the source, so the copy is near-instant and costs
+    almost no extra space regardless of file size. Later writes to either file
+    allocate fresh blocks, so the copy stays an independent, point-in-time
+    image. On filesystems or platforms without reflink support (for example,
+    macOS ``cp`` has no ``--reflink`` flag) this falls back to a regular copy.
+    """
+    result = subprocess.run(
+        ["cp", "--reflink=auto", str(source_path), str(target_path)],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    if result.returncode != 0:
+        shutil.copy2(source_path, target_path)
 
 
 def run_command(
@@ -168,9 +185,7 @@ async def async_run_command(
                 f"{RUNTIME_PRIVILEGE_SETUP_HINT}\n"
                 f"sudo stderr: {stderr_str.strip()}"
             )
-        raise SmolVMError(
-            f"Command failed: {' '.join(full_cmd)}\nstderr: {stderr_str}"
-        )
+        raise SmolVMError(f"Command failed: {' '.join(full_cmd)}\nstderr: {stderr_str}")
 
     return subprocess.CompletedProcess(
         args=full_cmd,

--- a/src/smolvm/utils.py
+++ b/src/smolvm/utils.py
@@ -59,6 +59,12 @@ def copy_with_reflink(source_path: Path, target_path: Path) -> None:
         check=False,
     )
     if result.returncode != 0:
+        logger.debug(
+            "cp --reflink failed for %s -> %s; falling back to a regular copy: %s",
+            source_path,
+            target_path,
+            (result.stderr or "").strip(),
+        )
         shutil.copy2(source_path, target_path)
 
 

--- a/src/smolvm/vm.py
+++ b/src/smolvm/vm.py
@@ -63,6 +63,7 @@ from smolvm.types import (
     GuestOS,
     NetworkConfig,
     SnapshotInfo,
+    SnapshotType,
     VMConfig,
     VMInfo,
     VMState,
@@ -1258,9 +1259,16 @@ class SmolVMManager:
         vm_id: str,
         snapshot_id: str | None = None,
         *,
+        snapshot_type: SnapshotType = SnapshotType.FULL,
         resume_source: bool = False,
     ) -> SnapshotInfo:
-        """Create a full snapshot for a paused or running VM."""
+        """Create a snapshot for a paused or running VM.
+
+        ``snapshot_type`` controls how the disk is stored. ``FULL`` (the
+        default) writes a self-contained copy that always restores on its own.
+        ``DIFF`` stores only what changed since the shared base image, which is
+        much smaller but depends on that base image still being present.
+        """
         if not vm_id:
             raise ValueError("vm_id cannot be empty")
 
@@ -1300,6 +1308,7 @@ class SmolVMManager:
                     managed_disk_path=managed_disk_path,
                     resume_source=resume_source,
                     original_status=original_status,
+                    snapshot_type=snapshot_type,
                 )
             )
 
@@ -1311,6 +1320,7 @@ class SmolVMManager:
                 vm_config=vm_info.config,
                 network_config=vm_info.network,
                 created_at=datetime.now(timezone.utc),
+                snapshot_type=snapshot_type,
             )
             self.state.create_snapshot(snapshot_info)
             snapshot_persisted = True

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -28,7 +28,13 @@ from smolvm.cli.main import (
     build_parser,
     main,
 )
-from smolvm.types import BrowserSessionState, NetworkConfig, VMState, WorkspaceMount
+from smolvm.types import (
+    BrowserSessionState,
+    NetworkConfig,
+    SnapshotType,
+    VMState,
+    WorkspaceMount,
+)
 
 
 def _make_vm_info(
@@ -89,6 +95,7 @@ def _make_snapshot_info(
     snapshot.snapshot_id = snapshot_id
     snapshot.vm_id = vm_id
     snapshot.backend = backend
+    snapshot.snapshot_type = SnapshotType.FULL
     snapshot.restored = restored
     snapshot.restored_vm_id = restored_vm_id
     snapshot.created_at = datetime(2026, 4, 3, 12, 0, tzinfo=timezone.utc)
@@ -1421,7 +1428,9 @@ class TestCliSnapshot:
 
         assert ret == 0
         mock_vm_cls.from_id.assert_called_once_with("vm001")
-        vm.snapshot.assert_called_once_with(snapshot_id="snap-001", resume_source=False)
+        vm.snapshot.assert_called_once_with(
+            snapshot_id="snap-001", snapshot_type="full", resume_source=False
+        )
         vm.close.assert_called_once()
         out = capsys.readouterr().out
         assert "Created snapshot 'snap-001'" in out

--- a/tests/test_snapshot.py
+++ b/tests/test_snapshot.py
@@ -22,7 +22,7 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 from smolvm.exceptions import SmolVMError, SnapshotNotFoundError, VMNotFoundError
-from smolvm.types import SnapshotArtifacts, SnapshotInfo, VMConfig, VMState
+from smolvm.types import SnapshotArtifacts, SnapshotInfo, SnapshotType, VMConfig, VMState
 from smolvm.vm import SmolVMManager
 
 
@@ -469,3 +469,55 @@ def test_delete_snapshot_rejects_unsafe_snapshot_id(
     """Snapshot deletion should reject IDs that could escape the snapshot directory."""
     with pytest.raises(ValueError, match="snapshot_id"):
         smol_vm.delete_snapshot(snapshot_id)
+
+
+def _stub_fc_snapshot(snapshot_path: Path, mem_path: Path, snapshot_type: str = "Full") -> None:
+    snapshot_path.write_text("vmstate")
+    mem_path.write_text("memory")
+
+
+def test_create_snapshot_defaults_to_full_type(
+    smol_vm: SmolVMManager,
+    sample_config: VMConfig,
+    tmp_path: Path,
+) -> None:
+    """Snapshots are full by default so they restore on their own."""
+    _running_vm(smol_vm, sample_config, tmp_path)
+    (smol_vm.data_dir / "disks" / "vm001.ext4").write_text("managed-disk")
+
+    with patch("smolvm.runtime.firecracker.FirecrackerClient") as mock_client_cls:
+        mock_client = MagicMock()
+        mock_client.create_snapshot.side_effect = _stub_fc_snapshot
+        mock_client_cls.return_value = mock_client
+        snapshot = smol_vm.create_snapshot("vm001", snapshot_id="snap-full")
+
+    assert snapshot.snapshot_type is SnapshotType.FULL
+    assert smol_vm.state.get_snapshot("snap-full").snapshot_type is SnapshotType.FULL
+
+
+def test_create_diff_snapshot_records_type_and_copies_disk(
+    smol_vm: SmolVMManager,
+    sample_config: VMConfig,
+    tmp_path: Path,
+) -> None:
+    """A diff snapshot persists its type and still captures the disk contents.
+
+    Firecracker VM state and memory are always full; ``diff`` only changes how
+    the disk is copied (a copy-on-write reflink clone, which falls back to a
+    regular copy on filesystems without reflink support).
+    """
+    _running_vm(smol_vm, sample_config, tmp_path)
+    (smol_vm.data_dir / "disks" / "vm001.ext4").write_text("managed-disk")
+
+    with patch("smolvm.runtime.firecracker.FirecrackerClient") as mock_client_cls:
+        mock_client = MagicMock()
+        mock_client.create_snapshot.side_effect = _stub_fc_snapshot
+        mock_client_cls.return_value = mock_client
+        snapshot = smol_vm.create_snapshot(
+            "vm001", snapshot_id="snap-diff", snapshot_type=SnapshotType.DIFF
+        )
+
+    persisted = smol_vm.state.get_snapshot("snap-diff")
+    assert snapshot.snapshot_type is SnapshotType.DIFF
+    assert persisted.snapshot_type is SnapshotType.DIFF
+    assert persisted.artifacts.disk_path.read_text() == "managed-disk"

--- a/tests/test_snapshot.py
+++ b/tests/test_snapshot.py
@@ -509,7 +509,13 @@ def test_create_diff_snapshot_records_type_and_copies_disk(
     _running_vm(smol_vm, sample_config, tmp_path)
     (smol_vm.data_dir / "disks" / "vm001.ext4").write_text("managed-disk")
 
-    with patch("smolvm.runtime.firecracker.FirecrackerClient") as mock_client_cls:
+    with (
+        patch("smolvm.runtime.firecracker.FirecrackerClient") as mock_client_cls,
+        patch(
+            "smolvm.runtime.firecracker.copy_with_reflink",
+            side_effect=lambda source, dest: dest.write_text(Path(source).read_text()),
+        ) as mock_reflink,
+    ):
         mock_client = MagicMock()
         mock_client.create_snapshot.side_effect = _stub_fc_snapshot
         mock_client_cls.return_value = mock_client
@@ -517,6 +523,7 @@ def test_create_diff_snapshot_records_type_and_copies_disk(
             "vm001", snapshot_id="snap-diff", snapshot_type=SnapshotType.DIFF
         )
 
+    mock_reflink.assert_called_once()
     persisted = smol_vm.state.get_snapshot("snap-diff")
     assert snapshot.snapshot_type is SnapshotType.DIFF
     assert persisted.snapshot_type is SnapshotType.DIFF

--- a/tests/test_snapshot_qemu.py
+++ b/tests/test_snapshot_qemu.py
@@ -27,6 +27,7 @@ from smolvm.types import (
     NetworkConfig,
     SnapshotArtifacts,
     SnapshotInfo,
+    SnapshotType,
     VMConfig,
     VMInfo,
     VMState,
@@ -384,9 +385,7 @@ def test_delete_qemu_snapshot_rejects_active_restored_vm(
         qemu_smol_vm.delete_snapshot("snap-001")
 
 
-def test_snapshot_rejected_for_windows_guests(
-    qemu_smol_vm: SmolVMManager, tmp_path: Path
-) -> None:
+def test_snapshot_rejected_for_windows_guests(qemu_smol_vm: SmolVMManager, tmp_path: Path) -> None:
     """Windows snapshot/restore is locked out in Phase 1 with a clear message."""
     rootfs = tmp_path / "win11.qcow2"
     rootfs.touch()
@@ -412,3 +411,47 @@ def test_snapshot_rejected_for_windows_guests(
     )
     with pytest.raises(SmolVMError, match="Windows guests"):
         qemu_smol_vm._ensure_snapshot_supported(vm_info)
+
+
+def test_create_qemu_snapshot_defaults_to_full_type(
+    qemu_smol_vm: SmolVMManager,
+    qemu_config: VMConfig,
+    tmp_path: Path,
+) -> None:
+    """QEMU snapshots default to full for self-contained restore."""
+    _running_qemu_vm(qemu_smol_vm, qemu_config, tmp_path)
+
+    with patch("smolvm.runtime.qemu.QMPClient") as mock_client_cls:
+        mock_client = _mock_qmp_client()
+        mock_client_cls.return_value = mock_client
+        snapshot = qemu_smol_vm.create_snapshot("vm001", snapshot_id="snap-full")
+
+    assert snapshot.snapshot_type is SnapshotType.FULL
+    assert qemu_smol_vm.state.get_snapshot("snap-full").snapshot_type is SnapshotType.FULL
+
+
+def test_create_qemu_diff_snapshot_records_type(
+    qemu_smol_vm: SmolVMManager,
+    qemu_config: VMConfig,
+    tmp_path: Path,
+) -> None:
+    """A diff QEMU snapshot records its type and still captures the disk.
+
+    The diff path keeps the thin qcow2 overlay (only changed clusters) when the
+    managed disk has a backing chain. In this unit harness the managed disk is a
+    plain stand-in file with no backing file, so the diff copy falls back to a
+    self-contained copy — which is the documented behavior.
+    """
+    _running_qemu_vm(qemu_smol_vm, qemu_config, tmp_path)
+
+    with patch("smolvm.runtime.qemu.QMPClient") as mock_client_cls:
+        mock_client = _mock_qmp_client()
+        mock_client_cls.return_value = mock_client
+        snapshot = qemu_smol_vm.create_snapshot(
+            "vm001", snapshot_id="snap-diff", snapshot_type=SnapshotType.DIFF
+        )
+
+    persisted = qemu_smol_vm.state.get_snapshot("snap-diff")
+    assert snapshot.snapshot_type is SnapshotType.DIFF
+    assert persisted.snapshot_type is SnapshotType.DIFF
+    assert persisted.artifacts.disk_path.read_text() == "managed-qcow2"

--- a/tests/test_snapshot_qemu.py
+++ b/tests/test_snapshot_qemu.py
@@ -435,22 +435,24 @@ def test_create_qemu_diff_snapshot_records_type(
     qemu_config: VMConfig,
     tmp_path: Path,
 ) -> None:
-    """A diff QEMU snapshot records its type and still captures the disk.
-
-    The diff path keeps the thin qcow2 overlay (only changed clusters) when the
-    managed disk has a backing chain. In this unit harness the managed disk is a
-    plain stand-in file with no backing file, so the diff copy falls back to a
-    self-contained copy — which is the documented behavior.
-    """
+    """A diff QEMU snapshot records its type and takes the overlay copy path."""
     _running_qemu_vm(qemu_smol_vm, qemu_config, tmp_path)
 
-    with patch("smolvm.runtime.qemu.QMPClient") as mock_client_cls:
+    with (
+        patch("smolvm.runtime.qemu.QMPClient") as mock_client_cls,
+        patch.object(
+            QemuRuntimeAdapter,
+            "_copy_disk_overlay",
+            side_effect=lambda source, dest: dest.write_text(Path(source).read_text()),
+        ) as mock_overlay,
+    ):
         mock_client = _mock_qmp_client()
         mock_client_cls.return_value = mock_client
         snapshot = qemu_smol_vm.create_snapshot(
             "vm001", snapshot_id="snap-diff", snapshot_type=SnapshotType.DIFF
         )
 
+    mock_overlay.assert_called_once()
     persisted = qemu_smol_vm.state.get_snapshot("snap-diff")
     assert snapshot.snapshot_type is SnapshotType.DIFF
     assert persisted.snapshot_type is SnapshotType.DIFF


### PR DESCRIPTION
## What & why

Snapshots always stored a **full copy of the disk**, which is space-hungry when many snapshots are taken. This adds a `snapshot_type` option so production systems can opt into storing **only the difference**, while keeping the self-contained full snapshot as the **default** for easy, no-surprises restore.

```
smolvm snapshot create <sandbox> --snapshot-type diff   # space-saving
smolvm snapshot create <sandbox>                         # full (default)
```

Also available in the SDK: `SmolVM.snapshot(snapshot_type="diff")` and `SmolVMManager.create_snapshot(snapshot_type=SnapshotType.DIFF)`.

## How it works

| | `full` (default) | `diff` |
|---|---|---|
| **QEMU** | flatten the qcow2 into a standalone image | keep the thin qcow2 overlay → only changed clusters are stored |
| **Firecracker** | byte-for-byte disk copy | copy-on-write reflink clone (`cp --reflink=auto`, falls back to full copy off CoW filesystems) |

- On **Firecracker**, the VM state (`vmstate.bin`) and guest memory (`mem.bin`) are **always full**, so a diff snapshot still restores on its own — `diff` only changes how the *disk* is stored. (Disk-only diff, per design discussion.)
- On **QEMU**, a diff snapshot depends on its base image still being present; restore validates this and fails with a clear, actionable message (with the missing path and the `--snapshot-type full` hint) if the base is gone.
- `snapshot_type` is persisted on `SnapshotInfo` (sqlite + postgres column with migrations) and shown in `snapshot list` and `--json` output.

## Compatibility

Default behavior is unchanged — snapshots are `full` unless `diff` is requested. Pre-existing snapshot rows (no `snapshot_type` column/value) read back as `full`.

## Tests

New unit tests for both backends and the CLI (full default + diff). Full affected suites green: `test_snapshot`, `test_snapshot_qemu`, `test_cli`, `test_storage`, `test_types`, `test_api` — 386 passed. `ruff format` clean on all changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Choose snapshot type: `full` (self-contained) or `diff` (stores changes relative to a shared base). CLI: new `--snapshot-type` for create (defaults to `full`); list shows a “Type” column and JSON includes `snapshot_type`. Persisted snapshots record the chosen type.
* **Documentation**
  * Added explanation of snapshot types and backend-specific behaviors for Firecracker and QEMU.
* **Reliability**
  * Diff restores validate backing images and fail with clear errors if bases are missing.
* **Tests**
  * Added snapshot-type coverage and regression tests for Firecracker and QEMU.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->