### PR TITLE
[codex] Skip guest agent binaries on preset image reruns

### DIFF
--- a/.github/workflows/build-published-images.yml
+++ b/.github/workflows/build-published-images.yml
@@ -97,6 +97,7 @@ jobs:
   # per architecture gives users and production builders a provenance/debug
   # artifact without making the private Celesto repo the source of truth.
   guest-agent-binaries:
+    if: ${{ inputs.presets == 'all' }}
     strategy:
       fail-fast: false
       matrix:

--- a/tests/test_guest_agent_image.py
+++ b/tests/test_guest_agent_image.py
@@ -57,6 +57,7 @@ def test_published_image_workflow_uploads_guest_agent_binaries() -> None:
     """The image release workflow should publish standalone guest-agent binaries."""
     workflow = (_REPO_ROOT / ".github" / "workflows" / "build-published-images.yml").read_text()
     assert "guest-agent-binaries:" in workflow
+    assert "if: ${{ inputs.presets == 'all' }}" in workflow
     assert 'cargo build --release --target "$target" -p smolvm-guest-agent' in workflow
     assert "smolvm-guest-agent-linux-amd64" in workflow
     assert "smolvm-guest-agent-linux-arm64" in workflow


### PR DESCRIPTION
## Summary

- Skip the standalone guest-agent binary upload job when `Build Published Images` is run for a preset subset.
- Keep guest-agent binary uploads for full `presets=all` release builds.
- Add a regression assertion for the workflow guard.

## Why

Preset-only reruns, such as rebuilding missing OpenClaw rootfs assets, should not fail on already-uploaded `smolvm-guest-agent-*` release assets. Those binaries are release-level provenance artifacts, while preset-only reruns are usually filling or rebuilding specific rootfs assets.

## Validation

- `uv run ruff check tests/test_guest_agent_image.py`
- `uv run pytest tests/test_guest_agent_image.py -q`
- YAML parse for `.github/workflows/build-published-images.yml`
- `git diff --check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized guest-agent binary build workflow to run only when necessary, improving CI efficiency.
  * Updated tests to verify build conditions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->