### PR TITLE
feat(qemu): host TAP networking mode for the QEMU backend

### DIFF
--- a/src/smolvm/runtime/qemu_args.py
+++ b/src/smolvm/runtime/qemu_args.py
@@ -116,13 +116,25 @@ def build_qemu_argv(
         ``subprocess.Popen``.
 
     Raises:
-        SmolVMError: When the VM has no reserved SSH host port; when
-            firmware boot is requested on aarch64 and no OVMF binary is
-            found on the host; or when the platform spec requires
-            firmware/swtpm and the caller didn't provide a per-VM path.
+        SmolVMError: When the VM has no network config; when slirp mode has
+            no reserved SSH host port; when firmware boot is requested on
+            aarch64 and no OVMF binary is found on the host; or when the
+            platform spec requires firmware/swtpm and the caller didn't
+            provide a per-VM path.
     """
-    if vm_info.network is None or vm_info.network.ssh_host_port is None:
-        raise SmolVMError("QEMU backend requires a reserved ssh_host_port in VM network config")
+    # Networking mode. ``slirp`` (default) is userspace NAT with host port
+    # forwards — the macOS/dev path. ``tap`` attaches the VM to a host TAP
+    # device managed by NetworkManager, giving the guest a real routable IP
+    # and bringing it under the same nftables NAT/isolation rules as the
+    # Firecracker backend (egress masquerade, cross-sandbox drop, IMDS block).
+    tap_mode = vm_info.config.qemu_network == "tap"
+
+    if vm_info.network is None:
+        raise SmolVMError("QEMU backend requires a VM network config")
+    if not tap_mode and vm_info.network.ssh_host_port is None:
+        raise SmolVMError(
+            "QEMU slirp networking requires a reserved ssh_host_port in VM network config"
+        )
 
     # Defensive sanity check: if the platform spec forces a specific boot
     # mode, the VMConfig must already match. The authoritative invariant
@@ -142,7 +154,6 @@ def build_qemu_argv(
             },
         )
 
-    ssh_port = vm_info.network.ssh_host_port
     guest_mac = vm_info.network.guest_mac.lower()
 
     qemu_name = qemu_bin.name
@@ -154,12 +165,19 @@ def build_qemu_argv(
         f"file={vm_info.config.rootfs_path},if=none,format={disk_format},"
         f"id={root_drive_id},node-name={root_node_name}"
     )
-    hostfwd_rules = [f"hostfwd=tcp:127.0.0.1:{ssh_port}-:22"]
-    for forward in vm_info.config.port_forwards:
-        hostfwd_rules.append(
-            f"hostfwd=tcp:{forward.host_address}:{forward.host_port}-:{forward.guest_port}"
+    if tap_mode:
+        # Attach to the pre-created host TAP. script=no/downscript=no: the host
+        # side (link up, IP, routes, NAT) is owned by NetworkManager, not QEMU.
+        netdev_arg = (
+            f"tap,id=net0,ifname={vm_info.network.tap_device},script=no,downscript=no"
         )
-    netdev_arg = f"user,id=net0,dns={QEMU_SLIRP_DNS},{','.join(hostfwd_rules)}"
+    else:
+        hostfwd_rules = [f"hostfwd=tcp:127.0.0.1:{vm_info.network.ssh_host_port}-:22"]
+        for forward in vm_info.config.port_forwards:
+            hostfwd_rules.append(
+                f"hostfwd=tcp:{forward.host_address}:{forward.host_port}-:{forward.guest_port}"
+            )
+        netdev_arg = f"user,id=net0,dns={QEMU_SLIRP_DNS},{','.join(hostfwd_rules)}"
 
     cmd: list[str] = [
         str(qemu_bin),

--- a/src/smolvm/types.py
+++ b/src/smolvm/types.py
@@ -309,6 +309,10 @@ class VMConfig(BaseModel):
         ssh_capable: Whether this boot path is expected to start guest SSH
             without relying on ``init=/init``.
         backend: Optional runtime backend override ("firecracker", "qemu", or "libkrun").
+        qemu_network: QEMU backend networking mode — ``"slirp"`` (default,
+            userspace NAT + host port forwards) or ``"tap"`` (host TAP device
+            under the shared nftables NAT/isolation rules). Ignored by non-QEMU
+            backends.
         disk_mode: Disk lifecycle mode:
             - ``"isolated"`` (default): clone rootfs per VM for sandbox isolation.
             - ``"shared"``: boot directly from ``rootfs_path``.

--- a/src/smolvm/types.py
+++ b/src/smolvm/types.py
@@ -347,6 +347,7 @@ class VMConfig(BaseModel):
     boot_args: str = "console=ttyS0 reboot=k panic=1 pci=off"
     ssh_capable: bool = False
     backend: str | None = None
+    qemu_network: Literal["slirp", "tap"] = "slirp"
     disk_mode: Literal["isolated", "shared"] = "isolated"
     retain_disk_on_delete: bool = False
     env_vars: dict[str, str] = {}

--- a/src/smolvm/vm.py
+++ b/src/smolvm/vm.py
@@ -928,6 +928,24 @@ class SmolVMManager:
         logger.info("VM %s will use vsock control channel (CID %d)", config.vm_id, cid)
         return self.state.update_vm(config.vm_id, config=updated)
 
+    @staticmethod
+    def _uses_host_tap_networking(config: VMConfig, backend: str) -> bool:
+        """Whether a VM is wired to a host TAP device (vs userspace slirp).
+
+        Firecracker always uses a host TAP. QEMU uses one only when the
+        config opts in via ``qemu_network='tap'`` — the default stays slirp
+        so the macOS/dev path is unchanged. libkrun never uses a host TAP.
+        TAP-mode VMs get a real routable IP and fall under the shared
+        nftables NAT/isolation rules (egress masquerade, cross-sandbox drop,
+        IMDS block); slirp VMs rely on QEMU userspace NAT + host port
+        forwards instead.
+        """
+        if backend == BACKEND_FIRECRACKER:
+            return True
+        if backend == BACKEND_QEMU:
+            return config.qemu_network == "tap"
+        return False
+
     def create(self, config: VMConfig) -> VMInfo:
         """Create a new microVM.
 
@@ -978,7 +996,7 @@ class SmolVMManager:
         try:
             ssh_host_port = self.state.reserve_ssh_port(effective_config.vm_id)
 
-            if backend in {BACKEND_QEMU, BACKEND_LIBKRUN}:
+            if not self._uses_host_tap_networking(effective_config, backend):
                 if (
                     effective_config.internet_settings is not None
                     and not effective_config.internet_settings.is_allow_all_domains
@@ -1057,6 +1075,13 @@ class SmolVMManager:
 
             # Update VM with network info
             vm_info = self.state.update_vm(effective_config.vm_id, network=network_config)
+
+            # QEMU-on-TAP still uses the vsock control channel (unique per-host
+            # CID reserved from state). Firecracker manages its own vsock via
+            # the VsockConfig passed directly in the VM config, so this is a
+            # no-op there.
+            if backend == BACKEND_QEMU:
+                vm_info = self._maybe_enable_vsock(effective_config, backend, vm_info)
 
             logger.info(
                 "VM created: %s (IP: %s, TAP: %s)",
@@ -2082,7 +2107,17 @@ class SmolVMManager:
             else:
                 ssh_host_port = self.state.get_ssh_port(vm_id)
 
-            if backend == BACKEND_FIRECRACKER and ssh_host_port is not None and guest_ip:
+            # Firecracker and QEMU-on-TAP both provision host TAP/NAT/ssh-forward
+            # resources; slirp-mode QEMU and libkrun do not. When vm_info is gone
+            # (early-failure cleanup), an IP lease is the tell that a TAP existed.
+            if vm_info is not None:
+                uses_tap = self._uses_host_tap_networking(vm_info.config, backend)
+            else:
+                uses_tap = backend == BACKEND_FIRECRACKER or (
+                    backend == BACKEND_QEMU and lease is not None
+                )
+
+            if uses_tap and ssh_host_port is not None and guest_ip:
                 with suppress(Exception):
                     self.network.cleanup_ssh_port_forward(
                         vm_id=vm_id,
@@ -2099,8 +2134,8 @@ class SmolVMManager:
             if lease:
                 _, tap_device = lease
 
-                if backend == BACKEND_FIRECRACKER:
-                    # Cleanup Linux TAP/NAT only for Firecracker backend.
+                if uses_tap:
+                    # Tear down host TAP/NAT for backends that provisioned it.
                     with suppress(Exception):
                         self.network.remove_egress_rules(tap_device)
                     self.network.cleanup_nat_rules(tap_device)
@@ -2194,7 +2229,7 @@ class SmolVMManager:
         try:
             ssh_host_port = self.state.reserve_ssh_port(effective_config.vm_id)
 
-            if backend in {BACKEND_QEMU, BACKEND_LIBKRUN}:
+            if not self._uses_host_tap_networking(effective_config, backend):
                 if (
                     effective_config.internet_settings is not None
                     and not effective_config.internet_settings.is_allow_all_domains
@@ -2255,6 +2290,12 @@ class SmolVMManager:
                 ssh_host_port=ssh_host_port,
             )
             vm_info = self.state.update_vm(effective_config.vm_id, network=network_config)
+
+            # QEMU-on-TAP still uses the vsock control channel (see the sync
+            # create path for the rationale). No-op for Firecracker.
+            if backend == BACKEND_QEMU:
+                vm_info = self._maybe_enable_vsock(effective_config, backend, vm_info)
+
             return vm_info
 
         except Exception as e:
@@ -2532,7 +2573,15 @@ class SmolVMManager:
             else:
                 ssh_host_port = self.state.get_ssh_port(vm_id)
 
-            if backend == BACKEND_FIRECRACKER and ssh_host_port is not None and guest_ip:
+            # See the sync cleanup path for the TAP-vs-slirp rationale.
+            if vm_info is not None:
+                uses_tap = self._uses_host_tap_networking(vm_info.config, backend)
+            else:
+                uses_tap = backend == BACKEND_FIRECRACKER or (
+                    backend == BACKEND_QEMU and lease is not None
+                )
+
+            if uses_tap and ssh_host_port is not None and guest_ip:
                 with suppress(Exception):
                     await self.network.async_cleanup_ssh_port_forward(
                         vm_id=vm_id,
@@ -2546,7 +2595,7 @@ class SmolVMManager:
             if lease:
                 _, tap_device = lease
 
-                if backend == BACKEND_FIRECRACKER:
+                if uses_tap:
                     with suppress(Exception):
                         await self.network.async_remove_egress_rules(tap_device)
                     await self.network.async_cleanup_nat_rules(tap_device)

--- a/src/smolvm/vm.py
+++ b/src/smolvm/vm.py
@@ -2109,13 +2109,13 @@ class SmolVMManager:
 
             # Firecracker and QEMU-on-TAP both provision host TAP/NAT/ssh-forward
             # resources; slirp-mode QEMU and libkrun do not. When vm_info is gone
-            # (early-failure cleanup), an IP lease is the tell that a TAP existed.
+            # (early-failure cleanup) the IP lease is the definitive tell that a
+            # TAP existed — `backend` is the manager default and may not match
+            # the VM's real backend, so we can't rely on it here.
             if vm_info is not None:
                 uses_tap = self._uses_host_tap_networking(vm_info.config, backend)
             else:
-                uses_tap = backend == BACKEND_FIRECRACKER or (
-                    backend == BACKEND_QEMU and lease is not None
-                )
+                uses_tap = lease is not None
 
             if uses_tap and ssh_host_port is not None and guest_ip:
                 with suppress(Exception):
@@ -2573,13 +2573,12 @@ class SmolVMManager:
             else:
                 ssh_host_port = self.state.get_ssh_port(vm_id)
 
-            # See the sync cleanup path for the TAP-vs-slirp rationale.
+            # See the sync cleanup path for the TAP-vs-slirp rationale. When
+            # vm_info is gone the IP lease is the definitive tell a TAP existed.
             if vm_info is not None:
                 uses_tap = self._uses_host_tap_networking(vm_info.config, backend)
             else:
-                uses_tap = backend == BACKEND_FIRECRACKER or (
-                    backend == BACKEND_QEMU and lease is not None
-                )
+                uses_tap = lease is not None
 
             if uses_tap and ssh_host_port is not None and guest_ip:
                 with suppress(Exception):

--- a/tests/test_qemu_args.py
+++ b/tests/test_qemu_args.py
@@ -449,3 +449,64 @@ def test_windows_argv_missing_swtpm_socket_raises(tmp_path: Path) -> None:
             swtpm_socket=None,
             host_system="Linux",
         )
+
+
+def _tap_vm_info(tmp_path: Path, *, ssh_host_port: int | None = None) -> VMInfo:
+    """A Linux QEMU VMInfo wired for host-TAP networking."""
+    base = _qemu_vm_info(tmp_path)
+    config = base.config.model_copy(update={"qemu_network": "tap"})
+    network = base.network.model_copy(
+        update={
+            "tap_device": "tap5",
+            "guest_ip": "172.16.0.5",
+            "ssh_host_port": ssh_host_port,
+        }
+    )
+    return base.model_copy(update={"config": config, "network": network})
+
+
+def test_build_qemu_argv_tap_mode_emits_tap_netdev(tmp_path: Path) -> None:
+    """qemu_network='tap' attaches the host TAP and drops slirp/hostfwd."""
+    vm = _tap_vm_info(tmp_path, ssh_host_port=2200)
+    cmd = build_qemu_argv(
+        vm,
+        qemu_bin=Path("/usr/bin/qemu-system-x86_64"),
+        boot_args="console=ttyS0 root=/dev/vda rw init=/init",
+        platform_spec=_LINUX_SPEC,
+        host_system="Linux",
+    )
+    joined = " ".join(cmd)
+    assert "tap,id=net0,ifname=tap5,script=no,downscript=no" in joined
+    assert "virtio-net-pci,netdev=net0,mac=52:54:00:12:34:56" in joined
+    # No userspace slirp NAT and no host port forwarding in tap mode.
+    assert "user,id=net0" not in joined
+    assert "hostfwd=" not in joined
+
+
+def test_build_qemu_argv_tap_mode_allows_no_ssh_host_port(tmp_path: Path) -> None:
+    """TAP mode does not require a reserved ssh_host_port (vsock control plane)."""
+    vm = _tap_vm_info(tmp_path, ssh_host_port=None)
+    # Must not raise despite ssh_host_port being None.
+    cmd = build_qemu_argv(
+        vm,
+        qemu_bin=Path("/usr/bin/qemu-system-x86_64"),
+        boot_args="console=ttyS0 root=/dev/vda rw init=/init",
+        platform_spec=_LINUX_SPEC,
+        host_system="Linux",
+    )
+    assert "tap,id=net0,ifname=tap5,script=no,downscript=no" in " ".join(cmd)
+
+
+def test_build_qemu_argv_slirp_still_requires_ssh_host_port(tmp_path: Path) -> None:
+    """Default (slirp) mode keeps requiring a reserved ssh_host_port."""
+    base = _qemu_vm_info(tmp_path)
+    network = base.network.model_copy(update={"ssh_host_port": None})
+    vm = base.model_copy(update={"network": network})
+    with pytest.raises(SmolVMError, match="ssh_host_port"):
+        build_qemu_argv(
+            vm,
+            qemu_bin=Path("/usr/bin/qemu-system-x86_64"),
+            boot_args="console=ttyS0 root=/dev/vda rw",
+            platform_spec=_LINUX_SPEC,
+            host_system="Linux",
+        )


### PR DESCRIPTION
## What

Adds an opt-in `qemu_network='tap'` mode to the QEMU backend so QEMU VMs can use a host TAP device + the existing nftables NAT/isolation machinery, at parity with the Firecracker backend. The default stays `slirp`, so the macOS/dev path is byte-identical and this ships dark.

## Why

QEMU VMs previously had only userspace slirp NAT + SSH host-port forwards. slirp traffic never traverses a `tap*` interface, so it bypasses the nftables rules the Firecracker backend relies on — egress masquerade, the `tap*→tap*` cross-sandbox drop, and the IMDS (169.254.169.254) block. That made the QEMU backend unsuitable for multi-tenant untrusted Linux prod. This is the SmolVM half of bringing a production QEMU backend to Celesto at Firecracker parity (GPU/Windows/long-running headroom comes later on this same path).

## Changes

- **`build_qemu_argv`**: in tap mode emit `-netdev tap,ifname=<tap>,script=no,downscript=no` (+ existing `virtio-net-pci`) instead of `-netdev user` + hostfwd; drop the hard `ssh_host_port` requirement in tap mode (vsock carries the control plane). slirp path unchanged.
- **`create()` / async `create()`**: route QEMU-on-TAP through the same IP-allocate + `create_tap` + `setup_nat` path as Firecracker via a new `_uses_host_tap_networking()` predicate, and reserve a unique per-host vsock CID.
- **`_cleanup_resources()` / async**: tear down TAP/NAT for any host-TAP backend, not just Firecracker.
- **`VMConfig.qemu_network`** field (`slirp` default).

The guest gets its IP from the existing `ip=` kernel boot-arg injection and falls under the shared nft isolation rules with **no rule changes**.

## Tests

New unit tests cover tap-netdev emission, no-ssh-port tap boots, and the slirp `ssh_host_port` guard. Existing QEMU/lifecycle/network/vsock/cleanup suites stay green (98 passed locally).

## Validation

argv assembly + create/cleanup wiring is unit-tested. Actual boot / TAP egress / cross-sandbox isolation / IMDS-block needs a KVM host and is validated downstream before the consuming flag is flipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an optional TAP networking mode for QEMU VMs to support host-side TAP networking.

* **Bug Fixes**
  * Improved network validation and clearer error handling for SLIRP vs TAP configurations.

* **Tests**
  * Added tests covering TAP mode behavior and validation differences between networking modes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->