### PR TITLE
test(e2e): real-KVM functional smoke of the SmolVM API (QEMU, nightly)

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -17,14 +17,6 @@ on:
     # 03:17 UTC nightly (off the top of the hour to dodge cron congestion).
     - cron: "17 3 * * *"
   workflow_dispatch:
-  # TEMPORARY: verify the suite on real KVM in PR #331 before merge.
-  # Remove this `pull_request` block before merging — the suite is meant to be
-  # nightly + manual, not per-PR (booting a real VM is slow on shared runners).
-  pull_request:
-    branches: [main]
-    paths:
-      - "tests/e2e/**"
-      - ".github/workflows/e2e.yml"
 
 permissions:
   contents: read

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -47,7 +47,7 @@ jobs:
             ~/.cargo/registry
             ~/.cargo/git
             target
-          key: rust-${{ runner.os }}-${{ hashFiles('Cargo.toml', 'smolvm-core/Cargo.toml') }}
+          key: rust-${{ runner.os }}-${{ hashFiles('Cargo.lock', 'Cargo.toml', 'smolvm-core/Cargo.toml') }}
           restore-keys: rust-${{ runner.os }}-
 
       - name: Install uv

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -1,0 +1,105 @@
+# Real-KVM end-to-end smoke of the public SmolVM API.
+#
+# Unlike the unit suite (which mocks the hypervisor) and smoke-published-images
+# (which shells out to raw qemu), this boots an actual QEMU micro-VM *through
+# the SmolVM Python API* and walks its whole lifecycle — start, exec, file
+# upload/download, pause/resume, snapshot/restore, stop/cleanup — over both the
+# SSH and vsock control transports.
+#
+# GH-hosted ubuntu-latest (x86) exposes /dev/kvm, so this runs with hardware
+# acceleration. It's nightly + manual rather than per-PR: booting a real VM is
+# slow and the shared runners are noisy.
+
+name: E2E (real KVM)
+
+on:
+  schedule:
+    # 03:17 UTC nightly (off the top of the hour to dodge cron congestion).
+    - cron: "17 3 * * *"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  e2e:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+
+      - name: Set up Python 3.13
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.13"
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Cache Rust build
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: rust-${{ runner.os }}-${{ hashFiles('Cargo.toml', 'smolvm-core/Cargo.toml') }}
+          restore-keys: rust-${{ runner.os }}-
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@caf0cab7a618c569241d31dcd442f54681755d39 # v3.2.4
+
+      - name: Install QEMU + tooling
+        run: |
+          sudo apt-get update -qq
+          sudo apt-get install -y --no-install-recommends \
+              qemu-system-x86 qemu-utils openssh-client
+
+      - name: Enable KVM and vsock
+        run: |
+          # The runner user isn't in the kvm group; SmolVM launches QEMU from
+          # its own process and can't sudo the subprocess, so widen /dev/kvm
+          # directly (CI-only). vsock needs the vhost_vsock module loaded so the
+          # vsock-transport variant of the suite isn't skipped.
+          sudo usermod -a -G kvm "$USER" || true
+          sudo chmod 666 /dev/kvm || true
+          sudo modprobe vhost_vsock || echo "vhost_vsock unavailable; vsock tests will skip"
+          ls -l /dev/kvm /dev/vhost-vsock || true
+
+      # uv workspace builds smolvm-core from the local smolvm-core/ directory.
+      - name: Install dependencies
+        run: uv sync --extra dev
+
+      - name: Assert native extension available
+        run: |
+          uv run python -c "
+          from smolvm_core import is_available
+          assert is_available(), 'Native extension reports not available on Linux'
+          print('smolvm-core: OK')
+          "
+
+      - name: Diagnostics (smolvm doctor)
+        run: uv run smolvm doctor || true
+
+      - name: Run e2e suite
+        run: uv run pytest -m e2e tests/e2e -v
+
+      - name: Dump VM logs on failure
+        if: failure()
+        run: |
+          echo "## e2e failed — recent VM/runtime logs" >> "$GITHUB_STEP_SUMMARY"
+          for d in "$HOME/.smolvm" "$HOME/.local/share/smolvm"; do
+            [ -d "$d" ] || continue
+            echo "### $d" >> "$GITHUB_STEP_SUMMARY"
+            find "$d" -name "*.log" -type f 2>/dev/null | while read -r f; do
+              echo "<details><summary>$f</summary>" >> "$GITHUB_STEP_SUMMARY"
+              echo '```' >> "$GITHUB_STEP_SUMMARY"
+              tail -100 "$f" >> "$GITHUB_STEP_SUMMARY" 2>/dev/null || true
+              echo '```' >> "$GITHUB_STEP_SUMMARY"
+              echo "</details>" >> "$GITHUB_STEP_SUMMARY"
+            done
+          done

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -17,6 +17,14 @@ on:
     # 03:17 UTC nightly (off the top of the hour to dodge cron congestion).
     - cron: "17 3 * * *"
   workflow_dispatch:
+  # TEMPORARY: verify the suite on real KVM in PR #331 before merge.
+  # Remove this `pull_request` block before merging — the suite is meant to be
+  # nightly + manual, not per-PR (booting a real VM is slow on shared runners).
+  pull_request:
+    branches: [main]
+    paths:
+      - "tests/e2e/**"
+      - ".github/workflows/e2e.yml"
 
 permissions:
   contents: read

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -7,12 +7,15 @@
 # SSH and vsock control transports.
 #
 # GH-hosted ubuntu-latest (x86) exposes /dev/kvm, so this runs with hardware
-# acceleration. It's nightly + manual rather than per-PR: booting a real VM is
-# slow and the shared runners are noisy.
+# acceleration. The whole suite boots in ~1.5 min on a runner, so it gates every
+# PR to main; the nightly cron still runs to catch runner/environment drift on
+# days with no PRs, and it can be launched manually.
 
 name: E2E (real KVM)
 
 on:
+  pull_request:
+    branches: [main]
   schedule:
     # 03:17 UTC nightly (off the top of the hour to dodge cron congestion).
     - cron: "17 3 * * *"

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -76,6 +76,11 @@ jobs:
           sudo usermod -a -G kvm "$USER" || true
           sudo chmod 666 /dev/kvm || true
           sudo modprobe vhost_vsock || echo "vhost_vsock unavailable; vsock tests will skip"
+          # /dev/vhost-vsock ships as root:kvm mode 660; the `usermod` above
+          # doesn't apply to this already-running job, so widen it directly the
+          # same way as /dev/kvm — otherwise QEMU can't open it and the vsock
+          # VM dies on boot (the device merely *existing* isn't enough).
+          sudo chmod 666 /dev/vhost-vsock || true
           ls -l /dev/kvm /dev/vhost-vsock || true
 
       # uv workspace builds smolvm-core from the local smolvm-core/ directory.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -106,4 +106,9 @@ members = ["smolvm-core"]
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]
-addopts = "-v --tb=short"
+# e2e tests boot a real KVM VM; deselect them from the default fast suite.
+# The nightly e2e workflow opts in explicitly with `pytest -m e2e`.
+addopts = "-v --tb=short -m 'not e2e'"
+markers = [
+    "e2e: boots a real KVM VM (QEMU); nightly only, needs /dev/kvm",
+]

--- a/tests/e2e/_util.py
+++ b/tests/e2e/_util.py
@@ -20,7 +20,7 @@ from pathlib import Path
 
 try:
     from smolvm_core import is_available as _core_available
-except Exception:  # pragma: no cover - native extension missing entirely
+except (ImportError, OSError):  # pragma: no cover - native extension missing entirely
     _core_available = None
 
 # Boot is fast under KVM, but auto-config may build/download the rootfs and

--- a/tests/e2e/_util.py
+++ b/tests/e2e/_util.py
@@ -1,0 +1,33 @@
+# Copyright 2026 Celesto AI
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Shared helpers for the real-KVM end-to-end suite."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+try:
+    from smolvm_core import is_available as _core_available
+except Exception:  # pragma: no cover - native extension missing entirely
+    _core_available = None
+
+# Boot is fast under KVM, but auto-config may build/download the rootfs and
+# base kernel on the first run; give the whole start() a generous budget.
+BOOT_TIMEOUT = 180.0
+
+
+def kvm_ready() -> bool:
+    """True when this host can actually run a hardware-accelerated VM."""
+    return Path("/dev/kvm").exists() and _core_available is not None and _core_available()

--- a/tests/e2e/conftest.py
+++ b/tests/e2e/conftest.py
@@ -46,7 +46,11 @@ def vm(request: pytest.FixtureRequest):
     transport = request.param
 
     if not kvm_ready():
-        pytest.skip("requires /dev/kvm and a working smolvm-core native extension")
+        pytest.skip(
+            "requires /dev/kvm and a working smolvm-core native extension "
+            "(enable KVM with `sudo modprobe kvm && sudo chmod 666 /dev/kvm`, "
+            "then re-run)"
+        )
     if transport == "vsock" and not host_supports_vsock():
         pytest.skip(
             "vsock requires a Linux host with /dev/vhost-vsock "

--- a/tests/e2e/conftest.py
+++ b/tests/e2e/conftest.py
@@ -1,0 +1,71 @@
+# Copyright 2026 Celesto AI
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Shared fixtures for the real-KVM end-to-end suite.
+
+These tests boot an actual QEMU micro-VM through the public ``SmolVM`` API
+(unlike the unit suite, which mocks the hypervisor). They run nightly on a
+GitHub ``ubuntu-latest`` runner, which exposes ``/dev/kvm``.
+
+The ``vm`` fixture is parametrized over both control transports — SSH and
+vsock — so the whole lifecycle (``test_lifecycle.py``) is exercised once per
+transport against a single, shared sandbox.
+"""
+
+from __future__ import annotations
+
+from contextlib import suppress
+
+import pytest
+from _util import BOOT_TIMEOUT, kvm_ready
+
+from smolvm import SmolVM
+from smolvm.comm import host_supports_vsock
+from smolvm.types import VMState
+
+
+@pytest.fixture(scope="module", params=["ssh", "vsock"])
+def vm(request: pytest.FixtureRequest):
+    """A single running QEMU sandbox, shared across the lifecycle tests.
+
+    Yields one started ``SmolVM`` per transport. Teardown is best-effort:
+    ``test_stop_and_cleanup`` deletes the sandbox as its final assertion, so
+    the ``stop``/``delete`` here are just a safety net for earlier failures.
+    """
+    transport = request.param
+
+    if not kvm_ready():
+        pytest.skip("requires /dev/kvm and a working smolvm-core native extension")
+    if transport == "vsock" and not host_supports_vsock():
+        pytest.skip(
+            "vsock requires a Linux host with /dev/vhost-vsock "
+            "(load it via `sudo modprobe vhost_vsock`)"
+        )
+
+    # Pin to Alpine: the SmolVM-*built* image (vsock guest agent + python3 baked
+    # in by ImageBuilder, SSH key injected on the kernel cmdline, no cloud-init
+    # seed ISO). The QEMU default is Ubuntu, whose cloud qcow2 carries a seed
+    # ISO as an extra drive (snapshot then rejects it) and lacks the baked-in
+    # agent (vsock never answers) — neither of which is what we want to smoke.
+    sandbox = SmolVM(backend="qemu", os="alpine", comm_channel=transport)
+    try:
+        sandbox.start(boot_timeout=BOOT_TIMEOUT)
+        assert sandbox.status == VMState.RUNNING
+        yield sandbox
+    finally:
+        # Best-effort: test_stop_and_cleanup may already have stopped/deleted it.
+        with suppress(Exception):
+            sandbox.stop()
+        with suppress(Exception):
+            sandbox.delete()

--- a/tests/e2e/test_lifecycle.py
+++ b/tests/e2e/test_lifecycle.py
@@ -1,0 +1,159 @@
+# Copyright 2026 Celesto AI
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""End-to-end lifecycle of a real QEMU sandbox via the public ``SmolVM`` API.
+
+The shared-sandbox tests are a deliberately *ordered, stateful* smoke: the one
+VM from the ``vm`` fixture (booted once per transport) is walked through its
+lifecycle, asserting one capability per step. An early failure (e.g. boot)
+cascades — the signal we want from a smoke suite.
+
+Sequence: start -> exec -> upload/download -> pause/resume -> stop/cleanup.
+
+Snapshot/restore is the exception: ``restore_snapshot`` rebuilds the *original*
+VM identity in place, which would corrupt a shared sandbox, so it runs against
+its own throwaway VM at the end.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import os
+from contextlib import suppress
+from pathlib import Path
+
+import pytest
+from _util import BOOT_TIMEOUT, kvm_ready
+
+from smolvm import SmolVM
+from smolvm.exceptions import SmolVMError, VMNotFoundError
+from smolvm.types import VMState
+
+pytestmark = pytest.mark.e2e
+
+
+# ---------------------------------------------------------------------------
+# Shared sandbox: one VM (per transport), walked through its lifecycle.
+# ---------------------------------------------------------------------------
+
+
+def test_start(vm: SmolVM) -> None:
+    """The fixture booted; the VM is running and ready to take commands."""
+    assert vm.status == VMState.RUNNING
+    assert vm.can_run_commands()
+
+
+def test_exec(vm: SmolVM) -> None:
+    """A command runs and its stdout comes back."""
+    result = vm.run("echo hello")
+    assert result.exit_code == 0
+    assert result.stdout.strip() == "hello"
+
+
+def test_exec_exit_code(vm: SmolVM) -> None:
+    """Non-zero exit codes propagate faithfully (not just the happy path)."""
+    result = vm.run("exit 7")
+    assert result.exit_code == 7
+
+
+def test_upload_download(vm: SmolVM, tmp_path: Path) -> None:
+    """A file round-trips host -> guest -> host byte-for-byte."""
+    payload = os.urandom(4096)
+    src = tmp_path / "payload.bin"
+    src.write_bytes(payload)
+    expected = hashlib.sha256(payload).hexdigest()
+
+    vm.upload_file(str(src), "/tmp/payload.bin")
+
+    digest = vm.run("sha256sum /tmp/payload.bin")
+    assert digest.exit_code == 0
+    assert digest.stdout.split()[0] == expected
+
+    dest = tmp_path / "roundtrip.bin"
+    vm.download_file("/tmp/payload.bin", str(dest))
+    assert dest.read_bytes() == payload
+
+
+def test_pause_resume(vm: SmolVM) -> None:
+    """Pause halts the VM; resume brings it back and it still runs commands."""
+    vm.pause()
+    assert vm.status == VMState.PAUSED
+
+    vm.resume()
+    assert vm.status == VMState.RUNNING
+    assert vm.run("echo back").stdout.strip() == "back"
+
+
+def test_stop_and_cleanup(vm: SmolVM) -> None:
+    """Stop transitions to STOPPED; delete removes the VM for good.
+
+    This is the shared sandbox's final step; the fixture teardown is just a
+    safety net for earlier failures.
+    """
+    vm_id = vm.vm_id
+
+    vm.stop()
+    assert vm.status == VMState.STOPPED
+
+    vm.delete()
+    with pytest.raises(VMNotFoundError):
+        SmolVM.from_id(vm_id)
+
+
+# ---------------------------------------------------------------------------
+# Snapshot / restore: standalone, own VM (restore rebuilds the VM in place).
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.xfail(
+    reason=(
+        "QEMU snapshot RESTORE is currently broken on the isolated-disk "
+        "overlay: loadvm reports \"Device 'rootdisk0-drive' is writable but "
+        'does not support snapshots". Snapshot *creation* works; restore needs '
+        "a runtime fix (attach the restored root disk as a snapshot-capable "
+        "qcow2 node). Remove this xfail once restore lands."
+    ),
+    raises=SmolVMError,
+    strict=False,
+)
+def test_snapshot_restore() -> None:
+    """Snapshot a VM, restore it, and confirm guest state survived.
+
+    Self-contained: ``from_snapshot`` restores into the *original* vm_id, so a
+    shared sandbox can't be used. We stop the source before restoring so the
+    restore path doesn't race to kill a still-live QEMU process.
+    """
+    if not kvm_ready():
+        pytest.skip("requires /dev/kvm and a working smolvm-core native extension")
+
+    sandbox = SmolVM(backend="qemu", os="alpine", comm_channel="ssh")
+    restored: SmolVM | None = None
+    try:
+        sandbox.start(boot_timeout=BOOT_TIMEOUT)
+        assert sandbox.run("echo sentinel-content > /root/sentinel.txt").exit_code == 0
+
+        snap = sandbox.snapshot()
+        sandbox.stop()
+
+        restored = SmolVM.from_snapshot(snap.snapshot_id)
+        result = restored.run("cat /root/sentinel.txt")
+        assert result.exit_code == 0
+        assert result.stdout.strip() == "sentinel-content"
+    finally:
+        # restored reuses the source vm_id, so deleting either removes the VM.
+        target = restored or sandbox
+        with suppress(Exception):
+            target.stop()
+        with suppress(Exception):
+            target.delete()


### PR DESCRIPTION
## What

Adds a nightly **end-to-end** suite that boots a real QEMU micro-VM **through the public `SmolVM` API** and walks its lifecycle.

Today nothing in CI exercises the real API on real hardware: the unit suite mocks the hypervisor, and `smoke-published-images` shells out to raw `qemu-system-*` (never touching the facade, the Firecracker/QEMU launch path, vsock, or scp upload). This fills that gap.

GitHub-hosted `ubuntu-latest` (x86) already exposes `/dev/kvm`, so this runs with hardware acceleration — no external infra.

## Coverage

One shared Alpine sandbox per run, **parametrized over both control transports (SSH and vsock)**:

| Capability | Status |
|---|---|
| start, exec, exit-code propagation | ✅ |
| `upload_file` / `download_file` (sha256 round-trip) | ✅ |
| pause / resume | ✅ |
| stop / cleanup (`delete` → `VMNotFoundError`) | ✅ |
| snapshot create | ✅ |
| snapshot **restore** | ⚠️ `xfail` (see below) |

Local run on real KVM: **12 passed, 1 xfailed**.

## How it's wired

- New `e2e` pytest marker; default suite deselects it via `addopts = "... -m 'not e2e'"`, so PR CI is unaffected. The nightly workflow opts in with `pytest -m e2e`.
- `.github/workflows/e2e.yml`: `schedule` (nightly) + `workflow_dispatch`, installs QEMU, `modprobe vhost_vsock`, builds `smolvm-core`, runs the suite, dumps VM logs on failure.
- Suite pins `os=alpine` — see finding #1.

## Two findings surfaced by running it

1. **QEMU auto-config defaults to Ubuntu, which can't snapshot or use vsock.** The Ubuntu cloud qcow2 attaches a cloud-init seed ISO (an *extra drive* → `_ensure_snapshot_supported` rejects it) and isn't built by `ImageBuilder` (no baked-in vsock agent → the agent never answers). Alpine — the SmolVM-built image — has the agent + python3 baked in and uses kernel-cmdline SSH injection (no seed ISO), so both work.

2. **QEMU snapshot _restore_ is broken (real bug).** Creation works; `from_snapshot` → `restore_snapshot` fails at QEMU `loadvm` with `Device 'rootdisk0-drive' is writable but does not support snapshots` — the restored root disk isn't attached as a snapshot-capable qcow2 node. Reproduces deterministically on both transports. `test_snapshot_restore` is `xfail(raises=SmolVMError, strict=False)` so it stays exercised and auto-flags (xpass) once restore is fixed. **Worth a separate issue/fix.**

## To validate on the first cloud run

- Runner `kvm`-group access — the workflow does `chmod 666 /dev/kvm` as a fallback to SmolVM's re-exec path.
- `vhost_vsock` availability — if the runner kernel lacks it, the vsock half cleanly **skips** rather than fails.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added a real-KVM end-to-end test suite validating VM lifecycle: startup, command execution, exit-code propagation, file transfer integrity, pause/resume, snapshot/restore (marked xfail), and cleanup.
  * Added helpers and a fixture to provision and manage real QEMU-backed VMs (ssh and vsock), with safe KVM availability checks and timeouts.
* **Chores**
  * Added a nightly/manual CI workflow to run the real-KVM e2e suite; e2e tests are excluded from default runs via a pytest marker.
  * CI now collects and attaches recent VM/runtime logs to failure summaries.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->