### PR TITLE
Fix DockerRootfsBuilder temp rootfs suffix for loopfs

### DIFF
--- a/src/smolvm/images/builder.py
+++ b/src/smolvm/images/builder.py
@@ -1935,7 +1935,7 @@ class DockerRootfsBuilder:
                 if not helper.check_docker():
                     raise helper.docker_requirement_error()
                 image_dir.mkdir(parents=True, exist_ok=True)
-                temp_rootfs = image_dir / f".{rootfs_path.name}.tmp"
+                temp_rootfs = image_dir / f".{rootfs_path.stem}.tmp{rootfs_path.suffix}"
                 temp_rootfs.unlink(missing_ok=True)
                 try:
                     self._build_rootfs(

--- a/src/smolvm/images/builder.py
+++ b/src/smolvm/images/builder.py
@@ -1900,7 +1900,7 @@ class DockerRootfsBuilder:
         self.docker_platform = docker_platform
         self.ssh_capable = ssh_capable
 
-    def ensure(
+    def build_boot_image(
         self,
         *,
         backend: str,
@@ -1912,7 +1912,7 @@ class DockerRootfsBuilder:
         if boot is not None and boot_args is not None:
             raise ValueError("boot and boot_args are mutually exclusive")
         if boot is None and boot_args is None:
-            raise ValueError("DockerRootfsBuilder.ensure() requires boot or boot_args")
+            raise ValueError("DockerRootfsBuilder.build_boot_image() requires boot or boot_args")
 
         resolved_backend = resolve_backend(backend)
         resolved_arch = to_published_arch(platform.machine() if arch == "host" else arch)
@@ -1965,6 +1965,22 @@ class DockerRootfsBuilder:
             backend=resolved_backend,
             arch=resolved_arch,
             ssh_capable=self.ssh_capable,
+        )
+
+    def ensure(
+        self,
+        *,
+        backend: str,
+        arch: KernelArch | str = "host",
+        boot: DirectKernelBoot | None = None,
+        boot_args: str | None = None,
+    ) -> BootImage:
+        """Backward-compatible alias for :meth:`build_boot_image`."""
+        return self.build_boot_image(
+            backend=backend,
+            arch=arch,
+            boot=boot,
+            boot_args=boot_args,
         )
 
     def _read_context_files(self) -> dict[str, bytes]:

--- a/tests/test_custom_boot_api.py
+++ b/tests/test_custom_boot_api.py
@@ -304,6 +304,50 @@ class TestDockerRootfsBuilder:
 
     @patch("smolvm.images.builder.ensure_base_kernel_for_backend")
     @patch("smolvm.images.builder.ImageBuilder.check_docker", return_value=True)
+    def test_ensure_uses_ext4_suffixed_temp_rootfs(
+        self,
+        _mock_check_docker: MagicMock,
+        mock_kernel: MagicMock,
+        tmp_path: Path,
+    ) -> None:
+        cache_dir = tmp_path / "cache"
+        kernel = _empty_file(tmp_path, "kernel/vmlinux.image")
+        mock_kernel.return_value = kernel
+        temp_paths: list[Path] = []
+
+        def fake_build_rootfs(**kwargs: object) -> None:
+            rootfs_path = kwargs["rootfs_path"]
+            assert isinstance(rootfs_path, Path)
+            temp_paths.append(rootfs_path)
+            rootfs_path.write_bytes(b"ext4")
+
+        builder = DockerRootfsBuilder(
+            name="loopfs-temp",
+            dockerfile="FROM scratch\n",
+            rootfs_size_mb=64,
+            cache_dir=cache_dir,
+        )
+        with patch.object(
+            DockerRootfsBuilder,
+            "_build_rootfs",
+            side_effect=fake_build_rootfs,
+        ):
+            image = builder.ensure(
+                backend="qemu",
+                arch="amd64",
+                boot=DirectKernelBoot(quiet=False),
+            )
+
+        assert image.rootfs_path.name == "rootfs.ext4"
+        assert len(temp_paths) == 1
+        temp_rootfs = temp_paths[0]
+        assert temp_rootfs.name == ".rootfs.tmp.ext4"
+        assert temp_rootfs.suffix == ".ext4"
+        assert temp_rootfs != image.rootfs_path
+        assert not temp_rootfs.exists()
+
+    @patch("smolvm.images.builder.ensure_base_kernel_for_backend")
+    @patch("smolvm.images.builder.ImageBuilder.check_docker", return_value=True)
     def test_cached_rootfs_is_reused_across_backends(
         self,
         _mock_check_docker: MagicMock,

--- a/tests/test_custom_boot_api.py
+++ b/tests/test_custom_boot_api.py
@@ -263,7 +263,7 @@ class TestDockerRootfsBuilder:
 
     @patch("smolvm.images.builder.ensure_base_kernel_for_backend")
     @patch("smolvm.images.builder.ImageBuilder.check_docker", return_value=True)
-    def test_ensure_builds_rootfs_and_returns_boot_image(
+    def test_build_boot_image_builds_rootfs_and_returns_boot_image(
         self,
         _mock_check_docker: MagicMock,
         mock_kernel: MagicMock,
@@ -286,7 +286,7 @@ class TestDockerRootfsBuilder:
             "_build_rootfs",
             side_effect=self._fake_build_rootfs,
         ):
-            image = builder.ensure(
+            image = builder.build_boot_image(
                 backend="qemu",
                 arch="amd64",
                 boot=DirectKernelBoot(quiet=False),
@@ -304,7 +304,7 @@ class TestDockerRootfsBuilder:
 
     @patch("smolvm.images.builder.ensure_base_kernel_for_backend")
     @patch("smolvm.images.builder.ImageBuilder.check_docker", return_value=True)
-    def test_ensure_uses_ext4_suffixed_temp_rootfs(
+    def test_build_boot_image_uses_ext4_suffixed_temp_rootfs(
         self,
         _mock_check_docker: MagicMock,
         mock_kernel: MagicMock,
@@ -332,7 +332,7 @@ class TestDockerRootfsBuilder:
             "_build_rootfs",
             side_effect=fake_build_rootfs,
         ):
-            image = builder.ensure(
+            image = builder.build_boot_image(
                 backend="qemu",
                 arch="amd64",
                 boot=DirectKernelBoot(quiet=False),
@@ -345,6 +345,37 @@ class TestDockerRootfsBuilder:
         assert temp_rootfs.suffix == ".ext4"
         assert temp_rootfs != image.rootfs_path
         assert not temp_rootfs.exists()
+
+    @patch("smolvm.images.builder.ensure_base_kernel_for_backend")
+    @patch("smolvm.images.builder.ImageBuilder.check_docker", return_value=True)
+    def test_ensure_remains_backward_compatible(
+        self,
+        _mock_check_docker: MagicMock,
+        mock_kernel: MagicMock,
+        tmp_path: Path,
+    ) -> None:
+        cache_dir = tmp_path / "cache"
+        kernel = _empty_file(tmp_path, "kernel/vmlinux.image")
+        mock_kernel.return_value = kernel
+        builder = DockerRootfsBuilder(
+            name="ensure-alias",
+            dockerfile="FROM scratch\n",
+            rootfs_size_mb=64,
+            cache_dir=cache_dir,
+        )
+        with patch.object(
+            DockerRootfsBuilder,
+            "_build_rootfs",
+            side_effect=self._fake_build_rootfs,
+        ):
+            image = builder.ensure(
+                backend="qemu",
+                arch="amd64",
+                boot=DirectKernelBoot(quiet=False),
+            )
+
+        assert image.name == "ensure-alias"
+        assert image.rootfs_path.name == "rootfs.ext4"
 
     @patch("smolvm.images.builder.ensure_base_kernel_for_backend")
     @patch("smolvm.images.builder.ImageBuilder.check_docker", return_value=True)
@@ -370,12 +401,12 @@ class TestDockerRootfsBuilder:
             "_build_rootfs",
             side_effect=self._fake_build_rootfs,
         ) as mock_build:
-            qemu_image = builder.ensure(
+            qemu_image = builder.build_boot_image(
                 backend="qemu",
                 arch="amd64",
                 boot=DirectKernelBoot(quiet=False),
             )
-            firecracker_image = builder.ensure(
+            firecracker_image = builder.build_boot_image(
                 backend="firecracker",
                 arch="amd64",
                 boot=DirectKernelBoot(quiet=False),
@@ -395,7 +426,7 @@ class TestDockerRootfsBuilder:
         )
 
         with pytest.raises(ValueError, match="relative and safe"):
-            builder.ensure(
+            builder.build_boot_image(
                 backend="qemu",
                 arch="amd64",
                 boot_args="console=ttyS0 root=/dev/vda rw",
@@ -410,7 +441,7 @@ class TestDockerRootfsBuilder:
         )
 
         with pytest.raises(ValueError, match="Dockerfile"):
-            builder.ensure(
+            builder.build_boot_image(
                 backend="qemu",
                 arch="amd64",
                 boot_args="console=ttyS0 root=/dev/vda rw",
@@ -425,7 +456,7 @@ class TestDockerRootfsBuilder:
         )
 
         with pytest.raises(ImageError, match="Build context file is missing"):
-            builder.ensure(
+            builder.build_boot_image(
                 backend="qemu",
                 arch="amd64",
                 boot_args="console=ttyS0 root=/dev/vda rw",


### PR DESCRIPTION
## Summary
- Keep `DockerRootfsBuilder.ensure()` writing through a temporary rootfs for atomic cache replacement.
- Rename the temp file so it still ends in `.ext4`, which satisfies the loopfs helper contract.
- Add regression coverage for the temp rootfs path and cleanup behavior.

## Testing
- Unit tests added for `DockerRootfsBuilder.ensure()` to verify the temp path suffix, final cache path, and temp-file cleanup.
- Unit test suite for `tests/test_custom_boot_api.py` passed locally.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a new public API for building boot images while preserving the previous API as a backward-compatible alias.

* **Bug Fixes**
  * Refined temporary root filesystem naming during image creation to improve file handling and avoid intermediate conflicts.

* **Tests**
  * Added tests to verify temporary rootfs naming, proper wiring of image metadata, and cleanup of temporary files.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->