### PR TITLE
feat(snapshot): disk-only SnapshotType.DISK + decouple QMP read timeout (0.0.19a1)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "smolvm"
-version = "0.0.19a0"
+version = "0.0.19a1"
 description = "Isolated computers that AI agents can use to browse, run code, and get real work done. Free and open-source from Celesto AI"
 readme = "README.md"
 license = "Apache-2.0"

--- a/src/smolvm/facade.py
+++ b/src/smolvm/facade.py
@@ -1326,8 +1326,10 @@ class SmolVM:
         Args:
             snapshot_id: Optional custom snapshot name.
             snapshot_type: ``"full"`` (default) for a self-contained copy that
-                always restores on its own, or ``"diff"`` to store only what
-                changed since the base image to save space.
+                always restores on its own, ``"diff"`` to store only what
+                changed since the base image to save space, or ``"disk"`` for a
+                self-contained disk-only copy that skips the guest RAM dump
+                (much faster/lighter; restores as a fresh boot, not a resume).
             resume_source: Keep this VM running after the snapshot is taken.
         """
         try:

--- a/src/smolvm/qmp.py
+++ b/src/smolvm/qmp.py
@@ -61,8 +61,17 @@ class QMPClient:
     def __exit__(self, *args: object) -> None:
         self.close()
 
-    def connect(self, timeout: float = 5.0) -> None:
-        """Connect to the QMP socket and negotiate capabilities."""
+    def connect(self, timeout: float = 5.0, read_timeout: float = 30.0) -> None:
+        """Connect to the QMP socket and negotiate capabilities.
+
+        ``timeout`` bounds how long we keep retrying the initial connect while
+        QEMU is still bringing the monitor socket up; each probe uses a short
+        (≤1s) socket timeout so a not-yet-ready socket fails fast and retries.
+        Once connected, the socket timeout is raised to ``read_timeout`` so that
+        replies to slow commands (e.g. ``snapshot-save`` while QEMU is busy
+        dumping guest RAM, which can take far longer than 1s to even
+        acknowledge) are not cut off mid-read with ``TimeoutError``.
+        """
         if self._socket is not None:
             return
 
@@ -73,6 +82,9 @@ class QMPClient:
                 qmp_socket = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
                 qmp_socket.settimeout(min(timeout, 1.0))
                 qmp_socket.connect(str(self.socket_path))
+                # Connected: switch from the short connect-probe timeout to a
+                # generous read timeout for command replies.
+                qmp_socket.settimeout(read_timeout)
                 self._socket = qmp_socket
                 self._reader = qmp_socket.makefile("r", encoding="utf-8")
                 self._writer = qmp_socket.makefile("w", encoding="utf-8")
@@ -193,6 +205,33 @@ class QMPClient:
             },
         )
 
+    def blockdev_snapshot_internal_sync(self, device: str, name: str) -> None:
+        """Create a **disk-only** internal qcow2 snapshot, synchronously.
+
+        Unlike ``snapshot-save``, this saves only the block device's data (no
+        guest RAM / vmstate), so it is fast, never dumps memory, and does not go
+        through the async job API — it returns once the consistent point is
+        written. ``device`` is the block node-name (or qdev id); ``name`` is the
+        internal snapshot tag.
+        """
+        self.execute(
+            "blockdev-snapshot-internal-sync",
+            {
+                "device": device,
+                "name": name,
+            },
+        )
+
+    def blockdev_snapshot_delete_internal_sync(self, device: str, name: str) -> None:
+        """Delete a disk-only internal qcow2 snapshot, synchronously."""
+        self.execute(
+            "blockdev-snapshot-delete-internal-sync",
+            {
+                "device": device,
+                "name": name,
+            },
+        )
+
     def query_jobs(self) -> list[QMPJob]:
         """Return normalized job status rows."""
         result = self.execute("query-jobs")
@@ -276,5 +315,7 @@ class QMPClient:
 
         line = self._reader.readline()
         if not line:
-            raise SmolVMError("QMP socket closed unexpectedly", {"socket_path": str(self.socket_path)})
+            raise SmolVMError(
+                "QMP socket closed unexpectedly", {"socket_path": str(self.socket_path)}
+            )
         return json.loads(line)

--- a/src/smolvm/qmp.py
+++ b/src/smolvm/qmp.py
@@ -67,8 +67,9 @@ class QMPClient:
         ``timeout`` bounds how long we keep retrying the initial connect while
         QEMU is still bringing the monitor socket up; each probe uses a short
         (≤1s) socket timeout so a not-yet-ready socket fails fast and retries.
-        Once connected, the socket timeout is raised to ``read_timeout`` so that
-        replies to slow commands (e.g. ``snapshot-save`` while QEMU is busy
+        Once QMP greeting/capabilities negotiation succeeds, the socket timeout
+        is raised to ``read_timeout`` so that replies to slow commands (e.g.
+        ``snapshot-save`` while QEMU is busy
         dumping guest RAM, which can take far longer than 1s to even
         acknowledge) are not cut off mid-read with ``TimeoutError``.
         """
@@ -82,9 +83,6 @@ class QMPClient:
                 qmp_socket = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
                 qmp_socket.settimeout(min(timeout, 1.0))
                 qmp_socket.connect(str(self.socket_path))
-                # Connected: switch from the short connect-probe timeout to a
-                # generous read timeout for command replies.
-                qmp_socket.settimeout(read_timeout)
                 self._socket = qmp_socket
                 self._reader = qmp_socket.makefile("r", encoding="utf-8")
                 self._writer = qmp_socket.makefile("w", encoding="utf-8")
@@ -107,6 +105,10 @@ class QMPClient:
                     {"socket_path": str(self.socket_path), "greeting": greeting},
                 )
             self.execute("qmp_capabilities")
+            assert self._socket is not None
+            # Handshake complete: switch from the short probe timeout to a
+            # generous read timeout for command replies.
+            self._socket.settimeout(read_timeout)
         except Exception:
             self.close()
             raise

--- a/src/smolvm/runtime/qemu.py
+++ b/src/smolvm/runtime/qemu.py
@@ -316,20 +316,27 @@ class QemuRuntimeAdapter(RuntimeAdapter):
     def create_snapshot(self, request: SnapshotCreateRequest) -> SnapshotCreateResult:
         """Create a QEMU snapshot and copy the managed qcow2 disk artifact."""
         vm_info = request.vm_info
+        # DISK snapshots store only the block device — no guest RAM (vmstate) —
+        # so they use the synchronous disk-only internal-snapshot primitive
+        # instead of the heavyweight ``snapshot-save`` job that dumps memory.
+        disk_only = request.snapshot_type == SnapshotType.DISK
         snapshot_saved = False
         with self._client(vm_info.control_socket_path) as client:
             if request.original_status == VMState.RUNNING:
                 client.stop_vm()
 
             try:
-                save_job_id = f"snapshot-save-{request.snapshot_id}"
-                client.snapshot_save(
-                    save_job_id,
-                    request.snapshot_id,
-                    QEMU_ROOT_NODE_NAME,
-                    [QEMU_ROOT_NODE_NAME],
-                )
-                client.wait_for_job(save_job_id)
+                if disk_only:
+                    client.blockdev_snapshot_internal_sync(QEMU_ROOT_NODE_NAME, request.snapshot_id)
+                else:
+                    save_job_id = f"snapshot-save-{request.snapshot_id}"
+                    client.snapshot_save(
+                        save_job_id,
+                        request.snapshot_id,
+                        QEMU_ROOT_NODE_NAME,
+                        [QEMU_ROOT_NODE_NAME],
+                    )
+                    client.wait_for_job(save_job_id)
                 snapshot_saved = True
 
                 disk_path = request.snapshot_root / "disk.qcow2"
@@ -338,9 +345,16 @@ class QemuRuntimeAdapter(RuntimeAdapter):
                 else:
                     self._copy_disk_standalone(request.managed_disk_path, disk_path)
 
-                delete_job_id = f"snapshot-delete-{request.snapshot_id}"
-                client.snapshot_delete(delete_job_id, request.snapshot_id, [QEMU_ROOT_NODE_NAME])
-                client.wait_for_job(delete_job_id)
+                if disk_only:
+                    client.blockdev_snapshot_delete_internal_sync(
+                        QEMU_ROOT_NODE_NAME, request.snapshot_id
+                    )
+                else:
+                    delete_job_id = f"snapshot-delete-{request.snapshot_id}"
+                    client.snapshot_delete(
+                        delete_job_id, request.snapshot_id, [QEMU_ROOT_NODE_NAME]
+                    )
+                    client.wait_for_job(delete_job_id)
 
                 return SnapshotCreateResult(
                     artifacts=SnapshotArtifacts(disk_path=disk_path),
@@ -349,13 +363,18 @@ class QemuRuntimeAdapter(RuntimeAdapter):
             except Exception:
                 if snapshot_saved:
                     with suppress(Exception):
-                        cleanup_job_id = f"snapshot-cleanup-{request.snapshot_id}"
-                        client.snapshot_delete(
-                            cleanup_job_id,
-                            request.snapshot_id,
-                            [QEMU_ROOT_NODE_NAME],
-                        )
-                        client.wait_for_job(cleanup_job_id)
+                        if disk_only:
+                            client.blockdev_snapshot_delete_internal_sync(
+                                QEMU_ROOT_NODE_NAME, request.snapshot_id
+                            )
+                        else:
+                            cleanup_job_id = f"snapshot-cleanup-{request.snapshot_id}"
+                            client.snapshot_delete(
+                                cleanup_job_id,
+                                request.snapshot_id,
+                                [QEMU_ROOT_NODE_NAME],
+                            )
+                            client.wait_for_job(cleanup_job_id)
                 if request.original_status == VMState.RUNNING:
                     with suppress(Exception):
                         client.cont()
@@ -392,6 +411,11 @@ class QemuRuntimeAdapter(RuntimeAdapter):
         if control_socket_path.exists():
             self._context.unlink_socket(control_socket_path)
 
+        # A DISK snapshot carries no guest RAM, so there is nothing to load —
+        # the guest boots fresh from the restored disk rather than resuming the
+        # exact running state. We still start paused so the caller controls when
+        # the cold boot begins (via ``resume_vm``).
+        disk_only = snapshot.snapshot_type == SnapshotType.DISK
         process: Any | None = None
         try:
             process = self._context.start_qemu(
@@ -404,18 +428,21 @@ class QemuRuntimeAdapter(RuntimeAdapter):
             self._wait_for_runtime(process, control_socket_path, request.boot_timeout)
 
             with self._client(control_socket_path) as client:
-                load_job_id = f"snapshot-load-{snapshot.snapshot_id}"
-                client.snapshot_load(
-                    load_job_id,
-                    snapshot.snapshot_id,
-                    QEMU_ROOT_NODE_NAME,
-                    [QEMU_ROOT_NODE_NAME],
-                )
-                client.wait_for_job(load_job_id)
+                if not disk_only:
+                    load_job_id = f"snapshot-load-{snapshot.snapshot_id}"
+                    client.snapshot_load(
+                        load_job_id,
+                        snapshot.snapshot_id,
+                        QEMU_ROOT_NODE_NAME,
+                        [QEMU_ROOT_NODE_NAME],
+                    )
+                    client.wait_for_job(load_job_id)
 
-                delete_job_id = f"snapshot-delete-{snapshot.snapshot_id}"
-                client.snapshot_delete(delete_job_id, snapshot.snapshot_id, [QEMU_ROOT_NODE_NAME])
-                client.wait_for_job(delete_job_id)
+                    delete_job_id = f"snapshot-delete-{snapshot.snapshot_id}"
+                    client.snapshot_delete(
+                        delete_job_id, snapshot.snapshot_id, [QEMU_ROOT_NODE_NAME]
+                    )
+                    client.wait_for_job(delete_job_id)
 
                 if request.resume_vm:
                     client.cont()

--- a/src/smolvm/types.py
+++ b/src/smolvm/types.py
@@ -61,10 +61,19 @@ class SnapshotType(str, Enum):
     disk, so the snapshot can be restored on its own. ``DIFF`` stores only
     the data that changed since the shared base image, which is much smaller
     but means the snapshot depends on that base image still being present.
+
+    ``DISK`` is like ``FULL`` (self-contained) but stores **only the disk** —
+    it does not save the guest's RAM (vmstate). Restoring a ``DISK`` snapshot
+    boots the guest fresh from that disk rather than resuming the exact running
+    state. Because it skips the RAM dump, taking a ``DISK`` snapshot is far
+    faster, never blocks the QEMU monitor, and uses far less disk — the right
+    choice when you only need the filesystem state and restore-as-cold-boot is
+    acceptable (e.g. sandbox suspend/restore across hosts).
     """
 
     FULL = "full"
     DIFF = "diff"
+    DISK = "disk"
 
 
 def _generate_vm_id() -> str:

--- a/src/smolvm/vm.py
+++ b/src/smolvm/vm.py
@@ -704,11 +704,17 @@ class SmolVMManager:
         if vm_info.network is None:
             raise SmolVMError("VM has no network configuration", {"vm_id": vm_info.vm_id})
 
-    def _warn_low_disk_space_for_snapshot(self, vm_info: VMInfo) -> None:
+    def _warn_low_disk_space_for_snapshot(
+        self, vm_info: VMInfo, snapshot_type: SnapshotType = SnapshotType.FULL
+    ) -> None:
         """Warn when snapshot creation looks likely to exhaust local disk space."""
         rootfs_size = vm_info.config.rootfs_path.stat().st_size
-        mem_size = vm_info.config.memory * 1024 * 1024
-        required_bytes = rootfs_size + (2 * mem_size)
+        # DISK snapshots don't dump guest RAM, so the memory term doesn't apply.
+        if snapshot_type == SnapshotType.DISK:
+            required_bytes = rootfs_size
+        else:
+            mem_size = vm_info.config.memory * 1024 * 1024
+            required_bytes = rootfs_size + (2 * mem_size)
         free_bytes = shutil.disk_usage(self.snapshot_dir).free
         if free_bytes < required_bytes:
             logger.warning(
@@ -1373,6 +1379,9 @@ class SmolVMManager:
         default) writes a self-contained copy that always restores on its own.
         ``DIFF`` stores only what changed since the shared base image, which is
         much smaller but depends on that base image still being present.
+        ``DISK`` is self-contained like ``FULL`` but stores only the disk (no
+        guest RAM), so it is much faster and lighter; restoring it boots the
+        guest fresh from the disk instead of resuming the running state.
         """
         if not vm_id:
             raise ValueError("vm_id cannot be empty")
@@ -1404,7 +1413,7 @@ class SmolVMManager:
 
         try:
             snapshot_root.mkdir(parents=True, exist_ok=False)
-            self._warn_low_disk_space_for_snapshot(vm_info)
+            self._warn_low_disk_space_for_snapshot(vm_info, snapshot_type)
             result = adapter.create_snapshot(
                 SnapshotCreateRequest(
                     vm_info=vm_info,

--- a/tests/test_qmp.py
+++ b/tests/test_qmp.py
@@ -198,6 +198,61 @@ def test_qmp_wait_for_job_raises_on_job_error(tmp_path: Path) -> None:
 
 
 @pytest.mark.skip(reason="Socket binding fails in macOS automated test sandbox")
+def test_qmp_connect_raises_read_timeout_above_connect_probe_timeout(tmp_path: Path) -> None:
+    """After connecting, the socket read timeout must be the generous read_timeout.
+
+    Regression guard for the snapshot-save read TimeoutError: the connect probe
+    used a ≤1s socket timeout that previously persisted for every command read,
+    cutting off replies to slow commands. Once connected we raise it.
+    """
+    socket_path = tmp_path / f"smolvm-qmp-{uuid4().hex}.sock"
+    requests: list[dict[str, object]] = []
+    responses: dict[str, list[dict[str, object] | list[dict[str, object]]]] = {
+        "qmp_capabilities": [{"return": {}}],
+    }
+    thread = _start_qmp_server(socket_path, responses, requests)
+
+    with QMPClient(socket_path) as client:
+        client.connect(timeout=5.0, read_timeout=30.0)
+        assert client._socket is not None
+        assert client._socket.gettimeout() == 30.0
+
+    thread.join(timeout=2.0)
+    if socket_path.exists():
+        socket_path.unlink()
+
+
+@pytest.mark.skip(reason="Socket binding fails in macOS automated test sandbox")
+def test_qmp_blockdev_internal_snapshot_round_trips(tmp_path: Path) -> None:
+    """Disk-only internal snapshot create/delete issue synchronous QMP commands."""
+    socket_path = tmp_path / f"smolvm-qmp-{uuid4().hex}.sock"
+    requests: list[dict[str, object]] = []
+    responses: dict[str, list[dict[str, object] | list[dict[str, object]]]] = {
+        "qmp_capabilities": [{"return": {}}],
+        "blockdev-snapshot-internal-sync": [{"return": {}}],
+        "blockdev-snapshot-delete-internal-sync": [{"return": {}}],
+    }
+    thread = _start_qmp_server(socket_path, responses, requests)
+
+    with QMPClient(socket_path) as client:
+        client.connect()
+        client.blockdev_snapshot_internal_sync("rootdisk0", "snap0")
+        client.blockdev_snapshot_delete_internal_sync("rootdisk0", "snap0")
+
+    thread.join(timeout=2.0)
+    if socket_path.exists():
+        socket_path.unlink()
+
+    assert [request["execute"] for request in requests] == [
+        "qmp_capabilities",
+        "blockdev-snapshot-internal-sync",
+        "blockdev-snapshot-delete-internal-sync",
+    ]
+    create_req = requests[1]
+    assert create_req["arguments"] == {"device": "rootdisk0", "name": "snap0"}
+
+
+@pytest.mark.skip(reason="Socket binding fails in macOS automated test sandbox")
 def test_qmp_connect_can_retry_after_capabilities_handshake_failure(tmp_path: Path) -> None:
     """Failed capability negotiation should not leave the client half-connected."""
     socket_path = tmp_path / f"smolvm-qmp-{uuid4().hex}.sock"

--- a/tests/test_qmp.py
+++ b/tests/test_qmp.py
@@ -18,6 +18,7 @@ from __future__ import annotations
 
 import json
 import socket
+import sys
 import threading
 import time
 from pathlib import Path
@@ -197,7 +198,10 @@ def test_qmp_wait_for_job_raises_on_job_error(tmp_path: Path) -> None:
     ]
 
 
-@pytest.mark.skip(reason="Socket binding fails in macOS automated test sandbox")
+@pytest.mark.skipif(
+    sys.platform == "darwin",
+    reason="Socket binding fails in macOS automated test sandbox",
+)
 def test_qmp_connect_raises_read_timeout_above_connect_probe_timeout(tmp_path: Path) -> None:
     """After connecting, the socket read timeout must be the generous read_timeout.
 
@@ -222,7 +226,10 @@ def test_qmp_connect_raises_read_timeout_above_connect_probe_timeout(tmp_path: P
         socket_path.unlink()
 
 
-@pytest.mark.skip(reason="Socket binding fails in macOS automated test sandbox")
+@pytest.mark.skipif(
+    sys.platform == "darwin",
+    reason="Socket binding fails in macOS automated test sandbox",
+)
 def test_qmp_blockdev_internal_snapshot_round_trips(tmp_path: Path) -> None:
     """Disk-only internal snapshot create/delete issue synchronous QMP commands."""
     socket_path = tmp_path / f"smolvm-qmp-{uuid4().hex}.sock"

--- a/tests/test_qmp.py
+++ b/tests/test_qmp.py
@@ -19,15 +19,23 @@ from __future__ import annotations
 import json
 import socket
 import sys
+import tempfile
 import threading
 import time
+from collections.abc import Iterator
 from pathlib import Path
-from uuid import uuid4
 
 import pytest
 
 from smolvm.exceptions import SmolVMError
 from smolvm.qmp import QMPClient
+
+
+@pytest.fixture
+def qmp_socket_path() -> Iterator[Path]:
+    """Return a short socket path so Linux AF_UNIX path limits do not hide QMP behavior."""
+    with tempfile.TemporaryDirectory(prefix="qmp-") as socket_dir:
+        yield Path(socket_dir) / "q.sock"
 
 
 def _start_qmp_server(
@@ -92,9 +100,9 @@ def _start_qmp_server(
 
 
 @pytest.mark.skip(reason="Socket binding fails in macOS automated test sandbox")
-def test_qmp_handshake_command_execution_and_job_polling(tmp_path: Path) -> None:
+def test_qmp_handshake_command_execution_and_job_polling(qmp_socket_path: Path) -> None:
     """QMPClient should negotiate capabilities, execute commands, and poll jobs."""
-    socket_path = tmp_path / f"smolvm-qmp-{uuid4().hex}.sock"
+    socket_path = qmp_socket_path
     requests: list[dict[str, object]] = []
     responses: dict[str, list[dict[str, object] | list[dict[str, object]]]] = {
         "qmp_capabilities": [{"return": {}}],
@@ -157,9 +165,9 @@ def test_qmp_handshake_command_execution_and_job_polling(tmp_path: Path) -> None
 
 
 @pytest.mark.skip(reason="Socket binding fails in macOS automated test sandbox")
-def test_qmp_wait_for_job_raises_on_job_error(tmp_path: Path) -> None:
+def test_qmp_wait_for_job_raises_on_job_error(qmp_socket_path: Path) -> None:
     """wait_for_job should surface the QMP job error field."""
-    socket_path = tmp_path / f"smolvm-qmp-{uuid4().hex}.sock"
+    socket_path = qmp_socket_path
     requests: list[dict[str, object]] = []
     responses: dict[str, list[dict[str, object] | list[dict[str, object]]]] = {
         "qmp_capabilities": [{"return": {}}],
@@ -202,14 +210,16 @@ def test_qmp_wait_for_job_raises_on_job_error(tmp_path: Path) -> None:
     sys.platform == "darwin",
     reason="Socket binding fails in macOS automated test sandbox",
 )
-def test_qmp_connect_raises_read_timeout_above_connect_probe_timeout(tmp_path: Path) -> None:
+def test_qmp_connect_raises_read_timeout_above_connect_probe_timeout(
+    qmp_socket_path: Path,
+) -> None:
     """After connecting, the socket read timeout must be the generous read_timeout.
 
     Regression guard for the snapshot-save read TimeoutError: the connect probe
     used a ≤1s socket timeout that previously persisted for every command read,
     cutting off replies to slow commands. Once connected we raise it.
     """
-    socket_path = tmp_path / f"smolvm-qmp-{uuid4().hex}.sock"
+    socket_path = qmp_socket_path
     requests: list[dict[str, object]] = []
     responses: dict[str, list[dict[str, object] | list[dict[str, object]]]] = {
         "qmp_capabilities": [{"return": {}}],
@@ -230,9 +240,9 @@ def test_qmp_connect_raises_read_timeout_above_connect_probe_timeout(tmp_path: P
     sys.platform == "darwin",
     reason="Socket binding fails in macOS automated test sandbox",
 )
-def test_qmp_blockdev_internal_snapshot_round_trips(tmp_path: Path) -> None:
+def test_qmp_blockdev_internal_snapshot_round_trips(qmp_socket_path: Path) -> None:
     """Disk-only internal snapshot create/delete issue synchronous QMP commands."""
-    socket_path = tmp_path / f"smolvm-qmp-{uuid4().hex}.sock"
+    socket_path = qmp_socket_path
     requests: list[dict[str, object]] = []
     responses: dict[str, list[dict[str, object] | list[dict[str, object]]]] = {
         "qmp_capabilities": [{"return": {}}],
@@ -260,9 +270,11 @@ def test_qmp_blockdev_internal_snapshot_round_trips(tmp_path: Path) -> None:
 
 
 @pytest.mark.skip(reason="Socket binding fails in macOS automated test sandbox")
-def test_qmp_connect_can_retry_after_capabilities_handshake_failure(tmp_path: Path) -> None:
+def test_qmp_connect_can_retry_after_capabilities_handshake_failure(
+    qmp_socket_path: Path,
+) -> None:
     """Failed capability negotiation should not leave the client half-connected."""
-    socket_path = tmp_path / f"smolvm-qmp-{uuid4().hex}.sock"
+    socket_path = qmp_socket_path
     failed_requests: list[dict[str, object]] = []
     failed_responses: dict[str, list[dict[str, object] | list[dict[str, object]]]] = {
         "qmp_capabilities": [

--- a/tests/test_snapshot_qemu.py
+++ b/tests/test_snapshot_qemu.py
@@ -430,6 +430,84 @@ def test_create_qemu_snapshot_defaults_to_full_type(
     assert qemu_smol_vm.state.get_snapshot("snap-full").snapshot_type is SnapshotType.FULL
 
 
+def test_create_qemu_disk_snapshot_uses_internal_sync_not_vmstate(
+    qemu_smol_vm: SmolVMManager,
+    qemu_config: VMConfig,
+    tmp_path: Path,
+) -> None:
+    """A disk-only snapshot must skip the RAM-dumping snapshot-save job.
+
+    It uses the synchronous block-device internal snapshot instead, and still
+    produces a self-contained disk artifact.
+    """
+    _running_qemu_vm(qemu_smol_vm, qemu_config, tmp_path)
+
+    with patch("smolvm.runtime.qemu.QMPClient") as mock_client_cls:
+        mock_client = _mock_qmp_client()
+        mock_client_cls.return_value = mock_client
+        snapshot = qemu_smol_vm.create_snapshot(
+            "vm001", snapshot_id="snap-disk", snapshot_type=SnapshotType.DISK
+        )
+
+    # No guest RAM dumped: the heavyweight job API is never touched.
+    mock_client.snapshot_save.assert_not_called()
+    mock_client.snapshot_delete.assert_not_called()
+    # Disk-only internal snapshot taken and cleaned up synchronously.
+    mock_client.blockdev_snapshot_internal_sync.assert_called_once()
+    mock_client.blockdev_snapshot_delete_internal_sync.assert_called_once()
+
+    persisted = qemu_smol_vm.state.get_snapshot("snap-disk")
+    assert snapshot.snapshot_type is SnapshotType.DISK
+    assert persisted.snapshot_type is SnapshotType.DISK
+    # Self-contained standalone copy (like FULL), not an overlay.
+    assert persisted.artifacts.disk_path.read_text() == "managed-qcow2"
+    assert qemu_smol_vm.get("vm001").status == VMState.PAUSED
+
+
+def test_restore_qemu_disk_snapshot_boots_fresh_without_loading_vmstate(
+    qemu_smol_vm: SmolVMManager,
+    qemu_config: VMConfig,
+) -> None:
+    """Restoring a disk-only snapshot boots fresh: no snapshot-load of RAM."""
+    _create_qemu_vm(qemu_smol_vm, qemu_config)
+    vm_info = qemu_smol_vm.get("vm001")
+
+    snapshot_dir = qemu_smol_vm.snapshot_dir / "snap-disk"
+    snapshot_dir.mkdir(parents=True)
+    snapshot = SnapshotInfo(
+        snapshot_id="snap-disk",
+        vm_id="vm001",
+        backend="qemu",
+        artifacts=SnapshotArtifacts(disk_path=snapshot_dir / "disk.qcow2"),
+        vm_config=vm_info.config,
+        network_config=vm_info.network,
+        created_at=datetime.now(timezone.utc),
+        snapshot_type=SnapshotType.DISK,
+    )
+    snapshot.artifacts.disk_path.write_text("disk-only-qcow2")
+    qemu_smol_vm.state.create_snapshot(snapshot)
+
+    qemu_smol_vm.delete("vm001")
+    process = MagicMock()
+    process.pid = 98765
+    process.poll.return_value = None
+
+    with (
+        patch.object(qemu_smol_vm, "_start_qemu", return_value=process),
+        patch("smolvm.runtime.qemu.QMPClient") as mock_client_cls,
+    ):
+        mock_client = _mock_qmp_client()
+        mock_client_cls.return_value = mock_client
+        restored = qemu_smol_vm.restore_snapshot("snap-disk", resume_vm=True)
+
+    managed_disk = qemu_smol_vm.data_dir / "disks" / "vm001.qcow2"
+    assert managed_disk.read_text() == "disk-only-qcow2"
+    # Fresh boot: never resumes saved RAM, just continues the cold boot.
+    mock_client.snapshot_load.assert_not_called()
+    mock_client.cont.assert_called_once()
+    assert restored.status == VMState.RUNNING
+
+
 def test_create_qemu_diff_snapshot_records_type(
     qemu_smol_vm: SmolVMManager,
     qemu_config: VMConfig,


### PR DESCRIPTION
## Why

QEMU snapshots via `vm.snapshot()` always run `snapshot-save` with a non-empty `vmstate` node, dumping the **entire guest RAM** into the qcow2. That is slow (blocks the QEMU monitor) and disk-hungry — and for consumers that restore as a **cold boot** (e.g. sandbox suspend/restore across hosts, where `restore_snapshot` would boot fresh anyway), the saved RAM is pure waste.

In production (celesto-agent's snapshot sweep) this surfaced as two distinct failures, both rooted in the RAM dump:

| Symptom | Mechanism |
|---|---|
| `TimeoutError: timed out` reading the `snapshot-save` reply | The connect-probe socket timeout (`min(timeout, 1.0)` = **1.0s**) persisted for **every** command read. A busy QEMU couldn't even *ack* `snapshot-save` within 1s. |
| `SmolVMError: QMP job failed` | The async vmstate save concluded **FAILED — ENOSPC**, the RAM dump exhausting local disk. |

## What

- **`SnapshotType.DISK`** (`types.py`) — self-contained like `FULL`, but **disk-only** (no vmstate). Restoring boots the guest fresh from the disk rather than resuming RAM. `FULL`/`DIFF` are unchanged; `DISK` is strictly opt-in.
- **`qmp.py`**:
  - `blockdev_snapshot_internal_sync` / `blockdev_snapshot_delete_internal_sync` — synchronous, RAM-free internal qcow2 snapshots (no job API).
  - Decouple the connect-probe timeout from command reads: once connected, raise the socket timeout to a generous `read_timeout` (default **30s**), keeping the ≤1s timeout only for connect probing. This is the direct fix for the read `TimeoutError`.
- **`runtime/qemu.py`**: `DISK` create uses the disk-only internal snapshot instead of `snapshot-save`; `DISK` restore skips `snapshot-load` and boots fresh.
- **`vm.py`**: disk-space pre-check drops the `2 × RAM` term for `DISK` snapshots.
- **Tests**: cover `DISK` create (uses internal-sync, never `snapshot-save`) / restore (no `snapshot-load`), plus the new QMP primitives and the read-timeout decouple.

## Test

`384 passed, 15 skipped` locally; ruff check + format clean. The new `test_qmp.py` cases are skipped on macOS (socket-binding sandbox limitation) and run on Linux CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Disk snapshot type: create lightweight, self-contained disk-only snapshots that skip RAM capture and restore as fresh boots.
  * QMP connection enhancements: separate timeouts for initial connect probing and subsequent command reads.

* **Behavior**
  * Reduced/adjusted disk-space warnings when creating disk-only snapshots.

* **Tests**
  * Added regression tests for disk-only snapshot create/restore and QMP timeout behavior.

* **Chores**
  * Package version bumped.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->