### PR TITLE
Add public custom boot kernel APIs

### DIFF
--- a/plan.md
+++ b/plan.md
@@ -1,0 +1,59 @@
+# Custom Dockerfile-backed boot image API plan
+
+This file tracks the temporary implementation plan for issue #341. Delete this file after all phases are complete.
+
+## Design principles
+
+- Make custom Dockerfile-backed direct-kernel images a first-class SDK flow.
+- Keep downstream callers away from SmolVM internals such as kernel asset names, backend-specific boot arguments, cache layout, and per-VM disk paths.
+- Do not inject SmolVM's guest agent into generic custom images unless the caller asks for it.
+- Separate rootfs building from backend/kernel/boot resolution so kernel changes do not force Docker rebuilds.
+- Keep user-facing errors short, plain, and actionable.
+
+## Phase 1 — public kernel and boot APIs
+
+- Add `smolvm.kernels.ensure_base_kernel_for_backend(backend, arch="host", cache_dir=None)`.
+- Add a public `DirectKernelBoot` model that renders backend-correct kernel arguments.
+- Preserve current backend quirks:
+  - Firecracker/libkrun use the ELF kernel format; QEMU uses the Image/bzImage format.
+  - Firecracker gets `pci=off`; QEMU/libkrun do not.
+  - QEMU arm64 uses `console=ttyAMA0`; x86_64 uses `console=ttyS0`.
+  - Safe boot trims (`tsc=reliable`, `no_timer_check`, and default `quiet`) remain enabled by default.
+- Export the new APIs from `smolvm` and `smolvm.images` where appropriate.
+- Add unit tests for kernel selection and boot argument rendering.
+
+## Phase 2 — `BootImage`
+
+- Add a public `BootImage` type representing a bootable base image, not a running VM.
+- Include rootfs/kernel/initrd paths, rootfs format, backend, arch, boot profile, optional boot-arg override, and SSH capability metadata.
+- Validate path existence and reject ambiguous `boot` + `boot_args` combinations unless an override rule is explicit.
+- Keep the type usable by Docker builders now and future catalogs later.
+
+## Phase 3 — generic `DockerRootfsBuilder`
+
+- Add a public builder that accepts Dockerfile text, build context entries, rootfs size, build args, cache directory, and fingerprint inputs.
+- Reuse the existing Docker build/export and ext4 creation helpers, but remove implicit SmolVM guest-agent injection for generic images.
+- Support context entries as `Path`, `str`, or `bytes`; reject absolute paths and path traversal inside the build context.
+- Cache rootfs artifacts under a stable content fingerprint that includes Dockerfile, context content, rootfs size, build args, target platform/arch, and user fingerprint inputs.
+- Add file locking around cache misses so concurrent callers do not race the same build.
+- Have `ensure()` resolve the backend/arch kernel and boot args, then return a `BootImage`.
+
+## Phase 4 — `SmolVM.from_image()`
+
+- Add a high-level constructor that consumes `BootImage` and builds the corresponding `VMConfig` internally.
+- Resolve backend, arch, kernel path, and boot args when missing.
+- Expose consistent knobs: `vm_id`, `vcpus`, `memory_mb`, `network`, port forwards, vsock, comm channel, disk mode, SSH capability, and readiness behavior.
+- Keep no-SSH custom images valid; do not assume command execution is available unless the image declares a supported control path.
+
+## Phase 5 — per-VM disk resize/grow
+
+- Move disk sizing into SmolVM's VM lifecycle so callers never read `vm.info.config.rootfs_path` to resize disks.
+- Add pre-start or create-time options for requested disk size and filesystem growth.
+- Always resize the isolated per-VM disk, never the shared base image.
+- Raw ext4 path: `truncate`, `e2fsck -fy`, then `resize2fs`.
+- qcow2 path: `qemu-img resize`; only claim filesystem growth when SmolVM can actually grow the guest filesystem.
+- Be explicit about QEMU raw-ext4 overlays: either materialize a growable raw disk or reject unsupported grow combinations with a clear error.
+
+## Final cleanup
+
+- Delete `plan.md` after all phases are implemented and accepted.

--- a/src/smolvm/__init__.py
+++ b/src/smolvm/__init__.py
@@ -40,8 +40,10 @@ from smolvm.exceptions import (
 )
 from smolvm.facade import SmolVM
 from smolvm.host.manager import HostManager
+from smolvm.images.boot import DirectKernelBoot
 from smolvm.images.builder import SSH_BOOT_ARGS, ImageBuilder
 from smolvm.images.manager import ImageManager, ImageSource, LocalImage, S3ImageManifest, S3ImageRef
+from smolvm.kernels import ensure_base_kernel_for_backend
 from smolvm.ssh import SSHClient
 from smolvm.types import (
     BrowserSessionConfig,
@@ -75,11 +77,13 @@ __all__ = [
     # Image management
     "ImageManager",
     "ImageBuilder",
+    "DirectKernelBoot",
     "SSH_BOOT_ARGS",
     "ImageSource",
     "LocalImage",
     "S3ImageManifest",
     "S3ImageRef",
+    "ensure_base_kernel_for_backend",
     # Host setup
     "HostManager",
     # SSH

--- a/src/smolvm/images/__init__.py
+++ b/src/smolvm/images/__init__.py
@@ -13,3 +13,7 @@
 # limitations under the License.
 
 """Guest image management and builders."""
+
+from smolvm.images.boot import DirectKernelBoot
+
+__all__ = ["DirectKernelBoot"]

--- a/src/smolvm/images/boot.py
+++ b/src/smolvm/images/boot.py
@@ -1,0 +1,131 @@
+# Copyright 2026 Celesto AI
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Public boot-profile helpers for custom SmolVM images."""
+
+from __future__ import annotations
+
+import platform
+from dataclasses import dataclass
+from typing import Literal
+
+from smolvm.runtime.backends import (
+    BACKEND_FIRECRACKER,
+    BACKEND_LIBKRUN,
+    BACKEND_QEMU,
+    resolve_backend,
+)
+from smolvm.runtime.boot_profiles import normalize_arch, safe_kernel_trim_args
+
+ConsoleMode = Literal["serial", "none"]
+
+
+def _check_kernel_token(label: str, value: str | None) -> str | None:
+    """Validate one kernel command-line token value."""
+    if value is None:
+        return None
+    stripped = value.strip()
+    if not stripped:
+        raise ValueError(f"{label} must not be empty")
+    if any(ch.isspace() for ch in stripped):
+        raise ValueError(f"{label} must be one kernel argument token, got {value!r}")
+    return stripped
+
+
+def _check_required_kernel_token(label: str, value: str | None) -> str:
+    """Validate a required kernel command-line token value."""
+    checked = _check_kernel_token(label, value)
+    if checked is None:
+        raise ValueError(f"{label} must not be None")
+    return checked
+
+
+def _check_extra_arg(value: str | None) -> str:
+    """Validate one caller-supplied extra kernel argument."""
+    checked = _check_kernel_token("extra_args", value)
+    if checked is None:
+        raise ValueError("extra_args entries must not be None")
+    return checked
+
+
+def _serial_console_for_backend(backend: str, arch: str) -> str:
+    """Return the serial console device for a backend/arch pair."""
+    normalized_arch = normalize_arch(arch)
+    if backend == BACKEND_FIRECRACKER:
+        return "ttyS0"
+    if backend in {BACKEND_QEMU, BACKEND_LIBKRUN}:
+        return "ttyAMA0" if normalized_arch == "aarch64" else "ttyS0"
+    raise ValueError(f"Unsupported backend {backend!r}")
+
+
+@dataclass(frozen=True, slots=True)
+class DirectKernelBoot:
+    """Render backend-correct direct-kernel boot arguments.
+
+    The root filesystem and init path are caller-owned, but SmolVM owns the
+    backend quirks: Firecracker needs ``pci=off``, QEMU/libkrun must not get
+    it, and QEMU aarch64 uses ``ttyAMA0`` for the serial console.
+    """
+
+    root: str = "/dev/vda"
+    init: str | None = "/init"
+    rw: bool = True
+    console: ConsoleMode = "serial"
+    panic: int = 1
+    reboot: str = "k"
+    safe_trims: bool = True
+    quiet: bool | None = None
+    extra_args: tuple[str, ...] = ()
+
+    def __post_init__(self) -> None:
+        if self.console not in {"serial", "none"}:
+            raise ValueError("console must be 'serial' or 'none'")
+        if self.panic < 0:
+            raise ValueError("panic must be >= 0")
+
+        checked_root = _check_required_kernel_token("root", self.root)
+        checked_reboot = _check_required_kernel_token("reboot", self.reboot)
+        object.__setattr__(self, "root", checked_root)
+        object.__setattr__(self, "init", _check_kernel_token("init", self.init))
+        object.__setattr__(self, "reboot", checked_reboot)
+        object.__setattr__(
+            self,
+            "extra_args",
+            tuple(_check_extra_arg(arg) for arg in self.extra_args),
+        )
+
+    def render(self, *, backend: str, arch: str = "host") -> str:
+        """Render this boot profile for a runtime backend and architecture."""
+        resolved_backend = resolve_backend(backend)
+        resolved_arch = platform.machine() if arch == "host" else arch
+        # Validate early so unknown arches fail before returning a partial string.
+        normalize_arch(resolved_arch)
+
+        parts: list[str] = []
+        if self.console == "serial":
+            console = _serial_console_for_backend(resolved_backend, resolved_arch)
+            parts.append(f"console={console}")
+
+        parts.extend([f"reboot={self.reboot}", f"panic={self.panic}"])
+        if resolved_backend == BACKEND_FIRECRACKER:
+            parts.append("pci=off")
+
+        parts.extend([f"root={self.root}", "rw" if self.rw else "ro"])
+        if self.init is not None:
+            parts.append(f"init={self.init}")
+
+        if self.safe_trims:
+            parts.extend(safe_kernel_trim_args(quiet=self.quiet))
+        parts.extend(self.extra_args)
+        return " ".join(parts)

--- a/src/smolvm/kernels.py
+++ b/src/smolvm/kernels.py
@@ -1,0 +1,60 @@
+# Copyright 2026 Celesto AI
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Public helpers for resolving SmolVM base kernels."""
+
+from __future__ import annotations
+
+import platform
+from pathlib import Path
+from typing import Literal, cast
+
+from smolvm.runtime.backends import resolve_backend
+from smolvm.runtime.boot_profiles import to_published_arch
+
+KernelArch = Literal["host", "amd64", "arm64", "x86_64", "aarch64"]
+PublishedArch = Literal["amd64", "arm64"]
+Vmm = Literal["firecracker", "qemu", "libkrun"]
+
+
+def _resolve_kernel_arch(arch: KernelArch | str) -> PublishedArch:
+    """Resolve a user-facing arch value to SmolVM's published-kernel arch key."""
+    raw_arch = platform.machine() if arch == "host" else arch
+    return cast(PublishedArch, to_published_arch(raw_arch))
+
+
+def ensure_base_kernel_for_backend(
+    backend: str | None = None,
+    arch: KernelArch | str = "host",
+    *,
+    cache_dir: Path | None = None,
+) -> Path:
+    """Return the SHA-verified SmolVM base kernel for a backend and arch.
+
+    SmolVM publishes the same kernel build in two container formats. The
+    backend determines which one is valid: Firecracker/libkrun use the ELF
+    artifact, while QEMU uses the Image/bzImage artifact. This helper keeps
+    callers from knowing those release asset details.
+    """
+    from smolvm.images.published import _kernel_format_for_vmm, ensure_base_kernel
+
+    resolved_backend = resolve_backend(backend)
+    resolved_arch = _resolve_kernel_arch(arch)
+    vmm = cast(Vmm, resolved_backend)
+    kernel_format = _kernel_format_for_vmm(vmm)
+    return ensure_base_kernel(
+        resolved_arch,
+        kernel_format,
+        cache_dir=cache_dir,
+    )

--- a/src/smolvm/runtime/boot_profiles.py
+++ b/src/smolvm/runtime/boot_profiles.py
@@ -60,6 +60,24 @@ def _quiet_flag() -> str:
     return " quiet"
 
 
+def safe_kernel_trim_args(*, quiet: bool | None = None) -> tuple[str, ...]:
+    """Return latency-safe kernel command-line trims.
+
+    ``quiet=None`` preserves SmolVM's default behavior: include ``quiet``
+    unless ``SMOLVM_VERBOSE_BOOT`` asks for verbose kernel output. Pass
+    ``quiet=True`` or ``quiet=False`` to force either behavior for a custom
+    boot profile.
+    """
+    args = _SAFE_TRIM_FLAGS.split()
+    if quiet is None:
+        quiet_arg = _quiet_flag().strip()
+        if quiet_arg:
+            args.append(quiet_arg)
+    elif quiet:
+        args.append("quiet")
+    return tuple(args)
+
+
 _MICROVM_DIRECT_FIRECRACKER_BASE = "console=ttyS0 reboot=k panic=1 pci=off root=/dev/vda rw"
 
 
@@ -86,7 +104,7 @@ class BootProfileSpec:
             )
 
         if self.profile is KernelBootProfile.MICROVM_DIRECT:
-            trims = f"{_SAFE_TRIM_FLAGS}{_quiet_flag()}"
+            trims = " ".join(safe_kernel_trim_args())
             if backend in {BACKEND_QEMU, BACKEND_LIBKRUN}:
                 console = "ttyAMA0" if normalized_arch == "aarch64" else "ttyS0"
                 return f"console={console} reboot=k panic=1 {trims} init=/init"

--- a/tests/test_custom_boot_api.py
+++ b/tests/test_custom_boot_api.py
@@ -1,0 +1,137 @@
+# Copyright 2026 Celesto AI
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for public custom-image boot and kernel APIs."""
+
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from smolvm.images import DirectKernelBoot
+from smolvm.kernels import ensure_base_kernel_for_backend
+
+
+def _tokens(args: str) -> set[str]:
+    return set(args.split())
+
+
+class TestDirectKernelBoot:
+    """DirectKernelBoot centralizes backend-specific kernel args."""
+
+    def test_firecracker_render_includes_pci_off_and_safe_trims(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.delenv("SMOLVM_VERBOSE_BOOT", raising=False)
+        args = DirectKernelBoot(root="/dev/vda", init="/init").render(
+            backend="firecracker",
+            arch="amd64",
+        )
+
+        assert args == (
+            "console=ttyS0 reboot=k panic=1 pci=off root=/dev/vda rw "
+            "init=/init tsc=reliable no_timer_check quiet"
+        )
+
+    def test_qemu_render_excludes_pci_off_but_keeps_root(self) -> None:
+        args = DirectKernelBoot(root="/dev/vda", init="/init", quiet=False).render(
+            backend="qemu",
+            arch="amd64",
+        )
+
+        tokens = _tokens(args)
+        assert "console=ttyS0" in tokens
+        assert "pci=off" not in tokens
+        assert "root=/dev/vda" in tokens
+        assert "rw" in tokens
+        assert "init=/init" in tokens
+        assert "quiet" not in tokens
+
+    def test_qemu_arm64_uses_pl011_console(self) -> None:
+        args = DirectKernelBoot(quiet=False).render(backend="qemu", arch="arm64")
+        assert args.startswith("console=ttyAMA0 ")
+
+    def test_libkrun_uses_qemu_style_args(self) -> None:
+        args = DirectKernelBoot(quiet=False).render(backend="libkrun", arch="amd64")
+        tokens = _tokens(args)
+        assert "console=ttyS0" in tokens
+        assert "pci=off" not in tokens
+        assert "root=/dev/vda" in tokens
+
+    def test_verbose_boot_env_drops_default_quiet(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("SMOLVM_VERBOSE_BOOT", "1")
+        args = DirectKernelBoot().render(backend="firecracker", arch="amd64")
+        assert "quiet" not in _tokens(args)
+        assert "tsc=reliable" in _tokens(args)
+
+    def test_console_none_and_extra_args(self) -> None:
+        args = DirectKernelBoot(
+            console="none",
+            init=None,
+            rw=False,
+            quiet=False,
+            extra_args=("foo=bar", "acpi=off"),
+        ).render(backend="qemu", arch="amd64")
+
+        tokens = _tokens(args)
+        assert not any(token.startswith("console=") for token in tokens)
+        assert "ro" in tokens
+        assert not any(token.startswith("init=") for token in tokens)
+        assert "foo=bar" in tokens
+        assert "acpi=off" in tokens
+
+    def test_extra_args_must_be_single_tokens(self) -> None:
+        with pytest.raises(ValueError, match="one kernel argument token"):
+            DirectKernelBoot(extra_args=("foo=bar baz=qux",))
+
+
+class TestEnsureBaseKernelForBackend:
+    """Kernel resolution hides published asset format details."""
+
+    @patch("smolvm.images.published.ensure_base_kernel")
+    def test_qemu_selects_image_kernel(self, mock_ensure: MagicMock) -> None:
+        kernel = Path("/tmp/vmlinux.image")
+        mock_ensure.return_value = kernel
+
+        assert ensure_base_kernel_for_backend("qemu", arch="amd64") == kernel
+        mock_ensure.assert_called_once_with("amd64", "image", cache_dir=None)
+
+    @patch("smolvm.images.published.ensure_base_kernel")
+    def test_firecracker_selects_elf_kernel(self, mock_ensure: MagicMock) -> None:
+        kernel = Path("/tmp/vmlinux.elf")
+        mock_ensure.return_value = kernel
+
+        assert ensure_base_kernel_for_backend("firecracker", arch="arm64") == kernel
+        mock_ensure.assert_called_once_with("arm64", "elf", cache_dir=None)
+
+    @patch("smolvm.images.published.ensure_base_kernel")
+    def test_libkrun_selects_elf_kernel(self, mock_ensure: MagicMock) -> None:
+        kernel = Path("/tmp/vmlinux.elf")
+        mock_ensure.return_value = kernel
+
+        assert ensure_base_kernel_for_backend("libkrun", arch="x86_64") == kernel
+        mock_ensure.assert_called_once_with("amd64", "elf", cache_dir=None)
+
+    @patch("smolvm.images.published.ensure_base_kernel")
+    def test_host_arch_is_normalized(
+        self,
+        mock_ensure: MagicMock,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        kernel = Path("/tmp/vmlinux.image")
+        mock_ensure.return_value = kernel
+        monkeypatch.setattr("smolvm.kernels.platform.machine", lambda: "aarch64")
+
+        assert ensure_base_kernel_for_backend("qemu", arch="host") == kernel
+        mock_ensure.assert_called_once_with("arm64", "image", cache_dir=None)

--- a/tests/test_custom_boot_api.py
+++ b/tests/test_custom_boot_api.py
@@ -101,7 +101,7 @@ class TestEnsureBaseKernelForBackend:
 
     @patch("smolvm.images.published.ensure_base_kernel")
     def test_qemu_selects_image_kernel(self, mock_ensure: MagicMock) -> None:
-        kernel = Path("/tmp/vmlinux.image")
+        kernel = Path("sentinels/vmlinux.image")
         mock_ensure.return_value = kernel
 
         assert ensure_base_kernel_for_backend("qemu", arch="amd64") == kernel
@@ -109,7 +109,7 @@ class TestEnsureBaseKernelForBackend:
 
     @patch("smolvm.images.published.ensure_base_kernel")
     def test_firecracker_selects_elf_kernel(self, mock_ensure: MagicMock) -> None:
-        kernel = Path("/tmp/vmlinux.elf")
+        kernel = Path("sentinels/vmlinux.elf")
         mock_ensure.return_value = kernel
 
         assert ensure_base_kernel_for_backend("firecracker", arch="arm64") == kernel
@@ -117,7 +117,7 @@ class TestEnsureBaseKernelForBackend:
 
     @patch("smolvm.images.published.ensure_base_kernel")
     def test_libkrun_selects_elf_kernel(self, mock_ensure: MagicMock) -> None:
-        kernel = Path("/tmp/vmlinux.elf")
+        kernel = Path("sentinels/vmlinux.elf")
         mock_ensure.return_value = kernel
 
         assert ensure_base_kernel_for_backend("libkrun", arch="x86_64") == kernel
@@ -129,7 +129,7 @@ class TestEnsureBaseKernelForBackend:
         mock_ensure: MagicMock,
         monkeypatch: pytest.MonkeyPatch,
     ) -> None:
-        kernel = Path("/tmp/vmlinux.image")
+        kernel = Path("sentinels/vmlinux.image")
         mock_ensure.return_value = kernel
         monkeypatch.setattr("smolvm.kernels.platform.machine", lambda: "aarch64")
 


### PR DESCRIPTION
## Summary
- add a temporary `plan.md` for the custom boot-image rollout
- add `DirectKernelBoot` for backend-correct direct-kernel args
- add `ensure_base_kernel_for_backend()` so callers do not need to know kernel asset formats
- export the new APIs from `smolvm` and `smolvm.images`

## Tests
- `uv run ruff check src/smolvm/kernels.py src/smolvm/images/boot.py src/smolvm/images/__init__.py src/smolvm/__init__.py src/smolvm/runtime/boot_profiles.py tests/test_custom_boot_api.py tests/test_boot_profiles.py`
- `uv run pytest tests/test_custom_boot_api.py tests/test_boot_profiles.py`

Part of #341.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Configurable kernel boot profiles with backend- and architecture-aware argument rendering for Firecracker, QEMU and libkrun.
  * Automatic resolution of appropriate base kernel artifacts per backend and architecture.
  * Utility to generate safe/optimized kernel command-line trim arguments.

* **Documentation**
  * Added a staged implementation plan describing phased rollout of the boot/kernel work.

* **Tests**
  * Added comprehensive tests for custom boot profiles and kernel-resolution behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->