### PR TITLE
[codex] Add guest agent release follow-ups

### DIFF
--- a/.github/workflows/build-microvm-kernel.yml
+++ b/.github/workflows/build-microvm-kernel.yml
@@ -21,7 +21,7 @@ on:
     inputs:
       release_tag:
         description: >-
-          Release tag to upload to (e.g. images-v0.0.14a0). Created as a
+          Release tag to upload to (e.g. images-2026.06.12.0). Created as a
           draft if missing. Leave empty to use IMAGES_RELEASE_TAG from
           published.py.
         type: string

--- a/.github/workflows/build-published-images.yml
+++ b/.github/workflows/build-published-images.yml
@@ -32,7 +32,7 @@ on:
         default: "all"
       release_tag:
         description: >-
-          Release tag (e.g. images-v0.0.13). Created as draft if missing.
+          Release tag (e.g. images-2026.06.12.0). Created as draft if missing.
           Leave empty to use IMAGES_RELEASE_TAG from published.py.
         type: string
         default: ""
@@ -90,6 +90,146 @@ jobs:
           name: base-rootfs-${{ matrix.os }}-${{ matrix.arch }}
           path: /tmp/base/base-rootfs.ext4
           retention-days: 1
+
+  # ── Standalone Rust guest-agent binaries ─────────────────────
+  #
+  # Rootfs jobs bake this same binary into /usr/local/bin. Uploading it once
+  # per architecture gives users and production builders a provenance/debug
+  # artifact without making the private Celesto repo the source of truth.
+  guest-agent-binaries:
+    strategy:
+      fail-fast: false
+      matrix:
+        arch: [amd64, arm64]
+    runs-on: ${{ matrix.arch == 'arm64' && 'ubuntu-24.04-arm' || 'ubuntu-latest' }}
+    timeout-minutes: 10
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Install Rust musl target
+        env:
+          ARCH: ${{ matrix.arch }}
+        run: |
+          case "$ARCH" in
+            amd64) target="x86_64-unknown-linux-musl" ;;
+            arm64) target="aarch64-unknown-linux-musl" ;;
+            *) echo "Unsupported arch: $ARCH" >&2; exit 1 ;;
+          esac
+          rustup target add "$target"
+
+      - name: Cache Rust build
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: rust-${{ runner.os }}-${{ matrix.arch }}-${{ hashFiles('Cargo.lock', 'Cargo.toml', 'smolvm-core/Cargo.toml', 'guest-agent/Cargo.toml') }}
+          restore-keys: rust-${{ runner.os }}-${{ matrix.arch }}-
+
+      - name: Resolve release tag
+        id: release
+        env:
+          INPUT_TAG: ${{ inputs.release_tag }}
+        run: |
+          if [ -n "$INPUT_TAG" ]; then
+            tag="$INPUT_TAG"
+          else
+            # Single source of truth — published.py::IMAGES_RELEASE_TAG.
+            # Read as string rather than importing: avoids forcing every
+            # job to install smolvm's Python deps just to print one tag.
+            tag=$(awk -F'"' '/^IMAGES_RELEASE_TAG[[:space:]]*=/{print $2; exit}' src/smolvm/images/published.py)
+          fi
+          if [ -z "$tag" ]; then
+            echo "ERROR: IMAGES_RELEASE_TAG could not be parsed from src/smolvm/images/published.py" >&2
+            exit 1
+          fi
+          echo "tag=${tag}" >> "$GITHUB_OUTPUT"
+          echo "Release tag: ${tag}"
+
+      - name: Build Rust guest agent
+        id: build
+        env:
+          ARCH: ${{ matrix.arch }}
+        run: |
+          case "$ARCH" in
+            amd64)
+              target="x86_64-unknown-linux-musl"
+              asset_name="smolvm-guest-agent-linux-amd64"
+              ;;
+            arm64)
+              target="aarch64-unknown-linux-musl"
+              asset_name="smolvm-guest-agent-linux-arm64"
+              ;;
+            *) echo "Unsupported arch: $ARCH" >&2; exit 1 ;;
+          esac
+          cargo build --release --target "$target" -p smolvm-guest-agent
+          cp "target/${target}/release/smolvm-guest-agent" "$asset_name"
+          chmod 0755 "$asset_name"
+          echo "asset_name=${asset_name}" >> "$GITHUB_OUTPUT"
+
+      - name: Compute SHA-256
+        id: sha
+        env:
+          ASSET_NAME: ${{ steps.build.outputs.asset_name }}
+        run: |
+          binary_sha=$(sha256sum "$ASSET_NAME" | cut -d' ' -f1)
+          binary_size=$(stat -c '%s' "$ASSET_NAME")
+          printf '%s  %s\n' "$binary_sha" "$ASSET_NAME" > "${ASSET_NAME}.sha256"
+          {
+            echo "binary_sha=${binary_sha}"
+            echo "binary_size=${binary_size}"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Upload to GitHub Releases (draft)
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG: ${{ steps.release.outputs.tag }}
+          ASSET_NAME: ${{ steps.build.outputs.asset_name }}
+          FORCE_OVERWRITE: ${{ inputs.force_overwrite }}
+        run: |
+          if ! gh release view "$TAG" --repo "$GITHUB_REPOSITORY" >/dev/null 2>&1; then
+            gh release create "$TAG" \
+              --repo "$GITHUB_REPOSITORY" \
+              --draft \
+              --title "Published images $TAG" \
+              --notes "Auto-generated draft release for SmolVM published images. Verify SHA-256 sums and content before publishing." \
+              || echo "Draft already exists (race with another matrix cell), continuing."
+          fi
+
+          upload_args=()
+          if [ "${FORCE_OVERWRITE:-false}" = "true" ]; then
+            upload_args+=(--clobber)
+          fi
+          gh release upload "$TAG" \
+            --repo "$GITHUB_REPOSITORY" \
+            "${upload_args[@]}" \
+            "$ASSET_NAME" \
+            "${ASSET_NAME}.sha256"
+
+      - name: Step summary
+        env:
+          ASSET_NAME: ${{ steps.build.outputs.asset_name }}
+          TAG: ${{ steps.release.outputs.tag }}
+          BINARY_SHA: ${{ steps.sha.outputs.binary_sha }}
+          BINARY_SIZE: ${{ steps.sha.outputs.binary_size }}
+        run: |
+          {
+            echo "## Guest agent binary: \`${ASSET_NAME}\`"
+            echo ""
+            echo "Uploaded to draft release [\`${TAG}\`](https://github.com/${GITHUB_REPOSITORY}/releases/tag/${TAG})."
+            echo ""
+            echo "| File | Size | SHA-256 |"
+            echo "| --- | --- | --- |"
+            echo "| ${ASSET_NAME} | $(numfmt --to=iec-i --suffix=B ${BINARY_SIZE}) | \`${BINARY_SHA}\` |"
+          } >> "$GITHUB_STEP_SUMMARY"
 
   # ── Stage 2a: Build openclaw (custom builder, not layered) ────
   #

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -40,11 +40,6 @@ jobs:
     name: ${{ matrix.backend }}
     runs-on: ubuntu-latest
     timeout-minutes: 30
-    env:
-      # PRs may bump IMAGES_RELEASE_TAG before the draft image release exists.
-      # Use the last published assets for real-KVM behavior; push/nightly/manual
-      # runs use the CalVer tag from published.py.
-      SMOLVM_IMAGES_RELEASE_TAG: ${{ github.event_name == 'pull_request' && 'images-v0.0.16' || '' }}
     strategy:
       fail-fast: false
       matrix:
@@ -55,6 +50,25 @@ jobs:
         uses: actions/checkout@v4
         with:
           persist-credentials: false
+
+      - name: Resolve PR image release fallback
+        id: image_release_fallback
+        if: github.event_name == 'pull_request'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          # PRs may bump IMAGES_RELEASE_TAG before the draft image release exists.
+          # Use the newest published images-* release for real-KVM behavior.
+          tag=$(
+            gh api "/repos/${{ github.repository }}/releases?per_page=100" \
+              --jq '[.[] | select(.draft == false and .prerelease == false) | .tag_name | select(startswith("images-"))][0]'
+          )
+          if [[ -z "$tag" || "$tag" == "null" ]]; then
+            echo "No published images-* GitHub Release was found for PR E2E fallback." >&2
+            exit 1
+          fi
+          echo "tag=$tag" >> "$GITHUB_OUTPUT"
+          echo "Using published image release fallback: $tag"
 
       - name: Set up Python 3.13
         uses: actions/setup-python@v5
@@ -125,6 +139,8 @@ jobs:
         run: sudo -n -E -u "$USER" -g kvm -- env "PATH=$PATH" "$(command -v uv)" run smolvm doctor --backend "${{ matrix.backend }}" || true
 
       - name: Run e2e suite
+        env:
+          SMOLVM_IMAGES_RELEASE_TAG: ${{ steps.image_release_fallback.outputs.tag }}
         run: sudo -n -E -u "$USER" -g kvm -- env "PATH=$PATH" "SMOLVM_IMAGES_RELEASE_TAG=${SMOLVM_IMAGES_RELEASE_TAG:-}" "$(command -v uv)" run pytest -m e2e tests/e2e -v --e2e-backend "${{ matrix.backend }}"
 
       - name: Dump VM logs on failure

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -40,6 +40,11 @@ jobs:
     name: ${{ matrix.backend }}
     runs-on: ubuntu-latest
     timeout-minutes: 30
+    env:
+      # PRs may bump IMAGES_RELEASE_TAG before the draft image release exists.
+      # Use the last published assets for real-KVM behavior; push/nightly/manual
+      # runs use the CalVer tag from published.py.
+      SMOLVM_IMAGES_RELEASE_TAG: ${{ github.event_name == 'pull_request' && 'images-v0.0.16' || '' }}
     strategy:
       fail-fast: false
       matrix:
@@ -120,7 +125,7 @@ jobs:
         run: sudo -n -E -u "$USER" -g kvm -- env "PATH=$PATH" "$(command -v uv)" run smolvm doctor --backend "${{ matrix.backend }}" || true
 
       - name: Run e2e suite
-        run: sudo -n -E -u "$USER" -g kvm -- env "PATH=$PATH" "$(command -v uv)" run pytest -m e2e tests/e2e -v --e2e-backend "${{ matrix.backend }}"
+        run: sudo -n -E -u "$USER" -g kvm -- env "PATH=$PATH" "SMOLVM_IMAGES_RELEASE_TAG=${SMOLVM_IMAGES_RELEASE_TAG:-}" "$(command -v uv)" run pytest -m e2e tests/e2e -v --e2e-backend "${{ matrix.backend }}"
 
       - name: Dump VM logs on failure
         if: failure()

--- a/.github/workflows/smoke-published-images.yml
+++ b/.github/workflows/smoke-published-images.yml
@@ -31,8 +31,8 @@ on:
     inputs:
       release_tag:
         description: >-
-          Release tag to smoke-test (e.g. images-v0.0.14a0). Leave empty to
-          derive from pyproject version (matches the build-* workflows).
+          Release tag to smoke-test (e.g. images-2026.06.12.0). Leave empty
+          to use IMAGES_RELEASE_TAG from published.py.
         type: string
         default: ""
   workflow_run:
@@ -92,8 +92,12 @@ jobs:
           if [ -n "${INPUT_TAG:-}" ]; then
             tag="$INPUT_TAG"
           else
-            version=$(python3 -c "import tomllib; print(tomllib.load(open('pyproject.toml','rb'))['project']['version'])")
-            tag="images-v${version}"
+            # Single source of truth — published.py::IMAGES_RELEASE_TAG.
+            tag=$(awk -F'"' '/^IMAGES_RELEASE_TAG[[:space:]]*=/{print $2; exit}' src/smolvm/images/published.py)
+          fi
+          if [ -z "$tag" ]; then
+            echo "ERROR: IMAGES_RELEASE_TAG could not be parsed from src/smolvm/images/published.py" >&2
+            exit 1
           fi
           echo "tag=${tag}" >> "$GITHUB_OUTPUT"
 

--- a/docs/deep-dive/microvm-from-first-principles.md
+++ b/docs/deep-dive/microvm-from-first-principles.md
@@ -429,7 +429,7 @@ These are intentionally separate. CLI bumps happen for any user-facing change (b
 
 But the decoupling needs to be explicit. The previous `_MANIFEST_VERSION` constant was a string version like `"0.0.14a0"` that *looked* like it should track `__version__`. When the CLI bumped to `0.0.14a1` and `_MANIFEST_VERSION` stayed at `0.0.14a0`, the CI workflows derived the upload tag from `pyproject` (`images-v0.0.14a1`) while the runtime looked for `images-v0.0.14a0`. Silent drift.
 
-The fix was to rename the constant to `IMAGES_RELEASE_TAG`, change its value from a version fragment to a full tag string like `"images-v0.0.14a0"`, and have CI workflows read it from the source file (not derive from pyproject). Now there is exactly one place to bump the image release tag, and it's named to make clear it's not the CLI version.
+The fix was to rename the constant to `IMAGES_RELEASE_TAG`, change its value from a version fragment to a full tag string, and have CI workflows read it from the source file (not derive from pyproject). Image/rootfs tags now use CalVer (calendar versioning), for example `images-2026.06.12.0`, because they are content snapshots with their own cadence. Now there is exactly one place to bump the image release tag, and it's named to make clear it's not the CLI version.
 
 ### The `--clobber` trap
 

--- a/src/smolvm/images/published.py
+++ b/src/smolvm/images/published.py
@@ -36,6 +36,7 @@ is policy-free.
 
 from __future__ import annotations
 
+import os
 from pathlib import Path
 from typing import Literal
 
@@ -141,6 +142,16 @@ class BaseKernel(BaseModel):
 IMAGES_RELEASE_TAG = "images-2026.06.12.0"
 
 
+def _images_release_tag() -> str:
+    """Return the image release tag used when constructing download URLs.
+
+    ``IMAGES_RELEASE_TAG`` remains the public source of truth. The environment
+    override is for CI jobs that need to test a branch before the bumped image
+    release has been published.
+    """
+    return os.environ.get("SMOLVM_IMAGES_RELEASE_TAG") or IMAGES_RELEASE_TAG
+
+
 def cache_name(
     preset: Preset, arch: Arch, vmm: Vmm, version: str = __version__, *, os: Os = "ubuntu"
 ) -> str:
@@ -173,7 +184,7 @@ def _release_asset_url(preset: Preset, arch: Arch, suffix: str, os: Os = "ubuntu
     segment. ``scripts/ci/build-preset.sh`` mirrors this on the upload side.
     """
     slug = f"{preset}-{arch}-{suffix}" if os == "ubuntu" else f"{preset}-{arch}-{os}-{suffix}"
-    return f"https://github.com/CelestoAI/SmolVM/releases/download/{IMAGES_RELEASE_TAG}/{slug}"
+    return f"https://github.com/CelestoAI/SmolVM/releases/download/{_images_release_tag()}/{slug}"
 
 
 def _release_kernel_url(arch: Arch, fmt: KernelFormat) -> str:
@@ -185,7 +196,7 @@ def _release_kernel_url(arch: Arch, fmt: KernelFormat) -> str:
     """
     return (
         f"https://github.com/CelestoAI/SmolVM/releases/download/"
-        f"{IMAGES_RELEASE_TAG}/vmlinux-{arch}.{fmt}"
+        f"{_images_release_tag()}/vmlinux-{arch}.{fmt}"
     )
 
 

--- a/src/smolvm/images/published.py
+++ b/src/smolvm/images/published.py
@@ -15,9 +15,11 @@
 """Published pre-built VM images for SmolVM presets.
 
 Images are built and signed in CI, hosted on GitHub Releases, and pinned
-lock-step to the CLI version: SmolVM ``X.Y.Z`` always pulls images from
-the ``images-vX.Y.Z`` release tag. The ``MANIFEST`` below is the bundled
-catalog the CLI ships with — entries are appended as CI publishes them.
+to a content release tag such as ``images-2026.06.12.0``. This tag is
+intentionally independent of the SmolVM package version because image and
+rootfs rebuilds have their own cadence. The ``MANIFEST`` below is the
+bundled catalog the CLI ships with — entries are appended as CI publishes
+them.
 
 Resolution flow: ``ensure_published_image(preset, arch, vmm)`` looks up the
 matching entry, converts it to an :class:`ImageSource`, delegates to
@@ -125,7 +127,8 @@ class BaseKernel(BaseModel):
 # deriving from pyproject — change here flows to both sides.
 #
 # Bumping protocol — one PR:
-#   1. Edit this string (e.g. ``images-v0.0.15``).
+#   1. Edit this CalVer string (e.g. ``images-2026.06.12.0``).
+#      Bump the final sequence when publishing more than once on a day.
 #   2. Run the kernel + published-image workflows, copy SHAs from the
 #      step summaries into ``BASE_KERNELS`` and ``MANIFEST``.
 #   3. Promote the draft release on GitHub.
@@ -135,7 +138,7 @@ class BaseKernel(BaseModel):
 # upload step instead of silently swapping bytes under the existing
 # pins. Re-bakes against the same tag must opt in via the
 # ``force_overwrite`` workflow_dispatch input.
-IMAGES_RELEASE_TAG = "images-v0.0.16"
+IMAGES_RELEASE_TAG = "images-2026.06.12.0"
 
 
 def cache_name(

--- a/tests/e2e/test_lifecycle.py
+++ b/tests/e2e/test_lifecycle.py
@@ -43,8 +43,8 @@ from _util import (
 )
 
 from smolvm import SmolVM
-from smolvm.exceptions import SmolVMError, VMNotFoundError
-from smolvm.runtime.backends import BACKEND_FIRECRACKER, BACKEND_QEMU
+from smolvm.exceptions import VMNotFoundError
+from smolvm.runtime.backends import BACKEND_FIRECRACKER
 from smolvm.types import SnapshotType, VMState
 
 pytestmark = pytest.mark.e2e
@@ -122,27 +122,7 @@ def test_stop_and_cleanup(vm: SmolVM) -> None:
 # ---------------------------------------------------------------------------
 
 
-@pytest.mark.parametrize(
-    "backend",
-    [
-        pytest.param(
-            BACKEND_QEMU,
-            marks=pytest.mark.xfail(
-                reason=(
-                    "QEMU snapshot RESTORE is currently broken on the isolated-disk "
-                    "overlay: loadvm reports \"Device 'rootdisk0-drive' is writable but "
-                    'does not support snapshots". Snapshot *creation* works; restore needs '
-                    "a runtime fix (attach the restored root disk as a snapshot-capable "
-                    "qcow2 node). Remove this xfail once restore lands."
-                ),
-                raises=SmolVMError,
-                strict=False,
-            ),
-        ),
-        *[backend for backend in E2E_BACKENDS if backend != BACKEND_QEMU],
-    ],
-    ids=str,
-)
+@pytest.mark.parametrize("backend", E2E_BACKENDS, ids=str)
 def test_snapshot_restore(backend: E2EBackend, request: pytest.FixtureRequest) -> None:
     """Snapshot a VM, restore it, and confirm guest state survived.
 

--- a/tests/test_guest_agent_image.py
+++ b/tests/test_guest_agent_image.py
@@ -22,6 +22,7 @@ import pytest
 
 from smolvm.images import builder as builder_mod
 from smolvm.images.builder import ImageBuilder
+from smolvm.images.published import IMAGES_RELEASE_TAG
 
 _REPO_ROOT = Path(__file__).resolve().parents[1]
 
@@ -66,7 +67,7 @@ def test_published_image_workflow_uploads_guest_agent_binaries() -> None:
 def test_smoke_published_images_uses_pinned_image_release_tag() -> None:
     """The smoke workflow should read the same image tag as build workflows."""
     workflow = (_REPO_ROOT / ".github" / "workflows" / "smoke-published-images.yml").read_text()
-    assert "images-2026.06.12.0" in workflow
+    assert IMAGES_RELEASE_TAG in workflow
     assert "IMAGES_RELEASE_TAG" in workflow
     assert "pyproject.toml" not in workflow
     assert "images-v${version}" not in workflow

--- a/tests/test_guest_agent_image.py
+++ b/tests/test_guest_agent_image.py
@@ -52,6 +52,26 @@ def test_ci_build_preset_bakes_guest_agent() -> None:
     assert "/usr/local/bin/smolvm-guest-agent" in script
 
 
+def test_published_image_workflow_uploads_guest_agent_binaries() -> None:
+    """The image release workflow should publish standalone guest-agent binaries."""
+    workflow = (_REPO_ROOT / ".github" / "workflows" / "build-published-images.yml").read_text()
+    assert "guest-agent-binaries:" in workflow
+    assert 'cargo build --release --target "$target" -p smolvm-guest-agent' in workflow
+    assert "smolvm-guest-agent-linux-amd64" in workflow
+    assert "smolvm-guest-agent-linux-arm64" in workflow
+    assert '"$ASSET_NAME"' in workflow
+    assert '"${ASSET_NAME}.sha256"' in workflow
+
+
+def test_smoke_published_images_uses_pinned_image_release_tag() -> None:
+    """The smoke workflow should read the same image tag as build workflows."""
+    workflow = (_REPO_ROOT / ".github" / "workflows" / "smoke-published-images.yml").read_text()
+    assert "images-2026.06.12.0" in workflow
+    assert "IMAGES_RELEASE_TAG" in workflow
+    assert "pyproject.toml" not in workflow
+    assert "images-v${version}" not in workflow
+
+
 def test_guest_agent_source_digest_tracks_rust_crate() -> None:
     digest = builder_mod._guest_agent_source_digest()
     assert len(digest) == 64

--- a/tests/test_published_images.py
+++ b/tests/test_published_images.py
@@ -15,6 +15,7 @@
 """Tests for the published-image manifest and resolution path."""
 
 import hashlib
+import re
 from collections import defaultdict
 from pathlib import Path
 from unittest.mock import MagicMock, patch
@@ -91,9 +92,9 @@ def sample_manifest(
 
 class TestNaming:
     def test_release_tag_constant_format(self) -> None:
-        # Sanity: the tag still resembles a release identifier so any
-        # downstream tooling that parses it doesn't break silently.
-        assert IMAGES_RELEASE_TAG.startswith("images-v")
+        # Image/rootfs releases use CalVer because they are content snapshots,
+        # not SmolVM package releases.
+        assert re.fullmatch(r"images-\d{4}\.\d{2}\.\d{2}\.\d+", IMAGES_RELEASE_TAG)
 
     def test_cache_name_includes_preset_version_arch_vmm(self) -> None:
         assert (
@@ -638,7 +639,7 @@ class TestBaseKernels:
         assert len(entry.image_sha256) == 64
         assert entry.elf_url.endswith("vmlinux-amd64.elf")
         assert entry.image_url.endswith("vmlinux-amd64.image")
-        assert "images-v" in entry.elf_url
+        assert "images-" in entry.elf_url
 
     def test_arm64_entry_shape(self) -> None:
         entry = BASE_KERNELS.get("arm64")
@@ -743,7 +744,7 @@ class TestBundledManifest:
         assert entry.rootfs_url.endswith("openclaw-amd64-rootfs.ext4.zst")
         # Firecracker rows get the ELF-format kernel.
         assert entry.kernel_url.endswith("vmlinux-amd64.elf")
-        assert "images-v" in entry.rootfs_url
+        assert "images-" in entry.rootfs_url
 
     def test_openclaw_arm64_firecracker_entry_shape(self) -> None:
         entry = MANIFEST.get(("openclaw", "arm64", "firecracker", "ubuntu"))

--- a/tests/test_published_images.py
+++ b/tests/test_published_images.py
@@ -23,6 +23,7 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 from smolvm.exceptions import ImageError
+from smolvm.images import published as published_module
 from smolvm.images.manager import LocalImage
 from smolvm.images.published import (
     BASE_KERNELS,
@@ -95,6 +96,20 @@ class TestNaming:
         # Image/rootfs releases use CalVer because they are content snapshots,
         # not SmolVM package releases.
         assert re.fullmatch(r"images-\d{4}\.\d{2}\.\d{2}\.\d+", IMAGES_RELEASE_TAG)
+
+    def test_release_url_uses_env_override_when_set(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("SMOLVM_IMAGES_RELEASE_TAG", "images-v0.0.16")
+
+        assert published_module._images_release_tag() == "images-v0.0.16"
+        assert "/images-v0.0.16/" in published_module._release_kernel_url("amd64", "elf")
+        assert "/images-v0.0.16/" in published_module._release_asset_url(
+            "openclaw", "amd64", "rootfs.ext4.zst"
+        )
+
+    def test_empty_release_tag_env_uses_pinned_tag(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("SMOLVM_IMAGES_RELEASE_TAG", "")
+
+        assert published_module._images_release_tag() == IMAGES_RELEASE_TAG
 
     def test_cache_name_includes_preset_version_arch_vmm(self) -> None:
         assert (


### PR DESCRIPTION
## Summary

- switch published image/rootfs release tags to CalVer (`images-YYYY.MM.DD.N`) instead of SmolVM semver-shaped tags
- make the smoke-published-images workflow read `IMAGES_RELEASE_TAG` from `published.py`, matching the build workflows
- publish standalone `smolvm-guest-agent` Linux binaries for amd64 and arm64 from the published-image workflow
- include `.sha256` files for those binaries in the same draft GitHub release
- remove the stale QEMU snapshot-restore e2e xfail now that restore passes
- add regression tests for guest-agent binary assets, CalVer tag shape, and smoke workflow tag resolution

## Why

Image/rootfs artifacts are content snapshots, not package releases. They drift independently from the SmolVM Python package version, so `images-2026.06.12.0` is clearer than a tag that looks tied to `pyproject.toml`.

The Rust guest-agent is now the public SmolVM control-plane core. Publishing the binary alongside rootfs assets gives us a provenance/debug artifact without depending on the private Celesto repo, while the rootfs pipeline continues to build and bake from SmolVM source.

## Release note

This PR intentionally remains draft until the new `images-2026.06.12.0` draft release is built, smoke-tested, and the generated kernel/rootfs SHAs are copied back into `BASE_KERNELS` and `MANIFEST`.

## Validation

- `uv run ruff format src/smolvm/images/published.py tests/test_published_images.py tests/test_guest_agent_image.py`
- `uv run ruff check src/smolvm/images/published.py tests/test_published_images.py tests/test_guest_agent_image.py`
- `uv run pytest tests/test_published_images.py tests/test_guest_agent_image.py`
- `uv run pytest -m e2e tests/e2e --e2e-backend all -q`
- `uv run pytest`
- `cargo test -p smolvm-guest-agent`
- YAML parse check for build-published-images, build-microvm-kernel, and smoke-published-images workflows


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **CI/CD Improvements**
  * Built guest-agent binaries for amd64/arm64 with SHA-256 and draft-release upload/overwrite support.
  * Centralized image release tag resolution; image tags now use CalVer (e.g., images-2026.06.12.0) and workflow dispatch inputs clarified.
  * e2e workflow exposes the images release tag to test runs as an environment variable.

* **Documentation**
  * Clarified image release tagging, CalVer usage, and content-snapshot cadence.

* **Tests**
  * Added/updated tests validating guest-agent publishing and pinned image-release tag behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->