### PR TITLE
Handle busy QEMU SSH forwarding ports

### DIFF
--- a/src/smolvm/storage/_base.py
+++ b/src/smolvm/storage/_base.py
@@ -42,9 +42,9 @@ from smolvm.types import (
 IP_POOL_START = 2  # 172.16.0.2
 IP_POOL_END = 65534  # 172.16.255.254
 
-# SSH host-port forwarding pool (65 300 ports — matches IP pool capacity)
+# SSH host-port forwarding pool. Keep the upper bound within the TCP port range.
 SSH_PORT_START = 2200
-SSH_PORT_END = 67499
+SSH_PORT_END = 65535
 
 # vsock guest-CID pool. CIDs 0/1/2 are reserved (hypervisor/local/host), so
 # allocation starts at 3. The upper bound is well within the 32-bit CID space

--- a/src/smolvm/storage/_postgres.py
+++ b/src/smolvm/storage/_postgres.py
@@ -434,6 +434,7 @@ class PostgresStateManager:
         vm_id: str,
         guest_port: int = 22,
         host_port: int | None = None,
+        excluded_host_ports: set[int] | None = None,
     ) -> int:
         if not vm_id:
             raise ValueError("vm_id cannot be empty")
@@ -459,12 +460,13 @@ class PostgresStateManager:
 
             allocated = conn.execute("SELECT host_port FROM ssh_forwards").fetchall()
             allocated_set = {int(row["host_port"]) for row in allocated}
+            excluded_set = excluded_host_ports or set()
 
             candidate_ports = (
                 [host_port] if host_port is not None else range(SSH_PORT_START, SSH_PORT_END + 1)
             )
             for candidate_port in candidate_ports:
-                if candidate_port in allocated_set:
+                if candidate_port in allocated_set or candidate_port in excluded_set:
                     continue
                 conn.execute(
                     """

--- a/src/smolvm/storage/_protocol.py
+++ b/src/smolvm/storage/_protocol.py
@@ -107,6 +107,7 @@ class StateManagerProtocol(Protocol):
         vm_id: str,
         guest_port: int = 22,
         host_port: int | None = None,
+        excluded_host_ports: set[int] | None = None,
     ) -> int:
         pass
 

--- a/src/smolvm/storage/_sqlite.py
+++ b/src/smolvm/storage/_sqlite.py
@@ -431,6 +431,7 @@ class SQLiteStateManager:
         vm_id: str,
         guest_port: int = 22,
         host_port: int | None = None,
+        excluded_host_ports: set[int] | None = None,
     ) -> int:
         if not vm_id:
             raise ValueError("vm_id cannot be empty")
@@ -454,12 +455,13 @@ class SQLiteStateManager:
 
             allocated = conn.execute("SELECT host_port FROM ssh_forwards").fetchall()
             allocated_set = {int(row["host_port"]) for row in allocated}
+            excluded_set = excluded_host_ports or set()
 
             candidate_ports = (
                 [host_port] if host_port is not None else range(SSH_PORT_START, SSH_PORT_END + 1)
             )
             for candidate_port in candidate_ports:
-                if candidate_port in allocated_set:
+                if candidate_port in allocated_set or candidate_port in excluded_set:
                     continue
                 conn.execute(
                     """

--- a/src/smolvm/vm.py
+++ b/src/smolvm/vm.py
@@ -29,6 +29,7 @@ import re
 import shlex
 import shutil
 import signal
+import socket
 import subprocess
 import time
 from contextlib import suppress
@@ -39,6 +40,7 @@ from uuid import uuid4
 
 from smolvm.comm.select import resolve_comm_channel
 from smolvm.exceptions import (
+    NetworkError,
     SmolVMError,
     SnapshotAlreadyExistsError,
     SnapshotNotFoundError,
@@ -58,7 +60,13 @@ from smolvm.runtime.guest_platforms import get_guest_platform
 from smolvm.runtime.libkrun import LibkrunRuntimeAdapter
 from smolvm.runtime.qemu import QEMU_ROOT_NODE_NAME, QemuRuntimeAdapter
 from smolvm.runtime.qemu_args import build_qemu_argv
-from smolvm.storage import StateManagerProtocol, create_state_manager, ip_to_pool_index
+from smolvm.storage import (
+    SSH_PORT_END,
+    SSH_PORT_START,
+    StateManagerProtocol,
+    create_state_manager,
+    ip_to_pool_index,
+)
 from smolvm.types import (
     GuestOS,
     NetworkConfig,
@@ -946,6 +954,76 @@ class SmolVMManager:
             return config.qemu_network == "tap"
         return False
 
+    @staticmethod
+    def _local_tcp_port_is_available(host: str, port: int) -> bool:
+        """Return whether a local TCP forward target can be bound."""
+        try:
+            with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
+                sock.bind((host, port))
+        except (OSError, OverflowError):
+            return False
+        return True
+
+    @classmethod
+    def _local_ssh_port_is_available(cls, port: int) -> bool:
+        """Return whether the localhost SSH forward port can be bound."""
+        return cls._local_tcp_port_is_available("127.0.0.1", port)
+
+    def _reserve_available_ssh_port(self, vm_id: str) -> int:
+        """Reserve an SSH host port that is free in state and on localhost."""
+        excluded_ports: set[int] = set()
+        pool_size = SSH_PORT_END - SSH_PORT_START + 1
+
+        while len(excluded_ports) < pool_size:
+            port = self.state.reserve_ssh_port(
+                vm_id,
+                excluded_host_ports=excluded_ports,
+            )
+            if self._local_ssh_port_is_available(port):
+                return port
+
+            self.state.release_ssh_port(vm_id)
+            excluded_ports.add(port)
+            logger.warning(
+                "Skipping SSH host port %d for VM %s because it is already in use",
+                port,
+                vm_id,
+            )
+
+        raise NetworkError(
+            f"No local SSH port is available for sandbox '{vm_id}'. "
+            f"Free a port in {SSH_PORT_START}-{SSH_PORT_END}, then retry."
+        )
+
+    def _check_qemu_slirp_host_forward_ports(self, vm_info: VMInfo) -> None:
+        """Fail before QEMU starts if any slirp host-forward port is busy."""
+        if vm_info.config.qemu_network == "tap" or vm_info.network is None:
+            return
+
+        # This is an early, user-friendly guard. QEMU still owns the final bind,
+        # so a process that grabs the port after this check can still win the race.
+        ssh_port = vm_info.network.ssh_host_port
+        if ssh_port is not None and not self._local_ssh_port_is_available(ssh_port):
+            raise SmolVMError(
+                f"Local SSH port {ssh_port} is already in use. Free that port, or run "
+                f"'smolvm delete {vm_info.vm_id}' to remove the sandbox.",
+                {"vm_id": vm_info.vm_id, "ssh_host_port": ssh_port},
+            )
+
+        for forward in vm_info.config.port_forwards:
+            if self._local_tcp_port_is_available(forward.host_address, forward.host_port):
+                continue
+            raise SmolVMError(
+                f"Local port {forward.host_address}:{forward.host_port} is already in use. "
+                f"Free that port, or run 'smolvm delete {vm_info.vm_id}' to remove the sandbox.",
+                {
+                    "vm_id": vm_info.vm_id,
+                    "host_address": forward.host_address,
+                    "host_port": forward.host_port,
+                    "guest_port": forward.guest_port,
+                },
+            )
+
     def create(self, config: VMConfig) -> VMInfo:
         """Create a new microVM.
 
@@ -994,7 +1072,7 @@ class SmolVMManager:
         vm_info = self.state.create_vm(effective_config)
 
         try:
-            ssh_host_port = self.state.reserve_ssh_port(effective_config.vm_id)
+            ssh_host_port = self._reserve_available_ssh_port(effective_config.vm_id)
 
             if not self._uses_host_tap_networking(effective_config, backend):
                 if (
@@ -1142,6 +1220,8 @@ class SmolVMManager:
         self._check_workspace_mounts(vm_info)
 
         backend = self._backend_for_vm(vm_info)
+        if backend == BACKEND_QEMU:
+            self._check_qemu_slirp_host_forward_ports(vm_info)
         log_path = self.data_dir / f"{vm_id}.log"
         adapter = self._runtime_adapter_for_backend(backend)
         try:
@@ -2227,7 +2307,7 @@ class SmolVMManager:
         self.state.create_vm(effective_config)
 
         try:
-            ssh_host_port = self.state.reserve_ssh_port(effective_config.vm_id)
+            ssh_host_port = self._reserve_available_ssh_port(effective_config.vm_id)
 
             if not self._uses_host_tap_networking(effective_config, backend):
                 if (
@@ -2330,6 +2410,8 @@ class SmolVMManager:
         self._check_workspace_mounts(vm_info)
 
         backend = self._backend_for_vm(vm_info)
+        if backend == BACKEND_QEMU:
+            self._check_qemu_slirp_host_forward_ports(vm_info)
         log_path = self.data_dir / f"{vm_id}.log"
         adapter = self._runtime_adapter_for_backend(backend)
         try:

--- a/tests/test_storage.py
+++ b/tests/test_storage.py
@@ -25,7 +25,7 @@ from smolvm.exceptions import (
     VMAlreadyExistsError,
     VMNotFoundError,
 )
-from smolvm.storage import StateManager
+from smolvm.storage import SSH_PORT_END, StateManager
 from smolvm.types import (
     BrowserSessionConfig,
     BrowserSessionInfo,
@@ -322,6 +322,10 @@ class TestSSHPortAllocation:
         assert port == 2200
         assert state_manager.get_ssh_port("vm001") == 2200
 
+    def test_ssh_port_pool_ends_at_tcp_max_port(self) -> None:
+        """The SSH port pool must not allocate invalid TCP ports."""
+        assert SSH_PORT_END == 65535
+
     def test_reserve_ssh_port_is_stable(
         self, state_manager: StateManager, sample_config: VMConfig
     ) -> None:
@@ -354,6 +358,19 @@ class TestSSHPortAllocation:
             ports.append(state_manager.reserve_ssh_port(f"vm-ssh-{i}"))
 
         assert ports == [2200, 2201, 2202]
+
+    def test_reserve_ssh_port_skips_excluded_ports(
+        self,
+        state_manager: StateManager,
+        sample_config: VMConfig,
+    ) -> None:
+        """Port reservation can skip ports that are busy outside SmolVM state."""
+        state_manager.create_vm(sample_config)
+
+        port = state_manager.reserve_ssh_port("vm001", excluded_host_ports={2200, 2201})
+
+        assert port == 2202
+        assert state_manager.get_ssh_port("vm001") == 2202
 
     def test_release_ssh_port(self, state_manager: StateManager, sample_config: VMConfig) -> None:
         """Test releasing a reserved SSH host port."""

--- a/tests/test_vm_qemu.py
+++ b/tests/test_vm_qemu.py
@@ -67,6 +67,84 @@ def test_start_qemu_missing_binary_uses_linux_install_hint(tmp_path: Path) -> No
     assert "brew install qemu" not in message
 
 
+def test_create_qemu_skips_local_ssh_port_that_is_already_in_use(tmp_path: Path) -> None:
+    """QEMU slirp VMs should not reserve a localhost port QEMU cannot bind."""
+    kernel = tmp_path / "vmlinux"
+    rootfs = tmp_path / "rootfs.ext4"
+    kernel.touch()
+    rootfs.touch()
+    config = VMConfig(
+        vm_id="vm-qemu-busy-port",
+        kernel_path=kernel,
+        rootfs_path=rootfs,
+        backend="qemu",
+    )
+    sdk = SmolVMManager(data_dir=tmp_path / "data", socket_dir=tmp_path / "sockets", backend="qemu")
+
+    with (
+        patch.object(SmolVMManager, "_create_qemu_overlay_disk") as mock_overlay,
+        patch.object(
+            SmolVMManager,
+            "_local_ssh_port_is_available",
+            side_effect=lambda port: port != 2200,
+        ),
+    ):
+        mock_overlay.side_effect = lambda _source, target: target.touch()
+        vm_info = sdk.create(config)
+
+    assert vm_info.network is not None
+    assert vm_info.network.ssh_host_port == 2201
+
+
+def test_local_tcp_port_probe_handles_invalid_ports() -> None:
+    """Invalid TCP ports should be treated as unavailable, not crash the probe."""
+    assert SmolVMManager._local_tcp_port_is_available("127.0.0.1", 65536) is False
+
+
+def test_start_qemu_slirp_reports_busy_ssh_port_before_launch(tmp_path: Path) -> None:
+    """A stopped QEMU slirp VM should fail clearly before QEMU exits early."""
+    vm_info = _qemu_vm_info(tmp_path)
+    sdk = SmolVMManager(data_dir=tmp_path / "data", socket_dir=tmp_path / "sockets", backend="qemu")
+    sdk.state.create_vm(vm_info.config)
+    sdk.state.update_vm(vm_info.vm_id, network=vm_info.network)
+
+    with (
+        patch.object(SmolVMManager, "_local_ssh_port_is_available", return_value=False),
+        patch.object(sdk, "_runtime_adapter_for_backend") as mock_adapter_factory,
+        pytest.raises(SmolVMError, match="Local SSH port 2200 is already in use"),
+    ):
+        sdk.start(vm_info.vm_id)
+
+    mock_adapter_factory.assert_not_called()
+    assert sdk.state.get_vm(vm_info.vm_id).status == VMState.CREATED
+
+
+def test_start_qemu_slirp_reports_busy_custom_forward_before_launch(tmp_path: Path) -> None:
+    """Configured QEMU host forwards should get the same clear preflight error."""
+    vm_info = _qemu_vm_info(tmp_path)
+    config = vm_info.config.model_copy(
+        update={"port_forwards": [PortForwardConfig(host_port=39011, guest_port=9222)]}
+    )
+    vm_info = vm_info.model_copy(update={"config": config})
+    sdk = SmolVMManager(data_dir=tmp_path / "data", socket_dir=tmp_path / "sockets", backend="qemu")
+    sdk.state.create_vm(vm_info.config)
+    sdk.state.update_vm(vm_info.vm_id, network=vm_info.network)
+
+    with (
+        patch.object(
+            SmolVMManager,
+            "_local_tcp_port_is_available",
+            side_effect=lambda _host, port: port != 39011,
+        ),
+        patch.object(sdk, "_runtime_adapter_for_backend") as mock_adapter_factory,
+        pytest.raises(SmolVMError, match="Local port 127.0.0.1:39011 is already in use"),
+    ):
+        sdk.start(vm_info.vm_id)
+
+    mock_adapter_factory.assert_not_called()
+    assert sdk.state.get_vm(vm_info.vm_id).status == VMState.CREATED
+
+
 @patch("smolvm.vm.subprocess.Popen")
 @patch.object(
     SmolVMManager,


### PR DESCRIPTION
## Summary
- Skip localhost SSH ports that are already in use when reserving ports for new sandboxes
- Fail before launching QEMU when a stopped slirp sandbox's SSH port is busy
- Cover SQLite/Postgres reservation filtering and QEMU startup behavior with tests

## Tests
- `uv run ruff check src/smolvm/vm.py src/smolvm/storage/_protocol.py src/smolvm/storage/_sqlite.py src/smolvm/storage/_postgres.py tests/test_vm_qemu.py tests/test_storage.py`
- `uv run pytest tests/test_storage.py::TestSSHPortAllocation tests/test_vm_qemu.py -q`
- `uv run pytest -q` *(fails one unrelated local-path issue: `tests/test_vsock_channel.py::TestUdsTransport::test_from_uds_handshake_then_ping` with `OSError: AF_UNIX path too long`)*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * SSH port allocation now supports excluding specific host ports and enforces local bindability before reserving.
  * VM creation will skip unavailable ports and pick the next free port.
  * VM startup validates SSH/forwarded port availability and fails early with clear errors if ports are in use.
  * SSH port pool capped to the valid TCP port range.

* **Tests**
  * Added coverage for exclusion, pool bounds, and port-availability preflight scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->