### PR TITLE
fix(upload): land vsock uploads inside guest directory destination

### DIFF
--- a/src/smolvm/comm/protocol.py
+++ b/src/smolvm/comm/protocol.py
@@ -39,8 +39,11 @@ version):
 - ``run``   ``{"cmd": str, "shell": "login"|"raw", "timeout": int|null, "env": {}}``
   → interleaved ``STDOUT``/``STDERR`` frames, terminated by a control frame
   ``{"op": "exit", "exit_code": int}`` or ``{"op": "timeout", "timeout": float}``.
-- ``put_file`` ``{"path": str, "mode": int|null, "size": int}`` followed by
-  exactly ``size`` bytes in ``DATA`` frames → ``{"ok": bool, "error"?: str}``.
+- ``put_file`` ``{"path": str, "name"?: str, "mode": int|null, "size": int}``
+  followed by exactly ``size`` bytes in ``DATA`` frames →
+  ``{"ok": bool, "error"?: str}``. When ``path`` is an existing directory the
+  guest lands the file inside it using ``name`` (the source basename); only
+  the guest can see its own filesystem, so the directory check happens there.
 - ``get_file`` ``{"path": str}`` → ``{"ok": true, "mode": int, "size": int}``
   then ``DATA`` frames terminated by ``EOF`` (or ``{"ok": false, "error": str}``).
 """

--- a/src/smolvm/comm/vsock_channel.py
+++ b/src/smolvm/comm/vsock_channel.py
@@ -229,6 +229,7 @@ class VsockChannel:
                     "v": protocol.PROTOCOL_VERSION,
                     "op": "put_file",
                     "path": remote_path,
+                    "name": source.name,
                     "mode": mode,
                     "size": len(data),
                 },

--- a/src/smolvm/guest_agent/agent.py
+++ b/src/smolvm/guest_agent/agent.py
@@ -236,9 +236,12 @@ def handle_put_file(conn: Any, req: dict[str, Any]) -> None:
             base = os.path.basename(name) if name else ""
             # basename() collapses "../escape" to a contained name, but "." and
             # ".." survive it and would join back to a directory — failing later
-            # with a cryptic Errno 21. Reject them up front like a missing name.
-            if not base or base in (os.curdir, os.pardir):
+            # with a cryptic Errno 21. Reject them up front, distinguishing a
+            # missing name from one that resolves to no real filename.
+            if not base:
                 error = f"destination is a directory and no filename was provided: {path}"
+            elif base in (os.curdir, os.pardir):
+                error = f"destination filename is invalid: {name} (cannot be '.' or '..')"
             else:
                 target = os.path.join(target, base)
         if error is None:

--- a/src/smolvm/guest_agent/agent.py
+++ b/src/smolvm/guest_agent/agent.py
@@ -214,22 +214,37 @@ def handle_run(conn: Any, req: dict[str, Any]) -> None:
 
 def handle_put_file(conn: Any, req: dict[str, Any]) -> None:
     path = req.get("path")
+    name = req.get("name")
     size = int(req.get("size", 0))
     mode = req.get("mode")
 
     error: str | None = None
+    target: str | None = None
     tmp_path: str | None = None
     handle = None
     if not path:
         error = "missing 'path'"
     else:
         target = os.path.abspath(path)
-        parent = os.path.dirname(target) or "/"
-        try:
-            tmp_fd, tmp_path = tempfile.mkstemp(dir=parent, prefix=".smolvm-put-")
-            handle = os.fdopen(tmp_fd, "wb")
-        except OSError as exc:
-            error = f"cannot create file: {exc}"
+        # If the destination is an existing directory, land the file *inside*
+        # it (matching `cp file dir/`). Only the guest can see its own
+        # filesystem, so this directory check has to happen here rather than
+        # host-side; the host supplies the source basename as `name`.
+        # basename() blocks path traversal (e.g. name="../escape") — SFTP got
+        # this sanitization from its server, but our raw agent must do it.
+        if os.path.isdir(target):
+            base = os.path.basename(name) if name else ""
+            if not base:
+                error = f"destination is a directory and no filename was provided: {path}"
+            else:
+                target = os.path.join(target, base)
+        if error is None:
+            parent = os.path.dirname(target) or "/"
+            try:
+                tmp_fd, tmp_path = tempfile.mkstemp(dir=parent, prefix=".smolvm-put-")
+                handle = os.fdopen(tmp_fd, "wb")
+            except OSError as exc:
+                error = f"cannot create file: {exc}"
 
     # Always drain exactly `size` payload bytes so the stream stays framed even
     # when the write target is unwritable; discard them if we have no file.
@@ -256,7 +271,7 @@ def handle_put_file(conn: Any, req: dict[str, Any]) -> None:
         try:
             if mode is not None:
                 os.chmod(tmp_path, int(mode))
-            os.replace(tmp_path, os.path.abspath(path))
+            os.replace(tmp_path, target)
         except OSError as exc:
             error = str(exc)
 

--- a/src/smolvm/guest_agent/agent.py
+++ b/src/smolvm/guest_agent/agent.py
@@ -234,7 +234,10 @@ def handle_put_file(conn: Any, req: dict[str, Any]) -> None:
         # this sanitization from its server, but our raw agent must do it.
         if os.path.isdir(target):
             base = os.path.basename(name) if name else ""
-            if not base:
+            # basename() collapses "../escape" to a contained name, but "." and
+            # ".." survive it and would join back to a directory — failing later
+            # with a cryptic Errno 21. Reject them up front like a missing name.
+            if not base or base in (os.curdir, os.pardir):
                 error = f"destination is a directory and no filename was provided: {path}"
             else:
                 target = os.path.join(target, base)

--- a/tests/test_guest_agent.py
+++ b/tests/test_guest_agent.py
@@ -276,7 +276,8 @@ class TestFileTransfer:
             resp = protocol.recv_json(host)
             thread.join(timeout=5)
         assert resp["ok"] is False
-        assert "directory" in resp["error"]
+        assert "invalid" in resp["error"]
+        assert name in resp["error"]
 
     def test_put_file_into_directory_without_name_errors(self, tmp_path) -> None:
         # A directory destination with no usable filename fails with a clear

--- a/tests/test_guest_agent.py
+++ b/tests/test_guest_agent.py
@@ -200,6 +200,74 @@ class TestFileTransfer:
         assert resp["ok"] is False
         assert "error" in resp
 
+    def test_put_file_lands_inside_directory(self, tmp_path) -> None:
+        # Destination is an existing directory: the file should land inside it
+        # under the source basename (`name`), matching `cp file dir/`.
+        payload = b"inside-the-dir"
+        host, guest = socket.socketpair()
+        with host:
+            thread = _serve_once(guest)
+            protocol.send_json(
+                host,
+                {
+                    "op": "put_file",
+                    "path": str(tmp_path),
+                    "name": "report.md",
+                    "mode": None,
+                    "size": len(payload),
+                },
+            )
+            protocol.send_frame(host, protocol.FRAME_DATA, payload)
+            resp = protocol.recv_json(host)
+            thread.join(timeout=5)
+        assert resp["ok"] is True
+        landed = tmp_path / "report.md"
+        assert landed.read_bytes() == payload
+
+    def test_put_file_into_directory_strips_traversal(self, tmp_path) -> None:
+        # A malicious/buggy `name` must not escape the destination directory:
+        # basename() collapses "../escape" to "escape".
+        dest = tmp_path / "dest"
+        dest.mkdir()
+        payload = b"no-escape"
+        host, guest = socket.socketpair()
+        with host:
+            thread = _serve_once(guest)
+            protocol.send_json(
+                host,
+                {
+                    "op": "put_file",
+                    "path": str(dest),
+                    "name": "../escape",
+                    "mode": None,
+                    "size": len(payload),
+                },
+            )
+            protocol.send_frame(host, protocol.FRAME_DATA, payload)
+            resp = protocol.recv_json(host)
+            thread.join(timeout=5)
+        assert resp["ok"] is True
+        assert (dest / "escape").read_bytes() == payload
+        assert not (tmp_path / "escape").exists()
+
+    def test_put_file_into_directory_without_name_errors(self, tmp_path) -> None:
+        # A directory destination with no usable filename fails with a clear
+        # message instead of a cryptic "Is a directory" errno later.
+        payload = b"data"
+        host, guest = socket.socketpair()
+        with host:
+            thread = _serve_once(guest)
+            protocol.send_json(
+                host,
+                {"op": "put_file", "path": str(tmp_path), "mode": None, "size": len(payload)},
+            )
+            # Bytes must still be drained so the stream stays framed.
+            protocol.send_frame(host, protocol.FRAME_DATA, payload)
+            resp = protocol.recv_json(host)
+            thread.join(timeout=5)
+        assert resp["ok"] is False
+        assert "directory" in resp["error"]
+
     def test_get_file_streams_bytes_and_mode(self, tmp_path) -> None:
         source = tmp_path / "blob.bin"
         payload = os.urandom(200_000)  # spans multiple CHUNK_SIZE frames

--- a/tests/test_guest_agent.py
+++ b/tests/test_guest_agent.py
@@ -250,6 +250,34 @@ class TestFileTransfer:
         assert (dest / "escape").read_bytes() == payload
         assert not (tmp_path / "escape").exists()
 
+    @pytest.mark.parametrize("name", [".", ".."])
+    def test_put_file_into_directory_rejects_dot_names(self, tmp_path, name) -> None:
+        # "." and ".." survive basename() and would join back to a directory,
+        # failing later with a cryptic Errno 21. They're rejected up front with
+        # the same clear message as a missing name.
+        dest = tmp_path / "dest"
+        dest.mkdir()
+        payload = b"data"
+        host, guest = socket.socketpair()
+        with host:
+            thread = _serve_once(guest)
+            protocol.send_json(
+                host,
+                {
+                    "op": "put_file",
+                    "path": str(dest),
+                    "name": name,
+                    "mode": None,
+                    "size": len(payload),
+                },
+            )
+            # Bytes must still be drained so the stream stays framed.
+            protocol.send_frame(host, protocol.FRAME_DATA, payload)
+            resp = protocol.recv_json(host)
+            thread.join(timeout=5)
+        assert resp["ok"] is False
+        assert "directory" in resp["error"]
+
     def test_put_file_into_directory_without_name_errors(self, tmp_path) -> None:
         # A directory destination with no usable filename fails with a clear
         # message instead of a cryptic "Is a directory" errno later.


### PR DESCRIPTION
## What

`smolvm file upload <vm> ./f /root` over the **vsock** backend failed with a cryptic "Is a directory" (Errno 21) when the destination was an existing directory. This is the same user-facing bug fixed for SSH in #323, now fixed for vsock — but designed around vsock's own constraints rather than copied.

Closes #324.

## Why it broke

`handle_put_file` always treated `path` as the final file path and re-derived `abspath(path)` at `os.replace` time, so the temp file was renamed *onto* the directory.

## The design

The information split is forced by vsock, and the fix follows from it:

- **Only the guest can see its filesystem** → the directory check happens guest-side.
- **Only the host knows the source filename** → the host now ships `name` (the source basename) in the `put_file` request.

The decision lives entirely in one guest-side message — no extra round-trip, no TOCTOU race.

## Changes

- **`comm/vsock_channel.py`** (host) — adds `"name": source.name` to the `put_file` request.
- **`guest_agent/agent.py`** (the fix) — in `handle_put_file`, before `mkstemp`: if the destination is an existing directory, retarget to `<dir>/<basename(name)>`.
  - `os.path.basename(name)` sanitizes path traversal (e.g. `name="../escape"`) — a guard SFTP got for free from its server, but our raw agent must do itself.
  - Done before `mkstemp` so the temp file is created in the right parent and `os.replace` stays atomic on the same filesystem.
  - A directory destination with no usable `name` returns a clear error instead of `Errno 21`, and the byte drain still runs so the stream stays framed.
  - `os.replace` now targets the resolved path instead of re-deriving `abspath(path)`.
- **`comm/protocol.py`** — documents the new optional `name` field.

## Tests

Three new cases in `tests/test_guest_agent.py`:
- lands inside an existing directory under the source basename
- strips `../escape` traversal so the file can't leave the directory
- errors clearly when a directory destination has no `name`

`pytest tests/test_guest_agent.py` → 17 passed. `ruff check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * File uploads can include an optional filename so files may be placed directly into existing directories using that name.
* **Bug Fixes**
  * Uploads to a directory without a usable filename now fail cleanly with a clear "directory" error while the upload stream is drained.
* **Security**
  * Filename validation sanitizes traversal-like names to prevent escaping the target directory.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->