### PR TITLE
fix(setup): always install QEMU on macOS regardless of --skip-deps

### DIFF
--- a/scripts/system-setup-macos.sh
+++ b/scripts/system-setup-macos.sh
@@ -119,14 +119,14 @@ fi
 
 echo "=== SmolVM macOS setup (qemu backend) ==="
 
-if [[ "$SKIP_DEPS" == "true" ]]; then
-    echo "Skipping dependency installation (--skip-deps)"
-else
-    if ! find_qemu; then
-        echo "Installing qemu via Homebrew..."
-        brew install qemu
-    fi
+if ! find_qemu; then
+    echo "Installing qemu via Homebrew..."
+    brew install qemu
+fi
 
+if [[ "$SKIP_DEPS" == "true" ]]; then
+    echo "Skipping optional dependency installation (--skip-deps)"
+else
     if [[ "$WITH_DOCKER" == "true" ]] && ! command -v docker >/dev/null 2>&1; then
         echo "Installing Docker Desktop cask via Homebrew..."
         brew install --cask docker

--- a/scripts/system-setup-macos.sh
+++ b/scripts/system-setup-macos.sh
@@ -64,8 +64,8 @@ if [[ "$(uname -s)" != "Darwin" ]]; then
     exit 1
 fi
 
-# Homebrew is only required when we may install dependencies.
-if [[ "$CHECK_ONLY" != "true" && "$SKIP_DEPS" != "true" ]]; then
+# Homebrew is required whenever we may need to install QEMU or other deps.
+if [[ "$CHECK_ONLY" != "true" ]]; then
     if ! command -v brew >/dev/null 2>&1; then
         echo "❌ Homebrew not found. Install from https://brew.sh and rerun."
         exit 1

--- a/scripts/system-setup-macos.sh
+++ b/scripts/system-setup-macos.sh
@@ -64,8 +64,8 @@ if [[ "$(uname -s)" != "Darwin" ]]; then
     exit 1
 fi
 
-# Homebrew is required whenever we may need to install QEMU or other deps.
-if [[ "$CHECK_ONLY" != "true" ]]; then
+# Homebrew is only required when we may install dependencies.
+if [[ "$CHECK_ONLY" != "true" && "$SKIP_DEPS" != "true" ]]; then
     if ! command -v brew >/dev/null 2>&1; then
         echo "❌ Homebrew not found. Install from https://brew.sh and rerun."
         exit 1
@@ -120,6 +120,10 @@ fi
 echo "=== SmolVM macOS setup (qemu backend) ==="
 
 if ! find_qemu; then
+    if ! command -v brew >/dev/null 2>&1; then
+        echo "❌ Homebrew not found. Install from https://brew.sh and rerun."
+        exit 1
+    fi
     echo "Installing qemu via Homebrew..."
     brew install qemu
 fi


### PR DESCRIPTION
Fixes #335.

## Problem

On a fresh Mac, running the one-liner installer:

```bash
curl -sSL https://celesto.ai/install.sh | bash
```

`install.sh` unconditionally passes `--skip-deps` to `smolvm setup`, which forwards it to `system-setup-macos.sh`. That flag caused the entire dependency install block to be skipped — including `brew install qemu`. Since QEMU is the only hard runtime requirement on macOS, the install completed silently but left the system broken. `smolvm doctor` would then report QEMU missing with no automatic recovery.

## Root Cause

`--skip-deps` was designed for CI/power-user scenarios where dependencies are already present. But `system-setup-macos.sh` treated QEMU (a hard requirement) and Docker (optional) identically inside the skip block — bypassing both when the flag was set.

Additionally, the Homebrew presence check was gated behind `--skip-deps`, so if QEMU was missing and `--skip-deps` was passed, `brew install qemu` would fail with `brew: command not found` and no actionable error message.

## Fix

Move the QEMU install check outside the `--skip-deps` guard. Add an inline Homebrew check inside the `find_qemu` block so it only fires when actually needed.

```
Before:
  --skip-deps → skips QEMU install + Docker install + Homebrew check

After:
  --skip-deps → skips Docker install only
  QEMU        → always installed if missing (with inline Homebrew check)
```

## Test plan

- [ ] Run `system-setup-macos.sh` with QEMU absent and `--skip-deps` — confirm QEMU gets installed
- [ ] Run `system-setup-macos.sh` with QEMU already present and `--skip-deps` — confirm no reinstall
- [ ] Run `system-setup-macos.sh` with QEMU absent, `--skip-deps`, and no Homebrew — confirm actionable error
- [ ] Run `system-setup-macos.sh --check-only` — confirm behavior unchanged
- [ ] Run the one-liner on a fresh Mac without QEMU — confirm `smolvm doctor` passes at the end