### PR TITLE
[codex] Add Firecracker e2e coverage

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -84,19 +84,21 @@ jobs:
 
       - name: Enable KVM and optional vsock
         run: |
-          # The runner user isn't in the kvm group; SmolVM launches QEMU from
-          # its own process and Firecracker opens /dev/kvm directly, so widen
-          # /dev/kvm directly (CI-only). QEMU's vsock variant also needs the
-          # vhost_vsock module loaded so that leg isn't skipped.
+          # The runner user isn't in the active kvm group for this already-
+          # running job. Add it to /etc/group, set the devices to the same
+          # root:kvm mode used by system setup, then run KVM commands below via
+          # `sg kvm -c ...` so the group is active for each command.
+          sudo groupadd -f kvm
           sudo usermod -a -G kvm "$USER" || true
-          sudo chmod 666 /dev/kvm || true
+          sudo chgrp kvm /dev/kvm || true
+          sudo chmod 660 /dev/kvm || true
           if [[ "${{ matrix.backend }}" == "qemu" ]]; then
             sudo modprobe vhost_vsock || echo "vhost_vsock unavailable; vsock tests will skip"
             # /dev/vhost-vsock ships as root:kvm mode 660; the `usermod` above
-            # doesn't apply to this already-running job, so widen it directly
-            # the same way as /dev/kvm — otherwise QEMU can't open it and the
-            # vsock VM dies on boot (the device merely *existing* isn't enough).
-            sudo chmod 666 /dev/vhost-vsock || true
+            # doesn't apply to this already-running job, so normalize the
+            # device and run pytest under `sg kvm` below.
+            sudo chgrp kvm /dev/vhost-vsock || true
+            sudo chmod 660 /dev/vhost-vsock || true
           fi
           ls -l /dev/kvm /dev/vhost-vsock || true
 
@@ -106,17 +108,17 @@ jobs:
 
       - name: Assert native extension available
         run: |
-          uv run python -c "
+          sg kvm -c 'uv run python -c "
           from smolvm_core import is_available
           assert is_available(), 'Native extension reports not available on Linux'
           print('smolvm-core: OK')
-          "
+          "'
 
       - name: Diagnostics (smolvm doctor)
-        run: uv run smolvm doctor --backend "${{ matrix.backend }}" || true
+        run: sg kvm -c 'uv run smolvm doctor --backend "${{ matrix.backend }}"' || true
 
       - name: Run e2e suite
-        run: uv run pytest -m e2e tests/e2e -v --e2e-backend "${{ matrix.backend }}"
+        run: sg kvm -c 'uv run pytest -m e2e tests/e2e -v --e2e-backend "${{ matrix.backend }}"'
 
       - name: Dump VM logs on failure
         if: failure()

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -87,7 +87,7 @@ jobs:
           # The runner user isn't in the active kvm group for this already-
           # running job. Add it to /etc/group, set the devices to the same
           # root:kvm mode used by system setup, then run KVM commands below via
-          # `sg kvm -c ...` so the group is active for each command.
+          # `sudo -u "$USER" -g kvm` so the group is active for each command.
           sudo groupadd -f kvm
           sudo usermod -a -G kvm "$USER" || true
           sudo chgrp kvm /dev/kvm || true
@@ -96,7 +96,7 @@ jobs:
             sudo modprobe vhost_vsock || echo "vhost_vsock unavailable; vsock tests will skip"
             # /dev/vhost-vsock ships as root:kvm mode 660; the `usermod` above
             # doesn't apply to this already-running job, so normalize the
-            # device and run pytest under `sg kvm` below.
+            # device and run pytest with the kvm group active below.
             sudo chgrp kvm /dev/vhost-vsock || true
             sudo chmod 660 /dev/vhost-vsock || true
           fi
@@ -108,17 +108,13 @@ jobs:
 
       - name: Assert native extension available
         run: |
-          sg kvm -c 'uv run python -c "
-          from smolvm_core import is_available
-          assert is_available(), 'Native extension reports not available on Linux'
-          print('smolvm-core: OK')
-          "'
+          sudo -n -E -u "$USER" -g kvm -- "$(command -v uv)" run python -c "from smolvm_core import is_available; assert is_available(), 'Native extension reports not available on Linux'; print('smolvm-core: OK')"
 
       - name: Diagnostics (smolvm doctor)
-        run: sg kvm -c 'uv run smolvm doctor --backend "${{ matrix.backend }}"' || true
+        run: sudo -n -E -u "$USER" -g kvm -- "$(command -v uv)" run smolvm doctor --backend "${{ matrix.backend }}" || true
 
       - name: Run e2e suite
-        run: sg kvm -c 'uv run pytest -m e2e tests/e2e -v --e2e-backend "${{ matrix.backend }}"'
+        run: sudo -n -E -u "$USER" -g kvm -- "$(command -v uv)" run pytest -m e2e tests/e2e -v --e2e-backend "${{ matrix.backend }}"
 
       - name: Dump VM logs on failure
         if: failure()

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -1,15 +1,15 @@
 # Real-KVM end-to-end smoke of the public SmolVM API.
 #
 # Unlike the unit suite (which mocks the hypervisor) and smoke-published-images
-# (which shells out to raw qemu), this boots an actual QEMU micro-VM *through
-# the SmolVM Python API* and walks its whole lifecycle — start, exec, file
-# upload/download, pause/resume, snapshot/restore, stop/cleanup — over both the
-# SSH and vsock control transports.
+# (which shells out to raw qemu), this boots actual micro-VMs *through the
+# SmolVM Python API* and walks their lifecycle — start, exec, file
+# upload/download, pause/resume, snapshot/restore, stop/cleanup. QEMU is
+# exercised over SSH and vsock; Firecracker is exercised over SSH.
 #
 # GH-hosted ubuntu-latest (x86) exposes /dev/kvm, so this runs with hardware
-# acceleration. The whole suite boots in ~1.5 min on a runner, so it gates every
-# PR to main; the nightly cron still runs to catch runner/environment drift on
-# days with no PRs, and it can be launched manually.
+# acceleration. The suite is short enough to gate every PR to main; the nightly
+# cron still runs to catch runner/environment drift on days with no PRs, and it
+# can be launched manually.
 
 name: E2E (real KVM)
 
@@ -33,8 +33,13 @@ permissions:
 
 jobs:
   e2e:
+    name: ${{ matrix.backend }}
     runs-on: ubuntu-latest
     timeout-minutes: 30
+    strategy:
+      fail-fast: false
+      matrix:
+        backend: [qemu, firecracker]
 
     steps:
       - name: Check out repository
@@ -64,25 +69,35 @@ jobs:
         uses: astral-sh/setup-uv@caf0cab7a618c569241d31dcd442f54681755d39 # v3.2.4
 
       - name: Install QEMU + tooling
+        if: matrix.backend == 'qemu'
         run: |
           sudo apt-get update -qq
           sudo apt-get install -y --no-install-recommends \
               qemu-system-x86 qemu-utils openssh-client
 
-      - name: Enable KVM and vsock
+      - name: Install Firecracker + tooling
+        if: matrix.backend == 'firecracker'
+        run: |
+          sudo bash scripts/system-setup.sh \
+            --configure-runtime \
+            --runtime-user "$USER"
+
+      - name: Enable KVM and optional vsock
         run: |
           # The runner user isn't in the kvm group; SmolVM launches QEMU from
-          # its own process and can't sudo the subprocess, so widen /dev/kvm
-          # directly (CI-only). vsock needs the vhost_vsock module loaded so the
-          # vsock-transport variant of the suite isn't skipped.
+          # its own process and Firecracker opens /dev/kvm directly, so widen
+          # /dev/kvm directly (CI-only). QEMU's vsock variant also needs the
+          # vhost_vsock module loaded so that leg isn't skipped.
           sudo usermod -a -G kvm "$USER" || true
           sudo chmod 666 /dev/kvm || true
-          sudo modprobe vhost_vsock || echo "vhost_vsock unavailable; vsock tests will skip"
-          # /dev/vhost-vsock ships as root:kvm mode 660; the `usermod` above
-          # doesn't apply to this already-running job, so widen it directly the
-          # same way as /dev/kvm — otherwise QEMU can't open it and the vsock
-          # VM dies on boot (the device merely *existing* isn't enough).
-          sudo chmod 666 /dev/vhost-vsock || true
+          if [[ "${{ matrix.backend }}" == "qemu" ]]; then
+            sudo modprobe vhost_vsock || echo "vhost_vsock unavailable; vsock tests will skip"
+            # /dev/vhost-vsock ships as root:kvm mode 660; the `usermod` above
+            # doesn't apply to this already-running job, so widen it directly
+            # the same way as /dev/kvm — otherwise QEMU can't open it and the
+            # vsock VM dies on boot (the device merely *existing* isn't enough).
+            sudo chmod 666 /dev/vhost-vsock || true
+          fi
           ls -l /dev/kvm /dev/vhost-vsock || true
 
       # uv workspace builds smolvm-core from the local smolvm-core/ directory.
@@ -98,10 +113,10 @@ jobs:
           "
 
       - name: Diagnostics (smolvm doctor)
-        run: uv run smolvm doctor || true
+        run: uv run smolvm doctor --backend "${{ matrix.backend }}" || true
 
       - name: Run e2e suite
-        run: uv run pytest -m e2e tests/e2e -v
+        run: uv run pytest -m e2e tests/e2e -v --e2e-backend "${{ matrix.backend }}"
 
       - name: Dump VM logs on failure
         if: failure()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -106,9 +106,9 @@ members = ["smolvm-core"]
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]
-# e2e tests boot a real KVM VM; deselect them from the default fast suite.
-# The nightly e2e workflow opts in explicitly with `pytest -m e2e`.
+# e2e tests boot real KVM VMs; deselect them from the default fast suite.
+# The e2e workflow opts in explicitly with `pytest -m e2e`.
 addopts = "-v --tb=short -m 'not e2e'"
 markers = [
-    "e2e: boots a real KVM VM (QEMU); nightly only, needs /dev/kvm",
+    "e2e: boots real KVM VMs; CI/explicit only, needs /dev/kvm",
 ]

--- a/tests/e2e/_util.py
+++ b/tests/e2e/_util.py
@@ -16,11 +16,14 @@
 
 from __future__ import annotations
 
+import os
 import platform
 from dataclasses import dataclass
 from pathlib import Path
 from shutil import which
 from typing import Literal
+
+import pytest
 
 try:
     from smolvm_core import is_available as _core_available
@@ -46,11 +49,11 @@ class E2EVariant:
         return f"{self.backend}-{self.transport}"
 
 
-E2E_BACKENDS: tuple[E2EBackend, ...] = ("qemu", "firecracker")
+E2E_BACKENDS: tuple[E2EBackend, ...] = (BACKEND_QEMU, BACKEND_FIRECRACKER)
 E2E_VARIANTS: tuple[E2EVariant, ...] = (
-    E2EVariant("qemu", "ssh"),
-    E2EVariant("qemu", "vsock"),
-    E2EVariant("firecracker", "ssh"),
+    E2EVariant(BACKEND_QEMU, "ssh"),
+    E2EVariant(BACKEND_QEMU, "vsock"),
+    E2EVariant(BACKEND_FIRECRACKER, "ssh"),
 )
 
 # Boot is fast under KVM, but auto-config may build/download the rootfs and
@@ -63,6 +66,10 @@ def kvm_ready() -> bool:
     return Path("/dev/kvm").exists() and _core_available is not None and _core_available()
 
 
+def _kvm_accessible() -> bool:
+    return Path("/dev/kvm").exists() and os.access("/dev/kvm", os.R_OK | os.W_OK)
+
+
 def _qemu_binary_available() -> bool:
     arch = platform.machine().lower()
     candidates = (
@@ -73,23 +80,60 @@ def _qemu_binary_available() -> bool:
     return any(which(candidate) is not None for candidate in candidates)
 
 
-def backend_unavailable_reasons(backend: E2EBackend) -> list[str]:
+def backend_unavailable_reasons(backend: E2EBackend, *, sandbox_name: str) -> list[str]:
     """Return human-readable reasons the backend cannot run on this host."""
     reasons: list[str] = []
     if not kvm_ready():
         reasons.append(
-            "requires /dev/kvm and a working smolvm-core native extension "
-            "(enable KVM with `sudo modprobe kvm && sudo chmod 666 /dev/kvm`, "
-            "then re-run)"
+            "Enable KVM and allow access: sudo modprobe kvm && sudo chmod 666 "
+            f"/dev/kvm && re-run tests in sandbox '{sandbox_name}'"
         )
 
     if backend == BACKEND_QEMU and not _qemu_binary_available():
-        reasons.append("requires qemu-system for this host architecture")
+        reasons.append(
+            "Install qemu-system for your host (e.g. sudo apt install qemu-system) "
+            f"and re-run tests in sandbox '{sandbox_name}'"
+        )
 
     if backend == BACKEND_FIRECRACKER:
         if platform.system() != "Linux":
-            reasons.append("Firecracker requires a Linux host")
+            reasons.append(
+                f"Run tests on a Linux host and re-run in sandbox '{sandbox_name}'"
+            )
+        if Path("/dev/kvm").exists() and not _kvm_accessible():
+            reasons.append(
+                "Allow Firecracker to read and write /dev/kvm: sudo chmod 666 /dev/kvm "
+                f"&& re-run tests in sandbox '{sandbox_name}'"
+            )
         if HostManager().find_firecracker() is None:
-            reasons.append("requires the firecracker binary on PATH or in ~/.smolvm/bin")
+            reasons.append(
+                "Download Firecracker to ~/.smolvm/bin, make it executable "
+                "(chmod +x ~/.smolvm/bin/firecracker), and re-run tests in "
+                f"sandbox '{sandbox_name}'"
+            )
 
     return reasons
+
+
+def selected_backend(config: pytest.Config) -> str:
+    return str(config.getoption("--e2e-backend"))
+
+
+def require_backend_available(
+    backend: E2EBackend,
+    config: pytest.Config,
+    *,
+    sandbox_name: str | None = None,
+) -> None:
+    sandbox = sandbox_name or f"e2e-{backend}"
+    reasons = backend_unavailable_reasons(backend, sandbox_name=sandbox)
+    if not reasons:
+        return
+
+    message = (
+        f"End-to-end tests for '{backend}' cannot run because {'; '.join(reasons)}; "
+        f"fix that and rerun: pytest tests/e2e -k '{backend}'."
+    )
+    if selected_backend(config) == backend:
+        pytest.fail(message)
+    pytest.skip(message)

--- a/tests/e2e/_util.py
+++ b/tests/e2e/_util.py
@@ -16,12 +16,42 @@
 
 from __future__ import annotations
 
+import platform
+from dataclasses import dataclass
 from pathlib import Path
+from shutil import which
+from typing import Literal
 
 try:
     from smolvm_core import is_available as _core_available
 except (ImportError, OSError):  # pragma: no cover - native extension missing entirely
     _core_available = None
+
+from smolvm.host.manager import HostManager
+from smolvm.runtime.backends import BACKEND_FIRECRACKER, BACKEND_QEMU
+
+E2EBackend = Literal["qemu", "firecracker"]
+E2ETransport = Literal["ssh", "vsock"]
+
+
+@dataclass(frozen=True, slots=True)
+class E2EVariant:
+    """One backend/transport combination exercised by the real-KVM suite."""
+
+    backend: E2EBackend
+    transport: E2ETransport
+
+    @property
+    def id(self) -> str:
+        return f"{self.backend}-{self.transport}"
+
+
+E2E_BACKENDS: tuple[E2EBackend, ...] = ("qemu", "firecracker")
+E2E_VARIANTS: tuple[E2EVariant, ...] = (
+    E2EVariant("qemu", "ssh"),
+    E2EVariant("qemu", "vsock"),
+    E2EVariant("firecracker", "ssh"),
+)
 
 # Boot is fast under KVM, but auto-config may build/download the rootfs and
 # base kernel on the first run; give the whole start() a generous budget.
@@ -31,3 +61,35 @@ BOOT_TIMEOUT = 180.0
 def kvm_ready() -> bool:
     """True when this host can actually run a hardware-accelerated VM."""
     return Path("/dev/kvm").exists() and _core_available is not None and _core_available()
+
+
+def _qemu_binary_available() -> bool:
+    arch = platform.machine().lower()
+    candidates = (
+        ("qemu-system-aarch64",)
+        if arch in {"aarch64", "arm64"}
+        else ("qemu-system-x86_64", "qemu-system-x86")
+    )
+    return any(which(candidate) is not None for candidate in candidates)
+
+
+def backend_unavailable_reasons(backend: E2EBackend) -> list[str]:
+    """Return human-readable reasons the backend cannot run on this host."""
+    reasons: list[str] = []
+    if not kvm_ready():
+        reasons.append(
+            "requires /dev/kvm and a working smolvm-core native extension "
+            "(enable KVM with `sudo modprobe kvm && sudo chmod 666 /dev/kvm`, "
+            "then re-run)"
+        )
+
+    if backend == BACKEND_QEMU and not _qemu_binary_available():
+        reasons.append("requires qemu-system for this host architecture")
+
+    if backend == BACKEND_FIRECRACKER:
+        if platform.system() != "Linux":
+            reasons.append("Firecracker requires a Linux host")
+        if HostManager().find_firecracker() is None:
+            reasons.append("requires the firecracker binary on PATH or in ~/.smolvm/bin")
+
+    return reasons

--- a/tests/e2e/conftest.py
+++ b/tests/e2e/conftest.py
@@ -14,55 +14,99 @@
 
 """Shared fixtures for the real-KVM end-to-end suite.
 
-These tests boot an actual QEMU micro-VM through the public ``SmolVM`` API
-(unlike the unit suite, which mocks the hypervisor). They run nightly on a
-GitHub ``ubuntu-latest`` runner, which exposes ``/dev/kvm``.
+These tests boot actual micro-VMs through the public ``SmolVM`` API (unlike
+the unit suite, which mocks the hypervisor). They run in CI on GitHub
+``ubuntu-latest`` runners, which expose ``/dev/kvm``.
 
-The ``vm`` fixture is parametrized over both control transports — SSH and
-vsock — so the whole lifecycle (``test_lifecycle.py``) is exercised once per
-transport against a single, shared sandbox.
+The ``vm`` fixture is parametrized over supported backend/transport variants
+so the whole lifecycle (``test_lifecycle.py``) is exercised against a single,
+shared sandbox for each variant.
 """
 
 from __future__ import annotations
 
+import os
 from contextlib import suppress
 
 import pytest
-from _util import BOOT_TIMEOUT, kvm_ready
+from _util import (
+    BOOT_TIMEOUT,
+    E2E_BACKENDS,
+    E2E_VARIANTS,
+    E2EBackend,
+    E2EVariant,
+    backend_unavailable_reasons,
+)
 
 from smolvm import SmolVM
 from smolvm.comm import host_supports_vsock
+from smolvm.runtime.backends import BACKEND_QEMU
 from smolvm.types import VMState
 
 
-@pytest.fixture(scope="module", params=["ssh", "vsock"])
-def vm(request: pytest.FixtureRequest):
-    """A single running QEMU sandbox, shared across the lifecycle tests.
+def pytest_addoption(parser: pytest.Parser) -> None:
+    """Add a backend selector so CI can run one backend per matrix job."""
+    parser.addoption(
+        "--e2e-backend",
+        choices=("all", *E2E_BACKENDS),
+        default=os.environ.get("SMOLVM_E2E_BACKEND", "all"),
+        help="Backend to exercise in tests/e2e (default: all available backends).",
+    )
 
-    Yields one started ``SmolVM`` per transport. Teardown is best-effort:
-    ``test_stop_and_cleanup`` deletes the sandbox as its final assertion, so
-    the ``stop``/``delete`` here are just a safety net for earlier failures.
+
+def _selected_backend(config: pytest.Config) -> str:
+    return str(config.getoption("--e2e-backend"))
+
+
+def _require_backend_available(backend: E2EBackend, config: pytest.Config) -> None:
+    reasons = backend_unavailable_reasons(backend)
+    if not reasons:
+        return
+
+    message = f"{backend} e2e unavailable: {'; '.join(reasons)}"
+    if _selected_backend(config) == backend:
+        pytest.fail(message)
+    pytest.skip(message)
+
+
+@pytest.fixture(scope="module", params=E2E_VARIANTS, ids=lambda variant: variant.id)
+def e2e_variant(request: pytest.FixtureRequest) -> E2EVariant:
+    """Selected backend/transport variant for this module fixture instance."""
+    variant = request.param
+    selected = _selected_backend(request.config)
+    if selected != "all" and variant.backend != selected:
+        pytest.skip(f"selected e2e backend is {selected!r}")
+    _require_backend_available(variant.backend, request.config)
+    return variant
+
+
+@pytest.fixture(scope="module")
+def vm(e2e_variant: E2EVariant):
+    """A single running sandbox, shared across the lifecycle tests.
+
+    Yields one started ``SmolVM`` per backend/transport variant. Teardown is
+    best-effort: ``test_stop_and_cleanup`` deletes the sandbox as its final
+    assertion, so the ``stop``/``delete`` here are just a safety net for
+    earlier failures.
     """
-    transport = request.param
-
-    if not kvm_ready():
-        pytest.skip(
-            "requires /dev/kvm and a working smolvm-core native extension "
-            "(enable KVM with `sudo modprobe kvm && sudo chmod 666 /dev/kvm`, "
-            "then re-run)"
-        )
-    if transport == "vsock" and not host_supports_vsock():
+    if e2e_variant.transport == "vsock" and not host_supports_vsock():
         pytest.skip(
             "vsock requires a Linux host with /dev/vhost-vsock "
             "(load it via `sudo modprobe vhost_vsock`)"
         )
+    if e2e_variant.transport == "vsock" and e2e_variant.backend != BACKEND_QEMU:
+        pytest.skip("vsock e2e is only supported on the QEMU backend in this release")
 
     # Pin to Alpine: the SmolVM-*built* image (vsock guest agent + python3 baked
     # in by ImageBuilder, SSH key injected on the kernel cmdline, no cloud-init
     # seed ISO). The QEMU default is Ubuntu, whose cloud qcow2 carries a seed
     # ISO as an extra drive (snapshot then rejects it) and lacks the baked-in
     # agent (vsock never answers) — neither of which is what we want to smoke.
-    sandbox = SmolVM(backend="qemu", os="alpine", comm_channel=transport)
+    sandbox = SmolVM(
+        backend=e2e_variant.backend,
+        os="alpine",
+        comm_channel=e2e_variant.transport,
+    )
     try:
         sandbox.start(boot_timeout=BOOT_TIMEOUT)
         assert sandbox.status == VMState.RUNNING

--- a/tests/e2e/conftest.py
+++ b/tests/e2e/conftest.py
@@ -33,9 +33,9 @@ from _util import (
     BOOT_TIMEOUT,
     E2E_BACKENDS,
     E2E_VARIANTS,
-    E2EBackend,
     E2EVariant,
-    backend_unavailable_reasons,
+    require_backend_available,
+    selected_backend,
 )
 
 from smolvm import SmolVM
@@ -53,30 +53,17 @@ def pytest_addoption(parser: pytest.Parser) -> None:
         help="Backend to exercise in tests/e2e (default: all available backends).",
     )
 
-
-def _selected_backend(config: pytest.Config) -> str:
-    return str(config.getoption("--e2e-backend"))
-
-
-def _require_backend_available(backend: E2EBackend, config: pytest.Config) -> None:
-    reasons = backend_unavailable_reasons(backend)
-    if not reasons:
-        return
-
-    message = f"{backend} e2e unavailable: {'; '.join(reasons)}"
-    if _selected_backend(config) == backend:
-        pytest.fail(message)
-    pytest.skip(message)
-
-
 @pytest.fixture(scope="module", params=E2E_VARIANTS, ids=lambda variant: variant.id)
 def e2e_variant(request: pytest.FixtureRequest) -> E2EVariant:
     """Selected backend/transport variant for this module fixture instance."""
     variant = request.param
-    selected = _selected_backend(request.config)
+    selected = selected_backend(request.config)
     if selected != "all" and variant.backend != selected:
-        pytest.skip(f"selected e2e backend is {selected!r}")
-    _require_backend_available(variant.backend, request.config)
+        pytest.skip(
+            f"End-to-end tests for '{variant.backend}' are skipped because this run "
+            f"selected '{selected}'; rerun all backends with: pytest tests/e2e."
+        )
+    require_backend_available(variant.backend, request.config, sandbox_name=variant.id)
     return variant
 
 

--- a/tests/e2e/test_lifecycle.py
+++ b/tests/e2e/test_lifecycle.py
@@ -173,6 +173,7 @@ def test_snapshot_restore(backend: E2EBackend, request: pytest.FixtureRequest) -
 
         snap = sandbox.snapshot()
         sandbox.stop()
+        sandbox.delete()
 
         restored = SmolVM.from_snapshot(snap.snapshot_id, backend=backend, resume_vm=True)
         result = restored.run("cat /root/sentinel.txt")

--- a/tests/e2e/test_lifecycle.py
+++ b/tests/e2e/test_lifecycle.py
@@ -34,7 +34,13 @@ from contextlib import suppress
 from pathlib import Path
 
 import pytest
-from _util import BOOT_TIMEOUT, E2E_BACKENDS, E2EBackend, backend_unavailable_reasons
+from _util import (
+    BOOT_TIMEOUT,
+    E2E_BACKENDS,
+    E2EBackend,
+    require_backend_available,
+    selected_backend,
+)
 
 from smolvm import SmolVM
 from smolvm.exceptions import SmolVMError, VMNotFoundError
@@ -42,22 +48,6 @@ from smolvm.runtime.backends import BACKEND_QEMU
 from smolvm.types import VMState
 
 pytestmark = pytest.mark.e2e
-
-
-def _selected_backend(config: pytest.Config) -> str:
-    return str(config.getoption("--e2e-backend"))
-
-
-def _require_backend_available(backend: E2EBackend, config: pytest.Config) -> None:
-    reasons = backend_unavailable_reasons(backend)
-    if not reasons:
-        return
-
-    message = f"{backend} e2e unavailable: {'; '.join(reasons)}"
-    if _selected_backend(config) == backend:
-        pytest.fail(message)
-    pytest.skip(message)
-
 
 # ---------------------------------------------------------------------------
 # Shared sandbox: one VM (per transport), walked through its lifecycle.
@@ -160,10 +150,13 @@ def test_snapshot_restore(backend: E2EBackend, request: pytest.FixtureRequest) -
     shared sandbox can't be used. We stop the source before restoring so the
     restore path doesn't race to kill a still-live runtime process.
     """
-    selected = _selected_backend(request.config)
+    selected = selected_backend(request.config)
     if selected != "all" and backend != selected:
-        pytest.skip(f"selected e2e backend is {selected!r}")
-    _require_backend_available(backend, request.config)
+        pytest.skip(
+            f"End-to-end tests for '{backend}' are skipped because this run selected "
+            f"'{selected}'; rerun all backends with: pytest tests/e2e."
+        )
+    require_backend_available(backend, request.config, sandbox_name=f"snapshot-{backend}")
 
     sandbox = SmolVM(backend=backend, os="alpine", comm_channel="ssh")
     restored: SmolVM | None = None

--- a/tests/e2e/test_lifecycle.py
+++ b/tests/e2e/test_lifecycle.py
@@ -12,10 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""End-to-end lifecycle of a real QEMU sandbox via the public ``SmolVM`` API.
+"""End-to-end lifecycle of real sandboxes via the public ``SmolVM`` API.
 
 The shared-sandbox tests are a deliberately *ordered, stateful* smoke: the one
-VM from the ``vm`` fixture (booted once per transport) is walked through its
+VM from the ``vm`` fixture (booted once per variant) is walked through its
 lifecycle, asserting one capability per step. An early failure (e.g. boot)
 cascades — the signal we want from a smoke suite.
 
@@ -34,13 +34,29 @@ from contextlib import suppress
 from pathlib import Path
 
 import pytest
-from _util import BOOT_TIMEOUT, kvm_ready
+from _util import BOOT_TIMEOUT, E2E_BACKENDS, E2EBackend, backend_unavailable_reasons
 
 from smolvm import SmolVM
 from smolvm.exceptions import SmolVMError, VMNotFoundError
+from smolvm.runtime.backends import BACKEND_QEMU
 from smolvm.types import VMState
 
 pytestmark = pytest.mark.e2e
+
+
+def _selected_backend(config: pytest.Config) -> str:
+    return str(config.getoption("--e2e-backend"))
+
+
+def _require_backend_available(backend: E2EBackend, config: pytest.Config) -> None:
+    reasons = backend_unavailable_reasons(backend)
+    if not reasons:
+        return
+
+    message = f"{backend} e2e unavailable: {'; '.join(reasons)}"
+    if _selected_backend(config) == backend:
+        pytest.fail(message)
+    pytest.skip(message)
 
 
 # ---------------------------------------------------------------------------
@@ -116,28 +132,40 @@ def test_stop_and_cleanup(vm: SmolVM) -> None:
 # ---------------------------------------------------------------------------
 
 
-@pytest.mark.xfail(
-    reason=(
-        "QEMU snapshot RESTORE is currently broken on the isolated-disk "
-        "overlay: loadvm reports \"Device 'rootdisk0-drive' is writable but "
-        'does not support snapshots". Snapshot *creation* works; restore needs '
-        "a runtime fix (attach the restored root disk as a snapshot-capable "
-        "qcow2 node). Remove this xfail once restore lands."
-    ),
-    raises=SmolVMError,
-    strict=False,
+@pytest.mark.parametrize(
+    "backend",
+    [
+        pytest.param(
+            BACKEND_QEMU,
+            marks=pytest.mark.xfail(
+                reason=(
+                    "QEMU snapshot RESTORE is currently broken on the isolated-disk "
+                    "overlay: loadvm reports \"Device 'rootdisk0-drive' is writable but "
+                    'does not support snapshots". Snapshot *creation* works; restore needs '
+                    "a runtime fix (attach the restored root disk as a snapshot-capable "
+                    "qcow2 node). Remove this xfail once restore lands."
+                ),
+                raises=SmolVMError,
+                strict=False,
+            ),
+        ),
+        *[backend for backend in E2E_BACKENDS if backend != BACKEND_QEMU],
+    ],
+    ids=str,
 )
-def test_snapshot_restore() -> None:
+def test_snapshot_restore(backend: E2EBackend, request: pytest.FixtureRequest) -> None:
     """Snapshot a VM, restore it, and confirm guest state survived.
 
     Self-contained: ``from_snapshot`` restores into the *original* vm_id, so a
     shared sandbox can't be used. We stop the source before restoring so the
-    restore path doesn't race to kill a still-live QEMU process.
+    restore path doesn't race to kill a still-live runtime process.
     """
-    if not kvm_ready():
-        pytest.skip("requires /dev/kvm and a working smolvm-core native extension")
+    selected = _selected_backend(request.config)
+    if selected != "all" and backend != selected:
+        pytest.skip(f"selected e2e backend is {selected!r}")
+    _require_backend_available(backend, request.config)
 
-    sandbox = SmolVM(backend="qemu", os="alpine", comm_channel="ssh")
+    sandbox = SmolVM(backend=backend, os="alpine", comm_channel="ssh")
     restored: SmolVM | None = None
     try:
         sandbox.start(boot_timeout=BOOT_TIMEOUT)
@@ -146,7 +174,7 @@ def test_snapshot_restore() -> None:
         snap = sandbox.snapshot()
         sandbox.stop()
 
-        restored = SmolVM.from_snapshot(snap.snapshot_id)
+        restored = SmolVM.from_snapshot(snap.snapshot_id, backend=backend, resume_vm=True)
         result = restored.run("cat /root/sentinel.txt")
         assert result.exit_code == 0
         assert result.stdout.strip() == "sentinel-content"


### PR DESCRIPTION
## Summary

Add Firecracker to the real-KVM e2e workflow as a CI matrix backend alongside QEMU.
The e2e fixtures now select backend/transport variants, fail explicitly when a requested backend is unavailable, and keep QEMU vsock coverage scoped to QEMU.
Snapshot restore coverage now runs per backend while preserving the existing QEMU restore xfail.

## Related Issues

- None

## Testing

- `uv run ruff check tests/e2e/_util.py tests/e2e/conftest.py tests/e2e/test_lifecycle.py` passed
- `uv run pytest -m e2e tests/e2e --collect-only -q` passed, collecting 20 e2e cases
- `uv run pytest` failed locally: `tests/test_vsock_channel.py::TestUdsTransport::test_from_uds_handshake_then_ping` hit `OSError: AF_UNIX path too long` in this Conductor workspace path
- `uv run ruff check .` failed on existing lint issues outside this change
- `uv run mypy src` failed on existing type issues and missing optional stubs outside this change

## Checklist

- [x] Scope is focused and limited to this change
- [x] Tests added/updated for behavior changes
- [x] Docs updated for user-visible changes
- [x] No secrets or sensitive data included


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * E2E suite now runs across multiple micro‑VM backends and transport methods, parametrized per variant.
  * Tests perform backend availability checks and skip incompatible variants (e.g., vsock when unsupported).
  * Snapshot/restore lifecycle test is parameterized per backend, with QEMU kept as an expected-failure where applicable.

* **Chores**
  * CI workflow updated to run smoke tests across a backend matrix with backend-specific setup and a backend-selection option for test runs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->