### PR TITLE
ci(e2e): fix VM-log dump paths + cancel stale runs (follow-up to #331)

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -21,6 +21,13 @@ on:
     - cron: "17 3 * * *"
   workflow_dispatch:
 
+# A real-KVM run takes a runner slot for ~1.5 min; on stacked PR pushes, cancel
+# the in-flight run so only the newest commit is verified. Keyed per ref so PRs,
+# the nightly cron, and manual dispatches don't cancel each other across refs.
+concurrency:
+  group: e2e-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 permissions:
   contents: read
 
@@ -100,8 +107,16 @@ jobs:
         if: failure()
         run: |
           echo "## e2e failed — recent VM/runtime logs" >> "$GITHUB_STEP_SUMMARY"
-          for d in "$HOME/.smolvm" "$HOME/.local/share/smolvm"; do
-            [ -d "$d" ] || continue
+          # SmolVM writes per-VM logs to <data_dir>/<vm_id>.log. data_dir resolves
+          # (see resolve_data_dir / _candidate_data_dirs in smolvm/vm.py) to
+          # $SMOLVM_DATA_DIR, else ${XDG_STATE_HOME:-$HOME/.local/state}/smolvm,
+          # else /var/lib/smolvm. (~/.smolvm holds image/key logs — kept too.)
+          for d in \
+              "$SMOLVM_DATA_DIR" \
+              "${XDG_STATE_HOME:-$HOME/.local/state}/smolvm" \
+              "/var/lib/smolvm" \
+              "$HOME/.smolvm"; do
+            [ -n "$d" ] && [ -d "$d" ] || continue
             echo "### $d" >> "$GITHUB_STEP_SUMMARY"
             find "$d" -name "*.log" -type f 2>/dev/null | while read -r f; do
               echo "<details><summary>$f</summary>" >> "$GITHUB_STEP_SUMMARY"


### PR DESCRIPTION
Follow-up to review comments on #331.

## Changes
- **Fix the failure log dump (real bug).** `Dump VM logs on failure` searched `~/.smolvm` and `~/.local/share/smolvm`, but SmolVM writes per-VM logs to `<data_dir>/<vm_id>.log` (`vm.py:1225`), where `data_dir` resolves (`resolve_data_dir` / `_candidate_data_dirs`) to `$SMOLVM_DATA_DIR`, else `${XDG_STATE_HOME:-$HOME/.local/state}/smolvm`, else `/var/lib/smolvm`. None of the old globs matched — which is why the first #331 run's dump came up empty. Now searches the real locations (kept `~/.smolvm` for image/key logs).
- **Add a `concurrency` block.** Stacked PR pushes cancel the in-flight KVM run (`cancel-in-progress: true`). Keyed per `github.ref` so PRs, the nightly cron, and manual dispatches don't cancel each other across refs.

## Deliberately skipped
Reviewers suggested pinning `actions/checkout`, `actions/setup-python`, `dtolnay/rust-toolchain`, and `actions/cache` to commit SHAs. Skipped here because:
- Those four are **tag-pinned in all 7 workflows** (only `setup-uv` is SHA-pinned repo-wide) — pinning just this one diverges from the established pattern.
- `dependabot.yml` covers only the **`uv`** ecosystem, not `github-actions`, so pinned SHAs would rot with no auto-bump.

Doing it properly is a repo-wide change plus a `github-actions` dependabot entry — out of scope for this follow-up. Happy to open that as a separate PR if wanted.

## Validation
YAML parses; diff is +17/-2, scoped to `.github/workflows/e2e.yml`. The `pull_request` trigger means this PR's own run exercises the new concurrency config; the log-dump path only executes on failure.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced end-to-end testing workflow reliability and log collection on test failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->