### PR TITLE
Add SmolVM from_image constructor

### DIFF
--- a/plan.md
+++ b/plan.md
@@ -84,10 +84,30 @@ Implementation plan:
 
 ## Phase 4 — `SmolVM.from_image()`
 
-- Add a high-level constructor that consumes `BootImage` and builds the corresponding `VMConfig` internally.
-- Resolve backend, arch, kernel path, and boot args when missing.
-- Expose consistent knobs: `vm_id`, `vcpus`, `memory_mb`, `network`, port forwards, vsock, comm channel, disk mode, SSH capability, and readiness behavior.
-- Keep no-SSH custom images valid; do not assume command execution is available unless the image declares a supported control path.
+Goal: let SDK callers launch a `BootImage` without manually constructing `VMConfig`.
+
+Implementation plan:
+
+- Add `SmolVM.from_image(image, ...)` as a high-level constructor parallel to `SmolVM.from_id()` and `SmolVM.from_snapshot()`.
+- Resolve backend from explicit argument, image metadata, or normal backend auto-selection. Firmware images default to QEMU.
+- Resolve arch from explicit argument, image metadata, or host arch.
+- Resolve a missing direct-kernel `kernel_path` with `ensure_base_kernel_for_backend()`.
+- Render boot args from `BootImage.render_boot_args()`.
+- Build `VMConfig` internally with caller knobs for `vm_id`, `vcpus`, `memory_mb`, `network`, `port_forwards`, `vsock`, `comm_channel`, `disk_mode`, `guest_os`, and SSH facade settings.
+- Keep no-SSH custom images valid by copying `image.ssh_capable` into `VMConfig.ssh_capable` and not generating SSH keys for custom images.
+- Add the future Phase 5 knobs (`disk_size_mb`, `grow_filesystem`) to the method signature, but reject them with a clear error until disk growth is implemented.
+- Validate important mismatches early:
+  - backend mismatch with image metadata,
+  - firmware/qcow2 images on non-QEMU backends,
+  - initrd images on unsupported backends,
+  - `port_forwards` outside QEMU slirp.
+- Tests:
+  - direct-kernel image resolves a missing base kernel and creates a VM,
+  - direct-kernel image with an existing kernel does not fetch a kernel,
+  - no-SSH metadata is preserved,
+  - firmware image creates firmware-mode `VMConfig`,
+  - slirp port forwards are normalized,
+  - invalid backend/resize/port-forward combinations fail early.
 
 ## Phase 5 — per-VM disk resize/grow
 

--- a/plan.md
+++ b/plan.md
@@ -86,6 +86,13 @@ Implementation plan:
 
 Goal: let SDK callers launch a `BootImage` without manually constructing `VMConfig`.
 
+Key terms:
+
+- `BootImage` is an image used to start a VM.
+- `VMConfig` is the runtime configuration object for one VM.
+- `slirp` is user-mode network forwarding used for NAT and port forwarding.
+- `vsock` is a virtual socket for host–guest communication.
+
 Implementation plan:
 
 - Add `SmolVM.from_image(image, ...)` as a high-level constructor parallel to `SmolVM.from_id()` and `SmolVM.from_snapshot()`.

--- a/src/smolvm/facade.py
+++ b/src/smolvm/facade.py
@@ -44,6 +44,8 @@ from pathlib import Path
 from typing import Any, Literal
 from urllib.parse import urlparse
 
+from pydantic import ValidationError as PydanticValidationError
+
 from smolvm._naming import generate_sandbox_name
 from smolvm.callbacks import Callback, CallbackDispatcher, RunContext
 from smolvm.comm import VsockChannel
@@ -839,35 +841,68 @@ def _build_auto_config(
     return config, resolved_ssh_key_path
 
 
-def _normalize_from_image_arch(image: BootImage, arch: str | None) -> str:
+def _from_image_config_help(vm_id: str) -> str:
+    """Return the recovery command shown by from_image validation errors."""
+    return f"smolvm create --name {vm_id} --help"
+
+
+def _from_image_port_help(vm_id: str) -> str:
+    """Return the recovery command shown by port-forward validation errors."""
+    return f"smolvm port expose {vm_id} --help"
+
+
+def _normalize_from_image_arch(image: BootImage, arch: str | None, vm_id: str) -> str:
     """Resolve the architecture used for kernel lookup and boot-arg rendering."""
-    requested_arch = to_published_arch(platform.machine()) if arch in {None, "host"} else arch
-    if requested_arch not in {"amd64", "arm64"}:
-        requested_arch = to_published_arch(requested_arch)
+    try:
+        requested_arch = to_published_arch(platform.machine()) if arch in {None, "host"} else arch
+        if requested_arch not in {"amd64", "arm64"}:
+            requested_arch = to_published_arch(requested_arch)
+    except ValueError as exc:
+        raise ValueError(
+            f"Unsupported image architecture for sandbox '{vm_id}'; to fix, run "
+            f"`{_from_image_config_help(vm_id)}`."
+        ) from exc
     if image.arch is not None and arch not in {None, "host"} and image.arch != requested_arch:
         raise ValueError(
-            f"Boot image was prepared for arch={image.arch!r}; requested arch={requested_arch!r}."
+            f"Boot image was prepared for arch={image.arch!r}, but arch={requested_arch!r} "
+            f"was requested; to fix, run `{_from_image_config_help(vm_id)}`."
         )
     return image.arch or requested_arch
 
 
-def _normalize_from_image_backend(image: BootImage, backend: str | None) -> str:
+def _normalize_from_image_backend(image: BootImage, backend: str | None, vm_id: str) -> str:
     """Resolve the backend used to launch a BootImage."""
     if image.boot_mode == "firmware" and backend is None and image.backend is None:
         return BACKEND_QEMU
 
-    resolved_backend = resolve_backend(backend or image.backend)
+    try:
+        resolved_backend = resolve_backend(backend or image.backend)
+    except ValueError as exc:
+        raise ValueError(
+            f"Unsupported backend for sandbox '{vm_id}'; to fix, run "
+            f"`{_from_image_config_help(vm_id)}`."
+        ) from exc
     if image.backend is not None and backend is not None and image.backend != resolved_backend:
         raise ValueError(
-            f"Boot image was prepared for backend={image.backend!r}; "
-            f"requested backend={resolved_backend!r}."
+            f"Boot image was prepared for backend={image.backend!r}, but "
+            f"backend={resolved_backend!r} was requested; to fix, run "
+            f"`{_from_image_config_help(vm_id)}`."
         )
     if image.boot_mode == "firmware" and resolved_backend != BACKEND_QEMU:
-        raise ValueError("Firmware boot images require backend='qemu'.")
+        raise ValueError(
+            f"Firmware boot images require backend='qemu'; to fix, run "
+            f"`{_from_image_config_help(vm_id)}`."
+        )
     if image.rootfs_format == "qcow2" and resolved_backend != BACKEND_QEMU:
-        raise ValueError("qcow2 boot images require backend='qemu'.")
+        raise ValueError(
+            f"qcow2 boot images require backend='qemu'; to fix, run "
+            f"`{_from_image_config_help(vm_id)}`."
+        )
     if image.initrd_path is not None and resolved_backend == BACKEND_FIRECRACKER:
-        raise ValueError("initrd boot images are not supported with backend='firecracker'.")
+        raise ValueError(
+            f"initrd boot images are not supported with backend='firecracker'; to fix, run "
+            f"`{_from_image_config_help(vm_id)}`."
+        )
     return resolved_backend
 
 
@@ -875,19 +910,28 @@ def _normalize_from_image_network(
     *,
     backend: str,
     network: Literal["tap", "slirp"] | None,
+    vm_id: str,
 ) -> Literal["tap", "slirp"]:
     """Return the QEMU network mode for a BootImage launch."""
     if network is None:
         return "slirp"
     if network not in {"tap", "slirp"}:
-        raise ValueError("network must be 'tap' or 'slirp'")
+        raise ValueError(
+            f"network must be 'tap' or 'slirp'; to fix, run "
+            f"`{_from_image_config_help(vm_id)}`."
+        )
     if backend != BACKEND_QEMU and network == "slirp":
-        raise ValueError("network='slirp' is only supported with backend='qemu'.")
+        raise ValueError(
+            f"network='slirp' is only supported with backend='qemu'; to fix, run "
+            f"`{_from_image_config_help(vm_id)}`."
+        )
     return network
 
 
 def _normalize_port_forwards(
     forwards: list[PortForwardConfig | dict[str, Any]] | None,
+    *,
+    vm_id: str,
 ) -> list[PortForwardConfig]:
     """Normalize from_image port-forward inputs."""
     normalized: list[PortForwardConfig] = []
@@ -895,7 +939,13 @@ def _normalize_port_forwards(
         if isinstance(forward, PortForwardConfig):
             normalized.append(forward)
         else:
-            normalized.append(PortForwardConfig(**forward))
+            try:
+                normalized.append(PortForwardConfig(**forward))
+            except PydanticValidationError as exc:
+                raise ValueError(
+                    f"Invalid port-forward entry for sandbox '{vm_id}'; to fix, run "
+                    f"`{_from_image_port_help(vm_id)}`."
+                ) from exc
     return normalized
 
 
@@ -1241,27 +1291,32 @@ class SmolVM:
         per-VM runtime settings and delegates disk isolation/network setup to
         the normal SmolVM lifecycle.
         """
+        resolved_vm_id = _resolve_vm_name(vm_id, prefix=name_prefix)
         if disk_size_mb is not None or grow_filesystem:
             raise SmolVMError(
-                "Custom image disk resizing is not implemented yet; omit "
-                "disk_size_mb and grow_filesystem for now."
+                f"Custom image disk resizing is not implemented yet for sandbox "
+                f"'{resolved_vm_id}'; omit disk_size_mb and grow_filesystem, then run "
+                f"`{_from_image_config_help(resolved_vm_id)}`."
             )
 
-        resolved_backend = _normalize_from_image_backend(image, backend)
-        resolved_arch = _normalize_from_image_arch(image, arch)
+        resolved_backend = _normalize_from_image_backend(image, backend, resolved_vm_id)
+        resolved_arch = _normalize_from_image_arch(image, arch, resolved_vm_id)
         qemu_network = _normalize_from_image_network(
             backend=resolved_backend,
             network=network,
+            vm_id=resolved_vm_id,
         )
-        normalized_forwards = _normalize_port_forwards(port_forwards)
+        normalized_forwards = _normalize_port_forwards(port_forwards, vm_id=resolved_vm_id)
         if normalized_forwards and (resolved_backend != BACKEND_QEMU or qemu_network != "slirp"):
-            raise ValueError("port_forwards require backend='qemu' and network='slirp'.")
+            raise ValueError(
+                f"port_forwards require backend='qemu' and network='slirp'; to fix, run "
+                f"`{_from_image_port_help(resolved_vm_id)}`."
+            )
 
         kernel_path = image.kernel_path
         if image.boot_mode == "direct_kernel" and kernel_path is None:
             kernel_path = ensure_base_kernel_for_backend(resolved_backend, arch=resolved_arch)
 
-        resolved_vm_id = _resolve_vm_name(vm_id, prefix=name_prefix)
         config = VMConfig(
             vm_id=resolved_vm_id,
             vcpu_count=vcpus,

--- a/src/smolvm/facade.py
+++ b/src/smolvm/facade.py
@@ -64,6 +64,7 @@ from smolvm.exceptions import (
     OperationTimeoutError,
     SmolVMError,
 )
+from smolvm.images.boot import BootImage
 from smolvm.images.cloud_init import (
     build_seed_iso,
     default_meta_data,
@@ -71,7 +72,13 @@ from smolvm.images.cloud_init import (
     seed_cache_key,
 )
 from smolvm.images.manager import ImageManager
-from smolvm.runtime.backends import BACKEND_LIBKRUN, BACKEND_QEMU, resolve_backend
+from smolvm.kernels import ensure_base_kernel_for_backend
+from smolvm.runtime.backends import (
+    BACKEND_FIRECRACKER,
+    BACKEND_LIBKRUN,
+    BACKEND_QEMU,
+    resolve_backend,
+)
 from smolvm.runtime.boot_profiles import (
     KernelBootProfile,
     get_boot_profile_spec,
@@ -83,11 +90,13 @@ from smolvm.types import (
     CommandResult,
     GuestOS,
     InternetSettings,
+    PortForwardConfig,
     SnapshotInfo,
     SnapshotType,
     VMConfig,
     VMInfo,
     VMState,
+    VsockConfig,
     WorkspaceMount,
 )
 from smolvm.vm import SmolVMManager
@@ -830,6 +839,73 @@ def _build_auto_config(
     return config, resolved_ssh_key_path
 
 
+def _normalize_from_image_arch(image: BootImage, arch: str | None) -> str:
+    """Resolve the architecture used for kernel lookup and boot-arg rendering."""
+    requested_arch = to_published_arch(platform.machine()) if arch in {None, "host"} else arch
+    if requested_arch not in {"amd64", "arm64"}:
+        requested_arch = to_published_arch(requested_arch)
+    if image.arch is not None and arch not in {None, "host"} and image.arch != requested_arch:
+        raise ValueError(
+            f"Boot image was prepared for arch={image.arch!r}; requested arch={requested_arch!r}."
+        )
+    return image.arch or requested_arch
+
+
+def _normalize_from_image_backend(image: BootImage, backend: str | None) -> str:
+    """Resolve the backend used to launch a BootImage."""
+    if image.boot_mode == "firmware" and backend is None and image.backend is None:
+        return BACKEND_QEMU
+
+    resolved_backend = resolve_backend(backend or image.backend)
+    if image.backend is not None and backend is not None and image.backend != resolved_backend:
+        raise ValueError(
+            f"Boot image was prepared for backend={image.backend!r}; "
+            f"requested backend={resolved_backend!r}."
+        )
+    if image.boot_mode == "firmware" and resolved_backend != BACKEND_QEMU:
+        raise ValueError("Firmware boot images require backend='qemu'.")
+    if image.rootfs_format == "qcow2" and resolved_backend != BACKEND_QEMU:
+        raise ValueError("qcow2 boot images require backend='qemu'.")
+    if image.initrd_path is not None and resolved_backend == BACKEND_FIRECRACKER:
+        raise ValueError("initrd boot images are not supported with backend='firecracker'.")
+    return resolved_backend
+
+
+def _normalize_from_image_network(
+    *,
+    backend: str,
+    network: Literal["tap", "slirp"] | None,
+) -> Literal["tap", "slirp"]:
+    """Return the QEMU network mode for a BootImage launch."""
+    if network is None:
+        return "slirp"
+    if network not in {"tap", "slirp"}:
+        raise ValueError("network must be 'tap' or 'slirp'")
+    if backend != BACKEND_QEMU and network == "slirp":
+        raise ValueError("network='slirp' is only supported with backend='qemu'.")
+    return network
+
+
+def _normalize_port_forwards(
+    forwards: list[PortForwardConfig | dict[str, Any]] | None,
+) -> list[PortForwardConfig]:
+    """Normalize from_image port-forward inputs."""
+    normalized: list[PortForwardConfig] = []
+    for forward in forwards or []:
+        if isinstance(forward, PortForwardConfig):
+            normalized.append(forward)
+        else:
+            normalized.append(PortForwardConfig(**forward))
+    return normalized
+
+
+def _normalize_vsock_config(vsock: VsockConfig | dict[str, Any] | None) -> VsockConfig | None:
+    """Normalize from_image vsock input."""
+    if vsock is None or isinstance(vsock, VsockConfig):
+        return vsock
+    return VsockConfig(**vsock)
+
+
 @dataclass(slots=True)
 class _LocalForward:
     """Internal tracking for localhost exposure transport."""
@@ -1128,6 +1204,94 @@ class SmolVM:
             ssh_key_path=ssh_key_path,
             ssh_password=ssh_password,
             comm_channel=comm_channel,
+        )
+
+    @classmethod
+    def from_image(
+        cls,
+        image: BootImage,
+        *,
+        vm_id: str | None = None,
+        name_prefix: str = "sbx",
+        data_dir: Path | None = None,
+        socket_dir: Path | None = None,
+        backend: str | None = None,
+        arch: str | None = None,
+        vcpus: int = 1,
+        memory_mb: int = 512,
+        guest_os: GuestOS | str = GuestOS.ALPINE,
+        network: Literal["tap", "slirp"] | None = None,
+        port_forwards: list[PortForwardConfig | dict[str, Any]] | None = None,
+        vsock: VsockConfig | dict[str, Any] | None = None,
+        comm_channel: CommChannelKind | None = None,
+        disk_mode: Literal["isolated", "shared"] = "isolated",
+        disk_size_mb: int | None = None,
+        grow_filesystem: bool = False,
+        ssh_user: str = "root",
+        ssh_key_path: str | None = None,
+        ssh_password: str | None = None,
+        internet_settings: InternetSettings | dict[str, Any] | None = None,
+        mounts: list[str] | None = None,
+        writable_mounts: bool = False,
+        callbacks: list[Callback] | None = None,
+    ) -> SmolVM:
+        """Create a VM from a custom boot image.
+
+        The image supplies rootfs/kernel boot metadata. This constructor adds
+        per-VM runtime settings and delegates disk isolation/network setup to
+        the normal SmolVM lifecycle.
+        """
+        if disk_size_mb is not None or grow_filesystem:
+            raise SmolVMError(
+                "Custom image disk resizing is not implemented yet; omit "
+                "disk_size_mb and grow_filesystem for now."
+            )
+
+        resolved_backend = _normalize_from_image_backend(image, backend)
+        resolved_arch = _normalize_from_image_arch(image, arch)
+        qemu_network = _normalize_from_image_network(
+            backend=resolved_backend,
+            network=network,
+        )
+        normalized_forwards = _normalize_port_forwards(port_forwards)
+        if normalized_forwards and (resolved_backend != BACKEND_QEMU or qemu_network != "slirp"):
+            raise ValueError("port_forwards require backend='qemu' and network='slirp'.")
+
+        kernel_path = image.kernel_path
+        if image.boot_mode == "direct_kernel" and kernel_path is None:
+            kernel_path = ensure_base_kernel_for_backend(resolved_backend, arch=resolved_arch)
+
+        resolved_vm_id = _resolve_vm_name(vm_id, prefix=name_prefix)
+        config = VMConfig(
+            vm_id=resolved_vm_id,
+            vcpu_count=vcpus,
+            memory=memory_mb,
+            guest_os=_normalize_guest_os(guest_os),
+            boot_mode=image.boot_mode,
+            kernel_path=kernel_path,
+            initrd_path=image.initrd_path,
+            rootfs_path=image.rootfs_path,
+            boot_args=image.render_boot_args(backend=resolved_backend, arch=resolved_arch),
+            ssh_capable=image.ssh_capable,
+            backend=resolved_backend,
+            qemu_network=qemu_network,
+            disk_mode=disk_mode,
+            port_forwards=normalized_forwards,
+            vsock=_normalize_vsock_config(vsock),
+        )
+        return cls(
+            config=config,
+            data_dir=data_dir,
+            socket_dir=socket_dir,
+            backend=resolved_backend,
+            ssh_user=ssh_user,
+            ssh_key_path=ssh_key_path,
+            ssh_password=ssh_password,
+            comm_channel=comm_channel,
+            internet_settings=internet_settings,
+            mounts=mounts,
+            writable_mounts=writable_mounts,
+            callbacks=callbacks,
         )
 
     @classmethod

--- a/tests/test_facade.py
+++ b/tests/test_facade.py
@@ -25,8 +25,9 @@ from smolvm.exceptions import (
     SmolVMError,
 )
 from smolvm.facade import SmolVM, _build_auto_config
+from smolvm.images import BootImage, DirectKernelBoot, FirmwareBoot
 from smolvm.images.cloud_init import seed_cache_key
-from smolvm.types import GuestOS, VMConfig, VMState
+from smolvm.types import GuestOS, PortForwardConfig, VMConfig, VMState, VsockConfig
 
 
 @pytest.fixture
@@ -601,6 +602,205 @@ class TestVMInit:
 
         with pytest.raises(SmolVMError, match="does not match the snapshot backend"):
             SmolVM.from_snapshot("snap-001", backend="qemu")
+
+
+class TestFromBootImage:
+    """Tests for SmolVM.from_image()."""
+
+    @patch("smolvm.facade.SmolVMManager")
+    @patch("smolvm.facade.ensure_base_kernel_for_backend")
+    def test_from_image_resolves_kernel_and_creates_vm(
+        self,
+        mock_kernel: MagicMock,
+        mock_sdk_cls: MagicMock,
+        tmp_path: Path,
+    ) -> None:
+        rootfs = tmp_path / "rootfs.ext4"
+        kernel = tmp_path / "vmlinux.image"
+        rootfs.touch()
+        kernel.touch()
+        mock_kernel.return_value = kernel
+        mock_sdk = MagicMock()
+        mock_sdk.create.return_value = MagicMock(vm_id="vm-custom", status=VMState.CREATED)
+        mock_sdk_cls.return_value = mock_sdk
+        image = BootImage(
+            name="custom",
+            rootfs_path=rootfs,
+            rootfs_format="raw-ext4",
+            boot=DirectKernelBoot(quiet=False),
+        )
+
+        vm = SmolVM.from_image(
+            image,
+            vm_id="vm-custom",
+            backend="qemu",
+            arch="amd64",
+            vcpus=2,
+            memory_mb=2048,
+            network="tap",
+            comm_channel="vsock",
+            vsock={"guest_cid": 5},
+        )
+
+        assert vm.vm_id == "vm-custom"
+        created_config = mock_sdk.create.call_args.args[0]
+        assert created_config.vm_id == "vm-custom"
+        assert created_config.kernel_path == kernel
+        assert created_config.vcpu_count == 2
+        assert created_config.memory == 2048
+        assert created_config.backend == "qemu"
+        assert created_config.qemu_network == "tap"
+        assert created_config.comm_channel == "vsock"
+        assert created_config.vsock == VsockConfig(guest_cid=5)
+        assert "pci=off" not in created_config.boot_args
+        mock_kernel.assert_called_once_with("qemu", arch="amd64")
+
+    @patch("smolvm.facade.SmolVMManager")
+    @patch("smolvm.facade.ensure_base_kernel_for_backend")
+    def test_from_image_uses_existing_kernel_and_preserves_no_ssh(
+        self,
+        mock_kernel: MagicMock,
+        mock_sdk_cls: MagicMock,
+        tmp_path: Path,
+    ) -> None:
+        rootfs = tmp_path / "rootfs.ext4"
+        kernel = tmp_path / "vmlinux.elf"
+        rootfs.touch()
+        kernel.touch()
+        mock_sdk = MagicMock()
+        mock_sdk.create.return_value = MagicMock(vm_id="vm-agent", status=VMState.CREATED)
+        mock_sdk_cls.return_value = mock_sdk
+        image = BootImage(
+            name="agent-only",
+            rootfs_path=rootfs,
+            rootfs_format="raw-ext4",
+            kernel_path=kernel,
+            boot_args="console=ttyS0 root=/dev/vda rw init=/init",
+            backend="firecracker",
+            ssh_capable=False,
+        )
+
+        SmolVM.from_image(image, vm_id="vm-agent")
+
+        created_config = mock_sdk.create.call_args.args[0]
+        assert created_config.kernel_path == kernel
+        assert created_config.boot_args == "console=ttyS0 root=/dev/vda rw init=/init"
+        assert created_config.ssh_capable is False
+        mock_kernel.assert_not_called()
+
+    @patch("smolvm.facade.SmolVMManager")
+    def test_from_image_firmware_creates_firmware_config(
+        self,
+        mock_sdk_cls: MagicMock,
+        tmp_path: Path,
+    ) -> None:
+        rootfs = tmp_path / "rootfs.qcow2"
+        rootfs.touch()
+        mock_sdk = MagicMock()
+        mock_sdk.create.return_value = MagicMock(vm_id="vm-fw", status=VMState.CREATED)
+        mock_sdk_cls.return_value = mock_sdk
+        image = BootImage(
+            name="firmware",
+            rootfs_path=rootfs,
+            rootfs_format="qcow2",
+            boot=FirmwareBoot(),
+        )
+
+        SmolVM.from_image(image, vm_id="vm-fw", guest_os="windows")
+
+        created_config = mock_sdk.create.call_args.args[0]
+        assert created_config.boot_mode == "firmware"
+        assert created_config.backend == "qemu"
+        assert created_config.kernel_path is None
+        assert created_config.boot_args == ""
+        assert created_config.guest_os == GuestOS.WINDOWS
+
+    @patch("smolvm.facade.SmolVMManager")
+    def test_from_image_accepts_slirp_port_forwards(
+        self,
+        mock_sdk_cls: MagicMock,
+        tmp_path: Path,
+    ) -> None:
+        rootfs = tmp_path / "rootfs.ext4"
+        kernel = tmp_path / "vmlinux.image"
+        rootfs.touch()
+        kernel.touch()
+        mock_sdk = MagicMock()
+        mock_sdk.create.return_value = MagicMock(vm_id="vm-ports", status=VMState.CREATED)
+        mock_sdk_cls.return_value = mock_sdk
+        image = BootImage(
+            name="ports",
+            rootfs_path=rootfs,
+            rootfs_format="raw-ext4",
+            kernel_path=kernel,
+            boot_args="console=ttyS0 root=/dev/vda rw",
+            backend="qemu",
+        )
+
+        SmolVM.from_image(
+            image,
+            vm_id="vm-ports",
+            network="slirp",
+            port_forwards=[{"host_port": 8080, "guest_port": 80}],
+        )
+
+        created_config = mock_sdk.create.call_args.args[0]
+        assert created_config.qemu_network == "slirp"
+        assert created_config.port_forwards == [PortForwardConfig(host_port=8080, guest_port=80)]
+
+    def test_from_image_rejects_backend_mismatch(self, tmp_path: Path) -> None:
+        rootfs = tmp_path / "rootfs.ext4"
+        kernel = tmp_path / "vmlinux.image"
+        rootfs.touch()
+        kernel.touch()
+        image = BootImage(
+            name="qemu-only",
+            rootfs_path=rootfs,
+            rootfs_format="raw-ext4",
+            kernel_path=kernel,
+            boot_args="console=ttyS0 root=/dev/vda rw",
+            backend="qemu",
+        )
+
+        with pytest.raises(ValueError, match="prepared for backend"):
+            SmolVM.from_image(image, backend="firecracker")
+
+    def test_from_image_rejects_resize_knobs_until_phase_five(self, tmp_path: Path) -> None:
+        rootfs = tmp_path / "rootfs.ext4"
+        kernel = tmp_path / "vmlinux.image"
+        rootfs.touch()
+        kernel.touch()
+        image = BootImage(
+            name="resize",
+            rootfs_path=rootfs,
+            rootfs_format="raw-ext4",
+            kernel_path=kernel,
+            boot_args="console=ttyS0 root=/dev/vda rw",
+        )
+
+        with pytest.raises(SmolVMError, match="disk resizing is not implemented"):
+            SmolVM.from_image(image, disk_size_mb=4096)
+
+    def test_from_image_rejects_tap_port_forwards(self, tmp_path: Path) -> None:
+        rootfs = tmp_path / "rootfs.ext4"
+        kernel = tmp_path / "vmlinux.image"
+        rootfs.touch()
+        kernel.touch()
+        image = BootImage(
+            name="tap-ports",
+            rootfs_path=rootfs,
+            rootfs_format="raw-ext4",
+            kernel_path=kernel,
+            boot_args="console=ttyS0 root=/dev/vda rw",
+            backend="qemu",
+        )
+
+        with pytest.raises(ValueError, match="network='slirp'"):
+            SmolVM.from_image(
+                image,
+                network="tap",
+                port_forwards=[{"host_port": 8080, "guest_port": 80}],
+            )
 
 
 class TestVMImageParam:

--- a/tests/test_facade.py
+++ b/tests/test_facade.py
@@ -762,8 +762,8 @@ class TestFromBootImage:
             backend="qemu",
         )
 
-        with pytest.raises(ValueError, match="prepared for backend"):
-            SmolVM.from_image(image, backend="firecracker")
+        with pytest.raises(ValueError, match="smolvm create --name vm-mismatch --help"):
+            SmolVM.from_image(image, vm_id="vm-mismatch", backend="firecracker")
 
     def test_from_image_rejects_resize_knobs_until_phase_five(self, tmp_path: Path) -> None:
         rootfs = tmp_path / "rootfs.ext4"
@@ -779,7 +779,9 @@ class TestFromBootImage:
         )
 
         with pytest.raises(SmolVMError, match="disk resizing is not implemented"):
-            SmolVM.from_image(image, disk_size_mb=4096)
+            SmolVM.from_image(image, vm_id="vm-resize", disk_size_mb=4096)
+        with pytest.raises(SmolVMError, match="disk resizing is not implemented"):
+            SmolVM.from_image(image, vm_id="vm-grow", grow_filesystem=True)
 
     def test_from_image_rejects_tap_port_forwards(self, tmp_path: Path) -> None:
         rootfs = tmp_path / "rootfs.ext4"
@@ -795,11 +797,34 @@ class TestFromBootImage:
             backend="qemu",
         )
 
-        with pytest.raises(ValueError, match="network='slirp'"):
+        with pytest.raises(ValueError, match="smolvm port expose vm-tap-ports --help"):
             SmolVM.from_image(
                 image,
+                vm_id="vm-tap-ports",
                 network="tap",
                 port_forwards=[{"host_port": 8080, "guest_port": 80}],
+            )
+
+    def test_from_image_rejects_invalid_port_forward_entry(self, tmp_path: Path) -> None:
+        rootfs = tmp_path / "rootfs.ext4"
+        kernel = tmp_path / "vmlinux.image"
+        rootfs.touch()
+        kernel.touch()
+        image = BootImage(
+            name="bad-port",
+            rootfs_path=rootfs,
+            rootfs_format="raw-ext4",
+            kernel_path=kernel,
+            boot_args="console=ttyS0 root=/dev/vda rw",
+            backend="qemu",
+        )
+
+        with pytest.raises(ValueError, match="smolvm port expose vm-bad-port --help"):
+            SmolVM.from_image(
+                image,
+                vm_id="vm-bad-port",
+                network="slirp",
+                port_forwards=[{"host_port": 8080}],
             )
 
 


### PR DESCRIPTION
## Summary
- add `SmolVM.from_image()` to launch custom `BootImage` objects without manual `VMConfig` construction
- resolve backend, arch, missing base kernels, and boot args from image metadata
- support runtime knobs for vCPUs, memory, network mode, port forwards, vsock, comm channel, disk mode, guest OS, and SSH facade settings
- preserve no-SSH custom images by honoring `image.ssh_capable`
- add Phase 5 resize knobs to the signature but reject them until disk growth is implemented
- update the temporary rollout `plan.md` with Phase 4 details

## Tests
- `uv run ruff check src/smolvm/facade.py tests/test_facade.py`
- `uv run pytest tests/test_facade.py::TestFromBootImage`
- `uv run pytest tests/test_facade.py tests/test_custom_boot_api.py tests/test_boot_profiles.py`

Part of #341.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a method to create VMs directly from custom boot images with flexible backend/arch selection, networking (tap/slirp), port-forwarding, vsock, resource sizing, and SSH handling.

* **Tests**
  * Added comprehensive tests for image-based VM creation covering kernel resolution, firmware-mode behavior, networking/port-forward normalization, metadata preservation, and error cases.

* **Documentation**
  * Expanded design plan with detailed resolution, validation rules, and a test checklist for the new workflow.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->