### PR TITLE
Fix 8s QEMU sandbox startup + boot-latency improvements

### DIFF
--- a/docs/benchmarks/boot-latency-learnings.md
+++ b/docs/benchmarks/boot-latency-learnings.md
@@ -1,8 +1,16 @@
 # SmolVM boot-latency learnings (QEMU vs Firecracker)
 
-Investigation into "time to create a VM and run a command" for the two Linux
-backends. All numbers measured on one Linux host with KVM, 16 vCPUs, an Alpine
-guest (1 vCPU / 512 MB), running `echo hello`. Scripts live under `scripts/`:
+**Takeaway:** out of the box, Firecracker gets you to your first command faster
+than QEMU — but only because QEMU's default was hitting an 8-second bug (now
+fixed). Once that's removed, both reach a usable sandbox in ~1.2–1.4 seconds,
+and almost all of that time is the guest operating system starting up, not the
+choice of virtual-machine engine. That matters because it tells you where to
+spend effort to make sandboxes start faster: in the guest, not the hypervisor.
+
+## Test setup
+
+Numbers measured on one Linux host with KVM, 16 CPUs, an Alpine Linux guest
+(1 CPU / 512 MB), running `echo hello`. Scripts live under `scripts/`:
 `bench_backends.py`, `profile_boot.py`, `exp_vsock_trim.py`, `exp_userspace.py`.
 
 > **Methodology note.** SmolVM's `.start()` returns as soon as the hypervisor

--- a/docs/benchmarks/boot-latency-learnings.md
+++ b/docs/benchmarks/boot-latency-learnings.md
@@ -1,0 +1,169 @@
+# SmolVM boot-latency learnings (QEMU vs Firecracker)
+
+Investigation into "time to create a VM and run a command" for the two Linux
+backends. All numbers measured on one Linux host with KVM, 16 vCPUs, an Alpine
+guest (1 vCPU / 512 MB), running `echo hello`. Scripts live under `scripts/`:
+`bench_backends.py`, `profile_boot.py`, `exp_vsock_trim.py`, `exp_userspace.py`.
+
+> **Methodology note.** SmolVM's `.start()` returns as soon as the hypervisor
+> *process* is up — it does **not** wait for the guest to finish booting. The
+> guest boot (kernel + init + sshd/agent) happens during the *first command*,
+> while the SDK waits for the control channel. So the only honest headline
+> metric is **TOTAL → interact** = create + launch + first-command (wall-clock
+> from nothing to a command returning). Splitting the phases flatters whichever
+> backend defers more work.
+
+## Headline numbers
+
+| Configuration | create | launch | first cmd | **TOTAL→interact** | warm cmd |
+|---|---:|---:|---:|---:|---:|
+| Firecracker, SSH (default image) | 135 | 121 | 1337 | **1594 ms** | 43 |
+| QEMU, SSH (default image) | 9 | 53 | 1879 | **1940 ms** | 42 |
+| QEMU, vsock (default boot) | 11 | 53 | 1507 | **1571 ms** | 1 |
+| QEMU, vsock + trimmed boot | 11 | 54 | 1278 | **1343 ms** | 1 |
+
+All in milliseconds. Variance was tiny (stdev ≤ 2 ms per phase, except
+Firecracker's first-command at ±72 ms).
+
+## Finding 1 — Firecracker is faster to a usable VM, not slower
+
+Out of the box (each backend's default guest), Firecracker reaches an
+interactive command in **~1.59 s vs QEMU's ~1.94 s** — ~350 ms (18%) quicker,
+and that is on Firecracker's *unprivileged* network path (it prints "Using the
+slower networking path… Run with sudo to use the faster path."). With `sudo`
+its create/launch overhead would shrink further.
+
+An earlier draft wrongly reported QEMU as faster — that was an artifact of
+quoting the create+launch sub-phases (tens of ms) instead of the end-to-end
+total. The hypervisor's own overhead is <10% of the wall-clock; **~95% is the
+guest booting.**
+
+## Finding 2 — the bottleneck is guest boot, dominated by userspace
+
+Breaking the ~1.5 s first-command into real sub-steps (`profile_boot.py`):
+
+- **create + launch**: 60–260 ms (hypervisor only).
+- **guest kernel boot**: ~1.0–1.2 s of in-kernel time (last printk).
+- **userspace init** (host-key generation + sshd/agent startup): the rest.
+- **SSH handshake + auth**: ~68 ms.
+- **command exec**: 3–43 ms.
+
+QEMU's guest takes ~250 ms longer to reach userspace than Firecracker's because
+it emulates more devices the kernel must probe (biggest single stall:
+`ata1: SATA link down`, ~260 ms; plus ACPI, PS/2, VGA). Firecracker's lean
+virtio-only model (`pci=off`, no SATA/VGA) avoids most of it — which is the
+whole point of a microVM.
+
+## Finding 3 — vsock helps, but is QEMU-only and needs python3 in the image
+
+`comm_channel="vsock"` uses a persistent guest agent instead of SSH.
+
+- **first command**: ~370 ms faster (1879 → 1507) — skips the SSH handshake and
+  first-boot host-key generation.
+- **warm command**: **42 ms → 1 ms** (~40× faster). This is the biggest single
+  win for command-heavy workloads: SSH pays a fresh exec round-trip per command;
+  the vsock agent is a kept-open connection.
+
+Two real blockers found:
+
+1. **QEMU-only today.** `comm/select.py` gates vsock to the QEMU backend;
+   requesting it on Firecracker raises. QEMU uses native `AF_VSOCK` over the
+   host's `/dev/vhost-vsock`; Firecracker multiplexes vsock over a host Unix
+   socket whose host-side bridge client SmolVM hasn't implemented.
+2. **Default image can't run the agent.** The auto-config image
+   (`ImageBuilder.build_alpine_ssh_key`) installs `openssh iproute2 curl bash`
+   but **no `python3`**. The guest agent is a Python script that `/init` only
+   launches `if command -v python3`. No python3 → agent never starts → vsock
+   times out and (in auto mode) silently falls back to SSH. The password-auth
+   recipe (`build_alpine_ssh`) *does* install python3, which is what made vsock
+   measurable here. **This looks like a latent bug worth filing:** the default
+   image bakes the agent binary but omits its runtime.
+
+Host requirement (present on this machine): `vhost_vsock` module loaded and
+`/dev/vhost-vsock` available.
+
+## Finding 4 — boot-cmdline trimming: real but smaller than it first looked
+
+Adding `acpi=off quiet no_timer_check tsc=reliable` dropped the kernel's
+*last printk* from ~1.15 s to ~0.41 s — but **most of that is a measurement
+artifact**: `quiet` suppresses late printks, so "last printk" understates true
+boot time. The ground-truth `SMOLVM_TS` uptime markers baked into `/init` show
+userspace actually starting at ~0.87 s (trimmed) vs ~0.94 s (default) — a real
+saving of **~70 ms**, mostly from `acpi=off` skipping ACPI/device probing.
+Total-to-interact still improved (1571 → 1343, ~230 ms) because `quiet` also
+cuts time spent formatting console output over the serial line.
+
+Caveat: `acpi=off` is safe for this minimal headless virtio guest but not
+universally (some setups need ACPI for clean shutdown / IRQ routing); validate
+per image before defaulting it.
+
+## Userspace timeline (ground truth, from `SMOLVM_TS` markers)
+
+Default boot, SSH path:
+
+```
+0.94s  kernel boot done / mounts-ready
+0.95s  net-ready            (+10ms)
+0.96s  guest-agent-started  (+10ms)   <- vsock becomes answerable here
+0.96s  ssh-hostkey-check-start
+1.15s  ssh-hostkey-check-done (+190ms) <- ssh-keygen -A, runs EVERY boot
+1.16s  sshd-invoked         (+10ms)    <- SSH becomes answerable here
+```
+
+Key insight: the Dockerfile deletes host keys (`rm -f /etc/ssh/ssh_host_*`) so
+`/init` regenerates them on **every** boot — a fixed **~120–190 ms** tax on the
+SSH critical path. vsock skips it entirely (agent is ready at 0.96 s, before
+keygen). This is the lever Experiment C targets.
+
+## Finding 5 (Experiment C) — the SSH bottleneck is host-side, not the guest
+
+Baking SSH host keys at build time (so `/init` skips `ssh-keygen -A`):
+
+| Cell | keygen in guest | guest sshd ready | **TOTAL→interact** |
+|---|---:|---:|---:|
+| C0 baseline (keygen each boot) | 123 ms | 1.10 s uptime | **1941 ms** |
+| C1 baked host keys | 8 ms | 1.00 s uptime | **1940 ms** |
+
+Baking keys made the **guest** ready ~100 ms sooner — but **total time-to-interact
+did not move (1941 → 1940 ms).** The guest is not the bottleneck on the SSH path.
+
+A tight-polling probe (10 ms) showed real SSH auth succeeds at **~1601 ms** after
+launch, while the SDK reports **~1878 ms**. So on the SSH path the wall-clock is
+set by the **host-side wait loop**, not guest readiness:
+
+- The SDK's `SSHClient.wait_for_ssh` Phase-2 connect loop polls every **200 ms**
+  (`time.sleep(min(0.2, remaining))`), adding up to ~280 ms of pure slack.
+- QEMU's user-mode NAT forwarder accepts the host's TCP connection *immediately*
+  (before guest sshd is really up), so the fast TCP probe returns instantly and
+  the real wait is hidden in repeated paramiko handshake retries against a
+  not-yet-ready sshd.
+
+This is exactly why **vsock wins**: it bypasses the SSH wait loop entirely and
+becomes answerable the moment the agent starts (~0.9 s uptime). Guest-side
+userspace trims (baked keys) only pay off once the host-side wait is also tight
+or replaced by vsock.
+
+## Finding 6 — default QEMU auto-config has an 8-second vsock-probe penalty
+
+The most severe issue found. On the QEMU backend, the channel selector
+*auto-prefers* vsock with SSH fallback (`vsock_possible = is_qemu and …`). But
+the default auto-config image lacks python3, so the agent never answers. The
+host then waits the full `_VSOCK_AUTO_PROBE_TIMEOUT = 8.0 s` before falling back
+to SSH:
+
+```
+QEMU auto-config (default), first command: 8066 ms   <- 8s vsock probe + SSH
+QEMU explicit comm_channel="ssh", first command: 1876 ms
+```
+
+So the real out-of-box QEMU number is **~8.1 s to interact**, not ~1.9 s — the
+earlier ~1.9 s figures were taken with vsock-capable or explicit-SSH paths.
+Two independent bugs compound here:
+
+1. Default image bakes the agent but omits its python3 runtime (Finding 3).
+2. Auto-mode pays an 8 s timeout discovering that, every single boot.
+
+Mitigations (any one fixes it): ship python3 in the default image; or shorten
+the auto vsock probe; or have auto-mode skip vsock when the image has no agent;
+or default QEMU auto-config to `comm_channel="ssh"`.
+```

--- a/docs/benchmarks/final-report.md
+++ b/docs/benchmarks/final-report.md
@@ -14,28 +14,39 @@ cell after an untimed warm-up; variance was small. Scripts: `scripts/exp_final.p
 
 ## Before / After
 
-Measured before and after the fixes on branch `perf/boot-latency-fixes`.
+Same machine, same 5-run methodology, out-of-box defaults (`SmolVM(backend=...)`
+with no forced channel). BEFORE measured on `main`, AFTER on
+`perf/boot-latency-fixes`; only the code differs. Image cache busted between
+runs so each builds its own image.
 
 | Configuration | create | launch | first cmd | **TOTAL→interact** | warm cmd |
 |---|---:|---:|---:|---:|---:|
-| **BEFORE** — QEMU default (true out-of-box) | 12 | 53 | 8068 | **8133 ms** | 42 |
-| BEFORE — Firecracker default (SSH) | 135 | 121 | 1223 | **1479 ms** | 43 |
-| **AFTER** — QEMU default (now vsock + trimmed boot) | 11 | 53 | 1276 | **1340 ms** | **1.3** |
-| AFTER — QEMU explicit SSH (Firecracker-style path) | 12 | 53 | 1120 | **1184 ms** | 1.1* |
+| **BEFORE** — QEMU default (true out-of-box) | 12 | 54 | 8068 | **8134 ms** | 42.2 |
+| **AFTER** — QEMU default (now vsock + trimmed boot) | 11 | 53 | 1114 | **1177 ms** | **1.0** |
+| BEFORE — Firecracker default (SSH) | 133 | 122 | 1391 | **1645 ms** | 42.6 |
+| AFTER — Firecracker default (SSH) | 145 | 121 | 1142 | **1408 ms** | 42.7 |
 
-All values milliseconds, mean of 5 runs. *The explicit-SSH cell auto-upgrades
-to vsock for *commands* once connected, hence the ~1ms warm — the 1184 ms is
-the SSH-gated first-command path now benefiting from the tightened poll (Q4).
+All values milliseconds, mean of 5 runs.
+
+On `main`, QEMU "resolves" to vsock but the agent can't run (no python3 in the
+image), so it burns the full 8 s probe then silently falls back to SSH — hence
+`warm=42 ms` despite the channel reading vsock. On the branch, vsock genuinely
+works (`warm=1.0 ms`).
+
+> Firecracker ran on its unprivileged "slower networking path" in both runs (no
+> passwordless sudo), inflating its create/launch equally on both sides — the
+> *delta* is still a fair comparison.
 
 ### Headline
 
-- **The QEMU default went from 8133 ms → 1340 ms — 6.1× faster** (−6.79 s). The
+- **The QEMU default went from 8134 ms → 1177 ms — 6.9× faster** (−6.96 s). The
   default `SmolVM(backend="qemu")` no longer pays the 8-second vsock probe.
-- **Warm commands: 42 ms → ~1.3 ms (~32×)** now that vsock is the working
+- **Warm commands: 42 ms → 1.0 ms (~42×)** now that vsock is the working
   default — this dominates any multi-command (agentic) workload.
-- The SSH path that **Firecracker** still depends on also got faster: the
-  tightened poll (Q4) trims ~210 ms off first-command (measured ~1878 → ~1669 ms
-  in isolation).
+- The SSH path that **Firecracker** still depends on also got faster:
+  **1645 ms → 1408 ms (1.17×)**, ~240 ms off first-command from the tightened
+  poll (Q4) plus the boot trims (Q3). Its warm command stays ~42 ms because it's
+  still on SSH — the gap the (deferred) Firecracker-vsock bridge would close.
 
 ### What changed (4 commits)
 
@@ -79,7 +90,7 @@ answerable at ~0.9 s guest uptime.
 | **vsock instead of SSH** | first cmd −370 ms; warm cmd 42 → 1 ms (~28–40×) | QEMU-only today; needs python3 in the image |
 | **Trim boot cmdline** (`acpi=off quiet …`) | ~230 ms off total (~70 ms real boot + console savings) | `acpi=off` not universally safe; validate per image |
 | **Bake SSH host keys** | guest ready ~100 ms sooner | **0 ms** end-to-end on SSH — host wait loop hides it |
-| (host) tighten SSH poll < 200 ms | up to ~280 ms recoverable on SSH path | not yet changed; code lever, not config |
+| (host) tighten SSH poll < 200 ms | ~240 ms off the SSH-path first command | shipped in Q4; the AFTER numbers include this change |
 
 The two levers that actually moved the AFTER number are **vsock** and
 **boot trimming**. Baking host keys is only worth it once the host-side wait is

--- a/docs/benchmarks/final-report.md
+++ b/docs/benchmarks/final-report.md
@@ -1,0 +1,118 @@
+# SmolVM boot-latency: before / after report
+
+**Goal:** measure how long it takes to create a SmolVM sandbox and run a command,
+find the bottleneck, and improve it.
+
+**Setup:** one Linux host with KVM (16 vCPUs). Guest: Alpine, 1 vCPU / 512 MB.
+Workload: `echo hello`. Metric: **TOTAL→interact** = create + launch +
+first-command = wall-clock from nothing to a command returning. 5 timed runs per
+cell after an untimed warm-up; variance was small. Scripts: `scripts/exp_final.py`
+(headline), plus `bench_backends.py`, `profile_boot.py`, `exp_vsock_trim.py`,
+`exp_userspace.py`. Full reasoning in `boot-latency-learnings.md`.
+
+---
+
+## Before / After
+
+Measured before and after the fixes on branch `perf/boot-latency-fixes`.
+
+| Configuration | create | launch | first cmd | **TOTAL→interact** | warm cmd |
+|---|---:|---:|---:|---:|---:|
+| **BEFORE** — QEMU default (true out-of-box) | 12 | 53 | 8068 | **8133 ms** | 42 |
+| BEFORE — Firecracker default (SSH) | 135 | 121 | 1223 | **1479 ms** | 43 |
+| **AFTER** — QEMU default (now vsock + trimmed boot) | 11 | 53 | 1276 | **1340 ms** | **1.3** |
+| AFTER — QEMU explicit SSH (Firecracker-style path) | 12 | 53 | 1120 | **1184 ms** | 1.1* |
+
+All values milliseconds, mean of 5 runs. *The explicit-SSH cell auto-upgrades
+to vsock for *commands* once connected, hence the ~1ms warm — the 1184 ms is
+the SSH-gated first-command path now benefiting from the tightened poll (Q4).
+
+### Headline
+
+- **The QEMU default went from 8133 ms → 1340 ms — 6.1× faster** (−6.79 s). The
+  default `SmolVM(backend="qemu")` no longer pays the 8-second vsock probe.
+- **Warm commands: 42 ms → ~1.3 ms (~32×)** now that vsock is the working
+  default — this dominates any multi-command (agentic) workload.
+- The SSH path that **Firecracker** still depends on also got faster: the
+  tightened poll (Q4) trims ~210 ms off first-command (measured ~1878 → ~1669 ms
+  in isolation).
+
+### What changed (4 commits)
+
+| # | Change | Effect measured |
+|---|---|---|
+| Q1 | python3 in auto-config image → vsock agent runs | first cmd 8066 → 1509 ms; warm 42 → 1.0 ms |
+| Q2 | vsock auto-probe 8s → 2.5s (guardrail for agent-less images) | agent-less fallback 8066 → 2567 ms |
+| Q3 | default safe boot trims (`tsc=reliable no_timer_check quiet`) | ~150–230 ms; `acpi=off` left opt-in |
+| Q4 | SSH wait loop 200ms fixed → 20ms exp backoff | SSH first cmd ~1878 → ~1669 ms |
+
+> The "BEFORE QEMU" cell was not a strawman — it is what `SmolVM(backend="qemu")`
+> did before this branch, dominated by the 8-second agent-probe bug (Q1/Q2).
+
+---
+
+## Where the time went (and the bottleneck)
+
+Decomposing the ~1.5 s first-command:
+
+1. **Hypervisor (create + launch):** 60–260 ms. Not the bottleneck.
+2. **Guest kernel boot:** ~0.9–1.0 s of guest uptime to reach userspace.
+3. **Userspace init:** networking (~10 ms), then on the SSH path SSH host-key
+   generation (~120 ms) + sshd start.
+4. **Host-side control-channel wait:** the real SSH bottleneck — see below.
+5. **Command exec:** 3–43 ms.
+
+**The bottleneck is not the hypervisor and not even the guest — for the SSH
+channel it is the host-side wait loop.** Experiment C proved this: baking SSH
+host keys made the guest ready ~100 ms sooner (keygen 123 → 8 ms) yet
+**total time-to-interact did not change** (1941 → 1940 ms). A tight 10 ms probe
+showed SSH actually answers at ~1601 ms while the SDK's 200 ms-cadence loop
+reports ~1878 ms. vsock wins by **bypassing that loop entirely** — its agent is
+answerable at ~0.9 s guest uptime.
+
+---
+
+## What each lever was worth
+
+| Lever | Effect | Caveat |
+|---|---|---|
+| **vsock instead of SSH** | first cmd −370 ms; warm cmd 42 → 1 ms (~28–40×) | QEMU-only today; needs python3 in the image |
+| **Trim boot cmdline** (`acpi=off quiet …`) | ~230 ms off total (~70 ms real boot + console savings) | `acpi=off` not universally safe; validate per image |
+| **Bake SSH host keys** | guest ready ~100 ms sooner | **0 ms** end-to-end on SSH — host wait loop hides it |
+| (host) tighten SSH poll < 200 ms | up to ~280 ms recoverable on SSH path | not yet changed; code lever, not config |
+
+The two levers that actually moved the AFTER number are **vsock** and
+**boot trimming**. Baking host keys is only worth it once the host-side wait is
+also tightened (or replaced by vsock).
+
+---
+
+## Bugs found (worth filing)
+
+1. **8-second vsock-probe penalty on QEMU defaults.** QEMU auto-config
+   auto-prefers vsock with SSH fallback, but the default image has no python3 to
+   run the agent, so every boot waits the full 8 s probe before falling back to
+   SSH. Out-of-box QEMU is ~8.1 s to interact, not ~1.9 s.
+2. **Default image ships the agent without its runtime.** `build_alpine_ssh_key`
+   (auto-config) bakes `/usr/local/bin/smolvm-guest-agent` but installs no
+   python3, so the agent can never start and vsock silently never works.
+3. **Firecracker can't use vsock at all** in this release (selector hard-gates
+   vsock to QEMU), despite the device being wired in the Firecracker adapter.
+
+Any one of these fixes for #1/#2 (ship python3, shorten the probe, skip vsock
+when no agent, or default QEMU to SSH) would restore QEMU's out-of-box number to
+the ~1.9 s SSH path; vsock + trim then takes it to ~1.35 s.
+
+---
+
+## Recommendations
+
+1. **Fix the 8 s penalty first** — it is the single biggest real-world win
+   (6.8 s) and is pure bug, not tuning.
+2. **Ship python3 in the default image** so vsock works out of the box; then make
+   vsock the default channel on QEMU.
+3. **Adopt the trimmed boot cmdline** (after per-image validation of `acpi=off`).
+4. **Tighten the host-side SSH wait loop** (sub-200 ms cadence) for the SSH path
+   that Firecracker still depends on.
+5. **Implement the Firecracker vsock host bridge** to bring the warm-command and
+   first-command wins to the default Linux backend.

--- a/scripts/bench_backends.py
+++ b/scripts/bench_backends.py
@@ -1,0 +1,164 @@
+"""Benchmark SmolVM QEMU vs Firecracker backends.
+
+Same guest OS (Alpine) on both backends to isolate the hypervisor.
+Per backend, over N timed iterations, measures (seconds):
+  create     : build config + SmolVM(config=...) (registers VM, materializes rootfs overlay)
+  boot       : .start() until the VM is running
+  first_cmd  : first vm.run() — includes waiting for SSH = "time to interact"
+  warm_cmd   : mean latency of subsequent vm.run() calls in the same VM
+
+Explicit unique VM names (bench-<backend>-<n>) avoid the auto-namer.
+A warm-up iteration per backend (untimed) builds/downloads any missing
+image artifacts so those costs don't land in the timings.
+"""
+
+from __future__ import annotations
+
+import json
+import statistics as st
+import time
+import traceback
+
+from smolvm import SmolVM
+from smolvm.facade import _build_auto_config
+
+OS = "alpine"
+ITERS = 5
+WARM_RUNS = 5
+CMD = "echo hello"
+
+_counter = 0
+
+
+def _unique_name(backend: str) -> str:
+    global _counter
+    _counter += 1
+    return f"bench-{backend}-{_counter}"
+
+
+def time_one(backend: str) -> dict:
+    """One full create->boot->run->stop cycle; returns phase timings (seconds)."""
+    rec: dict = {}
+    vm = None
+    try:
+        name = _unique_name(backend)
+        t0 = time.perf_counter()
+        config, key = _build_auto_config(vm_name=name, os=OS, backend=backend)
+        vm = SmolVM(config=config, ssh_key_path=key)
+        rec["create"] = time.perf_counter() - t0
+
+        t0 = time.perf_counter()
+        vm.start()
+        rec["boot"] = time.perf_counter() - t0
+
+        t0 = time.perf_counter()
+        vm.run(CMD)
+        rec["first_cmd"] = time.perf_counter() - t0
+
+        warm = []
+        for _ in range(WARM_RUNS):
+            t0 = time.perf_counter()
+            vm.run(CMD)
+            warm.append(time.perf_counter() - t0)
+        rec["warm"] = warm
+    finally:
+        if vm is not None:
+            try:
+                vm.stop()
+            except Exception:
+                pass
+            try:
+                vm.delete()
+            except Exception:
+                pass
+    return rec
+
+
+def bench(backend: str) -> dict:
+    print(f"== {backend}: warm-up (untimed) ==", flush=True)
+    try:
+        time_one(backend)
+    except Exception as e:
+        print(f"  warm-up failed: {e}", flush=True)
+        traceback.print_exc()
+
+    create, boot, first, warm = [], [], [], []
+    errors = []
+    for i in range(ITERS):
+        try:
+            r = time_one(backend)
+            create.append(r["create"])
+            boot.append(r["boot"])
+            first.append(r["first_cmd"])
+            warm.extend(r["warm"])
+            print(
+                f"  [{backend}] {i + 1}/{ITERS}  "
+                f"create={r['create'] * 1000:.0f}ms boot={r['boot'] * 1000:.0f}ms "
+                f"first={r['first_cmd'] * 1000:.0f}ms",
+                flush=True,
+            )
+        except Exception as e:
+            errors.append(str(e))
+            traceback.print_exc()
+
+    def summ(v):
+        return None if not v else {
+            "n": len(v),
+            "min": min(v),
+            "mean": st.mean(v),
+            "median": st.median(v),
+            "stdev": st.stdev(v) if len(v) > 1 else 0.0,
+            "max": max(v),
+        }
+
+    return {
+        "backend": backend,
+        "os": OS,
+        "create": summ(create),
+        "boot": summ(boot),
+        "first_cmd": summ(first),
+        "warm_cmd": summ(warm),
+        "create_to_ready": summ([c + b for c, b in zip(create, boot)]),
+        # The honest end-to-end metric: nothing -> command returned.
+        "total_to_interact": summ([c + b + f for c, b, f in zip(create, boot, first)]),
+        "errors": errors,
+    }
+
+
+def main():
+    results = [bench("qemu"), bench("firecracker")]
+    with open("/tmp/bench_results.json", "w") as f:
+        json.dump(
+            {"iters": ITERS, "warm_runs": WARM_RUNS, "cmd": CMD, "results": results},
+            f,
+            indent=2,
+        )
+
+    def ms(s, k="mean"):
+        return f"{s[k] * 1000:.0f}" if s else "-"
+
+    print("\n=== RESULTS (ms, mean over timed iters) ===", flush=True)
+    cols = (
+        f"{'backend':<13}{'create':>9}{'launch':>9}{'first_cmd':>11}"
+        f"{'TOTAL->interact':>17}{'warm_cmd':>10}"
+    )
+    print(cols)
+    print("-" * len(cols))
+    for r in results:
+        print(
+            f"{r['backend']:<13}"
+            f"{ms(r['create']):>9}"
+            f"{ms(r['boot']):>9}"
+            f"{ms(r['first_cmd']):>11}"
+            f"{ms(r['total_to_interact']):>17}"
+            f"{ms(r['warm_cmd']):>10}"
+        )
+        if r["errors"]:
+            print(f"   errors ({len(r['errors'])}): {r['errors'][:2]}")
+    print("\n(create=ctor, launch=hypervisor up, first_cmd=wait-for-SSH+run,", flush=True)
+    print(" TOTAL->interact = create+launch+first_cmd = nothing -> command returned)", flush=True)
+    print("\nwrote /tmp/bench_results.json", flush=True)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/exp_final.py
+++ b/scripts/exp_final.py
@@ -63,17 +63,25 @@ def bench(label, make_vm) -> dict:
     try: cycle(make_vm)
     except Exception as e: print("  warmup err:", e, flush=True)
     runs = []
+    errors = []
     for i in range(N):
         try:
             r = cycle(make_vm); runs.append(r)
             print(f"  {i+1}/{N} create={r['create']*1000:.0f} launch={r['launch']*1000:.0f} "
                   f"first={r['first']*1000:.0f} warm={r['warm']*1000:.1f}", flush=True)
         except Exception as e:
+            errors.append(str(e))
             print(f"  {i+1}/{N} ERROR {e}", flush=True)
+    if not runs:
+        print(f"  [{label}] all {N} runs failed", flush=True)
+        return {"label": label, "n": 0, "errors": errors,
+                "create": None, "launch": None, "first": None,
+                "warm": None, "total": None}
     def m(k): return st.mean(x[k] for x in runs) * 1000
     total = m("create") + m("launch") + m("first")
     return {"label": label, "create": m("create"), "launch": m("launch"),
-            "first": m("first"), "warm": m("warm"), "total": total, "n": len(runs)}
+            "first": m("first"), "warm": m("warm"), "total": total,
+            "n": len(runs), "errors": errors}
 
 
 def main():
@@ -81,7 +89,12 @@ def main():
     print("Building python3 Alpine image for the AFTER cell...", flush=True)
     pk, pr = build_py_alpine()
     ba_default = get_boot_profile_spec(PROF).base_boot_args_for_backend("qemu", ARCH)
-    ba_trim = ba_default + " acpi=off quiet no_timer_check tsc=reliable"
+    # The default profile already carries tsc=reliable/no_timer_check/quiet
+    # (shipped in Q3); only append the delta this experiment tests (acpi=off).
+    _present = set(ba_default.split())
+    ba_trim = ba_default + "".join(
+        f" {flag}" for flag in ("acpi=off",) if flag not in _present
+    )
 
     def mk_default(backend):
         def f():
@@ -105,6 +118,9 @@ def main():
     h = f"{'configuration':<44}{'create':>8}{'launch':>8}{'first':>8}{'TOTAL':>8}{'warm':>7}"
     print(h); print("-" * len(h))
     for r in res:
+        if not r["n"]:
+            print(f"{r['label']:<44}  (all runs failed)")
+            continue
         print(f"{r['label']:<44}{r['create']:>8.0f}{r['launch']:>8.0f}{r['first']:>8.0f}"
               f"{r['total']:>8.0f}{r['warm']:>7.1f}")
     print("DONE", flush=True)

--- a/scripts/exp_final.py
+++ b/scripts/exp_final.py
@@ -1,0 +1,114 @@
+"""Final before/after: consolidate the winning levers.
+
+BEFORE: the actual out-of-box defaults
+  - Firecracker + SSH (Linux default backend, default Alpine image)
+  - QEMU + SSH (default image)
+AFTER: best stack on QEMU
+  - QEMU + vsock + trimmed boot args (needs python3 in image)
+
+5 timed runs each after 1 untimed warm-up. Headline = TOTAL->interact.
+"""
+
+from __future__ import annotations
+
+import platform
+import statistics as st
+import time
+
+from smolvm import SmolVM
+from smolvm.facade import _build_auto_config
+from smolvm.images.builder import ImageBuilder
+from smolvm.images.published import BASE_KERNELS, _kernel_format_for_vmm
+from smolvm.runtime.boot_profiles import (
+    KernelBootProfile,
+    get_boot_profile_spec,
+    to_published_arch,
+)
+from smolvm.types import VMConfig
+
+ARCH = platform.machine()
+PROF = KernelBootProfile.MICROVM_DIRECT
+N = 5
+_seq = 0
+
+
+def build_py_alpine():
+    b = ImageBuilder()
+    kurl = BASE_KERNELS[to_published_arch(ARCH)].url_for(_kernel_format_for_vmm("qemu"))
+    k, r = b.build_alpine_ssh(name="alpine-py-test", ssh_password="smolvm",
+                              rootfs_size_mb=512, kernel_profile=PROF, kernel_url=kurl)
+    return str(k), str(r)
+
+
+def cycle(make_vm) -> dict:
+    rec = {}
+    vm = None
+    try:
+        t0 = time.perf_counter(); vm = make_vm(); rec["create"] = time.perf_counter() - t0
+        t0 = time.perf_counter(); vm.start(); rec["launch"] = time.perf_counter() - t0
+        t0 = time.perf_counter(); vm.run("echo hello"); rec["first"] = time.perf_counter() - t0
+        warm = []
+        for _ in range(5):
+            t0 = time.perf_counter(); vm.run("echo hello"); warm.append(time.perf_counter() - t0)
+        rec["warm"] = sum(warm) / len(warm)
+    finally:
+        if vm is not None:
+            try: vm.stop(); vm.delete()
+            except Exception: pass
+    return rec
+
+
+def bench(label, make_vm) -> dict:
+    print(f"\n== {label}: warm-up ==", flush=True)
+    try: cycle(make_vm)
+    except Exception as e: print("  warmup err:", e, flush=True)
+    runs = []
+    for i in range(N):
+        try:
+            r = cycle(make_vm); runs.append(r)
+            print(f"  {i+1}/{N} create={r['create']*1000:.0f} launch={r['launch']*1000:.0f} "
+                  f"first={r['first']*1000:.0f} warm={r['warm']*1000:.1f}", flush=True)
+        except Exception as e:
+            print(f"  {i+1}/{N} ERROR {e}", flush=True)
+    def m(k): return st.mean(x[k] for x in runs) * 1000
+    total = m("create") + m("launch") + m("first")
+    return {"label": label, "create": m("create"), "launch": m("launch"),
+            "first": m("first"), "warm": m("warm"), "total": total, "n": len(runs)}
+
+
+def main():
+    global _seq
+    print("Building python3 Alpine image for the AFTER cell...", flush=True)
+    pk, pr = build_py_alpine()
+    ba_default = get_boot_profile_spec(PROF).base_boot_args_for_backend("qemu", ARCH)
+    ba_trim = ba_default + " acpi=off quiet no_timer_check tsc=reliable"
+
+    def mk_default(backend):
+        def f():
+            global _seq; _seq += 1
+            cfg, key = _build_auto_config(vm_name=f"fin-{backend}-{_seq}", os="alpine", backend=backend)
+            return SmolVM(config=cfg, ssh_key_path=key)
+        return f
+
+    def mk_after():
+        global _seq; _seq += 1
+        cfg = VMConfig(vm_id=f"fin-after-{_seq}", vcpu_count=1, memory=512,
+                       kernel_path=pk, rootfs_path=pr, boot_args=ba_trim, backend="qemu")
+        return SmolVM(config=cfg, comm_channel="vsock")
+
+    res = []
+    res.append(bench("BEFORE: Firecracker + SSH (Linux default)", mk_default("firecracker")))
+    res.append(bench("BEFORE: QEMU + SSH (default image)", mk_default("qemu")))
+    res.append(bench("AFTER:  QEMU + vsock + trimmed boot", mk_after))
+
+    print("\n\n=== FINAL BEFORE/AFTER (ms, mean) ===", flush=True)
+    h = f"{'configuration':<44}{'create':>8}{'launch':>8}{'first':>8}{'TOTAL':>8}{'warm':>7}"
+    print(h); print("-" * len(h))
+    for r in res:
+        print(f"{r['label']:<44}{r['create']:>8.0f}{r['launch']:>8.0f}{r['first']:>8.0f}"
+              f"{r['total']:>8.0f}{r['warm']:>7.1f}")
+    print("DONE", flush=True)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/exp_userspace.py
+++ b/scripts/exp_userspace.py
@@ -118,12 +118,19 @@ def run(label, kernel, rootfs, tag):
     except Exception as e: print("  warmup err:", e, flush=True)
     runs = []
     for i in range(N):
-        r = one(kernel, rootfs, tag)
+        try:
+            r = one(kernel, rootfs, tag)
+        except Exception as e:
+            print(f"  {i+1}/{N} ERROR {e}", flush=True)
+            continue
         runs.append(r)
         kg = f"{r['keygen_ms']:.0f}" if r['keygen_ms'] is not None else "-"
         su = f"{r['sshd_uptime']:.3f}" if r['sshd_uptime'] is not None else "-"
         print(f"  {i+1}/{N} create={r['create']*1000:.0f} launch={r['launch']*1000:.0f} "
               f"first={r['first']*1000:.0f}  keygen={kg}ms sshd_up={su}s", flush=True)
+
+    if not runs:
+        raise RuntimeError(f"{label}: all {N} runs failed; no samples collected")
 
     def m(k): return sum(x[k] for x in runs) / len(runs) * 1000
     total = m("create") + m("launch") + m("first")

--- a/scripts/exp_userspace.py
+++ b/scripts/exp_userspace.py
@@ -1,0 +1,162 @@
+"""Experiment C: trim userspace on the SSH critical path.
+
+Finding 3/4 showed that for the SSH channel, /init regenerates SSH host keys on
+every boot (~190 ms) because the Dockerfile deletes them. This experiment builds
+a variant image that bakes host keys at build time and skips keygen in /init,
+then measures SSH-path time-to-interact vs the baseline.
+
+All on QEMU, same Alpine+python3 base, default boot args. Ground-truth boot time
+comes from the guest's SMOLVM_TS uptime markers (not 'quiet'-suppressed printk).
+"""
+
+from __future__ import annotations
+
+import platform
+import re
+import time
+
+from smolvm import SmolVM
+from smolvm.images.builder import ImageBuilder
+from smolvm.images.published import BASE_KERNELS, _kernel_format_for_vmm
+from smolvm.runtime.boot_profiles import (
+    KernelBootProfile,
+    get_boot_profile_spec,
+    to_published_arch,
+)
+from smolvm.types import VMConfig
+from smolvm.vm import resolve_data_dir
+
+PROF = KernelBootProfile.MICROVM_DIRECT
+ARCH = platform.machine()
+N = 4
+_seq = 0
+
+# Baseline Dockerfile = build_alpine_ssh recipe (deletes host keys -> per-boot keygen).
+BASELINE_DOCKERFILE = """
+FROM alpine:3.19
+ARG SSH_PASSWORD
+RUN apk add --no-cache openssh iproute2 curl bash python3
+RUN rm -f /etc/ssh/ssh_host_* && \\
+    echo "root:${SSH_PASSWORD}" | chpasswd && \\
+    sed -i 's/#PermitRootLogin.*/PermitRootLogin yes/' /etc/ssh/sshd_config && \\
+    sed -i 's/#PasswordAuthentication.*/PasswordAuthentication yes/' /etc/ssh/sshd_config
+COPY init /init
+RUN chmod +x /init
+"""
+
+# Variant Dockerfile = bake host keys at build time (ssh-keygen -A once).
+BAKED_DOCKERFILE = """
+FROM alpine:3.19
+ARG SSH_PASSWORD
+RUN apk add --no-cache openssh iproute2 curl bash python3
+RUN rm -f /etc/ssh/ssh_host_* && ssh-keygen -A && \\
+    echo "root:${SSH_PASSWORD}" | chpasswd && \\
+    sed -i 's/#PermitRootLogin.*/PermitRootLogin yes/' /etc/ssh/sshd_config && \\
+    sed -i 's/#PasswordAuthentication.*/PasswordAuthentication yes/' /etc/ssh/sshd_config
+COPY init /init
+RUN chmod +x /init
+"""
+
+
+def build(name: str, dockerfile: str):
+    b = ImageBuilder()
+    image_dir = b.cache_dir / name
+    kernel_path = image_dir / "vmlinux.bin"
+    rootfs_path = image_dir / "rootfs.ext4"
+    kurl = BASE_KERNELS[to_published_arch(ARCH)].url_for(_kernel_format_for_vmm("qemu"))
+    init_script = b._default_init_script()
+    image_dir.mkdir(parents=True, exist_ok=True)
+    b._do_build(
+        name, dockerfile, init_script, image_dir, kernel_path, rootfs_path,
+        rootfs_size_mb=512, build_args={"SSH_PASSWORD": "smolvm"}, kernel_url=kurl,
+    )
+    return str(kernel_path), str(rootfs_path)
+
+
+def markers(name: str) -> dict:
+    """Parse SMOLVM_TS uptime markers; return stage -> uptime_s."""
+    log = resolve_data_dir() / f"{name}.log"
+    out = {}
+    if log.exists():
+        for m in re.finditer(r"SMOLVM_TS stage=(\S+).*?uptime_s=([\d.]+)", log.read_text(errors="replace")):
+            out[m.group(1)] = float(m.group(2))
+    return out
+
+
+def one(kernel, rootfs, tag) -> dict:
+    global _seq
+    _seq += 1
+    name = f"ec-{tag}-{_seq}"
+    ba = get_boot_profile_spec(PROF).base_boot_args_for_backend("qemu", ARCH)
+    cfg = VMConfig(vm_id=name, vcpu_count=1, memory=512, kernel_path=kernel,
+                   rootfs_path=rootfs, boot_args=ba, backend="qemu")
+    rec = {}
+    vm = None
+    try:
+        t0 = time.perf_counter()
+        vm = SmolVM(config=cfg, ssh_password="smolvm", comm_channel="ssh")
+        rec["create"] = time.perf_counter() - t0
+        t0 = time.perf_counter(); vm.start(); rec["launch"] = time.perf_counter() - t0
+        t0 = time.perf_counter(); vm.run("echo hello"); rec["first"] = time.perf_counter() - t0
+        time.sleep(0.3)  # let init flush trailing markers to the log
+        mk = markers(name)
+        rec["keygen_ms"] = (
+            (mk["ssh-hostkey-check-done"] - mk["ssh-hostkey-check-start"]) * 1000
+            if "ssh-hostkey-check-done" in mk and "ssh-hostkey-check-start" in mk else None
+        )
+        rec["sshd_uptime"] = mk.get("sshd-invoked")
+    finally:
+        if vm is not None:
+            try: vm.stop(); vm.delete()
+            except Exception: pass
+    return rec
+
+
+def run(label, kernel, rootfs, tag):
+    print(f"\n== {label}: warm-up ==", flush=True)
+    try: one(kernel, rootfs, tag)
+    except Exception as e: print("  warmup err:", e, flush=True)
+    runs = []
+    for i in range(N):
+        r = one(kernel, rootfs, tag)
+        runs.append(r)
+        kg = f"{r['keygen_ms']:.0f}" if r['keygen_ms'] is not None else "-"
+        su = f"{r['sshd_uptime']:.3f}" if r['sshd_uptime'] is not None else "-"
+        print(f"  {i+1}/{N} create={r['create']*1000:.0f} launch={r['launch']*1000:.0f} "
+              f"first={r['first']*1000:.0f}  keygen={kg}ms sshd_up={su}s", flush=True)
+
+    def m(k): return sum(x[k] for x in runs) / len(runs) * 1000
+    total = m("create") + m("launch") + m("first")
+    kgs = [x["keygen_ms"] for x in runs if x["keygen_ms"] is not None]
+    sus = [x["sshd_uptime"] for x in runs if x["sshd_uptime"] is not None]
+    print(f"  MEAN create={m('create'):.0f} launch={m('launch'):.0f} first={m('first'):.0f} "
+          f"TOTAL->interact={total:.0f} ms  "
+          f"keygen={sum(kgs)/len(kgs):.0f}ms " if kgs else "",
+          f"sshd_uptime={sum(sus)/len(sus):.3f}s" if sus else "", flush=True)
+    return {"label": label, "create": m("create"), "launch": m("launch"),
+            "first": m("first"), "total": total,
+            "keygen": sum(kgs)/len(kgs) if kgs else None,
+            "sshd_uptime": sum(sus)/len(sus) if sus else None}
+
+
+def main():
+    print("Building baseline (per-boot keygen) image...", flush=True)
+    bk, br = build("ec-baseline", BASELINE_DOCKERFILE)
+    print("Building baked-host-keys image...", flush=True)
+    xk, xr = build("ec-baked", BAKED_DOCKERFILE)
+
+    res = []
+    res.append(run("C0 baseline (keygen each boot)", bk, br, "base"))
+    res.append(run("C1 baked host keys", xk, xr, "baked"))
+
+    print("\n\n=== EXPERIMENT C SUMMARY (ms) ===", flush=True)
+    h = f"{'cell':<32}{'create':>8}{'launch':>8}{'first':>8}{'TOTAL':>8}{'keygen':>8}"
+    print(h); print("-" * len(h))
+    for r in res:
+        kg = f"{r['keygen']:.0f}" if r['keygen'] is not None else "-"
+        print(f"{r['label']:<32}{r['create']:>8.0f}{r['launch']:>8.0f}{r['first']:>8.0f}{r['total']:>8.0f}{kg:>8}")
+    print("DONE", flush=True)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/exp_vsock_trim.py
+++ b/scripts/exp_vsock_trim.py
@@ -1,0 +1,138 @@
+"""Two experiments on QEMU, same python3-equipped Alpine image:
+
+  EXP A: comm channel — SSH vs vsock (time to interact)
+  EXP B: boot cmdline — default vs trimmed device probing (kernel time + total)
+
+All on one image so only the variable under test changes. 4 timed runs each
+after 1 untimed warm-up. Reports per-phase means in ms and the kernel's last
+printk timestamp (in-kernel boot seconds) from each VM's log.
+"""
+
+from __future__ import annotations
+
+import platform
+import re
+import time
+
+from smolvm import SmolVM
+from smolvm.images.builder import ImageBuilder
+from smolvm.images.published import BASE_KERNELS, _kernel_format_for_vmm
+from smolvm.runtime.boot_profiles import (
+    KernelBootProfile,
+    get_boot_profile_spec,
+    to_published_arch,
+)
+from smolvm.types import VMConfig
+from smolvm.vm import resolve_data_dir
+
+PROF = KernelBootProfile.MICROVM_DIRECT
+ARCH = platform.machine()
+CMD = "echo hello"
+N = 4
+_seq = 0
+
+
+def build_image():
+    b = ImageBuilder()
+    kurl = BASE_KERNELS[to_published_arch(ARCH)].url_for(_kernel_format_for_vmm("qemu"))
+    k, r = b.build_alpine_ssh(
+        name="alpine-py-test", ssh_password="smolvm", rootfs_size_mb=512,
+        kernel_profile=PROF, kernel_url=kurl,
+    )
+    return str(k), str(r)
+
+
+DEFAULT_ARGS = get_boot_profile_spec(PROF).base_boot_args_for_backend("qemu", ARCH)
+# Trim device probing: disable ACPI, PCI off already? default has init=/init only.
+# Add quiet + noacpi-style trims that are safe for a headless virtio guest.
+TRIMMED_ARGS = DEFAULT_ARGS + " acpi=off quiet no_timer_check tsc=reliable"
+
+
+def kernel_last(name: str):
+    log = resolve_data_dir() / f"{name}.log"
+    if not log.exists():
+        return None
+    stamps = re.findall(r"\[\s*(\d+\.\d+)\]", log.read_text(errors="replace"))
+    return float(stamps[-1]) if stamps else None
+
+
+def one(kernel, rootfs, *, channel, boot_args, tag) -> dict:
+    global _seq
+    _seq += 1
+    name = f"exp-{tag}-{_seq}"
+    cfg = VMConfig(vm_id=name, vcpu_count=1, memory=512, kernel_path=kernel,
+                   rootfs_path=rootfs, boot_args=boot_args, backend="qemu")
+    rec = {}
+    vm = None
+    try:
+        t0 = time.perf_counter()
+        kw = {"comm_channel": channel}
+        if channel == "ssh":
+            kw["ssh_password"] = "smolvm"
+        vm = SmolVM(config=cfg, **kw)
+        rec["create"] = time.perf_counter() - t0
+        t0 = time.perf_counter(); vm.start(); rec["launch"] = time.perf_counter() - t0
+        t0 = time.perf_counter(); vm.run(CMD); rec["first"] = time.perf_counter() - t0
+        warm = []
+        for _ in range(5):
+            t0 = time.perf_counter(); vm.run(CMD); warm.append(time.perf_counter() - t0)
+        rec["warm"] = sum(warm) / len(warm)
+        rec["kernel_last"] = kernel_last(name)
+    finally:
+        if vm is not None:
+            try: vm.stop(); vm.delete()
+            except Exception: pass
+    return rec
+
+
+def run(label, kernel, rootfs, *, channel, boot_args, tag):
+    print(f"\n== {label}: warm-up ==", flush=True)
+    try:
+        one(kernel, rootfs, channel=channel, boot_args=boot_args, tag=tag)
+    except Exception as e:
+        print("  warmup err:", e, flush=True)
+    runs = []
+    for i in range(N):
+        r = one(kernel, rootfs, channel=channel, boot_args=boot_args, tag=tag)
+        runs.append(r)
+        print(f"  {i+1}/{N} create={r['create']*1000:.0f} launch={r['launch']*1000:.0f} "
+              f"first={r['first']*1000:.0f} warm={r['warm']*1000:.0f} "
+              f"klast={r['kernel_last']}s", flush=True)
+
+    def m(k):
+        return sum(x[k] for x in runs) / len(runs) * 1000
+    kl = [x["kernel_last"] for x in runs if x["kernel_last"]]
+    total = m("create") + m("launch") + m("first")
+    print(f"  MEAN create={m('create'):.0f} launch={m('launch'):.0f} first={m('first'):.0f} "
+          f"warm={m('warm'):.0f}  TOTAL->interact={total:.0f} ms  "
+          f"kernel_last={sum(kl)/len(kl):.2f}s" if kl else "", flush=True)
+    return {"label": label, "create": m("create"), "launch": m("launch"),
+            "first": m("first"), "warm": m("warm"), "total": total,
+            "kernel_last": sum(kl)/len(kl) if kl else None}
+
+
+def main():
+    print("Building python3-equipped Alpine image (shared by all cells)...", flush=True)
+    kernel, rootfs = build_image()
+    print("default boot args:", DEFAULT_ARGS, flush=True)
+    print("trimmed boot args:", TRIMMED_ARGS, flush=True)
+
+    res = []
+    # EXP A: channel (default boot args)
+    res.append(run("A1 SSH   (default boot)", kernel, rootfs, channel="ssh", boot_args=DEFAULT_ARGS, tag="ssh"))
+    res.append(run("A2 vsock (default boot)", kernel, rootfs, channel="vsock", boot_args=DEFAULT_ARGS, tag="vsk"))
+    # EXP B: boot args (vsock, to isolate boot from SSH-handshake noise)
+    res.append(run("B1 vsock + trimmed boot", kernel, rootfs, channel="vsock", boot_args=TRIMMED_ARGS, tag="trim"))
+
+    print("\n\n=== SUMMARY (ms) ===", flush=True)
+    h = f"{'cell':<26}{'create':>8}{'launch':>8}{'first':>8}{'TOTAL':>8}{'warm':>7}{'kern_s':>8}"
+    print(h); print("-" * len(h))
+    for r in res:
+        ks = f"{r['kernel_last']:.2f}" if r['kernel_last'] else "-"
+        print(f"{r['label']:<26}{r['create']:>8.0f}{r['launch']:>8.0f}{r['first']:>8.0f}"
+              f"{r['total']:>8.0f}{r['warm']:>7.0f}{ks:>8}")
+    print("DONE", flush=True)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/exp_vsock_trim.py
+++ b/scripts/exp_vsock_trim.py
@@ -43,9 +43,14 @@ def build_image():
 
 
 DEFAULT_ARGS = get_boot_profile_spec(PROF).base_boot_args_for_backend("qemu", ARCH)
-# Trim device probing: disable ACPI, PCI off already? default has init=/init only.
-# Add quiet + noacpi-style trims that are safe for a headless virtio guest.
-TRIMMED_ARGS = DEFAULT_ARGS + " acpi=off quiet no_timer_check tsc=reliable"
+# The default profile already carries tsc=reliable/no_timer_check/quiet (Q3);
+# append only the flags this experiment adds that aren't already present so we
+# don't duplicate tokens and muddy the measurement.
+_present = set(DEFAULT_ARGS.split())
+TRIMMED_ARGS = DEFAULT_ARGS + "".join(
+    f" {flag}" for flag in ("acpi=off", "quiet", "no_timer_check", "tsc=reliable")
+    if flag not in _present
+)
 
 
 def kernel_last(name: str):

--- a/scripts/profile_boot.py
+++ b/scripts/profile_boot.py
@@ -50,57 +50,61 @@ def profile(backend: str) -> dict:
     vm = SmolVM(config=config, ssh_key_path=key)
     r["create"] = time.perf_counter() - t0
 
-    t0 = time.perf_counter()
-    vm.start()
-    r["launch"] = time.perf_counter() - t0
-
-    # Use the SDK's own endpoint resolution (QEMU = forwarded 127.0.0.1:port,
-    # Firecracker = TAP guest_ip:22).
-    host, port = vm._ssh_endpoints()[0]
-    r["endpoint"] = f"{host}:{port}"
-
-    # Phase A: spin on TCP connect until sshd is listening.
-    t0 = time.perf_counter()
-    deadline = t0 + 30
-    while time.perf_counter() < deadline:
-        if tcp_open(host, port):
-            break
-        time.sleep(0.02)
-    r["tcp_open"] = time.perf_counter() - t0
-
-    # Phase B: paramiko handshake + auth on the open port.
-    t0 = time.perf_counter()
-    client = SSHClient(host=host, port=port, user="root", key_path=key)
-    client.wait_for_ssh(timeout=30)
-    r["ssh_auth"] = time.perf_counter() - t0
-
-    # Phase C: run the command over the established connection.
-    t0 = time.perf_counter()
-    client.run(CMD)
-    r["cmd"] = time.perf_counter() - t0
-
-    # Kernel log: last "[ TIMESTAMP ]" printk = seconds of in-kernel time.
-    log_path = resolve_data_dir() / f"{name}.log"
-    kernel_last = None
-    n_lines = 0
-    if log_path.exists():
-        text = log_path.read_text(errors="replace")
-        n_lines = text.count("\n")
-        stamps = re.findall(r"\[\s*(\d+\.\d+)\]", text)
-        if stamps:
-            kernel_last = float(stamps[-1])
-    r["kernel_last_printk_s"] = kernel_last
-    r["log_lines"] = n_lines
-
+    client = None
     try:
-        client.close()
-    except Exception:
-        pass
-    try:
-        vm.stop()
-        vm.delete()
-    except Exception:
-        pass
+        t0 = time.perf_counter()
+        vm.start()
+        r["launch"] = time.perf_counter() - t0
+
+        # Use the SDK's own endpoint resolution (QEMU = forwarded 127.0.0.1:port,
+        # Firecracker = TAP guest_ip:22).
+        host, port = vm._ssh_endpoints()[0]
+        r["endpoint"] = f"{host}:{port}"
+
+        # Phase A: spin on TCP connect until sshd is listening.
+        t0 = time.perf_counter()
+        deadline = t0 + 30
+        while time.perf_counter() < deadline:
+            if tcp_open(host, port):
+                break
+            time.sleep(0.02)
+        r["tcp_open"] = time.perf_counter() - t0
+
+        # Phase B: paramiko handshake + auth on the open port.
+        t0 = time.perf_counter()
+        client = SSHClient(host=host, port=port, user="root", key_path=key)
+        client.wait_for_ssh(timeout=30)
+        r["ssh_auth"] = time.perf_counter() - t0
+
+        # Phase C: run the command over the established connection.
+        t0 = time.perf_counter()
+        client.run(CMD)
+        r["cmd"] = time.perf_counter() - t0
+
+        # Kernel log: last "[ TIMESTAMP ]" printk = seconds of in-kernel time.
+        log_path = resolve_data_dir() / f"{name}.log"
+        kernel_last = None
+        n_lines = 0
+        if log_path.exists():
+            text = log_path.read_text(errors="replace")
+            n_lines = text.count("\n")
+            stamps = re.findall(r"\[\s*(\d+\.\d+)\]", text)
+            if stamps:
+                kernel_last = float(stamps[-1])
+        r["kernel_last_printk_s"] = kernel_last
+        r["log_lines"] = n_lines
+    finally:
+        if client is not None:
+            try:
+                client.close()
+            except Exception as e:
+                print(f"  cleanup: client.close failed: {e}", flush=True)
+        if vm is not None:
+            try:
+                vm.stop()
+                vm.delete()
+            except Exception as e:
+                print(f"  cleanup: vm stop/delete failed: {e}", flush=True)
     return r
 
 

--- a/scripts/profile_boot.py
+++ b/scripts/profile_boot.py
@@ -1,0 +1,143 @@
+"""Break the ~1.5s 'time to interact' into its real sub-components.
+
+For each backend, one VM:
+  t_create   : SmolVM(config) constructor
+  t_launch   : .start() (hypervisor process up; does NOT wait for guest)
+  t_tcp_open : from launch-return until the guest's SSH port (22) accepts a
+               TCP connection  = guest kernel boot + init + sshd listening
+  t_ssh_auth : paramiko handshake + key auth on the now-open port
+  t_cmd      : actually running `echo hello`
+
+Also greps the guest kernel log for the last printk timestamp, which tells us
+how much of t_tcp_open is kernel boot vs userspace (init + sshd).
+"""
+
+from __future__ import annotations
+
+import re
+import socket
+import time
+from pathlib import Path
+
+from smolvm import SmolVM
+from smolvm.facade import _build_auto_config
+from smolvm.ssh import SSHClient
+from smolvm.vm import resolve_data_dir
+
+OS = "alpine"
+CMD = "echo hello"
+
+
+def tcp_open(host: str, port: int) -> bool:
+    try:
+        with socket.create_connection((host, port), timeout=0.5):
+            return True
+    except OSError:
+        return False
+
+
+_seq = 0
+
+
+def profile(backend: str) -> dict:
+    global _seq
+    _seq += 1
+    name = f"prof-{backend}-{_seq}"
+    r: dict = {"backend": backend}
+
+    t0 = time.perf_counter()
+    config, key = _build_auto_config(vm_name=name, os=OS, backend=backend)
+    vm = SmolVM(config=config, ssh_key_path=key)
+    r["create"] = time.perf_counter() - t0
+
+    t0 = time.perf_counter()
+    vm.start()
+    r["launch"] = time.perf_counter() - t0
+
+    # Use the SDK's own endpoint resolution (QEMU = forwarded 127.0.0.1:port,
+    # Firecracker = TAP guest_ip:22).
+    host, port = vm._ssh_endpoints()[0]
+    r["endpoint"] = f"{host}:{port}"
+
+    # Phase A: spin on TCP connect until sshd is listening.
+    t0 = time.perf_counter()
+    deadline = t0 + 30
+    while time.perf_counter() < deadline:
+        if tcp_open(host, port):
+            break
+        time.sleep(0.02)
+    r["tcp_open"] = time.perf_counter() - t0
+
+    # Phase B: paramiko handshake + auth on the open port.
+    t0 = time.perf_counter()
+    client = SSHClient(host=host, port=port, user="root", key_path=key)
+    client.wait_for_ssh(timeout=30)
+    r["ssh_auth"] = time.perf_counter() - t0
+
+    # Phase C: run the command over the established connection.
+    t0 = time.perf_counter()
+    client.run(CMD)
+    r["cmd"] = time.perf_counter() - t0
+
+    # Kernel log: last "[ TIMESTAMP ]" printk = seconds of in-kernel time.
+    log_path = resolve_data_dir() / f"{name}.log"
+    kernel_last = None
+    n_lines = 0
+    if log_path.exists():
+        text = log_path.read_text(errors="replace")
+        n_lines = text.count("\n")
+        stamps = re.findall(r"\[\s*(\d+\.\d+)\]", text)
+        if stamps:
+            kernel_last = float(stamps[-1])
+    r["kernel_last_printk_s"] = kernel_last
+    r["log_lines"] = n_lines
+
+    try:
+        client.close()
+    except Exception:
+        pass
+    try:
+        vm.stop()
+        vm.delete()
+    except Exception:
+        pass
+    return r
+
+
+def main():
+    for backend in ("qemu", "firecracker"):
+        print(f"== {backend}: warm-up ==", flush=True)
+        try:
+            profile(backend)  # warm caches
+        except Exception as e:
+            print("warmup err", e, flush=True)
+
+        print(f"== {backend}: profiling 3 runs ==", flush=True)
+        runs = []
+        for i in range(3):
+            r = profile(backend)
+            runs.append(r)
+            print(
+                f"  run {i + 1}: [{r['endpoint']}] create={r['create']*1000:.0f}  launch={r['launch']*1000:.0f}  "
+                f"tcp_open={r['tcp_open']*1000:.0f}  ssh_auth={r['ssh_auth']*1000:.0f}  "
+                f"cmd={r['cmd']*1000:.0f}  | kernel_last={r['kernel_last_printk_s']}s  "
+                f"loglines={r['log_lines']}",
+                flush=True,
+            )
+        # mean
+        def mean(k):
+            return sum(x[k] for x in runs) / len(runs) * 1000
+        print(
+            f"  MEAN  create={mean('create'):.0f}  launch={mean('launch'):.0f}  "
+            f"tcp_open={mean('tcp_open'):.0f}  ssh_auth={mean('ssh_auth'):.0f}  "
+            f"cmd={mean('cmd'):.0f}  (ms)",
+            flush=True,
+        )
+        kl = [x["kernel_last_printk_s"] for x in runs if x["kernel_last_printk_s"]]
+        if kl:
+            print(f"  kernel last printk (mean): {sum(kl)/len(kl):.2f}s", flush=True)
+    print("DONE", flush=True)
+
+
+if __name__ == "__main__":
+    main()

--- a/src/smolvm/facade.py
+++ b/src/smolvm/facade.py
@@ -96,9 +96,13 @@ logger = logging.getLogger(__name__)
 _DEFAULT_RUN_READY_TIMEOUT = 30.0
 
 # When auto-selecting the channel, how long to wait for the vsock agent before
-# falling back to SSH. Kept short: the agent comes up early in boot, so if it
-# hasn't answered by now the image probably lacks it and SSH is the real path.
-_VSOCK_AUTO_PROBE_TIMEOUT = 8.0
+# falling back to SSH. Kept short: the agent binds its vsock port early in boot
+# (before sshd, ~0.9s guest uptime on Alpine), so if it hasn't answered by now
+# the image almost certainly can't run it (e.g. no python3) and SSH is the real
+# path. This is a guardrail — an agent-less image now costs ~2.5s of wasted
+# probe instead of 8s. (Images SmolVM builds ship the agent + python3, so they
+# answer well inside this window and never hit the fallback.)
+_VSOCK_AUTO_PROBE_TIMEOUT = 2.5
 _LOCAL_FORWARD_PROBE_TIMEOUT = 2.0
 _LOCAL_FORWARD_PROBE_INTERVAL = 0.2
 _LOCAL_TUNNEL_START_TIMEOUT = 10.0

--- a/src/smolvm/images/builder.py
+++ b/src/smolvm/images/builder.py
@@ -320,11 +320,15 @@ RUN chmod +x /init
         dockerfile_content = """
 FROM alpine:3.19
 
+# python3 powers the SmolVM guest agent (vsock control plane); the agent is
+# stdlib-only, so no pip deps. Without it /init silently skips the agent and the
+# host falls back to SSH after an 8s vsock probe (see _VSOCK_AUTO_PROBE_TIMEOUT).
 RUN apk add --no-cache \
     openssh \
     iproute2 \
     curl \
-    bash
+    bash \
+    python3
 
 # Host keys generated at first boot in /init so each VM has unique identity.
 # 'rm -f' purges keys planted by the openssh install postinst.

--- a/src/smolvm/runtime/boot_profiles.py
+++ b/src/smolvm/runtime/boot_profiles.py
@@ -25,9 +25,9 @@ the same across all SmolVM-built profiles.
 
 from __future__ import annotations
 
+import os
 from dataclasses import dataclass
 from enum import Enum
-import os
 from pathlib import Path
 from typing import TYPE_CHECKING, Literal
 

--- a/src/smolvm/runtime/boot_profiles.py
+++ b/src/smolvm/runtime/boot_profiles.py
@@ -27,6 +27,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 from enum import Enum
+import os
 from pathlib import Path
 from typing import TYPE_CHECKING, Literal
 
@@ -35,9 +36,31 @@ from smolvm.runtime.backends import BACKEND_FIRECRACKER, BACKEND_LIBKRUN, BACKEN
 if TYPE_CHECKING:
     from smolvm.images.published import Arch as PublishedArch
 
-_MICROVM_DIRECT_FIRECRACKER_BOOT_ARGS = (
-    "console=ttyS0 reboot=k panic=1 pci=off root=/dev/vda rw init=/init"
-)
+# Latency-safe kernel cmdline trims for minimal headless virtio/KVM guests.
+# - tsc=reliable      : trust the host TSC clocksource, skip calibration checks.
+# - no_timer_check    : skip the legacy "is the timer IRQ arriving" probe.
+# Both are safe on any KVM virtio guest and shave kernel-init time. `quiet` is
+# added separately (it suppresses console printk, which is useful to keep when
+# debugging a stuck boot — see _quiet_flag). `acpi=off` is deliberately NOT
+# defaulted: it saves ~70ms but isn't universally safe (clean shutdown / IRQ
+# routing), so it stays opt-in per image.
+_SAFE_TRIM_FLAGS = "tsc=reliable no_timer_check"
+
+
+def _quiet_flag() -> str:
+    """Return ``" quiet"`` unless verbose boot was requested.
+
+    Set ``SMOLVM_VERBOSE_BOOT=1`` to keep full kernel console output when
+    debugging a boot that hangs or panics; the default suppresses it to cut
+    time spent formatting printk over the serial line.
+    """
+    verbose = os.environ.get("SMOLVM_VERBOSE_BOOT", "").strip().lower()
+    if verbose in {"1", "true", "yes", "on"}:
+        return ""
+    return " quiet"
+
+
+_MICROVM_DIRECT_FIRECRACKER_BASE = "console=ttyS0 reboot=k panic=1 pci=off root=/dev/vda rw"
 
 
 class KernelBootProfile(str, Enum):
@@ -63,10 +86,12 @@ class BootProfileSpec:
             )
 
         if self.profile is KernelBootProfile.MICROVM_DIRECT:
+            trims = f"{_SAFE_TRIM_FLAGS}{_quiet_flag()}"
             if backend in {BACKEND_QEMU, BACKEND_LIBKRUN}:
                 console = "ttyAMA0" if normalized_arch == "aarch64" else "ttyS0"
-                return f"console={console} reboot=k panic=1 init=/init"
-            return _MICROVM_DIRECT_FIRECRACKER_BOOT_ARGS
+                return f"console={console} reboot=k panic=1 {trims} init=/init"
+            # Firecracker: keep pci=off + root=/dev/vda, append the same trims.
+            return f"{_MICROVM_DIRECT_FIRECRACKER_BASE} {trims} init=/init"
 
         console = "ttyAMA0" if normalized_arch == "aarch64" else "ttyS0"
         return f"console={console} reboot=k panic=1"

--- a/src/smolvm/ssh.py
+++ b/src/smolvm/ssh.py
@@ -61,6 +61,13 @@ logger = logging.getLogger(__name__)
 #     logging.getLogger("paramiko.transport").setLevel(logging.WARNING)
 logging.getLogger("paramiko.transport").setLevel(logging.CRITICAL)
 
+# Poll backoff for wait_for_ssh: start tight (20ms) so we notice sshd within
+# tens of ms of it coming up early in boot, grow ×1.5 per miss, and let the
+# caller's ``interval`` cap it. The previous fixed 200ms cadence cost up to
+# ~280ms of slack on a VM that booted fast.
+_WAIT_BACKOFF_START = 0.02
+_WAIT_BACKOFF_FACTOR = 1.5
+
 ShellMode = Literal["login", "raw"]
 ShellKind = Literal["sh", "powershell", "cmd"]
 """Guest-side login-shell wrap. ``sh`` is the POSIX default
@@ -399,9 +406,16 @@ class SSHClient:
         2. **Paramiko connect** — full SSH handshake + auth.  The resulting
            connection is kept open for subsequent :meth:`run` calls.
 
+        Both phases poll with exponential backoff (starting at
+        :data:`_WAIT_BACKOFF_START`, growing ×1.5, capped at *interval*) so we
+        catch sshd within tens of ms of it coming up early in boot — the common
+        case — while a genuinely slow guest relaxes back to the *interval*
+        cadence and is no worse off than a fixed poll.
+
         Args:
             timeout: Maximum seconds to wait.
-            interval: Seconds between TCP probe attempts.
+            interval: Upper bound (seconds) on the poll backoff. Defaults to
+                0.1s, matching the previous fixed cadence.
 
         Raises:
             OperationTimeoutError: If SSH does not become available
@@ -420,6 +434,7 @@ class SSHClient:
         )
 
         # Phase 1: Fast TCP probe — detect when sshd port is open.
+        backoff = _WAIT_BACKOFF_START
         while time.monotonic() < deadline:
             if self._tcp_port_open(timeout=min(0.5, deadline - time.monotonic())):
                 logger.debug("TCP port %d is open on %s", self.port, self.host)
@@ -431,10 +446,15 @@ class SSHClient:
                     f"wait_for_ssh({self.host}:{self.port}): port never opened",
                     timeout,
                 )
-            time.sleep(min(interval, remaining))
+            time.sleep(min(backoff, remaining))
+            backoff = min(backoff * _WAIT_BACKOFF_FACTOR, interval)
 
-        # Phase 2: Establish persistent paramiko connection.
+        # Phase 2: Establish persistent paramiko connection. The TCP port is
+        # already open, but sshd may still be mid-startup (and on QEMU user-mode
+        # NAT the forwarder accepts the connection before sshd is up), so retry
+        # the full handshake with the same tight-then-relaxing backoff.
         last_error: str = ""
+        backoff = _WAIT_BACKOFF_START
         while time.monotonic() < deadline:
             try:
                 self._client = self._connect()
@@ -452,7 +472,8 @@ class SSHClient:
             remaining = deadline - time.monotonic()
             if remaining <= 0:
                 break
-            time.sleep(min(0.2, remaining))
+            time.sleep(min(backoff, remaining))
+            backoff = min(backoff * _WAIT_BACKOFF_FACTOR, max(interval, 0.2))
 
         raise OperationTimeoutError(
             f"wait_for_ssh({self.host}:{self.port}): last error: {last_error}",

--- a/src/smolvm/ssh.py
+++ b/src/smolvm/ssh.py
@@ -473,7 +473,7 @@ class SSHClient:
             if remaining <= 0:
                 break
             time.sleep(min(backoff, remaining))
-            backoff = min(backoff * _WAIT_BACKOFF_FACTOR, max(interval, 0.2))
+            backoff = min(backoff * _WAIT_BACKOFF_FACTOR, interval)
 
         raise OperationTimeoutError(
             f"wait_for_ssh({self.host}:{self.port}): last error: {last_error}",

--- a/tests/test_boot_profiles.py
+++ b/tests/test_boot_profiles.py
@@ -1,0 +1,73 @@
+# Copyright 2026 Celesto AI
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for default kernel boot-arg trims (MICROVM_DIRECT profile)."""
+
+import pytest
+
+from smolvm.runtime.backends import BACKEND_FIRECRACKER, BACKEND_QEMU
+from smolvm.runtime.boot_profiles import (
+    KernelBootProfile,
+    get_boot_profile_spec,
+)
+
+
+def _args(backend: str, arch: str = "x86_64") -> str:
+    spec = get_boot_profile_spec(KernelBootProfile.MICROVM_DIRECT)
+    return spec.base_boot_args_for_backend(backend, arch)
+
+
+class TestSafeBootTrims:
+    """The safe latency trims must be present, and acpi=off must NOT be."""
+
+    @pytest.mark.parametrize("backend", [BACKEND_QEMU, BACKEND_FIRECRACKER])
+    def test_safe_trims_present(self, backend: str, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.delenv("SMOLVM_VERBOSE_BOOT", raising=False)
+        args = _args(backend)
+        assert "tsc=reliable" in args
+        assert "no_timer_check" in args
+        assert "init=/init" in args
+
+    @pytest.mark.parametrize("backend", [BACKEND_QEMU, BACKEND_FIRECRACKER])
+    def test_acpi_off_is_not_defaulted(self, backend: str) -> None:
+        # acpi=off saves ~70ms but isn't universally safe; must stay opt-in.
+        assert "acpi=off" not in _args(backend)
+
+    def test_firecracker_keeps_pci_off_and_root(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.delenv("SMOLVM_VERBOSE_BOOT", raising=False)
+        args = _args(BACKEND_FIRECRACKER)
+        assert "pci=off" in args
+        assert "root=/dev/vda" in args
+
+    def test_qemu_does_not_get_pci_off(self) -> None:
+        # QEMU uses virtio-PCI; pci=off would break it.
+        assert "pci=off" not in _args(BACKEND_QEMU)
+
+    def test_quiet_on_by_default(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.delenv("SMOLVM_VERBOSE_BOOT", raising=False)
+        assert "quiet" in _args(BACKEND_QEMU)
+
+    @pytest.mark.parametrize("val", ["1", "true", "yes", "on", "TRUE"])
+    def test_verbose_boot_drops_quiet(
+        self, val: str, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("SMOLVM_VERBOSE_BOOT", val)
+        args = _args(BACKEND_QEMU)
+        assert "quiet" not in args
+        # the rest of the trims stay
+        assert "tsc=reliable" in args
+
+    def test_arm64_console_preserved(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.delenv("SMOLVM_VERBOSE_BOOT", raising=False)
+        assert "console=ttyAMA0" in _args(BACKEND_QEMU, arch="aarch64")

--- a/tests/test_build.py
+++ b/tests/test_build.py
@@ -202,6 +202,22 @@ class TestImageBuilderLoopFs:
         assert mock_run_command.call_count == 3
 
 
+def _apk_installs_python3(dockerfile: str) -> bool:
+    """Return True if python3 is an actual `apk add` package, not just text.
+
+    Joins backslash-continued lines so a multi-line `apk add ... \\ python3`
+    counts, but a bare comment mentioning python3 does not.
+    """
+    joined = dockerfile.replace("\\\n", " ")
+    for line in joined.splitlines():
+        stripped = line.strip()
+        if stripped.startswith("#"):
+            continue
+        if "apk add" in stripped and "python3" in stripped.split("apk add", 1)[1]:
+            return True
+    return False
+
+
 class TestAgentRuntimeBakedIntoImages:
     """Every SSH-capable recipe must install python3.
 
@@ -230,9 +246,10 @@ class TestAgentRuntimeBakedIntoImages:
             *args: object,
             **kwargs: object,
         ) -> None:
-            assert "python3" in dockerfile_content, (
-                "build_alpine_ssh_key must install python3 so the vsock guest "
-                "agent can run; without it the host pays an 8s vsock probe."
+            assert _apk_installs_python3(dockerfile_content), (
+                "build_alpine_ssh_key must install python3 (in an apk add) so "
+                "the vsock guest agent can run; without it the host pays an 8s "
+                "vsock probe."
             )
             args[2].touch()  # kernel_path
             args[3].touch()  # rootfs_path
@@ -261,7 +278,7 @@ class TestAgentRuntimeBakedIntoImages:
             *args: object,
             **kwargs: object,
         ) -> None:
-            assert "python3" in dockerfile_content
+            assert _apk_installs_python3(dockerfile_content)
             args[2].touch()
             args[3].touch()
 

--- a/tests/test_build.py
+++ b/tests/test_build.py
@@ -202,6 +202,74 @@ class TestImageBuilderLoopFs:
         assert mock_run_command.call_count == 3
 
 
+class TestAgentRuntimeBakedIntoImages:
+    """Every SSH-capable recipe must install python3.
+
+    The vsock guest agent (baked into every image by ``_do_build``) is a
+    python3 script that ``/init`` only launches ``if command -v python3``.
+    A recipe that omits python3 silently disables the agent, which makes the
+    host pay the full ``_VSOCK_AUTO_PROBE_TIMEOUT`` before falling back to SSH.
+    This locks the runtime in so the two recipes can't drift again.
+    """
+
+    @patch.object(ImageBuilder, "_host_arch_key", return_value="x86_64")
+    @patch.object(ImageBuilder, "check_docker", return_value=True)
+    @patch.object(ImageBuilder, "_do_build")
+    def test_build_alpine_ssh_key_installs_python3(
+        self,
+        mock_do_build: MagicMock,
+        _mock_check_docker: MagicMock,
+        _mock_host_arch_key: MagicMock,
+        tmp_path: Path,
+    ) -> None:
+        builder = ImageBuilder(cache_dir=tmp_path / "images")
+
+        def _fake_do_build(
+            name: str,
+            dockerfile_content: str,
+            *args: object,
+            **kwargs: object,
+        ) -> None:
+            assert "python3" in dockerfile_content, (
+                "build_alpine_ssh_key must install python3 so the vsock guest "
+                "agent can run; without it the host pays an 8s vsock probe."
+            )
+            args[2].touch()  # kernel_path
+            args[3].touch()  # rootfs_path
+
+        mock_do_build.side_effect = _fake_do_build
+
+        builder.build_alpine_ssh_key(
+            "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIMockKey user@test"
+        )
+
+    @patch.object(ImageBuilder, "_host_arch_key", return_value="x86_64")
+    @patch.object(ImageBuilder, "check_docker", return_value=True)
+    @patch.object(ImageBuilder, "_do_build")
+    def test_build_alpine_ssh_installs_python3(
+        self,
+        mock_do_build: MagicMock,
+        _mock_check_docker: MagicMock,
+        _mock_host_arch_key: MagicMock,
+        tmp_path: Path,
+    ) -> None:
+        builder = ImageBuilder(cache_dir=tmp_path / "images")
+
+        def _fake_do_build(
+            name: str,
+            dockerfile_content: str,
+            *args: object,
+            **kwargs: object,
+        ) -> None:
+            assert "python3" in dockerfile_content
+            args[2].touch()
+            args[3].touch()
+
+        mock_do_build.side_effect = _fake_do_build
+
+        builder.build_alpine_ssh()
+
+
 class TestBrowserImageBuilder:
     """Tests for browser image builder entrypoints."""
 

--- a/tests/test_facade_vsock.py
+++ b/tests/test_facade_vsock.py
@@ -89,6 +89,43 @@ def test_explicit_vsock_does_not_fall_back_to_ssh(
     assert vm._ssh_ready is False
 
 
+def test_auto_vsock_falls_back_to_ssh_within_probe_budget(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """An agent-less image (vsock never answers) must fall back to SSH and only
+    spend up to _VSOCK_AUTO_PROBE_TIMEOUT probing, not the full call timeout."""
+    import smolvm.facade as facade
+
+    monkeypatch.setattr("smolvm.comm.select.host_supports_vsock", lambda: True)
+
+    seen = {}
+
+    def _fail(self, timeout=60.0, interval=0.1):
+        seen["probe_timeout"] = timeout
+        raise OperationTimeoutError("vsock", timeout)
+
+    monkeypatch.setattr(VsockChannel, "wait_ready", _fail)
+
+    ssh_called = {}
+
+    def _ssh_ok(self, timeout):
+        ssh_called["timeout"] = timeout
+        self._ssh_ready = True
+
+    monkeypatch.setattr(SmolVM, "_wait_for_ssh_over_network", _ssh_ok)
+
+    # auto channel (comm_channel=None, request=None) → vsock with fallback
+    vm = _vsock_vm(tmp_path, comm_channel=None, request=None)
+    vm._wait_for_ssh(timeout=30)
+
+    # vsock probe was capped at the (short) auto budget, not the 30s call timeout
+    assert seen["probe_timeout"] == facade._VSOCK_AUTO_PROBE_TIMEOUT
+    assert facade._VSOCK_AUTO_PROBE_TIMEOUT <= 3.0  # guardrail stays short
+    # and we then fell back to SSH
+    assert ssh_called  # SSH path was taken
+    assert vm._ssh_ready is True
+
+
 def test_resolve_channel_reads_config_and_request(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:

--- a/tests/test_ssh.py
+++ b/tests/test_ssh.py
@@ -263,6 +263,39 @@ class TestSSHClientWaitForSSH:
         with pytest.raises(ValueError, match="timeout must be"):
             client.wait_for_ssh(timeout=0)
 
+    @patch.object(SSHClient, "_tcp_port_open", return_value=True)
+    def test_connect_loop_uses_tight_backoff_first(
+        self, _mock_port: MagicMock, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Phase 2 must poll tightly at first (not the old fixed 200ms).
+
+        The port is open but the first paramiko connect fails (sshd mid-startup);
+        the second succeeds. The sleep between them must be the tight backoff
+        start, so a fast-booting guest is noticed within tens of ms rather than
+        waiting a fixed 200ms.
+        """
+        from smolvm.ssh import _WAIT_BACKOFF_START
+
+        sleeps: list[float] = []
+        monkeypatch.setattr("smolvm.ssh.time.sleep", lambda s: sleeps.append(s))
+
+        calls = {"n": 0}
+
+        def _connect_then_succeed(self):
+            calls["n"] += 1
+            if calls["n"] == 1:
+                raise SmolVMError("sshd not ready yet")
+            return MagicMock()
+
+        monkeypatch.setattr(SSHClient, "_connect", _connect_then_succeed)
+
+        client = SSHClient("172.16.0.2")
+        client.wait_for_ssh(timeout=5)
+
+        assert calls["n"] == 2  # retried once then connected
+        assert sleeps, "expected at least one backoff sleep between retries"
+        assert sleeps[0] == _WAIT_BACKOFF_START  # tight first poll, not 0.2s
+
 
 class TestSSHClientShellKind:
     """Tests for the per-guest-OS login-shell wrapping."""


### PR DESCRIPTION
## Summary

A boot-latency investigation (QEMU vs Firecracker "time to create a VM and run a command") found that the **default QEMU sandbox takes ~8.1s to first command** instead of ~1.3s, plus several smaller wins. This PR fixes the bug and lands the incremental improvements. Full write-up in `docs/benchmarks/`.

### Before / After (Alpine guest, 1 vCPU/512MB, KVM host; metric = wall-clock create→launch→first-command)

| Configuration | TOTAL→interact | warm cmd |
|---|---:|---:|
| **BEFORE** — QEMU default (out-of-box) | **8133 ms** | 42 ms |
| BEFORE — Firecracker default (SSH) | 1479 ms | 43 ms |
| **AFTER** — QEMU default (vsock + trims) | **1340 ms** | **1.3 ms** |

**QEMU default: 6.1× faster. Warm commands ~32× faster.**

## Root cause

The default auto-config image baked the vsock guest agent (`/usr/local/bin/smolvm-guest-agent`) but installed **no python3**, so `/init`'s `if command -v python3` guard silently skipped it. With no agent answering, the host paid the full 8s `_VSOCK_AUTO_PROBE_TIMEOUT` every boot before falling back to SSH.

## Changes (each verified end-to-end)

| # | Change | Effect measured |
|---|---|---|
| Q1 | Install `python3` in `build_alpine_ssh_key` so the vsock agent runs | first cmd 8066 → 1509 ms; warm 42 → 1.0 ms |
| Q2 | Shorten vsock auto-probe 8s → 2.5s (guardrail for agent-less BYO images) | agent-less fallback 8066 → 2567 ms |
| Q3 | Default safe boot trims `tsc=reliable no_timer_check quiet`; `quiet` behind `SMOLVM_VERBOSE_BOOT`; `acpi=off` left opt-in | ~150–230 ms |
| Q4 | SSH wait loop 200ms fixed → 20ms exp backoff (helps the SSH path Firecracker uses) | SSH first cmd ~1878 → ~1669 ms |

## Testing

- Full suite: **1154 passed, 13 skipped**.
- New regression tests: python3 locked into both agent-capable image recipes; vsock fallback probe budget; SSH tight-backoff; boot-arg trims + `acpi=off` exclusion + verbose escape hatch.
- Each change verified by booting real VMs on a KVM host (numbers above), not just unit tests.

## Notes / follow-ups (not in this PR)

- Firecracker still can't use vsock (selector hard-gates it to QEMU) though the device is already wired in the adapter — implementing the host-side bridge would bring the ~32× warm-command win to the default Linux backend. Scoped in `docs/benchmarks/final-report.md`.
- `acpi=off` (~70ms) deliberately left opt-in pending per-image clean-shutdown validation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive boot-latency benchmark report with findings, methodology, and mitigation recommendations.

* **Performance**
  * Reduced default vsock probe timeout and trimmed kernel boot args to lower boot-to-interact latency.
  * Switched SSH readiness checks to exponential backoff for faster responsiveness.

* **Bug Fixes**
  * Ensure guest images include required runtime to avoid long vsock probe penalties.

* **Tools & Tests**
  * Added benchmarking and profiling scripts and new tests validating boot args, image runtime, vsock fallback, and SSH backoff.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->