### PR TITLE
feat(cli): add port forward command

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -361,7 +361,7 @@ checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
 
 [[package]]
 name = "smolvm-core"
-version = "0.0.11"
+version = "0.0.14"
 dependencies = [
  "futures-util",
  "libc",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -361,7 +361,7 @@ checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
 
 [[package]]
 name = "smolvm-core"
-version = "0.0.14"
+version = "0.0.11"
 dependencies = [
  "futures-util",
  "libc",

--- a/src/smolvm/cli/main.py
+++ b/src/smolvm/cli/main.py
@@ -1375,31 +1375,6 @@ def build_parser() -> argparse.ArgumentParser:
     _add_ssh_auth_args(port_list)
     _add_comm_channel_arg(port_list)
 
-    # port_forward = port_sub.add_parser(
-    #     "forward",
-    #     help="Forward a guest TCP port to localhost. Runs until Ctrl-C.",
-    # )
-    # port_forward.add_argument("vm_id", metavar="sandbox", help="Name or ID of the sandbox.")
-    # port_forward.add_argument(
-    #     "guest_port",
-    #     metavar="guest-port",
-    #     type=int,
-    #     help="TCP port inside the sandbox to forward.",
-    # )
-    # port_forward.add_argument(
-    #     "--host-port",
-    #     type=int,
-    #     default=None,
-    #     metavar="PORT",
-    #     help="Localhost port to listen on (default: auto-assigned).",
-    # )
-    # port_forward.add_argument(
-    #     "--json",
-    #     action="store_true",
-    #     help="Emit machine-readable JSON output.",
-    # )
-    # _add_ssh_auth_args(port_forward)
-    # _add_comm_channel_arg(port_forward)
     _add_comm_channel_arg(env_list)
 
     return parser

--- a/src/smolvm/cli/main.py
+++ b/src/smolvm/cli/main.py
@@ -1326,31 +1326,80 @@ def build_parser() -> argparse.ArgumentParser:
     )
     port_sub = port_parser.add_subparsers(dest="port_action")
 
-    port_forward = port_sub.add_parser(
-        "forward",
-        help="Forward a guest TCP port to localhost. Runs until Ctrl-C.",
+    port_expose = port_sub.add_parser(
+        "expose",
+        help="Forward a guest port to localhost.",
     )
-    port_forward.add_argument("vm_id", metavar="sandbox", help="Name or ID of the sandbox.")
-    port_forward.add_argument(
-        "guest_port",
-        metavar="guest-port",
-        type=int,
-        help="TCP port inside the sandbox to forward.",
+    port_expose.add_argument("vm_id", metavar="sandbox", help="Name or ID of the same sandbox.")
+    port_expose.add_argument(
+        "mapping",
+        metavar="[host-port:]sandbox-port",
+        help="Port mapping, e.g. 8080:3000 or just 3000 to auto-select host port.",
     )
-    port_forward.add_argument(
-        "--host-port",
-        type=int,
-        default=None,
-        metavar="PORT",
-        help="Localhost port to listen on (default: auto-assigned).",
-    )
-    port_forward.add_argument(
+    port_expose.add_argument(
         "--json",
         action="store_true",
         help="Emit machine-readable JSON output.",
     )
-    _add_ssh_auth_args(port_forward)
-    _add_comm_channel_arg(port_forward)
+    _add_ssh_auth_args(port_expose)
+    _add_comm_channel_arg(port_expose)
+
+    port_close = port_sub.add_parser(
+        "close",
+        help="Remove a forwarded port.",
+    )
+    port_close.add_argument("vm_id", metavar="sandbox", help="Name or ID of the sandbox.")
+    port_close.add_argument(
+        "mapping",
+        metavar="host-port:sandbox-port",
+        help="Mapping to remove, e.g. 8080:3000.",
+    )
+    port_close.add_argument(
+        "--json",
+        action="store_true",
+        help="Emit machine-readable JSON output.",
+    )
+    _add_ssh_auth_args(port_close)
+    _add_comm_channel_arg(port_close)
+
+    port_list = port_sub.add_parser(
+        "list",
+        help="List active port forwards for a sandbox.",
+    )
+    port_list.add_argument("vm_id", metavar="sandbox", help="Name or ID of the sandbox.")
+    port_list.add_argument(
+        "--json",
+        action="store_true",
+        help="Emit machine-readable JSON output.",
+    )
+    _add_ssh_auth_args(port_list)
+    _add_comm_channel_arg(port_list)
+
+    # port_forward = port_sub.add_parser(
+    #     "forward",
+    #     help="Forward a guest TCP port to localhost. Runs until Ctrl-C.",
+    # )
+    # port_forward.add_argument("vm_id", metavar="sandbox", help="Name or ID of the sandbox.")
+    # port_forward.add_argument(
+    #     "guest_port",
+    #     metavar="guest-port",
+    #     type=int,
+    #     help="TCP port inside the sandbox to forward.",
+    # )
+    # port_forward.add_argument(
+    #     "--host-port",
+    #     type=int,
+    #     default=None,
+    #     metavar="PORT",
+    #     help="Localhost port to listen on (default: auto-assigned).",
+    # )
+    # port_forward.add_argument(
+    #     "--json",
+    #     action="store_true",
+    #     help="Emit machine-readable JSON output.",
+    # )
+    # _add_ssh_auth_args(port_forward)
+    # _add_comm_channel_arg(port_forward)
     _add_comm_channel_arg(env_list)
 
     return parser
@@ -3237,63 +3286,209 @@ def _run_ssh(args: argparse.Namespace) -> int:
         if vm is not None:
             vm.close()
 
-def _run_port_forward(args: argparse.Namespace) -> int:
-    """Handle ``smolvm port forward``."""
-    import signal
+def _parse_port_mapping(mapping: str) -> tuple[int | None, int]:
+    """Parse '[host-port:]sandbox-port' into (host_port_or_None, sandbox_port)."""
+    if ":" in mapping:
+        host_str, guest_str = mapping.split(":", 1)
+        return int(host_str), int(guest_str)
+    return None, int(mapping)
+
+def _port_forwards_path(vm_id: str) -> Path:
+    """Path to the JSON file tracking active port forwards for a VM."""
+    state_dir = Path.home() / ".smolvm" / "forwards"
+    state_dir.mkdir(parents=True, exist_ok=True)
+    return state_dir / f"{vm_id}.json"
+
+def _load_port_forwards(vm_id: str) -> list[dict]:
+    p = _port_forwards_path(vm_id)
+    if not p.exists():
+        return []
+    try:
+        import json
+        return json.loads(p.read_text())
+    except Exception:
+        return []
+    
+def _save_port_forwards(vm_id: str, forwards: list[dict]) -> None:
+    import json
+    _port_forwards_path(vm_id).write_text(json.dumps(forwards, indent=2))
+
+def _run_port_expose(args: argparse.Namespace) -> int:
+    """Handle ``smolvm port expose``."""
     from smolvm.facade import SmolVM
 
     json_output: bool = args.json
     vm: SmolVM | None = None
-    host_port: int | None = None
 
-    try :
+    try:
+        host_port_req, guest_port = _parse_port_mapping(args.mapping)
+    except ValueError:
+        return _emit_cli_error(
+            "port expose",
+            1,
+            ValueError(
+                f"Invalid mapping {args.mapping!r}. Use 'host-port:sandbox-port' or 'sandbox-port'."
+            ),
+            json_output=json_output,
+        )
+    try:
         vm = SmolVM.from_id(
             args.vm_id,
             ssh_user=args.ssh_user,
             ssh_key_path=args.ssh_key,
+            comm_channel=args.comm_channel,
         )
+        host_port = vm.expose_local(guest_port, host_port_req)
 
-        host_port = vm.expose_local(args.guest_port, args.host_port)
+        # Persist forward info so `port close` and `port list` can find it.
+        forward_entry: dict = {"host_port": host_port, "guest_port": guest_port}
+        tracked = vm._local_forwards.get((host_port, guest_port))
+        if tracked is not None and tracked.tunnel_proc is not None:
+            forward_entry["pid"] = tracked.tunnel_proc.pid
+            forward_entry["transport"] = "ssh_tunnel"
+        else:
+            forward_entry["transport"] = "nftables"
+        forwards = _load_port_forwards(args.vm_id)
+        # Remove any stale entry for the same pair before appending.
+        forwards = [
+            f for f in forwards
+            if not (f["host_port"] == host_port and f["guest_port"] == guest_port)
+        ]
+        forwards.append(forward_entry)
+        _save_port_forwards(args.vm_id, forwards)
 
         if json_output:
             emit_json(
-                "port_forward",
+                "port expose",
                 0,
                 data={
                     "sandbox": args.vm_id,
-                    "guest_port": args.guest_port,
+                    "guest_port": guest_port,
                     "host_port": host_port,
+                    "mapping": f"{host_port}:{guest_port}",
                     "url": f"http://localhost:{host_port}",
                 },
             )
         else:
             console = console_stdout()
             console.print(
-                f"Forwarding [bold]localhost:{host_port}[/bold] -> "
-                f"guest:[bold]{args.guest_port}[/bold]"
+                f"Exposed [bold]localhost:{host_port}[/bold] → "
+                f"guest:[bold]{guest_port}[/bold]"
             )
             console.print(f"Open [link]http://localhost:{host_port}[/link]")
-            console.print("Press [bold]Ctrl-C[/bold] to stop.")
-        
-        signal.pause()
-    except KeyboardInterrupt:
-        pass
+            console.print(
+                f"Stop with: [bold]smolvm port close {args.vm_id} {host_port}:{guest_port}[/bold]"
+            )
     except Exception as exc:
-        return _emit_cli_error("port_forward", 1, exc, json_output=json_output)
+        return _emit_cli_error("port expose", 1, exc, json_output=json_output)
     finally:
-        if vm is not None and host_port is not None:
-            from contextlib import suppress
-            with suppress(Exception):
-                vm.unexpose_local(host_port, args.guest_port)
         if vm is not None:
             vm.close()
     
     return 0
+    
+
+def _run_port_close(args: argparse.Namespace) -> int:
+    """Handle ``smolvm port close``."""
+    import signal as _signal
+    from smolvm.facade import SmolVM
+
+    json_output: bool = args.json
+    vm: SmolVM | None = None
+
+    try:
+        host_port, guest_port = _parse_port_mapping(args.mapping)
+        if host_port is None:
+            raise ValueError("Use 'host-port:sandbox-port' format for port close.")
+    except ValueError as exc:
+        return _emit_cli_error("port close", 1, exc, json_output=json_output)
+
+    try:
+        # Kill stored SSH tunnel process if present.
+        forwards = _load_port_forwards(args.vm_id)
+        entry = next(
+            (f for f in forwards if f["host_port"] == host_port and f["guest_port"] == guest_port),
+            None,
+        )
+        if entry and entry.get("transport") == "ssh_tunnel" and entry.get("pid"):
+            try:
+                import os
+                import signal
+                os.kill(entry["pid"], signal.SIGTERM)
+            except (ProcessLookupError, OSError):
+                pass
+
+        # Clean up nftables rules via the facade.
+        vm = SmolVM.from_id(
+            args.vm_id,
+            ssh_user=args.ssh_user,
+            ssh_key_path=args.ssh_key,
+            comm_channel=args.comm_channel,
+        )
+        vm.unexpose_local(host_port, guest_port)
+
+        # Update state file.
+        forwards = [
+            f for f in forwards
+            if not (f["host_port"] == host_port and f["guest_port"] == guest_port)
+        ]
+        _save_port_forwards(args.vm_id, forwards)
+
+        if json_output:
+            emit_json(
+                "port close",
+                0,
+                data={"sandbox": args.vm_id, "host_port": host_port, "guest_port": guest_port},
+            )
+        else:
+            console_stdout().print(
+                f"Closed [bold]localhost:{host_port}[/bold] → guest:[bold]{guest_port}[/bold]"
+            )
+
+    except Exception as exc:
+        return _emit_cli_error("port close", 1, exc, json_output=json_output)
+    finally:
+        if vm is not None:
+            vm.close()
+
+    return 0
+
+def _run_port_list(args: argparse.Namespace) -> int:
+    """Handle ``smolvm port list``."""
+    json_output: bool = args.json
+    forwards = _load_port_forwards(args.vm_id)
+
+    if json_output:
+        emit_json("port list", 0 , data={"sandbox": args.vm_id, "forwards": forwards})
+    else:
+        console = console_stdout()
+        if not forwards:
+            render_empty("Port Forwards", f"No active port forwards for '{args.vm_id}'.")
+        else:
+            from rich.table import Table
+            table = Table(title=f"Port Forwards — {args.vm_id}")
+            table.add_column("Host port", justify="right")
+            table.add_column("Sandbox port", justify="right")
+            table.add_column("Transport")
+            for f in forwards:
+                table.add_row(
+                    str(f["host_port"]),
+                    str(f["guest_port"]),
+                    f.get("transport", "unknown"),
+                )
+            console.print(table)
+
+    return 0
 
 def _run_port(args: argparse.Namespace) -> int:
     """Dispatch ``smolvm port <action>``."""
-    if getattr(args, "port_action", None) == "forward":
-        return _run_port_forward(args)
+    action = getattr(args, "port_action", None)
+    if action == "expose":
+        return _run_port_expose(args)
+    if action == "close":
+        return _run_port_close(args)
+    if action == "list":
+        return _run_port_list(args)
     from smolvm.cli.main import build_parser
     build_parser().parse_args(["port", "--help"])
     return 2

--- a/src/smolvm/cli/main.py
+++ b/src/smolvm/cli/main.py
@@ -1319,6 +1319,37 @@ def build_parser() -> argparse.ArgumentParser:
         help="Emit machine-readable JSON output.",
     )
     _add_ssh_auth_args(env_list)
+
+    port_parser = subparsers.add_parser(
+        "port",
+        help="Manage port forwarding for a running sandbox.",
+    )
+    port_sub = port_parser.add_subparsers(dest="port_action")
+
+    port_forward = port_sub.add_parser(
+        "forward",
+        help="Forward a guest TCP port to localhost. Runs until Ctrl-C.",
+    )
+    port_forward.add_argument("vm_id", metavar="sandbox", help="Name or ID of the sandbox.")
+    port_forward.add_argument(
+        "guest_port",
+        metavar="guest-port",
+        type=int,
+        help="TCP port inside the sandbox to forward.",
+    )
+    port_forward.add_argument(
+        "--host-port",
+        type=int,
+        default=None,
+        metavar="PORT",
+        help="Localhost port to listen on (default: auto-assigned).",
+    )
+    port_forward.add_argument(
+        "--json",
+        action="store_true",
+        help="Emit machine-readable JSON output.",
+    )
+    _add_ssh_auth_args(port_forward)
     _add_comm_channel_arg(env_list)
 
     return parser
@@ -3205,6 +3236,66 @@ def _run_ssh(args: argparse.Namespace) -> int:
         if vm is not None:
             vm.close()
 
+def _run_port_forward(args: argparse.Namespace) -> int:
+    """Handle ``smolvm port forward``."""
+    import signal
+    from smolvm.facade import SmolVM
+
+    json_output: bool = args.json
+    vm: SmolVM | None = None
+    host_port: int | None = None
+
+    try :
+        vm = SmolVM.from_id(
+            args.vm_id,
+            ssh_user=args.ssh_user,
+            ssh_key_path=args.ssh_key,
+        )
+
+        host_port = vm.expose_local(args.guest_port, args.host_port)
+
+        if json_output:
+            emit_json(
+                "port_forward",
+                0,
+                data={
+                    "sandbox": args.vm_id,
+                    "guest_port": args.guest_port,
+                    "host_port": host_port,
+                    "url": f"http://localhost:{host_port}",
+                },
+            )
+        else:
+            console = console_stdout()
+            console.print(
+                f"Forwarding [bold]localhost:{host_port}[/bold] -> "
+                f"guest:[bold]{args.guest_port}[/bold]"
+            )
+            console.print(f"Open [link]http://localhost:{host_port}[/link]")
+            console.print("Press [bold]Ctrl-C[/bold] to stop.")
+        
+        signal.pause()
+    except KeyboardInterrupt:
+        pass
+    except Exception as exc:
+        return _emit_cli_error("port_forward", 1, exc, json_output=json_output)
+    finally:
+        if vm is not None and host_port is not None:
+            from contextlib import suppress
+            with suppress(Exception):
+                vm.unexpose_local(host_port, args.guest_port)
+        if vm is not None:
+            vm.close()
+    
+    return 0
+
+def _run_port(args: argparse.Namespace) -> int:
+    """Dispatch ``smolvm port <action>``."""
+    if getattr(args, "port_action", None) == "forward":
+        return _run_port_forward(args)
+    from smolvm.cli.main import build_parser
+    build_parser().parse_args(["port", "--help"])
+    return 2
 
 def _render_ui_startup(
     host: str,
@@ -3655,6 +3746,9 @@ def main(argv: Sequence[str] | None = None) -> int:
 
     if args.command == "env":
         return _run_env(args)
-
+    
+    if args.command == "port":
+        return _run_port(args)
+    
     parser.print_help()
     return 2

--- a/src/smolvm/cli/main.py
+++ b/src/smolvm/cli/main.py
@@ -1350,7 +1350,7 @@ def build_parser() -> argparse.ArgumentParser:
         help="Emit machine-readable JSON output.",
     )
     _add_ssh_auth_args(port_forward)
-    _add_comm_channel_arg(env_list)
+    _add_comm_channel_arg(port_forward)
 
     return parser
 

--- a/src/smolvm/cli/main.py
+++ b/src/smolvm/cli/main.py
@@ -1351,6 +1351,7 @@ def build_parser() -> argparse.ArgumentParser:
     )
     _add_ssh_auth_args(port_forward)
     _add_comm_channel_arg(port_forward)
+    _add_comm_channel_arg(env_list)
 
     return parser
 

--- a/src/smolvm/cli/main.py
+++ b/src/smolvm/cli/main.py
@@ -3295,19 +3295,31 @@ def _parse_port_mapping(mapping: str) -> tuple[int | None, int]:
 
 def _port_forwards_path(vm_id: str) -> Path:
     """Path to the JSON file tracking active port forwards for a VM."""
-    state_dir = Path.home() / ".smolvm" / "forwards"
+    state_dir = (Path.home() / ".smolvm" / "forwards").resolve()
     state_dir.mkdir(parents=True, exist_ok=True)
-    return state_dir / f"{vm_id}.json"
+    target = (state_dir / f"{vm_id}.json").resolve()
+    if not str(target).startswith(str(state_dir) + "/"):
+        raise ValueError(f"Invalid sandbox name: {vm_id!r}")
+    return target
 
 def _load_port_forwards(vm_id: str) -> list[dict]:
+    import json
     p = _port_forwards_path(vm_id)
     if not p.exists():
         return []
     try:
-        import json
-        return json.loads(p.read_text())
-    except Exception:
-        return []
+        data = json.loads(p.read_text())
+    except Exception as exc:
+        raise RuntimeError(
+            f"Port forward state for '{vm_id}' is unreadable. "
+            f"Remove '{p}' to reset: rm '{p}'"
+        ) from exc
+    if not isinstance(data, list):
+        raise RuntimeError(
+            f"Port forward state for '{vm_id}' is corrupt. "
+            f"Remove '{p}' to reset: rm '{p}'"
+        )
+    return data
     
 def _save_port_forwards(vm_id: str, forwards: list[dict]) -> None:
     import json
@@ -3327,7 +3339,9 @@ def _run_port_expose(args: argparse.Namespace) -> int:
             "port expose",
             1,
             ValueError(
-                f"Invalid mapping {args.mapping!r}. Use 'host-port:sandbox-port' or 'sandbox-port'."
+                f"Invalid mapping {args.mapping!r}. "
+                f"Run 'smolvm port expose {args.vm_id} 8080:3000' to forward host port 8080 to sandbox port 3000, "
+                f"or 'smolvm port expose {args.vm_id} 3000' to auto-select a host port."
             ),
             json_output=json_output,
         )
@@ -3366,7 +3380,6 @@ def _run_port_expose(args: argparse.Namespace) -> int:
                     "guest_port": guest_port,
                     "host_port": host_port,
                     "mapping": f"{host_port}:{guest_port}",
-                    "url": f"http://localhost:{host_port}",
                 },
             )
         else:
@@ -3375,7 +3388,7 @@ def _run_port_expose(args: argparse.Namespace) -> int:
                 f"Exposed [bold]localhost:{host_port}[/bold] → "
                 f"guest:[bold]{guest_port}[/bold]"
             )
-            console.print(f"Open [link]http://localhost:{host_port}[/link]")
+            console.print(f"Connect to [bold]localhost:{host_port}[/bold]")
             console.print(
                 f"Stop with: [bold]smolvm port close {args.vm_id} {host_port}:{guest_port}[/bold]"
             )
@@ -3399,7 +3412,10 @@ def _run_port_close(args: argparse.Namespace) -> int:
     try:
         host_port, guest_port = _parse_port_mapping(args.mapping)
         if host_port is None:
-            raise ValueError("Use 'host-port:sandbox-port' format for port close.")
+            raise ValueError(
+                f"Use 'host-port:sandbox-port' format. "
+                f"Run 'smolvm port list {args.vm_id}' to see active forwards."
+            )
     except ValueError as exc:
         return _emit_cli_error("port close", 1, exc, json_output=json_output)
 
@@ -3411,10 +3427,18 @@ def _run_port_close(args: argparse.Namespace) -> int:
             None,
         )
         if entry and entry.get("transport") == "ssh_tunnel" and entry.get("pid"):
+            import os
+            import signal
+            import subprocess as _sp
+            pid = entry["pid"]
             try:
-                import os
-                import signal
-                os.kill(entry["pid"], signal.SIGTERM)
+                # Verify it's still our SSH tunnel before killing.
+                result = _sp.run(
+                    ["ps", "-p", str(pid), "-o", "comm="],
+                    capture_output=True, text=True,
+                )
+                if "ssh" in result.stdout:
+                    os.kill(pid, signal.SIGTERM)
             except (ProcessLookupError, OSError):
                 pass
 

--- a/src/smolvm/facade.py
+++ b/src/smolvm/facade.py
@@ -2918,6 +2918,7 @@ modprobe 9pnet_virtio""".strip()
                 stdout=subprocess.DEVNULL,
                 stderr=subprocess.PIPE,
                 text=True,
+                start_new_session=True,
             )
         except FileNotFoundError:
             raise SmolVMError(

--- a/src/smolvm/facade.py
+++ b/src/smolvm/facade.py
@@ -2899,8 +2899,17 @@ modprobe 9pnet_virtio""".strip()
             "-L",
             f"127.0.0.1:{host_port}:127.0.0.1:{guest_port}",
         ]
-        if self._ssh_key_path:
-            cmd.extend(["-i", self._ssh_key_path])
+        key_path = self._ssh_key_path
+        if key_path is None:
+            from smolvm.utils import ensure_ssh_key
+
+            try:
+                default_key, _ = ensure_ssh_key()
+                key_path = str(default_key)
+            except Exception:
+                pass
+        if key_path:
+            cmd.extend(["-i", key_path])
         cmd.append(f"{self._ssh_user}@{ssh_host}")
 
         try:

--- a/src/smolvm/images/builder.py
+++ b/src/smolvm/images/builder.py
@@ -1601,34 +1601,33 @@ echo "Device-approver running with PID=${DEVICE_APPROVER_PID}"
             "set -e; "
             "apk add --no-cache e2fsprogs tar >/dev/null; "
             "mkdir -p /work/rootfs-staging; "
-            "cat > /tmp/rootfs.tar; "
-            "tar -xf /tmp/rootfs.tar -C /work/rootfs-staging; "
+            "tar -xf /work/in/rootfs.tar -C /work/rootfs-staging; "
             f"mke2fs -d /work/rootfs-staging -t ext4 -F /work/out/{rootfs_name} "
             f"{rootfs_size_mb}M >/dev/null"
         )
 
         try:
-            with open(tar_path, "rb") as tar_stdin:
-                proc = subprocess.run(
-                    [
-                        "docker",
-                        "run",
-                        "--rm",
-                        "-i",
-                        "-v",
-                        f"{rootfs_path.parent.resolve()}:/work/out",
-                        "alpine:3.19",
-                        "sh",
-                        "-lc",
-                        shell_cmd,
-                    ],
-                    stdin=tar_stdin,
-                    check=True,
-                    stdout=subprocess.DEVNULL,
-                    stderr=subprocess.PIPE,
-                )
+            subprocess.run(
+                [
+                    "docker",
+                    "run",
+                    "--rm",
+                    "-v",
+                    f"{tar_path.resolve()}:/work/in/rootfs.tar:ro",
+                    "-v",
+                    f"{rootfs_path.parent.resolve()}:/work/out",
+                    "alpine:3.19",
+                    "sh",
+                    "-lc",
+                    shell_cmd,
+                ],
+                check=True,
+                stdout=subprocess.DEVNULL,
+                stderr=subprocess.PIPE,
+                text=True,
+            )
         except subprocess.CalledProcessError as e:
-            stderr = (e.stderr.decode(errors="replace") if e.stderr else "").strip()
+            stderr = (e.stderr or "").strip()
             raise ImageError(
                 "Failed to create ext4 image via Docker helper.\n"
                 f"Command: docker run ... tar | mke2fs\n"

--- a/src/smolvm/images/builder.py
+++ b/src/smolvm/images/builder.py
@@ -1601,33 +1601,34 @@ echo "Device-approver running with PID=${DEVICE_APPROVER_PID}"
             "set -e; "
             "apk add --no-cache e2fsprogs tar >/dev/null; "
             "mkdir -p /work/rootfs-staging; "
-            "tar -xf /work/in/rootfs.tar -C /work/rootfs-staging; "
+            "cat > /tmp/rootfs.tar; "
+            "tar -xf /tmp/rootfs.tar -C /work/rootfs-staging; "
             f"mke2fs -d /work/rootfs-staging -t ext4 -F /work/out/{rootfs_name} "
             f"{rootfs_size_mb}M >/dev/null"
         )
 
         try:
-            subprocess.run(
-                [
-                    "docker",
-                    "run",
-                    "--rm",
-                    "-v",
-                    f"{tar_path.resolve()}:/work/in/rootfs.tar:ro",
-                    "-v",
-                    f"{rootfs_path.parent.resolve()}:/work/out",
-                    "alpine:3.19",
-                    "sh",
-                    "-lc",
-                    shell_cmd,
-                ],
-                check=True,
-                stdout=subprocess.DEVNULL,
-                stderr=subprocess.PIPE,
-                text=True,
-            )
+            with open(tar_path, "rb") as tar_stdin:
+                proc = subprocess.run(
+                    [
+                        "docker",
+                        "run",
+                        "--rm",
+                        "-i",
+                        "-v",
+                        f"{rootfs_path.parent.resolve()}:/work/out",
+                        "alpine:3.19",
+                        "sh",
+                        "-lc",
+                        shell_cmd,
+                    ],
+                    stdin=tar_stdin,
+                    check=True,
+                    stdout=subprocess.DEVNULL,
+                    stderr=subprocess.PIPE,
+                )
         except subprocess.CalledProcessError as e:
-            stderr = (e.stderr or "").strip()
+            stderr = (e.stderr.decode(errors="replace") if e.stderr else "").strip()
             raise ImageError(
                 "Failed to create ext4 image via Docker helper.\n"
                 f"Command: docker run ... tar | mke2fs\n"

--- a/tests/test_build.py
+++ b/tests/test_build.py
@@ -405,7 +405,7 @@ class TestBrowserImageBuilder:
 
             if cmd[:2] == ["docker", "run"]:
                 volumes = [cmd[i + 1] for i, token in enumerate(cmd) if token == "-v"]
-                out_host = Path(volumes[1].split(":", 1)[0])
+                out_host = Path(volumes[0].split(":", 1)[0])
                 (out_host / "rootfs.ext4").write_bytes(b"ext4")
                 return subprocess.CompletedProcess(cmd, 0, stdout="", stderr="")
 

--- a/tests/test_build.py
+++ b/tests/test_build.py
@@ -405,7 +405,7 @@ class TestBrowserImageBuilder:
 
             if cmd[:2] == ["docker", "run"]:
                 volumes = [cmd[i + 1] for i, token in enumerate(cmd) if token == "-v"]
-                out_host = Path(volumes[0].split(":", 1)[0])
+                out_host = Path(volumes[1].split(":", 1)[0])
                 (out_host / "rootfs.ext4").write_bytes(b"ext4")
                 return subprocess.CompletedProcess(cmd, 0, stdout="", stderr="")
 


### PR DESCRIPTION
Add `smolvm port expose` to expose guest ports on localhost. Fix SSH key resolution in tunnels.

## Summary
Add a new `smolvm port forward <vm> <guest-port>` command that forwards guest TCP ports to localhost, matching the Python SDK's `expose_local()` API.

## Changes
- New CLI command: `smolvm port expose minivm 8000 [--host-port PORT]`
- Auto port selection or fixed port via `--host-port`
- Supports `--json` for scripting

## Bug Fixes
- SSH key resolution in port tunnels (falls back to ~/.smolvm/keys/id_ed25519)
- Docker ext4 image building on macOS (pipe tar via stdin)

Closes #299 

## Checklist

- [ ] Scope is focused and limited to this change
- [ ] Tests added/updated for behavior changes
- [ ] Docs updated for user-visible changes
- [ ] No secrets or sensitive data included


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a top-level `smolvm port` command to manage port forwards with `expose`, `close`, and `list` subcommands; supports auto-assigned host ports, JSON or human output, and simple close/list workflows.

* **Bug Fixes**
  * Use the default SmolVM SSH key when no custom key is set.
  * More reliable ext4 image creation when building via Docker.

* **Tests**
  * Updated a Docker-related test to reflect changed volume handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->