### PR TITLE
[codex] fix clock sync init review findings

### DIFF
--- a/scripts/ci/preset-init.sh
+++ b/scripts/ci/preset-init.sh
@@ -150,7 +150,10 @@ fi
 # Mirrors _base_init_script() in src/smolvm/images/builder.py.
 HWCLOCK=""
 for cand in hwclock /usr/sbin/hwclock /sbin/hwclock; do
-    if command -v "$cand" >/dev/null 2>&1; then HWCLOCK="$cand"; break; fi
+    if HWCLOCK_PATH=$(command -v "$cand" 2>/dev/null); then
+        HWCLOCK="$HWCLOCK_PATH"
+        break
+    fi
 done
 if [ -n "$HWCLOCK" ]; then
     (

--- a/src/smolvm/images/builder.py
+++ b/src/smolvm/images/builder.py
@@ -1292,7 +1292,10 @@ log_ts "guest-agent-started"
 log_ts "clock-sync-start"
 HWCLOCK=""
 for cand in hwclock /usr/sbin/hwclock /sbin/hwclock; do
-    if command -v "$cand" >/dev/null 2>&1; then HWCLOCK="$cand"; break; fi
+    if HWCLOCK_PATH=$(command -v "$cand" 2>/dev/null); then
+        HWCLOCK="$HWCLOCK_PATH"
+        break
+    fi
 done
 if [ -n "$HWCLOCK" ]; then
     (
@@ -1302,10 +1305,11 @@ if [ -n "$HWCLOCK" ]; then
         done
     ) &
     echo "SmolVM init: clock-sync loop started (PID=$!)"
+    log_ts "clock-sync-started"
 else
     echo "SmolVM init: hwclock not found; clock-sync disabled"
+    log_ts "clock-sync-disabled"
 fi
-log_ts "clock-sync-started"
 
 # ── SSH ──────────────────────────────────────────────────────
 log_ts "ssh-hostkey-check-start"

--- a/tests/test_guest_agent_image.py
+++ b/tests/test_guest_agent_image.py
@@ -26,6 +26,13 @@ from smolvm.images.builder import ImageBuilder
 _REPO_ROOT = Path(__file__).resolve().parents[1]
 
 
+def _assert_clock_sync_loop_before_sshd(script: str) -> None:
+    assert 'HWCLOCK_PATH=$(command -v "$cand" 2>/dev/null)' in script
+    assert 'HWCLOCK="$HWCLOCK_PATH"' in script
+    assert '"$HWCLOCK" -s -u' in script
+    assert script.index('"$HWCLOCK" -s -u') < script.index("/usr/sbin/sshd")
+
+
 def test_ci_preset_init_launches_guest_agent_before_sshd() -> None:
     """The CI publish pipeline's /init must launch the agent before sshd,
     mirroring the Python builder. These two init paths have to stay in sync —
@@ -60,18 +67,20 @@ def test_base_init_script_runs_clock_sync_loop() -> None:
     """The PID 1 init must keep the guest clock pinned to the host RTC so it
     recovers from host-sleep drift (issue #330)."""
     script = ImageBuilder()._default_init_script()
-    assert "hwclock" in script
-    assert "-s -u" in script
+    _assert_clock_sync_loop_before_sshd(script)
+    assert script.index('echo "SmolVM init: clock-sync loop started') < script.index(
+        'log_ts "clock-sync-started"'
+    )
+    assert script.index('echo "SmolVM init: hwclock not found') < script.index(
+        'log_ts "clock-sync-disabled"'
+    )
 
 
 def test_ci_preset_init_runs_clock_sync_loop() -> None:
     """The CI publish pipeline's /init must carry the same clock-sync loop as
     the Python builder — the two init paths have to stay in sync."""
     script = (_REPO_ROOT / "scripts" / "ci" / "preset-init.sh").read_text()
-    assert "hwclock" in script
-    assert "-s -u" in script
-    # Started before sshd, like the guest agent.
-    assert script.index("hwclock") < script.index("/usr/sbin/sshd")
+    _assert_clock_sync_loop_before_sshd(script)
 
 
 def test_fingerprint_tracks_guest_agent(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary

This addresses the Copilot review findings from PR #339 around the guest clock-sync init loop.

- resolve `hwclock` to the actual `command -v` path before storing it in `HWCLOCK`
- only emit the `clock-sync-started` timestamp when the loop really starts, and emit `clock-sync-disabled` when `hwclock` is unavailable
- make the ordering test anchor on the actual `"$HWCLOCK" -s -u` invocation instead of the first `hwclock` word

## Validation

- `uv run --extra dev pytest tests/test_guest_agent_image.py`
- `uv run --extra dev ruff check src/smolvm/images/builder.py tests/test_guest_agent_image.py`

Note: `uv run --extra dev ruff check .` still reports existing unrelated lint findings outside this patch.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Refined hardware clock detection mechanism for improved system time synchronization

* **Tests**
  * Extended test coverage for clock synchronization initialization and diagnostics

<!-- end of auto-generated comment: release notes by coderabbit.ai -->