### PR TITLE
fix(types): VMConfig rejects unknown fields (extra=forbid)

### DIFF
--- a/src/smolvm/types.py
+++ b/src/smolvm/types.py
@@ -487,7 +487,7 @@ class VMConfig(BaseModel):
             seen_guest_paths.add(mount.guest_path)
         return v
 
-    model_config = {"frozen": True}
+    model_config = {"frozen": True, "extra": "forbid"}
 
 
 class BrowserSessionConfig(BaseModel):


### PR DESCRIPTION
## What

`VMConfig` used `model_config = {"frozen": True}` with no `extra` policy, so pydantic v2 **silently dropped unknown kwargs**. This change sets `extra="forbid"` so a wrong or renamed field raises at construction instead of being silently ignored.

## Why

The silent-drop behavior hid a real, live bug in **celesto-agent**: its Firecracker create/restore paths passed `mem_size_mib=` to `VMConfig`. There is no such field (the real one is `memory`), so the value was silently dropped and **every Firecracker VM booted at the 512 MiB default**, ignoring the requested RAM. `extra="forbid"` makes this class of bug fail loudly at construction.

## Audit (call sites checked)

Audited **every** `VMConfig(...)` call site for stray kwargs (AST scan + manual review):

- SmolVM `src/` (facade.py x5, browser.py, images/builder.py, windows/build_image.py, cli/main.py) — all use real fields only. `browser.py` correctly reads `browser_config.mem_size_mib` (a `BrowserSessionConfig` field) and maps it to `memory=`.
- SmolVM `examples/`, `scripts/`, and all `tests/` — clean. The `# type: ignore[arg-type]` cases in `test_types.py` (`vm_id=None`, `disk_mode="snapshot"`) pass *real* fields with invalid values to assert validation; they still raise correctly.
- celesto-agent — the **only** stray-kwarg caller is `mem_size_mib`, fixed in the paired agent PR.

No non-test caller passes a stray kwarg. Full suite green: **1175 passed, 13 skipped**.

## ⚠️ Deploy order matters

The celesto-agent fix [`fix/fc-ram-and-qemu-vsock`](https://github.com/CelestoAI/celesto-agent/pull/new/fix/fc-ram-and-qemu-vsock) (which removes the stray `mem_size_mib` kwarg) **MUST be deployed before or together with this change.** Otherwise the agent will crash constructing a now-forbidding `VMConfig`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Strengthened configuration validation to reject unknown or unsupported fields, improving system reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->