### PR TITLE
[codex] Fix draft image release workflows

### DIFF
--- a/.github/workflows/build-published-images.yml
+++ b/.github/workflows/build-published-images.yml
@@ -331,11 +331,29 @@ jobs:
           echo "tag=${tag}" >> "$GITHUB_OUTPUT"
           echo "Release tag: ${tag}"
 
+      - name: Download OpenClaw kernel
+        if: steps.filter.outputs.skip != 'true'
+        id: openclaw_kernel
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG: ${{ steps.release.outputs.tag }}
+          ARCH: ${{ matrix.arch }}
+        run: |
+          mkdir -p kernel-assets
+          gh release download "$TAG" \
+            --repo "$GITHUB_REPOSITORY" \
+            --pattern "vmlinux-${ARCH}.elf" \
+            -D kernel-assets
+          kernel_path="$PWD/kernel-assets/vmlinux-${ARCH}.elf"
+          test -s "$kernel_path"
+          echo "path=$kernel_path" >> "$GITHUB_OUTPUT"
+
       - name: Build openclaw image
         if: steps.filter.outputs.skip != 'true'
         id: build
         env:
           ARCH: ${{ matrix.arch }}
+          KERNEL_PATH: ${{ steps.openclaw_kernel.outputs.path }}
         run: |
           uv run python <<'PY'
           import os
@@ -343,12 +361,14 @@ jobs:
           from smolvm.images.builder import ImageBuilder
 
           arch = os.environ["ARCH"]
+          kernel_url = Path(os.environ["KERNEL_PATH"]).resolve().as_uri()
           name = f"openclaw-{arch}"
 
           builder = ImageBuilder()
           kernel, rootfs = builder.build_openclaw_rootfs(
               name=name,
               rootfs_size_mb=4096,
+              kernel_url=kernel_url,
           )
 
           with Path(os.environ["GITHUB_OUTPUT"]).open("a", encoding="utf-8") as fh:

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -51,24 +51,42 @@ jobs:
         with:
           persist-credentials: false
 
-      - name: Resolve PR image release fallback
+      - name: Resolve image release fallback
         id: image_release_fallback
-        if: github.event_name == 'pull_request'
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
-          # PRs may bump IMAGES_RELEASE_TAG before the draft image release exists.
-          # Use the newest published images-* release for real-KVM behavior.
-          tag=$(
+          source_tag=$(awk -F'"' '/^IMAGES_RELEASE_TAG[[:space:]]*=/{print $2; exit}' src/smolvm/images/published.py)
+          if [ -z "$source_tag" ]; then
+            echo "ERROR: IMAGES_RELEASE_TAG could not be parsed from src/smolvm/images/published.py" >&2
+            exit 1
+          fi
+
+          published_tag=$(
+            gh api "/repos/${{ github.repository }}/releases?per_page=100" \
+              --jq ".[] | select(.tag_name == \"$source_tag\" and .draft == false and .prerelease == false) | .tag_name" \
+              | head -n1
+          )
+          if [ "$published_tag" = "$source_tag" ]; then
+            echo "tag=" >> "$GITHUB_OUTPUT"
+            echo "Using pinned published image release: $source_tag"
+            exit 0
+          fi
+
+          fallback=$(
             gh api "/repos/${{ github.repository }}/releases?per_page=100" \
               --jq '[.[] | select(.draft == false and .prerelease == false) | .tag_name | select(startswith("images-"))][0]'
           )
-          if [[ -z "$tag" || "$tag" == "null" ]]; then
-            echo "No published images-* GitHub Release was found for PR E2E fallback." >&2
+          if [[ -z "$fallback" || "$fallback" == "null" ]]; then
+            echo "No published images-* GitHub Release was found for E2E fallback." >&2
             exit 1
           fi
-          echo "tag=$tag" >> "$GITHUB_OUTPUT"
-          echo "Using published image release fallback: $tag"
+          gh api \
+            -H "Accept: application/vnd.github.raw" \
+            "/repos/${{ github.repository }}/contents/src/smolvm/images/published.py?ref=$fallback" \
+            > src/smolvm/images/published.py
+          echo "tag=" >> "$GITHUB_OUTPUT"
+          echo "Pinned image release $source_tag is not public yet; using published-image catalog from $fallback"
 
       - name: Set up Python 3.13
         uses: actions/setup-python@v5

--- a/.github/workflows/smoke-published-images.yml
+++ b/.github/workflows/smoke-published-images.yml
@@ -38,18 +38,20 @@ on:
   workflow_run:
     # NB: these are matched by the upstream workflow's `name:` field (the
     # display name), NOT the YAML filename. Keep them in sync with
-    # build-microvm-kernel.yml (`name: Build microvm Kernel`) and
     # build-published-images.yml (`name: Build Published Images`). Renaming
-    # either workflow's display name without updating this list silently
-    # disables the smoke gate.
-    workflows: ["Build microvm Kernel", "Build Published Images"]
+    # that workflow's display name without updating this list silently disables
+    # the smoke gate. Kernel-only builds do not produce rootfs assets, so they
+    # cannot trigger this workflow.
+    workflows: ["Build Published Images"]
     types:
       - completed
     branches:
       - main
 
 permissions:
-  contents: read
+  # Draft release assets require an authenticated token with repository write
+  # access; otherwise `gh release download` reports "release not found".
+  contents: write
 
 jobs:
   smoke:

--- a/tests/test_guest_agent_image.py
+++ b/tests/test_guest_agent_image.py
@@ -64,6 +64,26 @@ def test_published_image_workflow_uploads_guest_agent_binaries() -> None:
     assert '"${ASSET_NAME}.sha256"' in workflow
 
 
+def test_published_image_workflow_openclaw_uses_authenticated_kernel_download() -> None:
+    """OpenClaw builds must not fetch draft kernel assets via public URLs."""
+    workflow = (_REPO_ROOT / ".github" / "workflows" / "build-published-images.yml").read_text()
+    assert "Download OpenClaw kernel" in workflow
+    assert "vmlinux-${ARCH}.elf" in workflow
+    assert "KERNEL_PATH: ${{ steps.openclaw_kernel.outputs.path }}" in workflow
+    assert "kernel_url=kernel_url" in workflow
+
+
+def test_e2e_uses_image_release_fallback_until_pinned_release_is_public() -> None:
+    workflow = (_REPO_ROOT / ".github" / "workflows" / "e2e.yml").read_text()
+    assert "Resolve image release fallback" in workflow
+    assert "draft == false and .prerelease == false" in workflow
+    assert "application/vnd.github.raw" in workflow
+    assert "contents/src/smolvm/images/published.py?ref=$fallback" in workflow
+    assert "using published-image catalog from $fallback" in workflow
+    assert "SMOLVM_IMAGES_RELEASE_TAG=${SMOLVM_IMAGES_RELEASE_TAG:-}" in workflow
+    assert "github.event_name == 'pull_request'" not in workflow
+
+
 def test_smoke_published_images_uses_pinned_image_release_tag() -> None:
     """The smoke workflow should read the same image tag as build workflows."""
     workflow = (_REPO_ROOT / ".github" / "workflows" / "smoke-published-images.yml").read_text()
@@ -71,6 +91,13 @@ def test_smoke_published_images_uses_pinned_image_release_tag() -> None:
     assert "IMAGES_RELEASE_TAG" in workflow
     assert "pyproject.toml" not in workflow
     assert "images-v${version}" not in workflow
+
+
+def test_smoke_published_images_waits_for_rootfs_publish() -> None:
+    workflow = (_REPO_ROOT / ".github" / "workflows" / "smoke-published-images.yml").read_text()
+    assert 'workflows: ["Build Published Images"]' in workflow
+    assert "Build microvm Kernel" not in workflow
+    assert "contents: write" in workflow
 
 
 def test_guest_agent_source_digest_tracks_rust_crate() -> None:


### PR DESCRIPTION
## Summary

- Download OpenClaw kernel assets from the draft images release with authenticated `gh release download` before building OpenClaw rootfs images.
- Let E2E use the pinned image release only after it is public; while the pinned CalVer release is still draft, fall back to the latest public `images-*` release.
- Trigger published-image smoke tests only after rootfs/image publication and allow authenticated draft release asset downloads.
- Add regression tests for these workflow links.

## Why

The current release flow can fail while `IMAGES_RELEASE_TAG` points at a draft release: public GitHub release URLs 404 for draft assets, and E2E should not block main while new image bytes are still being assembled and verified.

## Validation

- `uv run ruff check tests/test_guest_agent_image.py`
- `uv run pytest tests/test_guest_agent_image.py -q`
- YAML parse for `.github/workflows/e2e.yml`, `.github/workflows/build-published-images.yml`, and `.github/workflows/smoke-published-images.yml`
- `git diff --check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added CI tests validating image-publishing and end-to-end workflows, including kernel asset handling, release-fallback behavior, and workflow trigger/permission expectations.

* **Chores**
  * CI workflows updated to securely fetch kernel assets from draft releases, pass kernel locations into image builds, employ a robust image-release fallback, narrow downstream triggers, and grant permissions needed to download protected release assets.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->