### PR TITLE
Skip e2e CI for draft PRs

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -7,15 +7,18 @@
 # exercised over SSH and vsock; Firecracker is exercised over SSH.
 #
 # GH-hosted ubuntu-latest (x86) exposes /dev/kvm, so this runs with hardware
-# acceleration. The suite is short enough to gate every PR to main; the nightly
-# cron still runs to catch runner/environment drift on days with no PRs, and it
-# can be launched manually.
+# acceleration. The suite gates review-ready PRs and pushes to main; the
+# nightly cron still runs to catch runner/environment drift on days with no PRs,
+# and it can be launched manually.
 
 name: E2E (real KVM)
 
 on:
+  push:
+    branches: [main]
   pull_request:
     branches: [main]
+    types: [opened, synchronize, reopened, ready_for_review]
   schedule:
     # 03:17 UTC nightly (off the top of the hour to dodge cron congestion).
     - cron: "17 3 * * *"
@@ -33,6 +36,7 @@ permissions:
 
 jobs:
   e2e:
+    if: ${{ github.event_name != 'pull_request' || github.event.pull_request.draft == false }}
     name: ${{ matrix.backend }}
     runs-on: ubuntu-latest
     timeout-minutes: 30


### PR DESCRIPTION
## Summary

Update the real-KVM e2e workflow so draft PRs do not run the e2e matrix, while review-ready PRs and pushes to main still do.

## Related Issues

- None

## Testing

- `actionlint .github/workflows/e2e.yml`
- Ruby YAML parse for `.github/workflows/e2e.yml`

## Checklist

- [x] Scope is focused and limited to this change
- [x] Tests added/updated for behavior changes
- [x] Docs updated for user-visible changes
- [x] No secrets or sensitive data included


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated E2E testing workflow triggers to run on main branch pushes and pull requests with specific event types (opened, synchronize, reopened, ready_for_review).
  * Added automatic skipping of E2E tests for draft pull requests to optimize resource usage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->