### PR TITLE
Add boot image and Docker rootfs builder APIs

### DIFF
--- a/plan.md
+++ b/plan.md
@@ -24,19 +24,63 @@ This file tracks the temporary implementation plan for issue #341. Delete this f
 
 ## Phase 2 — `BootImage`
 
-- Add a public `BootImage` type representing a bootable base image, not a running VM.
-- Include rootfs/kernel/initrd paths, rootfs format, backend, arch, boot profile, optional boot-arg override, and SSH capability metadata.
-- Validate path existence and reject ambiguous `boot` + `boot_args` combinations unless an override rule is explicit.
-- Keep the type usable by Docker builders now and future catalogs later.
+Goal: add a small public type that describes a bootable base image without creating or launching a VM.
+
+Implementation plan:
+
+- Add `BootImage` in `src/smolvm/images/boot.py` next to `DirectKernelBoot` so boot-related SDK types stay together.
+- Add a minimal `FirmwareBoot` marker type for images whose kernel is inside the disk and QEMU boots through firmware.
+- Use a frozen Pydantic model for `BootImage`, matching the existing SDK models in `types.py` and `images/manager.py`.
+- Fields:
+  - `name: str`
+  - `rootfs_path: Path`
+  - `rootfs_format: Literal["raw-ext4", "qcow2"]`
+  - `kernel_path: Path | None = None`
+  - `initrd_path: Path | None = None`
+  - `boot: DirectKernelBoot | FirmwareBoot | None = None`
+  - `boot_args: str | None = None`
+  - `backend: Literal["firecracker", "qemu", "libkrun"] | None = None`
+  - `arch: Literal["amd64", "arm64"] | None = None`
+  - `ssh_capable: bool = False`
+- Validation:
+  - `name` and `boot_args` must not be blank.
+  - `rootfs_path`, `kernel_path`, and `initrd_path` must point to existing files when present.
+  - `boot` and `boot_args` are mutually exclusive; `boot_args` is an explicit override path, not a second source of truth.
+  - Direct-kernel images need either `boot` or `boot_args`; `kernel_path` may still be `None` because Phase 4 can resolve the base kernel from backend/arch.
+  - Firmware images must not set `kernel_path`, `initrd_path`, or `boot_args`.
+- Add helper methods/properties now to keep Phase 4 small:
+  - `boot_mode` property returning `"direct_kernel"` or `"firmware"`.
+  - `render_boot_args(backend, arch)` returning explicit `boot_args`, rendered `DirectKernelBoot`, or `""` for firmware.
+- Export `BootImage` and `FirmwareBoot` from `smolvm.images` and top-level `smolvm`.
+- Tests:
+  - valid direct-kernel image with `DirectKernelBoot`.
+  - valid direct-kernel image with explicit `boot_args`.
+  - direct-kernel image can omit `kernel_path` for later resolution.
+  - reject both `boot` and `boot_args`.
+  - reject missing direct-kernel boot information.
+  - valid firmware image and firmware invariants.
+  - path validation and top-level exports.
 
 ## Phase 3 — generic `DockerRootfsBuilder`
 
-- Add a public builder that accepts Dockerfile text, build context entries, rootfs size, build args, cache directory, and fingerprint inputs.
-- Reuse the existing Docker build/export and ext4 creation helpers, but remove implicit SmolVM guest-agent injection for generic images.
-- Support context entries as `Path`, `str`, or `bytes`; reject absolute paths and path traversal inside the build context.
-- Cache rootfs artifacts under a stable content fingerprint that includes Dockerfile, context content, rootfs size, build args, target platform/arch, and user fingerprint inputs.
+Goal: build and cache a Dockerfile-backed raw ext4 rootfs without forcing callers through SmolVM's SSH image builder.
+
+Implementation plan:
+
+- Add `DockerRootfsBuilder` in `src/smolvm/images/builder.py` and export it from `smolvm` and `smolvm.images`.
+- Accept Dockerfile text, build context entries, rootfs size, build args, cache directory, Docker platform override, fingerprint inputs, and `ssh_capable` metadata.
+- Reuse existing Docker build/export and ext4 creation helpers, but do not call `ImageBuilder._do_build()` because that injects SmolVM's guest agent into every image.
+- Support context entries as `Path`, `str`, or `bytes`; reject absolute paths, path traversal, and `Dockerfile` collisions inside the build context.
+- Cache rootfs artifacts under `~/.smolvm/images/custom/<name>/<fingerprint>/rootfs.ext4`.
+- Fingerprint only rootfs build inputs: Dockerfile hash, context content hashes, rootfs size, build args, target platform/arch, and user fingerprint inputs. Do not include backend or selected kernel identity, so Firecracker/QEMU can reuse the same rootfs for the same arch.
 - Add file locking around cache misses so concurrent callers do not race the same build.
-- Have `ensure()` resolve the backend/arch kernel and boot args, then return a `BootImage`.
+- Have `ensure()` resolve the backend/arch kernel and return a `BootImage` with rendered boot metadata supplied by the caller.
+- Tests:
+  - build path returns a `BootImage`.
+  - cache hit avoids a rebuild.
+  - QEMU and Firecracker reuse the same rootfs when the rootfs fingerprint is unchanged.
+  - unsafe context paths and missing context files fail before Docker work starts.
+  - exports are available at top level and `smolvm.images`.
 
 ## Phase 4 — `SmolVM.from_image()`
 

--- a/src/smolvm/__init__.py
+++ b/src/smolvm/__init__.py
@@ -40,8 +40,8 @@ from smolvm.exceptions import (
 )
 from smolvm.facade import SmolVM
 from smolvm.host.manager import HostManager
-from smolvm.images.boot import DirectKernelBoot
-from smolvm.images.builder import SSH_BOOT_ARGS, ImageBuilder
+from smolvm.images.boot import BootImage, DirectKernelBoot, FirmwareBoot
+from smolvm.images.builder import SSH_BOOT_ARGS, DockerRootfsBuilder, ImageBuilder
 from smolvm.images.manager import ImageManager, ImageSource, LocalImage, S3ImageManifest, S3ImageRef
 from smolvm.kernels import ensure_base_kernel_for_backend
 from smolvm.ssh import SSHClient
@@ -77,7 +77,10 @@ __all__ = [
     # Image management
     "ImageManager",
     "ImageBuilder",
+    "DockerRootfsBuilder",
+    "BootImage",
     "DirectKernelBoot",
+    "FirmwareBoot",
     "SSH_BOOT_ARGS",
     "ImageSource",
     "LocalImage",

--- a/src/smolvm/images/__init__.py
+++ b/src/smolvm/images/__init__.py
@@ -14,6 +14,7 @@
 
 """Guest image management and builders."""
 
-from smolvm.images.boot import DirectKernelBoot
+from smolvm.images.boot import BootImage, DirectKernelBoot, FirmwareBoot
+from smolvm.images.builder import DockerRootfsBuilder
 
-__all__ = ["DirectKernelBoot"]
+__all__ = ["BootImage", "DirectKernelBoot", "DockerRootfsBuilder", "FirmwareBoot"]

--- a/src/smolvm/images/boot.py
+++ b/src/smolvm/images/boot.py
@@ -18,7 +18,10 @@ from __future__ import annotations
 
 import platform
 from dataclasses import dataclass
+from pathlib import Path
 from typing import Literal
+
+from pydantic import BaseModel, ConfigDict, field_validator, model_validator
 
 from smolvm.runtime.backends import (
     BACKEND_FIRECRACKER,
@@ -29,6 +32,10 @@ from smolvm.runtime.backends import (
 from smolvm.runtime.boot_profiles import normalize_arch, safe_kernel_trim_args
 
 ConsoleMode = Literal["serial", "none"]
+RootfsFormat = Literal["raw-ext4", "qcow2"]
+BootBackend = Literal["firecracker", "qemu", "libkrun"]
+BootArch = Literal["amd64", "arm64"]
+BootMode = Literal["direct_kernel", "firmware"]
 
 
 def _check_kernel_token(label: str, value: str | None) -> str | None:
@@ -129,3 +136,102 @@ class DirectKernelBoot:
             parts.extend(safe_kernel_trim_args(quiet=self.quiet))
         parts.extend(self.extra_args)
         return " ".join(parts)
+
+
+@dataclass(frozen=True, slots=True)
+class FirmwareBoot:
+    """Marker for images that boot through firmware instead of ``-kernel``."""
+
+
+class BootImage(BaseModel):
+    """A bootable base image that can be turned into an isolated VM later.
+
+    ``BootImage`` describes image artifacts and boot metadata. It does not
+    allocate networking, clone disks, resize filesystems, or start a VM.
+    """
+
+    name: str
+    rootfs_path: Path
+    rootfs_format: RootfsFormat
+    kernel_path: Path | None = None
+    initrd_path: Path | None = None
+    boot: DirectKernelBoot | FirmwareBoot | None = None
+    boot_args: str | None = None
+    backend: BootBackend | None = None
+    arch: BootArch | None = None
+    ssh_capable: bool = False
+
+    @field_validator("name")
+    @classmethod
+    def _validate_name(cls, value: str) -> str:
+        """Reject blank image names."""
+        stripped = value.strip()
+        if not stripped:
+            raise ValueError("name must not be empty")
+        return stripped
+
+    @field_validator("boot_args")
+    @classmethod
+    def _validate_boot_args(cls, value: str | None) -> str | None:
+        """Reject blank boot-argument overrides."""
+        if value is None:
+            return None
+        stripped = value.strip()
+        if not stripped:
+            raise ValueError("boot_args must not be empty")
+        return stripped
+
+    @field_validator("rootfs_path", "kernel_path", "initrd_path")
+    @classmethod
+    def _validate_existing_file(cls, value: Path | None) -> Path | None:
+        """Ensure declared image artifacts exist and are regular files."""
+        if value is None:
+            return None
+        if not value.exists():
+            raise ValueError(f"Path does not exist: {value}")
+        if not value.is_file():
+            raise ValueError(f"Path is not a file: {value}")
+        return value
+
+    @model_validator(mode="after")
+    def _check_boot_contract(self) -> BootImage:
+        """Reject ambiguous boot metadata."""
+        if isinstance(self.boot, FirmwareBoot):
+            if self.kernel_path is not None:
+                raise ValueError("firmware images must not set kernel_path")
+            if self.initrd_path is not None:
+                raise ValueError("firmware images must not set initrd_path")
+            if self.boot_args is not None:
+                raise ValueError("firmware images must not set boot_args")
+            if self.backend is not None and self.backend != BACKEND_QEMU:
+                raise ValueError("firmware images require backend='qemu'")
+            return self
+
+        if self.boot is not None and self.boot_args is not None:
+            raise ValueError("boot and boot_args are mutually exclusive")
+        if self.boot is None and self.boot_args is None:
+            raise ValueError("direct-kernel images need boot or boot_args")
+        return self
+
+    @property
+    def boot_mode(self) -> BootMode:
+        """Return the VMConfig boot mode implied by this image."""
+        if isinstance(self.boot, FirmwareBoot):
+            return "firmware"
+        return "direct_kernel"
+
+    def render_boot_args(self, *, backend: str | None = None, arch: str | None = None) -> str:
+        """Render or return the direct-kernel command line for this image."""
+        if self.boot_mode == "firmware":
+            return ""
+        if self.boot_args is not None:
+            return self.boot_args
+        if not isinstance(self.boot, DirectKernelBoot):
+            raise ValueError("direct-kernel images need boot or boot_args")
+
+        resolved_backend = backend or self.backend
+        if resolved_backend is None:
+            raise ValueError("backend is required to render direct-kernel boot args")
+        return self.boot.render(backend=resolved_backend, arch=arch or self.arch or "host")
+
+    model_config = ConfigDict(frozen=True)

--- a/src/smolvm/images/builder.py
+++ b/src/smolvm/images/builder.py
@@ -30,12 +30,17 @@ import tempfile
 import typing
 import urllib.error
 import urllib.request
+from contextlib import contextmanager
 from pathlib import Path
 
 from smolvm.exceptions import ImageError, SmolVMError
+from smolvm.images.boot import BootImage, DirectKernelBoot
+from smolvm.kernels import KernelArch, ensure_base_kernel_for_backend
+from smolvm.runtime.backends import resolve_backend
 from smolvm.runtime.boot_profiles import (
     KernelBootProfile,
     normalize_arch,
+    to_published_arch,
 )
 from smolvm.utils import RUNTIME_PRIVILEGE_SETUP_HINT, run_command
 
@@ -63,6 +68,72 @@ _GUEST_AGENT_GUEST_PATH = "/usr/local/bin/smolvm-guest-agent"
 def _guest_agent_source() -> str:
     """Return the guest agent source baked into every built image."""
     return _GUEST_AGENT_SOURCE_PATH.read_text()
+
+
+DockerContextValue = Path | str | bytes
+
+
+def _safe_cache_name(name: str) -> str:
+    """Validate a user-provided image cache directory name."""
+    stripped = name.strip()
+    if not stripped:
+        raise ValueError("image name must not be empty")
+    if not re.fullmatch(r"[A-Za-z0-9_.-]+", stripped):
+        raise ValueError("image name must contain only letters, numbers, '.', '_', and '-'")
+    return stripped
+
+
+def _safe_context_destination(destination: str) -> Path:
+    """Return a safe relative path inside a Docker build context."""
+    path = Path(destination)
+    if path.is_absolute() or ".." in path.parts or path.name in {"", ".", ".."}:
+        raise ValueError(f"Build context path must be relative and safe: {destination!r}")
+    if path == Path("Dockerfile"):
+        raise ValueError("Build context path 'Dockerfile' is reserved")
+    return path
+
+
+def _context_value_bytes(destination: str, value: DockerContextValue) -> bytes:
+    """Read one Docker build-context value as bytes."""
+    if isinstance(value, bytes):
+        return value
+    if isinstance(value, Path):
+        if not value.exists():
+            raise ImageError(
+                f"Build context file is missing: {value}. Restore it, or update the "
+                "builder context."
+            )
+        if not value.is_file():
+            raise ImageError(
+                f"Build context path is not a file: {value}. Use file paths only."
+            )
+        return value.read_bytes()
+    if isinstance(value, str):
+        return value.encode("utf-8")
+    raise TypeError(f"Unsupported build context value for {destination!r}: {type(value).__name__}")
+
+
+def _docker_platform_for_arch(arch: str) -> str:
+    """Return Docker's platform string for a SmolVM arch key."""
+    if arch == "amd64":
+        return "linux/amd64"
+    if arch == "arm64":
+        return "linux/arm64"
+    raise ValueError(f"Unsupported Docker build arch: {arch!r}")
+
+
+@contextmanager
+def _exclusive_file_lock(lock_path: Path) -> typing.Iterator[None]:
+    """Hold an exclusive advisory lock for a cache build."""
+    import fcntl
+
+    lock_path.parent.mkdir(parents=True, exist_ok=True)
+    with lock_path.open("w") as lock_file:
+        fcntl.flock(lock_file.fileno(), fcntl.LOCK_EX)
+        try:
+            yield
+        finally:
+            fcntl.flock(lock_file.fileno(), fcntl.LOCK_UN)
 
 
 class ImageBuilder:
@@ -1765,3 +1836,238 @@ echo "Device-approver running with PID=${DEVICE_APPROVER_PID}"
             # 5. Write cache fingerprint if provided and successful
             if fingerprint_data is not None:
                 self._write_fingerprint(image_dir, fingerprint_data)
+
+
+class DockerRootfsBuilder:
+    """Build and cache a Dockerfile-backed raw ext4 rootfs.
+
+    This generic builder does not inject SmolVM's guest agent. The caller owns
+    the Dockerfile, init process, and any guest control agent they copy in.
+    """
+
+    def __init__(
+        self,
+        *,
+        name: str,
+        dockerfile: str,
+        context: dict[str, DockerContextValue] | None = None,
+        rootfs_size_mb: int = 512,
+        cache_dir: Path | None = None,
+        fingerprint_inputs: dict[str, typing.Any] | None = None,
+        build_args: dict[str, str] | None = None,
+        docker_platform: str | None = None,
+        ssh_capable: bool = False,
+    ) -> None:
+        """Initialize a custom Docker rootfs builder."""
+        self.name = _safe_cache_name(name)
+        if not dockerfile.strip():
+            raise ValueError("dockerfile must not be empty")
+        if rootfs_size_mb <= 0:
+            raise ValueError("rootfs_size_mb must be > 0")
+        self.dockerfile = dockerfile
+        self.context = dict(context or {})
+        self.rootfs_size_mb = rootfs_size_mb
+        self.cache_dir = cache_dir or ImageBuilder().cache_dir
+        self.fingerprint_inputs = dict(fingerprint_inputs or {})
+        self.build_args = dict(build_args or {})
+        self.docker_platform = docker_platform
+        self.ssh_capable = ssh_capable
+
+    def ensure(
+        self,
+        *,
+        backend: str,
+        arch: KernelArch | str = "host",
+        boot: DirectKernelBoot | None = None,
+        boot_args: str | None = None,
+    ) -> BootImage:
+        """Build/cache the rootfs and return a bootable image description."""
+        if boot is not None and boot_args is not None:
+            raise ValueError("boot and boot_args are mutually exclusive")
+        if boot is None and boot_args is None:
+            raise ValueError("DockerRootfsBuilder.ensure() requires boot or boot_args")
+
+        resolved_backend = resolve_backend(backend)
+        resolved_arch = to_published_arch(platform.machine() if arch == "host" else arch)
+        docker_platform = self.docker_platform or _docker_platform_for_arch(resolved_arch)
+        context_files = self._read_context_files()
+        fingerprint_data = self._fingerprint_data(
+            resolved_arch=resolved_arch,
+            docker_platform=docker_platform,
+            context_files=context_files,
+        )
+        fingerprint = self._hash_fingerprint_data(fingerprint_data)
+        image_dir = self.cache_dir / "custom" / self.name / fingerprint
+        rootfs_path = image_dir / "rootfs.ext4"
+        metadata_path = image_dir / "metadata.json"
+        lock_path = image_dir / ".build.lock"
+
+        with _exclusive_file_lock(lock_path):
+            if not self._cache_ready(rootfs_path, metadata_path, fingerprint_data):
+                helper = ImageBuilder(cache_dir=self.cache_dir)
+                if not helper.check_docker():
+                    raise helper.docker_requirement_error()
+                image_dir.mkdir(parents=True, exist_ok=True)
+                temp_rootfs = image_dir / f".{rootfs_path.name}.tmp"
+                temp_rootfs.unlink(missing_ok=True)
+                try:
+                    self._build_rootfs(
+                        helper=helper,
+                        rootfs_path=temp_rootfs,
+                        docker_platform=docker_platform,
+                        context_files=context_files,
+                        docker_tag=f"smolvm-custom-{fingerprint[:16]}",
+                    )
+                    temp_rootfs.replace(rootfs_path)
+                    metadata_path.write_text(json.dumps(fingerprint_data, sort_keys=True))
+                finally:
+                    temp_rootfs.unlink(missing_ok=True)
+
+        kernel_path = ensure_base_kernel_for_backend(
+            resolved_backend,
+            arch=resolved_arch,
+            cache_dir=self.cache_dir,
+        )
+        return BootImage(
+            name=self.name,
+            rootfs_path=rootfs_path,
+            rootfs_format="raw-ext4",
+            kernel_path=kernel_path,
+            boot=boot,
+            boot_args=boot_args,
+            backend=resolved_backend,
+            arch=resolved_arch,
+            ssh_capable=self.ssh_capable,
+        )
+
+    def _read_context_files(self) -> dict[str, bytes]:
+        """Read and validate all caller-provided Docker build-context files."""
+        files: dict[str, bytes] = {}
+        for destination, value in self.context.items():
+            safe_path = _safe_context_destination(destination)
+            safe_destination = safe_path.as_posix()
+            if safe_destination in files:
+                raise ValueError(f"Duplicate build context path: {safe_destination!r}")
+            files[safe_destination] = _context_value_bytes(destination, value)
+        return files
+
+    def _fingerprint_data(
+        self,
+        *,
+        resolved_arch: str,
+        docker_platform: str,
+        context_files: dict[str, bytes],
+    ) -> dict[str, typing.Any]:
+        """Return the stable rootfs-cache fingerprint inputs."""
+        data = {
+            "schema_version": 1,
+            "name": self.name,
+            "rootfs_size_mb": self.rootfs_size_mb,
+            "docker_platform": docker_platform,
+            "arch": resolved_arch,
+            "dockerfile_sha256": hashlib.sha256(self.dockerfile.encode()).hexdigest(),
+            "context": [
+                {
+                    "path": path,
+                    "sha256": hashlib.sha256(content).hexdigest(),
+                    "size": len(content),
+                }
+                for path, content in sorted(context_files.items())
+            ],
+            "build_args": self.build_args,
+            "fingerprint_inputs": self.fingerprint_inputs,
+        }
+        # Fail early with a targeted message instead of surfacing a raw JSON
+        # TypeError from deep inside the cache check.
+        try:
+            json.dumps(data, sort_keys=True)
+        except TypeError as exc:
+            raise ValueError("fingerprint_inputs and build_args must be JSON-serializable") from exc
+        return data
+
+    @staticmethod
+    def _hash_fingerprint_data(data: dict[str, typing.Any]) -> str:
+        """Return a stable SHA-256 cache key for fingerprint data."""
+        return hashlib.sha256(json.dumps(data, sort_keys=True).encode()).hexdigest()
+
+    @staticmethod
+    def _cache_ready(
+        rootfs_path: Path,
+        metadata_path: Path,
+        expected_data: dict[str, typing.Any],
+    ) -> bool:
+        """Return whether an existing cache entry is complete and current."""
+        if not rootfs_path.is_file() or not metadata_path.is_file():
+            return False
+        try:
+            cached_data = json.loads(metadata_path.read_text())
+        except (OSError, json.JSONDecodeError):
+            return False
+        return cached_data == expected_data
+
+    def _build_rootfs(
+        self,
+        *,
+        helper: ImageBuilder,
+        rootfs_path: Path,
+        docker_platform: str,
+        context_files: dict[str, bytes],
+        docker_tag: str,
+    ) -> None:
+        """Build a Docker image, export it, and convert it to raw ext4."""
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            tmp_path = Path(tmp_dir)
+            (tmp_path / "Dockerfile").write_text(self.dockerfile)
+            for destination, content in context_files.items():
+                output_path = tmp_path / destination
+                output_path.parent.mkdir(parents=True, exist_ok=True)
+                output_path.write_bytes(content)
+
+            logger.info("  [1/3] Building custom Docker image...")
+            build_cmd = ["docker", "build", "-t", docker_tag]
+            if docker_platform:
+                build_cmd.extend(["--platform", docker_platform])
+            for key, value in self.build_args.items():
+                build_cmd.extend(["--build-arg", f"{key}={value}"])
+            build_cmd.append(str(tmp_path))
+
+            subprocess.run(
+                build_cmd,
+                check=True,
+                stdout=subprocess.DEVNULL,
+                stderr=subprocess.PIPE,
+            )
+
+            logger.info("  [2/3] Exporting custom rootfs...")
+            container_id = subprocess.run(
+                ["docker", "create", docker_tag],
+                check=True,
+                capture_output=True,
+                text=True,
+            ).stdout.strip()
+
+            try:
+                tar_path = tmp_path / "rootfs.tar"
+                subprocess.run(["docker", "export", container_id, "-o", str(tar_path)], check=True)
+            finally:
+                subprocess.run(
+                    ["docker", "rm", container_id],
+                    stdout=subprocess.DEVNULL,
+                    stderr=subprocess.DEVNULL,
+                )
+
+            logger.info("  [3/3] Creating custom ext4 rootfs...")
+            if helper._loopfs_helper_path() is not None:
+                helper._create_ext4_with_loopfs(
+                    tar_path,
+                    rootfs_path,
+                    self.rootfs_size_mb,
+                    tmp_path,
+                )
+            else:
+                helper._create_ext4_with_docker(
+                    tar_path,
+                    rootfs_path,
+                    self.rootfs_size_mb,
+                    tmp_path,
+                )

--- a/src/smolvm/images/builder.py
+++ b/src/smolvm/images/builder.py
@@ -88,7 +88,7 @@ def _safe_context_destination(destination: str) -> Path:
     path = Path(destination)
     if path.is_absolute() or ".." in path.parts or path.name in {"", ".", ".."}:
         raise ValueError(f"Build context path must be relative and safe: {destination!r}")
-    if path == Path("Dockerfile"):
+    if path.name.lower() == "dockerfile":
         raise ValueError("Build context path 'Dockerfile' is reserved")
     return path
 
@@ -120,6 +120,33 @@ def _docker_platform_for_arch(arch: str) -> str:
     if arch == "arm64":
         return "linux/arm64"
     raise ValueError(f"Unsupported Docker build arch: {arch!r}")
+
+
+def _decode_process_output(output: object) -> str:
+    """Return subprocess output as a readable string."""
+    if output is None:
+        return ""
+    if isinstance(output, bytes):
+        return output.decode(errors="replace").strip()
+    return str(output).strip()
+
+
+def _run_custom_docker_command(
+    command: list[str],
+    *,
+    step: str,
+    **kwargs: typing.Any,
+) -> subprocess.CompletedProcess[typing.Any]:
+    """Run one Docker command and map failures to ImageError."""
+    try:
+        return subprocess.run(command, check=True, **kwargs)
+    except subprocess.CalledProcessError as exc:
+        stderr = _decode_process_output(exc.stderr)
+        stdout = _decode_process_output(exc.stdout)
+        details = stderr or stdout or "no output"
+        raise ImageError(
+            f"{step} failed with exit code {exc.returncode}. Docker error: {details}"
+        ) from exc
 
 
 @contextmanager
@@ -2031,24 +2058,29 @@ class DockerRootfsBuilder:
                 build_cmd.extend(["--build-arg", f"{key}={value}"])
             build_cmd.append(str(tmp_path))
 
-            subprocess.run(
+            _run_custom_docker_command(
                 build_cmd,
-                check=True,
+                step="Docker build",
                 stdout=subprocess.DEVNULL,
                 stderr=subprocess.PIPE,
             )
 
             logger.info("  [2/3] Exporting custom rootfs...")
-            container_id = subprocess.run(
+            container_id = _run_custom_docker_command(
                 ["docker", "create", docker_tag],
-                check=True,
+                step="Docker create",
                 capture_output=True,
                 text=True,
             ).stdout.strip()
 
             try:
                 tar_path = tmp_path / "rootfs.tar"
-                subprocess.run(["docker", "export", container_id, "-o", str(tar_path)], check=True)
+                _run_custom_docker_command(
+                    ["docker", "export", container_id, "-o", str(tar_path)],
+                    step="Docker export",
+                    capture_output=True,
+                    text=True,
+                )
             finally:
                 subprocess.run(
                     ["docker", "rm", container_id],

--- a/tests/test_custom_boot_api.py
+++ b/tests/test_custom_boot_api.py
@@ -19,12 +19,20 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
-from smolvm.images import DirectKernelBoot
+from smolvm.exceptions import ImageError
+from smolvm.images import BootImage, DirectKernelBoot, DockerRootfsBuilder, FirmwareBoot
 from smolvm.kernels import ensure_base_kernel_for_backend
 
 
 def _tokens(args: str) -> set[str]:
     return set(args.split())
+
+
+def _empty_file(tmp_path: Path, name: str) -> Path:
+    path = tmp_path / name
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_bytes(b"")
+    return path
 
 
 class TestDirectKernelBoot:
@@ -94,6 +102,269 @@ class TestDirectKernelBoot:
     def test_extra_args_must_be_single_tokens(self) -> None:
         with pytest.raises(ValueError, match="one kernel argument token"):
             DirectKernelBoot(extra_args=("foo=bar baz=qux",))
+
+
+class TestBootImage:
+    """BootImage describes bootable artifacts without launching a VM."""
+
+    def test_direct_kernel_image_renders_profile_args(self, tmp_path: Path) -> None:
+        rootfs = _empty_file(tmp_path, "rootfs.ext4")
+        kernel = _empty_file(tmp_path, "vmlinux.elf")
+
+        image = BootImage(
+            name=" custom-image ",
+            rootfs_path=rootfs,
+            rootfs_format="raw-ext4",
+            kernel_path=kernel,
+            boot=DirectKernelBoot(quiet=False),
+            backend="firecracker",
+            arch="amd64",
+        )
+
+        assert image.name == "custom-image"
+        assert image.boot_mode == "direct_kernel"
+        assert image.render_boot_args() == (
+            "console=ttyS0 reboot=k panic=1 pci=off root=/dev/vda rw "
+            "init=/init tsc=reliable no_timer_check"
+        )
+
+    def test_direct_kernel_image_accepts_explicit_boot_args(self, tmp_path: Path) -> None:
+        rootfs = _empty_file(tmp_path, "rootfs.ext4")
+
+        image = BootImage(
+            name="explicit-args",
+            rootfs_path=rootfs,
+            rootfs_format="raw-ext4",
+            boot_args=" console=ttyS0 root=/dev/vda rw init=/init ",
+        )
+
+        assert image.boot_mode == "direct_kernel"
+        assert image.render_boot_args() == "console=ttyS0 root=/dev/vda rw init=/init"
+
+    def test_direct_kernel_image_can_omit_kernel_for_later_resolution(
+        self, tmp_path: Path
+    ) -> None:
+        rootfs = _empty_file(tmp_path, "rootfs.ext4")
+
+        image = BootImage(
+            name="needs-kernel-resolution",
+            rootfs_path=rootfs,
+            rootfs_format="raw-ext4",
+            boot=DirectKernelBoot(quiet=False),
+            backend="qemu",
+            arch="amd64",
+        )
+
+        assert image.kernel_path is None
+        assert "pci=off" not in _tokens(image.render_boot_args())
+
+    def test_boot_and_boot_args_are_mutually_exclusive(self, tmp_path: Path) -> None:
+        rootfs = _empty_file(tmp_path, "rootfs.ext4")
+
+        with pytest.raises(ValueError, match="mutually exclusive"):
+            BootImage(
+                name="ambiguous",
+                rootfs_path=rootfs,
+                rootfs_format="raw-ext4",
+                boot=DirectKernelBoot(),
+                boot_args="console=ttyS0 root=/dev/vda rw",
+            )
+
+    def test_direct_kernel_image_needs_boot_metadata(self, tmp_path: Path) -> None:
+        rootfs = _empty_file(tmp_path, "rootfs.ext4")
+
+        with pytest.raises(ValueError, match="need boot or boot_args"):
+            BootImage(name="missing-boot", rootfs_path=rootfs, rootfs_format="raw-ext4")
+
+    def test_firmware_image_has_empty_boot_args(self, tmp_path: Path) -> None:
+        rootfs = _empty_file(tmp_path, "rootfs.qcow2")
+
+        image = BootImage(
+            name="firmware-image",
+            rootfs_path=rootfs,
+            rootfs_format="qcow2",
+            boot=FirmwareBoot(),
+            backend="qemu",
+        )
+
+        assert image.boot_mode == "firmware"
+        assert image.render_boot_args() == ""
+
+    def test_firmware_image_rejects_direct_kernel_fields(self, tmp_path: Path) -> None:
+        rootfs = _empty_file(tmp_path, "rootfs.qcow2")
+        kernel = _empty_file(tmp_path, "vmlinux.image")
+
+        with pytest.raises(ValueError, match="must not set kernel_path"):
+            BootImage(
+                name="bad-firmware",
+                rootfs_path=rootfs,
+                rootfs_format="qcow2",
+                kernel_path=kernel,
+                boot=FirmwareBoot(),
+                backend="qemu",
+            )
+
+    def test_firmware_image_rejects_non_qemu_backend(self, tmp_path: Path) -> None:
+        rootfs = _empty_file(tmp_path, "rootfs.qcow2")
+
+        with pytest.raises(ValueError, match="backend='qemu'"):
+            BootImage(
+                name="bad-firmware-backend",
+                rootfs_path=rootfs,
+                rootfs_format="qcow2",
+                boot=FirmwareBoot(),
+                backend="firecracker",
+            )
+
+    def test_path_fields_must_exist(self, tmp_path: Path) -> None:
+        missing_rootfs = tmp_path / "missing.ext4"
+
+        with pytest.raises(ValueError, match="Path does not exist"):
+            BootImage(
+                name="missing-path",
+                rootfs_path=missing_rootfs,
+                rootfs_format="raw-ext4",
+                boot_args="console=ttyS0 root=/dev/vda rw",
+            )
+
+    def test_top_level_exports(self) -> None:
+        from smolvm import BootImage as TopLevelBootImage
+        from smolvm import FirmwareBoot as TopLevelFirmwareBoot
+        from smolvm.images import BootImage as ImagesBootImage
+        from smolvm.images import FirmwareBoot as ImagesFirmwareBoot
+
+        assert TopLevelBootImage is BootImage
+        assert TopLevelFirmwareBoot is FirmwareBoot
+        assert ImagesBootImage is BootImage
+        assert ImagesFirmwareBoot is FirmwareBoot
+
+
+class TestDockerRootfsBuilder:
+    """DockerRootfsBuilder builds a generic rootfs and returns BootImage metadata."""
+
+    @staticmethod
+    def _fake_build_rootfs(**kwargs: object) -> None:
+        rootfs_path = kwargs["rootfs_path"]
+        assert isinstance(rootfs_path, Path)
+        rootfs_path.write_bytes(b"ext4")
+
+    @patch("smolvm.images.builder.ensure_base_kernel_for_backend")
+    @patch("smolvm.images.builder.ImageBuilder.check_docker", return_value=True)
+    def test_ensure_builds_rootfs_and_returns_boot_image(
+        self,
+        _mock_check_docker: MagicMock,
+        mock_kernel: MagicMock,
+        tmp_path: Path,
+    ) -> None:
+        cache_dir = tmp_path / "cache"
+        kernel = _empty_file(tmp_path, "kernel/vmlinux.image")
+        mock_kernel.return_value = kernel
+
+        builder = DockerRootfsBuilder(
+            name="celesto-scratch",
+            dockerfile="FROM scratch\nCOPY init /init\n",
+            context={"init": "#!/bin/sh\n"},
+            rootfs_size_mb=64,
+            cache_dir=cache_dir,
+            fingerprint_inputs={"template": "scratch"},
+        )
+        with patch.object(
+            DockerRootfsBuilder,
+            "_build_rootfs",
+            side_effect=self._fake_build_rootfs,
+        ):
+            image = builder.ensure(
+                backend="qemu",
+                arch="amd64",
+                boot=DirectKernelBoot(quiet=False),
+            )
+
+        assert image.name == "celesto-scratch"
+        assert image.rootfs_format == "raw-ext4"
+        assert image.rootfs_path.is_file()
+        assert image.kernel_path == kernel
+        assert image.backend == "qemu"
+        assert image.arch == "amd64"
+        assert "pci=off" not in _tokens(image.render_boot_args())
+        assert image.rootfs_path.parent.parent.name == "celesto-scratch"
+        mock_kernel.assert_called_once_with("qemu", arch="amd64", cache_dir=cache_dir)
+
+    @patch("smolvm.images.builder.ensure_base_kernel_for_backend")
+    @patch("smolvm.images.builder.ImageBuilder.check_docker", return_value=True)
+    def test_cached_rootfs_is_reused_across_backends(
+        self,
+        _mock_check_docker: MagicMock,
+        mock_kernel: MagicMock,
+        tmp_path: Path,
+    ) -> None:
+        cache_dir = tmp_path / "cache"
+        qemu_kernel = _empty_file(tmp_path, "kernel/vmlinux.image")
+        fc_kernel = _empty_file(tmp_path, "kernel/vmlinux.elf")
+        mock_kernel.side_effect = [qemu_kernel, fc_kernel]
+        builder = DockerRootfsBuilder(
+            name="shared-rootfs",
+            dockerfile="FROM scratch\n",
+            rootfs_size_mb=64,
+            cache_dir=cache_dir,
+        )
+
+        with patch.object(
+            DockerRootfsBuilder,
+            "_build_rootfs",
+            side_effect=self._fake_build_rootfs,
+        ) as mock_build:
+            qemu_image = builder.ensure(
+                backend="qemu",
+                arch="amd64",
+                boot=DirectKernelBoot(quiet=False),
+            )
+            firecracker_image = builder.ensure(
+                backend="firecracker",
+                arch="amd64",
+                boot=DirectKernelBoot(quiet=False),
+            )
+
+        assert qemu_image.rootfs_path == firecracker_image.rootfs_path
+        assert qemu_image.kernel_path == qemu_kernel
+        assert firecracker_image.kernel_path == fc_kernel
+        assert mock_build.call_count == 1
+
+    def test_context_paths_must_be_relative_and_safe(self, tmp_path: Path) -> None:
+        builder = DockerRootfsBuilder(
+            name="bad-context",
+            dockerfile="FROM scratch\n",
+            context={"../init": "#!/bin/sh\n"},
+            cache_dir=tmp_path / "cache",
+        )
+
+        with pytest.raises(ValueError, match="relative and safe"):
+            builder.ensure(
+                backend="qemu",
+                arch="amd64",
+                boot_args="console=ttyS0 root=/dev/vda rw",
+            )
+
+    def test_missing_context_file_fails_before_docker(self, tmp_path: Path) -> None:
+        builder = DockerRootfsBuilder(
+            name="missing-context",
+            dockerfile="FROM scratch\n",
+            context={"init": tmp_path / "missing-init"},
+            cache_dir=tmp_path / "cache",
+        )
+
+        with pytest.raises(ImageError, match="Build context file is missing"):
+            builder.ensure(
+                backend="qemu",
+                arch="amd64",
+                boot_args="console=ttyS0 root=/dev/vda rw",
+            )
+
+    def test_top_level_builder_export(self) -> None:
+        from smolvm import DockerRootfsBuilder as TopLevelDockerRootfsBuilder
+        from smolvm.images import DockerRootfsBuilder as ImagesDockerRootfsBuilder
+
+        assert TopLevelDockerRootfsBuilder is DockerRootfsBuilder
+        assert ImagesDockerRootfsBuilder is DockerRootfsBuilder
 
 
 class TestEnsureBaseKernelForBackend:

--- a/tests/test_custom_boot_api.py
+++ b/tests/test_custom_boot_api.py
@@ -14,6 +14,7 @@
 
 """Tests for public custom-image boot and kernel APIs."""
 
+import subprocess
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
@@ -344,6 +345,21 @@ class TestDockerRootfsBuilder:
                 boot_args="console=ttyS0 root=/dev/vda rw",
             )
 
+    def test_context_rejects_dockerfile_case_variants(self, tmp_path: Path) -> None:
+        builder = DockerRootfsBuilder(
+            name="bad-context",
+            dockerfile="FROM scratch\n",
+            context={"nested/dockerfile": "FROM scratch\n"},
+            cache_dir=tmp_path / "cache",
+        )
+
+        with pytest.raises(ValueError, match="Dockerfile"):
+            builder.ensure(
+                backend="qemu",
+                arch="amd64",
+                boot_args="console=ttyS0 root=/dev/vda rw",
+            )
+
     def test_missing_context_file_fails_before_docker(self, tmp_path: Path) -> None:
         builder = DockerRootfsBuilder(
             name="missing-context",
@@ -357,6 +373,92 @@ class TestDockerRootfsBuilder:
                 backend="qemu",
                 arch="amd64",
                 boot_args="console=ttyS0 root=/dev/vda rw",
+            )
+
+    def test_docker_build_failure_raises_image_error(self, tmp_path: Path) -> None:
+        builder = DockerRootfsBuilder(
+            name="build-fails",
+            dockerfile="FROM scratch\n",
+            cache_dir=tmp_path / "cache",
+        )
+
+        with (
+            patch(
+                "smolvm.images.builder.subprocess.run",
+                side_effect=subprocess.CalledProcessError(
+                    7,
+                    ["docker", "build"],
+                    stderr=b"build failed",
+                ),
+            ),
+            pytest.raises(ImageError, match="Docker build failed.*exit code 7.*build failed"),
+        ):
+            builder._build_rootfs(
+                helper=MagicMock(),
+                rootfs_path=tmp_path / "rootfs.ext4",
+                docker_platform="linux/amd64",
+                context_files={},
+                docker_tag="test-image",
+            )
+
+    def test_docker_create_failure_raises_image_error(self, tmp_path: Path) -> None:
+        builder = DockerRootfsBuilder(
+            name="create-fails",
+            dockerfile="FROM scratch\n",
+            cache_dir=tmp_path / "cache",
+        )
+
+        with (
+            patch(
+                "smolvm.images.builder.subprocess.run",
+                side_effect=[
+                    subprocess.CompletedProcess(["docker", "build"], 0),
+                    subprocess.CalledProcessError(
+                        8,
+                        ["docker", "create"],
+                        stderr="create failed",
+                    ),
+                ],
+            ),
+            pytest.raises(ImageError, match="Docker create failed.*exit code 8.*create failed"),
+        ):
+            builder._build_rootfs(
+                helper=MagicMock(),
+                rootfs_path=tmp_path / "rootfs.ext4",
+                docker_platform="linux/amd64",
+                context_files={},
+                docker_tag="test-image",
+            )
+
+    def test_docker_export_failure_raises_image_error(self, tmp_path: Path) -> None:
+        builder = DockerRootfsBuilder(
+            name="export-fails",
+            dockerfile="FROM scratch\n",
+            cache_dir=tmp_path / "cache",
+        )
+
+        with (
+            patch(
+                "smolvm.images.builder.subprocess.run",
+                side_effect=[
+                    subprocess.CompletedProcess(["docker", "build"], 0),
+                    subprocess.CompletedProcess(["docker", "create"], 0, stdout="container\n"),
+                    subprocess.CalledProcessError(
+                        9,
+                        ["docker", "export"],
+                        output="export failed",
+                    ),
+                    subprocess.CompletedProcess(["docker", "rm"], 0),
+                ],
+            ),
+            pytest.raises(ImageError, match="Docker export failed.*exit code 9.*export failed"),
+        ):
+            builder._build_rootfs(
+                helper=MagicMock(),
+                rootfs_path=tmp_path / "rootfs.ext4",
+                docker_platform="linux/amd64",
+                context_files={},
+                docker_tag="test-image",
             )
 
     def test_top_level_builder_export(self) -> None:


### PR DESCRIPTION
## Summary
- add `BootImage` and `FirmwareBoot` for custom boot-image metadata
- add `DockerRootfsBuilder` for generic Dockerfile-backed raw ext4 rootfs builds
- cache custom rootfs artifacts by build inputs and reuse them across backends for the same arch
- export the new APIs from `smolvm` and `smolvm.images`
- update the temporary rollout `plan.md` with Phase 2 and Phase 3 details

## Tests
- `uv run ruff check src/smolvm/images/builder.py src/smolvm/images/boot.py src/smolvm/images/__init__.py src/smolvm/__init__.py tests/test_custom_boot_api.py`
- `uv run pytest tests/test_custom_boot_api.py tests/test_boot_profiles.py`
- `uv run pytest tests/test_build.py tests/test_custom_boot_api.py tests/test_boot_profiles.py`

Part of #341.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * BootImage model for describing bootable images with validation and boot-argument rendering
  * FirmwareBoot marker for firmware-based images
  * DockerRootfsBuilder to build/cache root filesystems from Docker contexts with deterministic fingerprints
  * Public API expanded to expose boot image and builder utilities

* **Tests**
  * New test suites validating BootImage behaviors and DockerRootfsBuilder build/cache/error handling
<!-- end of auto-generated comment: release notes by coderabbit.ai -->