### PR TITLE
Fix QEMU snapshot inspection for locked disks

### DIFF
--- a/src/smolvm/runtime/qemu.py
+++ b/src/smolvm/runtime/qemu.py
@@ -524,7 +524,7 @@ class QemuRuntimeAdapter(RuntimeAdapter):
                 f"{_qemu_img_install_hint()}"
             )
         info = subprocess.run(
-            [str(qemu_img), "info", "--output=json", str(disk)],
+            [str(qemu_img), "info", "-U", "--output=json", str(disk)],
             capture_output=True,
             text=True,
             check=False,

--- a/tests/test_runtime_qemu.py
+++ b/tests/test_runtime_qemu.py
@@ -1,5 +1,6 @@
 """Unit tests for the QEMU runtime adapter."""
 
+import subprocess
 from pathlib import Path
 from unittest.mock import MagicMock, call, patch
 
@@ -98,3 +99,29 @@ def test_stop_raises_when_qemu_survives_hard_kill(tmp_path: Path) -> None:
         call(vm_info.pid, 5.0),
     ]
     context.unlink_socket.assert_not_called()
+
+
+def test_qcow2_backing_inspection_force_shares_running_qemu_disk(tmp_path: Path) -> None:
+    """Inspecting a paused-but-open QEMU disk must bypass qemu-img's image lock."""
+    disk = tmp_path / "vm.qcow2"
+    disk.touch()
+    result = subprocess.CompletedProcess(
+        args=[],
+        returncode=0,
+        stdout='{"full-backing-filename": "/tmp/base.qcow2"}',
+        stderr="",
+    )
+
+    with (
+        patch("smolvm.runtime.qemu.which", return_value=Path("/usr/bin/qemu-img")),
+        patch("smolvm.runtime.qemu.subprocess.run", return_value=result) as mock_run,
+    ):
+        backing = QemuRuntimeAdapter._qcow2_backing_file_required(disk)
+
+    assert backing == Path("/tmp/base.qcow2")
+    mock_run.assert_called_once_with(
+        ["/usr/bin/qemu-img", "info", "-U", "--output=json", str(disk)],
+        capture_output=True,
+        text=True,
+        check=False,
+    )


### PR DESCRIPTION
## Summary
- inspect QEMU qcow2 disks with `qemu-img info -U` during full/disk snapshot copying
- add a regression test for force-share inspection of paused-but-open QEMU disks

## Root cause
Live host snapshot sweeps had `qemu-img` installed, but SmolVM inspected running VM disks without force-share. QEMU still holds the qcow2 image lock while the VM is paused, so `qemu-img info` failed with: `Failed to get shared "write" lock`.

## Test
- `uv run pytest tests/test_runtime_qemu.py tests/test_snapshot_qemu.py`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced disk image inspection to properly handle open or actively-running images during snapshot backing file discovery and analysis

* **Tests**
  * Added test coverage for disk image backing file inspection with shared access scenarios

<!-- end of auto-generated comment: release notes by coderabbit.ai -->