### PR TITLE
feat(callbacks): class-based hooks around SmolVM.run()

### DIFF
--- a/src/smolvm/__init__.py
+++ b/src/smolvm/__init__.py
@@ -21,6 +21,7 @@ sandboxed environment.
 from importlib.metadata import version as _pkg_version
 
 from smolvm.browser import BrowserSession
+from smolvm.callbacks import Callback, CommandBlockedError, RunContext
 from smolvm.exceptions import (
     BrowserSessionAlreadyExistsError,
     BrowserSessionNotFoundError,
@@ -67,6 +68,10 @@ __all__ = [
     "SmolVM",
     "BrowserSession",
     "SmolVMManager",
+    # Callbacks / hooks
+    "Callback",
+    "RunContext",
+    "CommandBlockedError",
     # Image management
     "ImageManager",
     "ImageBuilder",

--- a/src/smolvm/callbacks.py
+++ b/src/smolvm/callbacks.py
@@ -1,0 +1,168 @@
+# Copyright 2026 Celesto AI
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Class-based callbacks for hooking into the SmolVM command lifecycle.
+
+A callback is a plain object that subclasses :class:`Callback` and overrides
+only the ``on_*`` hooks it cares about; every hook defaults to a no-op, so a
+callback never has to implement methods it does not use (the same shape as
+Keras and PyTorch Lightning callbacks).
+
+Callbacks are attached per-VM and fire around :meth:`smolvm.SmolVM.run`::
+
+    from smolvm import SmolVM, Callback, CommandBlockedError
+
+    class SafetyGuard(Callback):
+        DENY = ("rm -rf /", "mkfs", ":(){ :|:& };:")
+
+        def on_pre_run(self, ctx):
+            if any(bad in ctx.command for bad in self.DENY):
+                raise CommandBlockedError(
+                    f"Blocked unsafe command: {ctx.command!r}"
+                )
+
+    with SmolVM(config, callbacks=[SafetyGuard()]) as vm:
+        vm.run("rm -rf /")   # raises CommandBlockedError; never reaches guest
+
+Hook contract:
+
+* ``on_pre_run`` is the **veto** channel. If it raises, the command is aborted
+  before it ever reaches the guest and the exception propagates to the caller.
+  Raise :class:`CommandBlockedError` for an explicit, typed block.
+* ``on_post_run`` and ``on_run_error`` are passive **observers**. Exceptions
+  they raise are caught and logged so a faulty observer can never break a
+  command that already ran (or already failed); they do not propagate.
+"""
+
+from __future__ import annotations
+
+import logging
+from collections.abc import Iterable
+from dataclasses import dataclass
+
+from smolvm.exceptions import SmolVMError
+from smolvm.types import CommandResult
+
+logger = logging.getLogger(__name__)
+
+
+class CommandBlockedError(SmolVMError):
+    """Raised to veto a command from within :meth:`Callback.on_pre_run`.
+
+    Carries the offending command and VM id in ``details`` for logging.
+    """
+
+    def __init__(self, message: str, vm_id: str | None = None, command: str | None = None) -> None:
+        super().__init__(message, {"vm_id": vm_id, "command": command})
+        self.vm_id = vm_id
+        self.command = command
+
+
+@dataclass
+class RunContext:
+    """State passed to every command hook for a single :meth:`SmolVM.run` call.
+
+    Using one object (rather than loose keyword arguments) means new fields can
+    be added later without changing any callback's method signature.
+
+    Attributes:
+        vm_id: The VM the command targets.
+        command: The shell command as passed to ``run()``.
+        shell: Execution mode — ``"login"`` or ``"raw"``.
+        timeout: Per-command timeout in seconds.
+        result: The command result. ``None`` until ``on_post_run``.
+        error: The transport error raised during execution. ``None`` unless
+            the hook is ``on_run_error``.
+    """
+
+    vm_id: str
+    command: str
+    shell: str
+    timeout: int
+    result: CommandResult | None = None
+    error: Exception | None = None
+
+
+class Callback:
+    """Base class for SmolVM command-lifecycle callbacks.
+
+    Subclass this and override only the hooks you need; the defaults are
+    no-ops. See the module docstring for the veto-vs-observer contract.
+    """
+
+    def on_pre_run(self, ctx: RunContext) -> None:
+        """Called before a command is sent to the guest.
+
+        Raise to abort the command (e.g. :class:`CommandBlockedError`). The
+        exception propagates to the ``run()`` caller and nothing is executed.
+        """
+
+    def on_post_run(self, ctx: RunContext) -> None:
+        """Called after a command completes. ``ctx.result`` is populated.
+
+        Observer hook — exceptions are logged and swallowed.
+        """
+
+    def on_run_error(self, ctx: RunContext) -> None:
+        """Called when the transport raised while executing a command.
+
+        ``ctx.error`` is populated. Observer hook — exceptions are logged and
+        swallowed, and the original transport error still propagates.
+        """
+
+
+class CallbackDispatcher:
+    """Fans a single lifecycle event out to every registered callback in order.
+
+    Internal helper used by :class:`~smolvm.facade.SmolVM`. ``on_pre_run`` is
+    dispatched with ``propagate=True`` so a veto reaches the caller; observer
+    hooks are dispatched with ``propagate=False`` so one bad callback cannot
+    break the run.
+    """
+
+    def __init__(self, callbacks: Iterable[Callback] | None = None) -> None:
+        self._callbacks: list[Callback] = list(callbacks or [])
+
+    def add(self, callback: Callback) -> None:
+        if not isinstance(callback, Callback):
+            raise TypeError(f"callback must be a Callback instance, got {type(callback).__name__}")
+        self._callbacks.append(callback)
+
+    def __len__(self) -> int:
+        return len(self._callbacks)
+
+    def fire(self, hook: str, ctx: RunContext, *, propagate: bool) -> None:
+        """Invoke ``hook`` on every callback.
+
+        Args:
+            hook: Name of the ``on_*`` method to call.
+            ctx: The shared run context.
+            propagate: If True, a callback's exception is re-raised to the
+                caller (veto semantics). If False, it is logged and swallowed
+                (observer semantics).
+        """
+        for callback in self._callbacks:
+            method = getattr(callback, hook)
+            try:
+                method(ctx)
+            except Exception:
+                if propagate:
+                    raise
+                logger.exception(
+                    "Callback %s.%s raised; ignoring (vm_id=%s, command=%r)",
+                    type(callback).__name__,
+                    hook,
+                    ctx.vm_id,
+                    ctx.command,
+                )

--- a/src/smolvm/facade.py
+++ b/src/smolvm/facade.py
@@ -45,6 +45,7 @@ from typing import Any, Literal
 from urllib.parse import urlparse
 
 from smolvm._naming import generate_sandbox_name
+from smolvm.callbacks import Callback, CallbackDispatcher, RunContext
 from smolvm.comm import VsockChannel
 from smolvm.comm.base import CommChannelKind
 from smolvm.comm.select import ChannelResolution, resolve_comm_channel
@@ -912,6 +913,7 @@ class SmolVM:
         internet_settings: InternetSettings | dict[str, Any] | None = None,
         mounts: list[str] | None = None,
         writable_mounts: bool = False,
+        callbacks: list[Callback] | None = None,
     ) -> None:
         if config is not None and vm_id is not None:
             raise ValueError("Provide either config or vm_id, not both.")
@@ -1078,6 +1080,7 @@ class SmolVM:
         self._ssh: SSHClient | None = None
         self._ssh_ready = False
         self._local_forwards: dict[tuple[int, int], _LocalForward] = {}
+        self._callbacks = CallbackDispatcher(callbacks)
 
     # ------------------------------------------------------------------
     # Class methods
@@ -1378,6 +1381,8 @@ class SmolVM:
 
         Raises:
             SmolVMError: If the VM is not running or has no network.
+            CommandBlockedError: If an ``on_pre_run`` callback vetoes the
+                command (or any other exception a pre-run callback raises).
         """
         self._refresh_info()
 
@@ -1418,7 +1423,34 @@ class SmolVM:
                 {"vm_id": self._vm_id},
             )
 
-        return self._ssh.run(command, timeout=timeout, shell=shell)
+        ctx = RunContext(
+            vm_id=self._vm_id,
+            command=command,
+            shell=shell,
+            timeout=timeout,
+        )
+        # Pre-run hooks may veto: any exception they raise (e.g.
+        # CommandBlockedError) propagates and the command never runs.
+        self._callbacks.fire("on_pre_run", ctx, propagate=True)
+
+        try:
+            result = self._ssh.run(command, timeout=timeout, shell=shell)
+        except Exception as exc:
+            ctx.error = exc
+            self._callbacks.fire("on_run_error", ctx, propagate=False)
+            raise
+
+        ctx.result = result
+        self._callbacks.fire("on_post_run", ctx, propagate=False)
+        return result
+
+    def add_callback(self, callback: Callback) -> SmolVM:
+        """Register a :class:`~smolvm.callbacks.Callback` on this VM.
+
+        Returns ``self`` so calls can be chained.
+        """
+        self._callbacks.add(callback)
+        return self
 
     def _is_windows_guest(self) -> bool:
         """Return True when the running guest is Windows.

--- a/tests/test_callbacks.py
+++ b/tests/test_callbacks.py
@@ -1,0 +1,165 @@
+# Copyright 2026 Celesto AI
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for the command-lifecycle callback system."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from smolvm import Callback, CommandBlockedError, RunContext, SmolVM
+from smolvm.callbacks import CallbackDispatcher
+from smolvm.types import CommandResult, VMState
+
+
+def _make_vm(
+    callbacks: list[Callback] | None = None,
+    run_result: CommandResult | None = None,
+) -> SmolVM:
+    """Build a SmolVM wired just enough to exercise run()'s callback path.
+
+    Bypasses __init__ (which would create a real manager / VM) and stubs the
+    gating attributes run() checks before delegating to the SSH client.
+    """
+    vm = SmolVM.__new__(SmolVM)
+    vm._vm_id = "vm-test"
+    vm._refresh_info = MagicMock()  # type: ignore[method-assign]
+    vm.can_run_commands = MagicMock(return_value=True)  # type: ignore[method-assign]
+    vm._info = MagicMock(status=VMState.RUNNING, network=MagicMock())
+    vm._ssh_ready = True
+    result = run_result or CommandResult(exit_code=0, stdout="ok", stderr="")
+    vm._ssh = MagicMock()
+    vm._ssh.run.return_value = result
+    vm._callbacks = CallbackDispatcher(callbacks)
+    return vm
+
+
+def test_pre_run_veto_blocks_command() -> None:
+    class Guard(Callback):
+        def on_pre_run(self, ctx: RunContext) -> None:
+            if "rm -rf /" in ctx.command:
+                raise CommandBlockedError("unsafe", vm_id=ctx.vm_id, command=ctx.command)
+
+    vm = _make_vm(callbacks=[Guard()])
+
+    with pytest.raises(CommandBlockedError) as excinfo:
+        vm.run("rm -rf /")
+
+    assert excinfo.value.command == "rm -rf /"
+    vm._ssh.run.assert_not_called()  # command never reached the guest
+
+
+def test_allowed_command_runs_and_fires_post_run() -> None:
+    seen: list[RunContext] = []
+
+    class Recorder(Callback):
+        def on_post_run(self, ctx: RunContext) -> None:
+            seen.append(ctx)
+
+    vm = _make_vm(callbacks=[Recorder()])
+    result = vm.run("echo hi")
+
+    assert result.stdout == "ok"
+    vm._ssh.run.assert_called_once()
+    assert len(seen) == 1
+    assert seen[0].command == "echo hi"
+    assert seen[0].result is result
+
+
+def test_pre_run_receives_full_context() -> None:
+    captured: list[tuple] = []
+
+    class Recorder(Callback):
+        def on_pre_run(self, ctx: RunContext) -> None:
+            # Snapshot inside the hook: the ctx object is reused across the
+            # run, so result is only None *at this point*, before execution.
+            captured.append((ctx.vm_id, ctx.command, ctx.shell, ctx.timeout, ctx.result))
+
+    vm = _make_vm(callbacks=[Recorder()])
+    vm.run("uname -r", timeout=12, shell="raw")
+
+    assert captured[0] == ("vm-test", "uname -r", "raw", 12, None)
+
+
+def test_callbacks_fire_in_registration_order() -> None:
+    order: list[str] = []
+
+    class A(Callback):
+        def on_pre_run(self, ctx: RunContext) -> None:
+            order.append("a")
+
+    class B(Callback):
+        def on_pre_run(self, ctx: RunContext) -> None:
+            order.append("b")
+
+    vm = _make_vm(callbacks=[A(), B()])
+    vm.run("true")
+    assert order == ["a", "b"]
+
+
+def test_observer_exception_is_swallowed() -> None:
+    class Faulty(Callback):
+        def on_post_run(self, ctx: RunContext) -> None:
+            raise RuntimeError("boom")
+
+    vm = _make_vm(callbacks=[Faulty()])
+    # A broken observer must not break a command that already ran.
+    result = vm.run("echo hi")
+    assert result.stdout == "ok"
+
+
+def test_run_error_hook_fires_and_original_error_propagates() -> None:
+    seen: list[RunContext] = []
+
+    class Watcher(Callback):
+        def on_run_error(self, ctx: RunContext) -> None:
+            seen.append(ctx)
+
+    vm = _make_vm(callbacks=[Watcher()])
+    boom = RuntimeError("transport down")
+    vm._ssh.run.side_effect = boom
+
+    with pytest.raises(RuntimeError, match="transport down"):
+        vm.run("echo hi")
+
+    assert len(seen) == 1
+    assert seen[0].error is boom
+
+
+def test_add_callback_registers_and_chains() -> None:
+    class Guard(Callback):
+        def on_pre_run(self, ctx: RunContext) -> None:
+            raise CommandBlockedError("nope")
+
+    vm = _make_vm()
+    returned = vm.add_callback(Guard())
+    assert returned is vm  # chainable
+
+    with pytest.raises(CommandBlockedError):
+        vm.run("anything")
+
+
+def test_add_callback_rejects_non_callback() -> None:
+    vm = _make_vm()
+    with pytest.raises(TypeError):
+        vm.add_callback(object())  # type: ignore[arg-type]
+
+
+def test_no_callbacks_is_noop() -> None:
+    vm = _make_vm()
+    result = vm.run("echo hi")
+    assert result.stdout == "ok"
+    vm._ssh.run.assert_called_once()


### PR DESCRIPTION
## Summary

Adds a class-based callback system that fires around `SmolVM.run()`, with a **veto channel** so callers can block unsafe commands before they ever reach the guest. Shape follows Keras / PyTorch Lightning callbacks (subclass a base class, override only the hooks you need).

The motivating use case: a pre-run hook that inspects a command and aborts it if unsafe.

```python
from smolvm import SmolVM, Callback, CommandBlockedError

class SafetyGuard(Callback):
    DENY = ("rm -rf /", "mkfs", ":(){ :|:& };:")
    def on_pre_run(self, ctx):
        if any(bad in ctx.command for bad in self.DENY):
            raise CommandBlockedError(f"Blocked: {ctx.command!r}",
                                      vm_id=ctx.vm_id, command=ctx.command)

with SmolVM(config, callbacks=[SafetyGuard()]) as vm:
    vm.run("rm -rf /")   # raises CommandBlockedError; never reaches the guest
```

## What's included

- **New `smolvm.callbacks` module**
  - `Callback` — base class with no-op `on_pre_run` / `on_post_run` / `on_run_error` hooks.
  - `RunContext` — single dataclass passed to every hook (`vm_id`, `command`, `shell`, `timeout`, `result`, `error`); new fields can be added later without breaking signatures.
  - `CommandBlockedError` — typed exception for vetoing a command.
  - `CallbackDispatcher` — internal fan-out helper.
- **Facade wiring** (`facade.py`): `SmolVM(..., callbacks=[...])` kwarg, chainable `add_callback(cb)`, and dispatch inside `run()`. Hooks fire on the facade *before* delegating to the transport, so they cover both the SSH and vsock paths.
- **Exports**: `Callback`, `RunContext`, `CommandBlockedError`.
- **Tests**: `tests/test_callbacks.py` (9 cases).

## Hook contract

- `on_pre_run` is the **veto** channel — if it raises, the command is aborted before the guest sees it and the exception propagates to the caller. A blocked command keeps the connection open for the next allowed command (no forced reconnect).
- `on_post_run` / `on_run_error` are passive **observers** — their exceptions are logged and swallowed so a faulty observer can't break a command that already ran.

## Scope

First pass intentionally covers **command hooks only**. The same `CallbackDispatcher` + `RunContext` machinery extends cleanly to lifecycle hooks (`on_start` / `on_stop` / `on_error` from `SmolVMManager`) and file-transfer/connection hooks as follow-ups. Sync only for now, matching `run()`.

## Testing

- `pytest tests/test_callbacks.py` — 9 passed
- `pytest tests/test_facade.py` — 118 passed, 8 skipped (no regression)
- `ruff check` — clean on changed files

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added callback system for the command execution lifecycle, enabling pre-run command interception, post-execution hooks, and error handling.
  * Added ability to block commands from executing via pre-run callbacks.
  * Added chainable callback registration method for dynamic callback addition.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->