### PR TITLE
feat(cli): add smolvm update command

### DIFF
--- a/src/smolvm/cli/main.py
+++ b/src/smolvm/cli/main.py
@@ -543,6 +543,21 @@ def build_parser() -> argparse.ArgumentParser:
     )
     add_cleanup_args(cleanup)
 
+    update = subparsers.add_parser(
+        "update",
+        help="Upgrade SmolVM to the latest stable release.",
+    )
+    update.add_argument(
+        "--check",
+        action="store_true",
+        help="Report whether an update is available without installing it.",
+    )
+    update.add_argument(
+        "--json",
+        action="store_true",
+        help="Emit machine-readable JSON output.",
+    )
+
     prune = subparsers.add_parser(
         "prune",
         help="Remove stale image caches from older SmolVM versions.",
@@ -3885,6 +3900,11 @@ def main(argv: Sequence[str] | None = None) -> int:
             json_output=args.json,
             force=args.force,
         )
+
+    if args.command == "update":
+        from smolvm.cli.update import run_update
+
+        return run_update(args)
 
     if args.command == "prune":
         from smolvm.cli.prune import run_prune

--- a/src/smolvm/cli/update.py
+++ b/src/smolvm/cli/update.py
@@ -87,6 +87,8 @@ def _run_upgrade(*, json_output: bool) -> tuple[int, str]:
             result = subprocess.run(cmd)
             return result.returncode, ""
     except OSError as exc:
+        if not json_output:
+            sys.stderr.write(f"Upgrade failed: {exc}\n")
         return 1, str(exc)
 
 
@@ -115,7 +117,7 @@ def run_update(args: argparse.Namespace) -> int:
             else:
                 console = console_stdout()
                 console.print(
-                    f"smolvm {current} is up to date (or PyPI could not be reached)."
+                    f"smolvm {current} is up to date."
                 )
         else:
             data = {"current": current, "latest": latest, "update_available": True}

--- a/src/smolvm/cli/update.py
+++ b/src/smolvm/cli/update.py
@@ -17,6 +17,7 @@
 from __future__ import annotations
 
 import argparse
+import re
 import shutil
 import subprocess
 import sys
@@ -58,7 +59,7 @@ def _is_uv_tool_install() -> bool:
             capture_output=True,
             text=True,
         )
-        return "smolvm" in result.stdout
+        return bool(re.search(r"^smolvm[ \t]", result.stdout, re.MULTILINE))
     except OSError:
         return False
 
@@ -103,7 +104,10 @@ def run_update(args: argparse.Namespace) -> int:
                 if json_output:
                     emit_json("update", 1, data=data)
                 else:
-                    sys.stderr.write("Could not determine the installed smolvm version.\n")
+                    sys.stderr.write(
+                        "Could not determine the installed smolvm version. "
+                        "Run: pip install --upgrade smolvm\n"
+                    )
                 return 1
             data = {"current": current, "latest": None, "update_available": False}
             if json_output:
@@ -161,5 +165,7 @@ def run_update(args: argparse.Namespace) -> int:
         return returncode
 
     if returncode != 0:
-        sys.stderr.write("smolvm update failed. Check pip output above for details.\n")
+        sys.stderr.write(
+            "smolvm update failed. To retry, run: pip install --upgrade smolvm\n"
+        )
     return returncode

--- a/src/smolvm/cli/update.py
+++ b/src/smolvm/cli/update.py
@@ -1,0 +1,165 @@
+# Copyright 2026 Celesto AI
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""smolvm update — upgrade SmolVM to the latest stable release from PyPI."""
+
+from __future__ import annotations
+
+import argparse
+import shutil
+import subprocess
+import sys
+
+from smolvm.cli.output import console_stdout, emit_json
+from smolvm.cli.version_check import (
+    _fetch_latest_from_pypi,
+    _get_current_version,
+    _is_newer,
+)
+
+
+def _check_for_stable_update() -> tuple[str | None, str | None]:
+    """Return ``(current, latest)`` when an upgrade is available, else ``(current, None)``.
+
+    Never raises — any network failure silently returns ``(current, None)``.
+    """
+    current = _get_current_version()
+    latest = _fetch_latest_from_pypi()
+    if current is None or latest is None:
+        return current, None
+    if _is_newer(current, latest):
+        return current, latest
+    return current, None
+
+
+def _is_uv_tool_install() -> bool:
+    """Return True if smolvm was installed as a uv tool.
+
+    Checks whether the running smolvm executable lives inside uv's tool
+    bin directory, which is how ``uv tool install smolvm`` places it.
+    """
+    uv = shutil.which("uv")
+    if uv is None:
+        return False
+    try:
+        result = subprocess.run(
+            [uv, "tool", "list"],
+            capture_output=True,
+            text=True,
+        )
+        return "smolvm" in result.stdout
+    except OSError:
+        return False
+
+
+def _run_upgrade(*, json_output: bool) -> tuple[int, str]:
+    """Upgrade smolvm using the appropriate package manager and return ``(returncode, output)``.
+
+    Detects whether smolvm was installed via ``uv tool`` or ``pip`` and
+    calls the matching upgrade command. In terminal mode subprocess stdio
+    is inherited so output streams live to the user. In JSON mode
+    stdout+stderr are captured for embedding in the response payload.
+    """
+    if _is_uv_tool_install():
+        uv = shutil.which("uv") or "uv"
+        cmd = [uv, "tool", "upgrade", "smolvm"]
+    else:
+        cmd = [sys.executable, "-m", "pip", "install", "--upgrade", "smolvm"]
+
+    try:
+        if json_output:
+            result = subprocess.run(cmd, capture_output=True, text=True)
+            output = result.stdout + result.stderr
+            return result.returncode, output
+        else:
+            result = subprocess.run(cmd)
+            return result.returncode, ""
+    except OSError as exc:
+        return 1, str(exc)
+
+
+def run_update(args: argparse.Namespace) -> int:
+    """Execute ``smolvm update``."""
+    json_output: bool = getattr(args, "json", False)
+    check_only: bool = getattr(args, "check", False)
+
+    current, latest = _check_for_stable_update()
+
+    if check_only:
+        if latest is None:
+            if current is None:
+                data = {"current": None, "latest": None, "update_available": False}
+                if json_output:
+                    emit_json("update", 1, data=data)
+                else:
+                    sys.stderr.write("Could not determine the installed smolvm version.\n")
+                return 1
+            data = {"current": current, "latest": None, "update_available": False}
+            if json_output:
+                emit_json("update", 0, data=data)
+            else:
+                console = console_stdout()
+                console.print(
+                    f"smolvm {current} is up to date (or PyPI could not be reached)."
+                )
+        else:
+            data = {"current": current, "latest": latest, "update_available": True}
+            if json_output:
+                emit_json("update", 0, data=data)
+            else:
+                console = console_stdout()
+                console.print(
+                    f"Update available: {current} → {latest}. "
+                    f"Run [bold]smolvm update[/bold] to install."
+                )
+        return 0
+
+    if latest is None and current is not None:
+        if json_output:
+            emit_json(
+                "update",
+                0,
+                data={"current": current, "latest": current, "upgraded": False},
+            )
+        else:
+            console = console_stdout()
+            console.print(f"smolvm {current} is already the latest stable release.")
+        return 0
+
+    if not json_output:
+        console = console_stdout()
+        if latest:
+            console.print(f"Upgrading smolvm {current} → {latest} …")
+        else:
+            console.print("Upgrading smolvm to the latest stable release …")
+
+    returncode, pip_output = _run_upgrade(json_output=json_output)
+
+    if json_output:
+        new_version = _get_current_version()
+        emit_json(
+            "update",
+            returncode,
+            data={
+                "previous": current,
+                "current": new_version,
+                "upgraded": returncode == 0,
+                "pip_output": pip_output,
+            },
+        )
+        return returncode
+
+    if returncode != 0:
+        sys.stderr.write("smolvm update failed. Check pip output above for details.\n")
+    return returncode

--- a/tests/test_update.py
+++ b/tests/test_update.py
@@ -50,6 +50,7 @@ class TestCheckForStableUpdate:
             patch("smolvm.cli.update._fetch_latest_from_pypi", return_value=None),
         ):
             current, latest = _check_for_stable_update()
+            assert current == "1.0.0"
             assert latest is None
 
     def test_handles_missing_current_version(self) -> None:

--- a/tests/test_update.py
+++ b/tests/test_update.py
@@ -77,6 +77,15 @@ class TestIsUvToolInstall:
         ):
             assert _is_uv_tool_install() is True
 
+    def test_returns_false_when_only_smolvm_core_in_uv_tool_list(self) -> None:
+        mock_result = MagicMock()
+        mock_result.stdout = "smolvm-core v0.0.14\n"
+        with (
+            patch("smolvm.cli.update.shutil.which", return_value="/usr/bin/uv"),
+            patch("smolvm.cli.update.subprocess.run", return_value=mock_result),
+        ):
+            assert _is_uv_tool_install() is False
+
     def test_returns_false_when_smolvm_not_in_uv_tool_list(self) -> None:
         mock_result = MagicMock()
         mock_result.stdout = "other-tool v1.0\n"
@@ -108,6 +117,7 @@ class TestRunUpdate:
         assert rc == 1
         err = capsys.readouterr().err
         assert "Could not determine" in err
+        assert "pip install --upgrade smolvm" in err
 
     def test_check_only_update_available(self, capsys: pytest.CaptureFixture[str]) -> None:
         with (

--- a/tests/test_update.py
+++ b/tests/test_update.py
@@ -1,0 +1,168 @@
+# Copyright 2026 Celesto AI
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for smolvm update."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from smolvm.cli.update import _check_for_stable_update, _is_uv_tool_install, _run_upgrade, run_update
+
+
+class TestCheckForStableUpdate:
+    def test_returns_none_when_already_latest(self) -> None:
+        with (
+            patch("smolvm.cli.update._get_current_version", return_value="1.0.0"),
+            patch("smolvm.cli.update._fetch_latest_from_pypi", return_value="1.0.0"),
+        ):
+            current, latest = _check_for_stable_update()
+            assert current == "1.0.0"
+            assert latest is None
+
+    def test_returns_latest_when_update_available(self) -> None:
+        with (
+            patch("smolvm.cli.update._get_current_version", return_value="0.9.0"),
+            patch("smolvm.cli.update._fetch_latest_from_pypi", return_value="1.0.0"),
+        ):
+            current, latest = _check_for_stable_update()
+            assert current == "0.9.0"
+            assert latest == "1.0.0"
+
+    def test_returns_none_on_network_failure(self) -> None:
+        with (
+            patch("smolvm.cli.update._get_current_version", return_value="1.0.0"),
+            patch("smolvm.cli.update._fetch_latest_from_pypi", return_value=None),
+        ):
+            current, latest = _check_for_stable_update()
+            assert latest is None
+
+    def test_handles_missing_current_version(self) -> None:
+        with (
+            patch("smolvm.cli.update._get_current_version", return_value=None),
+            patch("smolvm.cli.update._fetch_latest_from_pypi", return_value="1.0.0"),
+        ):
+            current, latest = _check_for_stable_update()
+            assert current is None
+            assert latest is None
+
+
+class TestIsUvToolInstall:
+    def test_returns_false_when_uv_not_found(self) -> None:
+        with patch("smolvm.cli.update.shutil.which", return_value=None):
+            assert _is_uv_tool_install() is False
+
+    def test_returns_true_when_smolvm_in_uv_tool_list(self) -> None:
+        mock_result = MagicMock()
+        mock_result.stdout = "smolvm v0.0.19\n"
+        with (
+            patch("smolvm.cli.update.shutil.which", return_value="/usr/bin/uv"),
+            patch("smolvm.cli.update.subprocess.run", return_value=mock_result),
+        ):
+            assert _is_uv_tool_install() is True
+
+    def test_returns_false_when_smolvm_not_in_uv_tool_list(self) -> None:
+        mock_result = MagicMock()
+        mock_result.stdout = "other-tool v1.0\n"
+        with (
+            patch("smolvm.cli.update.shutil.which", return_value="/usr/bin/uv"),
+            patch("smolvm.cli.update.subprocess.run", return_value=mock_result),
+        ):
+            assert _is_uv_tool_install() is False
+
+
+class TestRunUpdate:
+    def _args(self, *, check: bool = False, json_output: bool = False) -> argparse.Namespace:
+        return argparse.Namespace(check=check, json=json_output)
+
+    def test_check_only_no_update(self, capsys: pytest.CaptureFixture[str]) -> None:
+        with (
+            patch("smolvm.cli.update._check_for_stable_update", return_value=("1.0.0", None)),
+        ):
+            rc = run_update(self._args(check=True))
+        assert rc == 0
+        out = capsys.readouterr().out
+        assert "up to date" in out
+
+    def test_check_only_unknown_version(self, capsys: pytest.CaptureFixture[str]) -> None:
+        with (
+            patch("smolvm.cli.update._check_for_stable_update", return_value=(None, None)),
+        ):
+            rc = run_update(self._args(check=True))
+        assert rc == 1
+        err = capsys.readouterr().err
+        assert "Could not determine" in err
+
+    def test_check_only_update_available(self, capsys: pytest.CaptureFixture[str]) -> None:
+        with (
+            patch("smolvm.cli.update._check_for_stable_update", return_value=("0.9.0", "1.0.0")),
+        ):
+            rc = run_update(self._args(check=True))
+        assert rc == 0
+        out = capsys.readouterr().out
+        assert "1.0.0" in out
+
+    def test_check_only_json_no_update(self, capsys: pytest.CaptureFixture[str]) -> None:
+        with (
+            patch("smolvm.cli.update._check_for_stable_update", return_value=("1.0.0", None)),
+        ):
+            rc = run_update(self._args(check=True, json_output=True))
+        assert rc == 0
+        payload = json.loads(capsys.readouterr().out)
+        assert payload["data"]["update_available"] is False
+
+    def test_already_latest_skips_pip(self, capsys: pytest.CaptureFixture[str]) -> None:
+        with (
+            patch("smolvm.cli.update._check_for_stable_update", return_value=("1.0.0", None)),
+            patch("smolvm.cli.update._run_upgrade") as mock_pip,
+        ):
+            rc = run_update(self._args())
+        assert rc == 0
+        mock_pip.assert_not_called()
+
+    def test_upgrade_calls_pip(self) -> None:
+        with (
+            patch("smolvm.cli.update._check_for_stable_update", return_value=("0.9.0", "1.0.0")),
+            patch("smolvm.cli.update._run_upgrade", return_value=(0, "")) as mock_pip,
+            patch("smolvm.cli.update._get_current_version", return_value="1.0.0"),
+        ):
+            rc = run_update(self._args())
+        assert rc == 0
+        mock_pip.assert_called_once_with(json_output=False)
+
+    def test_pip_failure_returns_nonzero(self, capsys: pytest.CaptureFixture[str]) -> None:
+        with (
+            patch("smolvm.cli.update._check_for_stable_update", return_value=("0.9.0", "1.0.0")),
+            patch("smolvm.cli.update._run_upgrade", return_value=(1, "error output")),
+            patch("smolvm.cli.update._get_current_version", return_value="0.9.0"),
+        ):
+            rc = run_update(self._args())
+        assert rc == 1
+
+    def test_upgrade_json_output(self, capsys: pytest.CaptureFixture[str]) -> None:
+        with (
+            patch("smolvm.cli.update._check_for_stable_update", return_value=("0.9.0", "1.0.0")),
+            patch("smolvm.cli.update._run_upgrade", return_value=(0, "Successfully installed smolvm-1.0.0")),
+            patch("smolvm.cli.update._get_current_version", return_value="1.0.0"),
+        ):
+            rc = run_update(self._args(json_output=True))
+        assert rc == 0
+        payload = json.loads(capsys.readouterr().out)
+        assert payload["data"]["upgraded"] is True
+        assert payload["data"]["current"] == "1.0.0"
+        assert payload["data"]["previous"] == "0.9.0"


### PR DESCRIPTION
## Summary

- Adds `smolvm update` to upgrade SmolVM to the latest stable PyPI release
- Detects install method at runtime (`uv tool` vs `pip`) and uses the matching upgrade command — mirrors what `install.sh` already does for upgrades
- Supports `--check` to report update availability without installing, and `--json` for machine-readable output

## Test plan

- [ ] `smolvm update --check` reports available update or confirms up to date
- [ ] `smolvm update` upgrades via `uv tool upgrade smolvm` when installed as a uv tool
- [ ] `smolvm update` falls back to `pip install --upgrade smolvm` for pip installs
- [ ] `smolvm update --json` emits structured JSON with `previous`, `current`, `upgraded`, `pip_output`
- [ ] `smolvm update --check --json` emits `update_available` boolean
- [ ] 15 unit tests pass: `uv run pytest tests/test_update.py`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a top-level update command to check for and apply new releases.
  * Check-only mode reports whether an update is available without installing.
  * JSON mode emits machine-readable results for automation and tooling.
  * Detects installation method and invokes the appropriate upgrade flow; surfaces progress and exit status.

* **Tests**
  * Added tests covering update checks, installer detection, upgrade execution, JSON output, and failure handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->