### PR TITLE
fix(preset): transfer keychain credentials in published-image boot path

### DIFF
--- a/src/smolvm/cli/main.py
+++ b/src/smolvm/cli/main.py
@@ -2294,6 +2294,14 @@ def _run_start_with_published_image(args: argparse.Namespace, preset: object) ->
             vm.start(boot_timeout=args.boot_timeout)
             vm.wait_for_ssh(timeout=args.boot_timeout)
 
+            # Transfer credentials — keychain only, no config copies or
+            # install scripts. The CLI is already baked into the image;
+            # we only need the OAuth token so the guest is logged in.
+            from smolvm.presets import transfer_keychain_secrets
+
+            ssh = vm._ensure_ssh_for_env()
+            extracted_secrets = transfer_keychain_secrets(ssh, _preset)
+
             network = vm.info.network
             data: StartPayload = {
                 "vm": {
@@ -2312,7 +2320,7 @@ def _run_start_with_published_image(args: argparse.Namespace, preset: object) ->
                 },
                 "preset": {
                     "name": _preset.name,
-                    "copied_configs": [],
+                    "copied_configs": extracted_secrets,
                     "injected_env_keys": [],
                     "no_env_hint": _preset.no_env_hint,
                 },

--- a/src/smolvm/presets/__init__.py
+++ b/src/smolvm/presets/__init__.py
@@ -22,7 +22,7 @@ along with any host config files and API keys the harness expects.
 from __future__ import annotations
 
 from smolvm.presets._git import GIT_HOST_CONFIGS
-from smolvm.presets._install import apply_preset, collect_host_env
+from smolvm.presets._install import apply_preset, collect_host_env, transfer_keychain_secrets
 from smolvm.presets._types import HostConfigCopy, HostKeychainSecret, Preset
 from smolvm.presets.claude_code import CLAUDE_CODE_PRESET
 from smolvm.presets.codex import CODEX_PRESET
@@ -92,6 +92,7 @@ __all__ = [
     "apply_preset",
     "collect_host_env",
     "get_preset",
+    "transfer_keychain_secrets",
     "list_presets",
     "preset_command_names",
     "preset_names",

--- a/src/smolvm/presets/_install.py
+++ b/src/smolvm/presets/_install.py
@@ -99,29 +99,9 @@ def apply_preset(
     # Keychain step runs after host_configs so a directory copy that
     # targets the same parent (e.g. ~/.claude → /root/.claude) cannot
     # tar-extract over a credential file we just wrote.
-    #
-    # Notify is per-found-secret rather than rolled up because keychain
-    # entries are user-visible (typically 1 OAuth blob) and the user
-    # cares whether their login actually transferred — a missing secret
-    # must not produce a "copied X" message.
-    extracted_secrets: list[str] = []
-    for secret in preset.host_keychain_secrets:
-        # Default the account to the current macOS login user. This is
-        # what Claude Code uses for its OAuth keychain entry, and it
-        # disambiguates when multiple items share the same service name
-        # (e.g. a separate entry under acct=root for MCP tokens).
-        account = secret.account if secret.account is not None else getpass.getuser()
-        plaintext = _extract_keychain_secret(secret.service, account=account)
-        if plaintext is None:
-            logger.debug(
-                "Skipping unavailable keychain secret: service=%s account=%s",
-                secret.service,
-                account,
-            )
-            continue
-        notify(f"Copying {secret.service} from macOS keychain → {secret.guest_path}")
-        _write_secret_to_guest(ssh, plaintext, secret.guest_path, secret.file_mode)
-        extracted_secrets.append(secret.guest_path)
+    extracted_secrets: list[str] = transfer_keychain_secrets(
+        ssh, preset, on_progress=on_progress
+    )
 
     env_vars = collect_host_env(preset)
     injected_keys: list[str] = []

--- a/src/smolvm/presets/_install.py
+++ b/src/smolvm/presets/_install.py
@@ -361,4 +361,39 @@ def _write_secret_to_guest(ssh: CommChannel, content: str, guest_path: str, file
         tmp_path.unlink(missing_ok=True)
 
 
-__all__ = ["apply_preset", "collect_host_env"]
+def transfer_keychain_secrets(
+    ssh: CommChannel,
+    preset: Preset,
+    *,
+    on_progress: Callable[[str], None] | None = None,
+) -> list[str]:
+    """Extract macOS keychain secrets and write them into the guest.
+
+    Runs only the keychain step from :func:`apply_preset` — no config
+    copies, no env injection, no install scripts. Used by the published-
+    image path where the CLI is already baked in and only credential
+    transfer is needed.
+
+    Returns a list of guest paths where secrets were written (empty when
+    not on macOS, when the keychain item is missing, or when the user
+    denies access).
+    """
+    notify = on_progress or (lambda _msg: None)
+    extracted: list[str] = []
+    for secret in preset.host_keychain_secrets:
+        account = secret.account if secret.account is not None else getpass.getuser()
+        plaintext = _extract_keychain_secret(secret.service, account=account)
+        if plaintext is None:
+            logger.debug(
+                "Skipping unavailable keychain secret: service=%s account=%s",
+                secret.service,
+                account,
+            )
+            continue
+        notify(f"Copying {secret.service} from macOS keychain → {secret.guest_path}")
+        _write_secret_to_guest(ssh, plaintext, secret.guest_path, secret.file_mode)
+        extracted.append(secret.guest_path)
+    return extracted
+
+
+__all__ = ["apply_preset", "collect_host_env", "transfer_keychain_secrets"]

--- a/src/smolvm/presets/_types.py
+++ b/src/smolvm/presets/_types.py
@@ -74,6 +74,11 @@ class HostKeychainSecret:
             entries can share a service name (e.g. one per account),
             and ``-s`` alone returns whichever the keychain hits first,
             which may not be the right one.
+        host_fallback_path: Host file path used as the credential source
+            on non-macOS hosts (e.g. ``~/.claude/.credentials.json`` on
+            Linux, where the same token lives as a plain file instead of
+            a keychain item). When ``None``, non-macOS hosts are a
+            silent no-op and the user must authenticate inside the guest.
         file_mode: Octal permission bits applied to the guest file.
             Defaults to ``0o600`` because credentials files should not
             be world-readable.
@@ -82,6 +87,7 @@ class HostKeychainSecret:
     service: str
     guest_path: str
     account: str | None = None
+    host_fallback_path: str | None = None
     file_mode: int = 0o600
 
 

--- a/src/smolvm/presets/_types.py
+++ b/src/smolvm/presets/_types.py
@@ -74,11 +74,6 @@ class HostKeychainSecret:
             entries can share a service name (e.g. one per account),
             and ``-s`` alone returns whichever the keychain hits first,
             which may not be the right one.
-        host_fallback_path: Host file path used as the credential source
-            on non-macOS hosts (e.g. ``~/.claude/.credentials.json`` on
-            Linux, where the same token lives as a plain file instead of
-            a keychain item). When ``None``, non-macOS hosts are a
-            silent no-op and the user must authenticate inside the guest.
         file_mode: Octal permission bits applied to the guest file.
             Defaults to ``0o600`` because credentials files should not
             be world-readable.
@@ -87,7 +82,6 @@ class HostKeychainSecret:
     service: str
     guest_path: str
     account: str | None = None
-    host_fallback_path: str | None = None
     file_mode: int = 0o600
 
 


### PR DESCRIPTION
## Problem

When `smolvm claude-code start` runs on macOS it takes the published-image
fast path (`_run_start_with_published_image`), which downloads a pre-baked
Firecracker image and skips `apply_preset` entirely — because the CLI is
already installed. The code hard-coded `copied_configs: []` and never ran
the keychain extraction step.

On macOS, Claude Code stores its OAuth tokens in the system Keychain under
the service name `"Claude Code-credentials"`, **not** in
`~/.claude/.credentials.json` (that file doesn't exist on a signed-in Mac).
So the guest booted with the user's name visible but no auth token —
prompting a full re-login inside the sandbox.

## Fix

Add `transfer_keychain_secrets(ssh, preset)` — a focused function that runs
only the keychain extraction step, writing the OAuth JSON blob to the
correct guest path at mode `0600`. The published-image path calls this
after `wait_for_ssh` and surfaces the result in the `Configs Copied` row of
the start summary.

```
│ Configs Copied     │ /root/.claude/.credentials.json │
```

Config file copies (`~/.claude.json`, `~/.claude/`) and install scripts are
intentionally excluded:
- The CLI is already baked in — re-running npm install would download ~200 MB for nothing.
- Bulk-copying `~/.claude/` would dump host-specific noise (cache, daemon
  files, CLAUDE.md, backups) into the guest.

## Test plan

- [ ] `pytest tests/test_presets.py` — all 79 pass
- [ ] `smolvm claude-code start` → `Configs Copied: /root/.claude/.credentials.json` appears
- [ ] SSH into guest: `/root/.claude/.credentials.json` exists at mode `600`
- [ ] `claude` launches inside the guest without prompting for login

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## New Features

* Enhanced credential management: When starting a VM with a preset, the CLI now automatically extracts and transfers system OAuth and keychain credentials to the guest environment after it boots. The response output displays which secrets were successfully copied.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->