### PR TITLE
fix(guest): sync guest clock to host RTC after host sleep (#330)

### DIFF
--- a/scripts/ci/preset-init.sh
+++ b/scripts/ci/preset-init.sh
@@ -140,6 +140,28 @@ if command -v python3 >/dev/null 2>&1 && [ -f /usr/local/bin/smolvm-guest-agent 
     echo "SmolVM init: guest agent started (PID=$!)"
 fi
 
+# ── Clock sync (host-sleep drift) ────────────────────────────
+# The guest's clocksource (the TSC under HVF/QEMU) stops advancing
+# while the host is asleep, so on wake the system clock lags by the
+# sleep duration (issue #330). With no NTP daemon in the sandbox, we
+# periodically re-read the emulated hardware RTC — which QEMU keeps
+# pinned to host wall-clock time (-rtc clock=host) — and step the
+# system clock to match. No-ops on backends with no RTC (Firecracker).
+# Mirrors _base_init_script() in src/smolvm/images/builder.py.
+HWCLOCK=""
+for cand in hwclock /usr/sbin/hwclock /sbin/hwclock; do
+    if command -v "$cand" >/dev/null 2>&1; then HWCLOCK="$cand"; break; fi
+done
+if [ -n "$HWCLOCK" ]; then
+    (
+        while true; do
+            "$HWCLOCK" -s -u 2>/dev/null || true
+            sleep 30
+        done
+    ) &
+    echo "SmolVM init: clock-sync loop started (PID=$!)"
+fi
+
 /usr/sbin/sshd -e &
 
 echo "SmolVM init complete: IP=${GUEST_IP}, SSH listening on port 22"

--- a/src/smolvm/images/builder.py
+++ b/src/smolvm/images/builder.py
@@ -1279,6 +1279,34 @@ else
 fi
 log_ts "guest-agent-started"
 
+# ── Clock sync (host-sleep drift) ────────────────────────────
+# The guest tracks time with its own clocksource (the TSC under
+# HVF/QEMU), which stops advancing while the host is asleep — so on
+# wake the system clock lags by the whole sleep duration (issue #330).
+# A sandbox has no NTP daemon and runs no systemd-timesyncd, so we
+# periodically re-read the emulated hardware RTC, which QEMU keeps
+# pinned to host wall-clock time (-rtc clock=host), and step the
+# system clock to match. The loop no-ops on backends with no RTC
+# (e.g. Firecracker). PID 1's PATH may not include /usr/sbin, so we
+# resolve hwclock explicitly.
+log_ts "clock-sync-start"
+HWCLOCK=""
+for cand in hwclock /usr/sbin/hwclock /sbin/hwclock; do
+    if command -v "$cand" >/dev/null 2>&1; then HWCLOCK="$cand"; break; fi
+done
+if [ -n "$HWCLOCK" ]; then
+    (
+        while true; do
+            "$HWCLOCK" -s -u 2>/dev/null || true
+            sleep 30
+        done
+    ) &
+    echo "SmolVM init: clock-sync loop started (PID=$!)"
+else
+    echo "SmolVM init: hwclock not found; clock-sync disabled"
+fi
+log_ts "clock-sync-started"
+
 # ── SSH ──────────────────────────────────────────────────────
 log_ts "ssh-hostkey-check-start"
 if ! ls /etc/ssh/ssh_host_*_key >/dev/null 2>&1; then

--- a/src/smolvm/runtime/qemu_args.py
+++ b/src/smolvm/runtime/qemu_args.py
@@ -34,7 +34,7 @@ from pathlib import Path
 from smolvm.exceptions import SmolVMError
 from smolvm.runtime.guest_platforms import GuestPlatformSpec
 from smolvm.runtime.qemu import QEMU_ROOT_NODE_NAME
-from smolvm.types import VMInfo
+from smolvm.types import GuestOS, VMInfo
 
 # DNS server announced to the guest by QEMU's SLIRP stack. The default would
 # also work; we set it explicitly so the guest sees the same address whether
@@ -209,6 +209,15 @@ def build_qemu_argv(
             "-no-reboot",
         ]
     )
+    # Pin the emulated hardware RTC to host wall-clock UTC. clock=host is
+    # already QEMU's default, but we set it explicitly because the guest's
+    # clock-sync loop depends on it: under HVF (macOS) there is no kvm-clock,
+    # so the guest's clocksource freezes while the host sleeps and the system
+    # clock wakes up stale (issue #330). The guest periodically re-reads this
+    # RTC to recover. Windows reads the RTC as local time, so leave its
+    # localtime default untouched.
+    if platform_spec.guest_os is not GuestOS.WINDOWS:
+        cmd.extend(["-rtc", "base=utc,clock=host"])
     if vm_info.config.boot_mode == "direct_kernel" and vm_info.config.initrd_path is not None:
         cmd.extend(["-initrd", str(vm_info.config.initrd_path)])
 

--- a/tests/test_guest_agent_image.py
+++ b/tests/test_guest_agent_image.py
@@ -56,6 +56,24 @@ def test_base_init_script_launches_guest_agent_before_sshd() -> None:
     assert script.index("smolvm-guest-agent") < script.index("/usr/sbin/sshd")
 
 
+def test_base_init_script_runs_clock_sync_loop() -> None:
+    """The PID 1 init must keep the guest clock pinned to the host RTC so it
+    recovers from host-sleep drift (issue #330)."""
+    script = ImageBuilder()._default_init_script()
+    assert "hwclock" in script
+    assert "-s -u" in script
+
+
+def test_ci_preset_init_runs_clock_sync_loop() -> None:
+    """The CI publish pipeline's /init must carry the same clock-sync loop as
+    the Python builder — the two init paths have to stay in sync."""
+    script = (_REPO_ROOT / "scripts" / "ci" / "preset-init.sh").read_text()
+    assert "hwclock" in script
+    assert "-s -u" in script
+    # Started before sshd, like the guest agent.
+    assert script.index("hwclock") < script.index("/usr/sbin/sshd")
+
+
 def test_fingerprint_tracks_guest_agent(tmp_path: Path) -> None:
     builder = ImageBuilder(cache_dir=tmp_path)
     fp = builder._fingerprint_with_content({"x": 1}, "FROM alpine", "init")

--- a/tests/test_qemu_args.py
+++ b/tests/test_qemu_args.py
@@ -86,6 +86,8 @@ def test_linux_x86_64_kvm_argv_byte_identical(tmp_path: Path) -> None:
         "user,id=net0,dns=10.0.2.3,hostfwd=tcp:127.0.0.1:2200-:22",
         "-nographic",
         "-no-reboot",
+        "-rtc",
+        "base=utc,clock=host",
         "-machine",
         "q35,accel=kvm",
         "-cpu",
@@ -188,6 +190,28 @@ def test_linux_aarch64_kvm_orders_rootdisk_last(tmp_path: Path) -> None:
     ]
     machine_arg = cmd[cmd.index("-machine") + 1]
     assert machine_arg == "virt,accel=kvm"
+
+
+@pytest.mark.parametrize(
+    "qemu_bin",
+    [
+        Path("/usr/bin/qemu-system-x86_64"),
+        Path("/opt/homebrew/bin/qemu-system-aarch64"),
+    ],
+)
+def test_linux_pins_rtc_to_host_clock(tmp_path: Path, qemu_bin: Path) -> None:
+    """Linux guests get -rtc base=utc,clock=host so the guest can recover
+    from host-sleep clock drift by re-reading the RTC (issue #330)."""
+    vm_info = _qemu_vm_info(tmp_path)
+    cmd = build_qemu_argv(
+        vm_info,
+        qemu_bin=qemu_bin,
+        boot_args=vm_info.config.boot_args,
+        platform_spec=_LINUX_SPEC,
+        host_system="Linux",
+    )
+    assert "-rtc" in cmd
+    assert cmd[cmd.index("-rtc") + 1] == "base=utc,clock=host"
 
 
 def test_firmware_mode_aarch64_needs_uefi_firmware(tmp_path: Path) -> None:
@@ -419,6 +443,21 @@ def test_windows_argv_emits_virtio_scsi_root_and_tpm(tmp_path: Path) -> None:
     # And the chardev + tpmdev tokens.
     assert "-tpmdev" in cmd
     assert "-chardev" in cmd
+
+
+def test_windows_argv_omits_rtc_override(tmp_path: Path) -> None:
+    """Windows reads the RTC as local time, so the UTC override is skipped —
+    QEMU's localtime default is left in place."""
+    cmd = build_qemu_argv(
+        _windows_vm_info(tmp_path),
+        qemu_bin=Path("/usr/bin/qemu-system-x86_64"),
+        boot_args="",
+        platform_spec=_fake_windows_spec(),
+        firmware_vars_path=Path("/state/OVMF_VARS.fd"),
+        swtpm_socket=Path("/state/swtpm-sock"),
+        host_system="Linux",
+    )
+    assert "-rtc" not in cmd
 
 
 def test_windows_argv_missing_firmware_vars_path_raises(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary

When the host Mac sleeps the guest's clocksource freezes (no kvm-clock under HVF) and the system clock wakes up stale — days behind, which breaks TLS (#330). This pins QEMU's emulated RTC to host wall-clock UTC for Linux guests (`-rtc base=utc,clock=host`) and adds a PID 1 loop that re-reads the RTC with `hwclock -s -u` every 30s to step the clock back in line. It needs no NTP or network and no-ops on backends without an RTC (Firecracker). The loop lives in both init paths — the Python builder and the CI `preset-init.sh` — kept in sync.

## Related Issues

- Closes #330

## Testing

- `uv run pytest` — 1185 passed, 13 skipped
- `uv run ruff check` — clean on changed files (repo has pre-existing unrelated lint errors)
- `uv run mypy src` — not run

## Checklist

- [x] Scope is focused and limited to this change
- [x] Tests added/updated for behavior changes
- [ ] Docs updated for user-visible changes
- [x] No secrets or sensitive data included

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Automatic hardware clock synchronization added for guest systems; background sync runs periodically and starts before SSH services.
  * QEMU guests on Linux are configured to use the host RTC clock while Windows guests retain prior behavior.

* **Tests**
  * Added tests verifying the clock synchronization loop is present and starts appropriately.
  * Added tests validating RTC configuration per operating system.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->