### PR TITLE
[codex] Expose Rust guest agent core as library

### DIFF
--- a/guest-agent/src/handler.rs
+++ b/guest-agent/src/handler.rs
@@ -28,16 +28,28 @@ pub fn router() -> Router {
         .route("/files/get", get(handle_file_get))
 }
 
-#[derive(Serialize)]
-struct HealthResponse {
-    status: &'static str,
-    uptime_seconds: u64,
-    agent_version: &'static str,
-    protocol: &'static str,
-    protocol_version: u32,
+pub fn extension_router() -> Router {
+    Lazy::force(&START_TIME);
+    Router::new()
+        .route("/version", get(handle_version))
+        .route("/capabilities", get(handle_capabilities))
+        .route(
+            "/files/put",
+            post(handle_file_put).layer(DefaultBodyLimit::max(FILE_PUT_BODY_LIMIT_BYTES)),
+        )
+        .route("/files/get", get(handle_file_get))
 }
 
-async fn handle_health() -> Json<HealthResponse> {
+#[derive(Serialize)]
+pub struct HealthResponse {
+    pub status: &'static str,
+    pub uptime_seconds: u64,
+    pub agent_version: &'static str,
+    pub protocol: &'static str,
+    pub protocol_version: u32,
+}
+
+pub async fn handle_health() -> Json<HealthResponse> {
     Json(HealthResponse {
         status: "ok",
         uptime_seconds: START_TIME.elapsed().as_secs(),
@@ -48,14 +60,14 @@ async fn handle_health() -> Json<HealthResponse> {
 }
 
 #[derive(Serialize)]
-struct VersionResponse {
-    agent_name: &'static str,
-    agent_version: &'static str,
-    protocol: &'static str,
-    protocol_version: u32,
+pub struct VersionResponse {
+    pub agent_name: &'static str,
+    pub agent_version: &'static str,
+    pub protocol: &'static str,
+    pub protocol_version: u32,
 }
 
-async fn handle_version() -> Json<VersionResponse> {
+pub async fn handle_version() -> Json<VersionResponse> {
     Json(VersionResponse {
         agent_name: "smolvm-guest-agent",
         agent_version: env!("CARGO_PKG_VERSION"),
@@ -65,15 +77,15 @@ async fn handle_version() -> Json<VersionResponse> {
 }
 
 #[derive(Serialize)]
-struct CapabilitiesResponse {
-    protocol_version: u32,
-    endpoints: Vec<&'static str>,
-    tcp_enabled: bool,
-    terminal_enabled: bool,
-    prod_metrics_enabled: bool,
+pub struct CapabilitiesResponse {
+    pub protocol_version: u32,
+    pub endpoints: Vec<&'static str>,
+    pub tcp_enabled: bool,
+    pub terminal_enabled: bool,
+    pub prod_metrics_enabled: bool,
 }
 
-async fn handle_capabilities() -> Json<CapabilitiesResponse> {
+pub async fn handle_capabilities() -> Json<CapabilitiesResponse> {
     Json(CapabilitiesResponse {
         protocol_version: PROTOCOL_VERSION,
         endpoints: vec![
@@ -90,15 +102,15 @@ async fn handle_capabilities() -> Json<CapabilitiesResponse> {
     })
 }
 
-async fn handle_exec(Json(req): Json<ExecRequest>) -> Json<ExecResponse> {
+pub async fn handle_exec(Json(req): Json<ExecRequest>) -> Json<ExecResponse> {
     Json(exec::run_command(req).await)
 }
 
-async fn handle_file_put(Json(req): Json<FilePutRequest>) -> Json<FilePutResponse> {
+pub async fn handle_file_put(Json(req): Json<FilePutRequest>) -> Json<FilePutResponse> {
     Json(files::put_file(req).await)
 }
 
-async fn handle_file_get(
+pub async fn handle_file_get(
     axum::extract::Query(query): axum::extract::Query<FileGetQuery>,
 ) -> Json<FileGetResponse> {
     Json(files::get_file(query).await)

--- a/guest-agent/src/lib.rs
+++ b/guest-agent/src/lib.rs
@@ -1,0 +1,7 @@
+pub mod exec;
+pub mod files;
+pub mod handler;
+pub mod server;
+
+pub use handler::router;
+pub use server::{DEFAULT_LISTEN, serve_listen_addr, serve_tcp, serve_vsock};

--- a/guest-agent/src/main.rs
+++ b/guest-agent/src/main.rs
@@ -1,17 +1,11 @@
-mod exec;
-mod files;
-mod handler;
-
 use clap::Parser;
-use tracing::info;
-
-const DEFAULT_LISTEN: &str = "vsock://1024";
+use smolvm_guest_agent::{handler, server};
 
 #[derive(Parser)]
 #[command(name = "smolvm-guest-agent", about = "SmolVM guest control agent")]
 struct Args {
     /// Listen address. Public builds default to vsock://1024.
-    #[arg(long, default_value = DEFAULT_LISTEN)]
+    #[arg(long, default_value = server::DEFAULT_LISTEN)]
     listen: String,
 }
 
@@ -26,75 +20,5 @@ async fn main() {
 
     let args = Args::parse();
     let app = handler::router();
-
-    if let Some(port) = args.listen.strip_prefix("vsock://") {
-        let port: u32 = port.parse().expect("vsock port must be a number");
-        serve_vsock(app, port).await;
-    } else if let Some(addr) = args.listen.strip_prefix("tcp://") {
-        serve_tcp(app, addr).await;
-    } else {
-        eprintln!(
-            "Invalid listen address: {}. Use vsock://PORT{}.",
-            args.listen,
-            if cfg!(feature = "tcp") {
-                " or tcp://HOST:PORT"
-            } else {
-                ""
-            },
-        );
-        std::process::exit(1);
-    }
-}
-
-#[cfg(all(feature = "vsock", target_os = "linux"))]
-async fn serve_vsock(app: axum::Router, port: u32) {
-    use tokio_vsock::{VsockAddr, VsockListener};
-    use tower::ServiceExt;
-
-    let addr = VsockAddr::new(u32::MAX, port);
-    let mut listener = VsockListener::bind(addr).expect("failed to bind vsock");
-    info!("Listening on vsock://{port}");
-
-    loop {
-        match listener.accept().await {
-            Ok((stream, addr)) => {
-                let app = app.clone();
-                tokio::spawn(async move {
-                    let io = hyper_util::rt::TokioIo::new(stream);
-                    let service = hyper::service::service_fn(move |req| {
-                        let app = app.clone();
-                        async move { app.oneshot(req).await.map_err(|e| match e {}) }
-                    });
-                    if let Err(error) = hyper::server::conn::http1::Builder::new()
-                        .serve_connection(io, service)
-                        .await
-                    {
-                        tracing::error!("vsock connection error from {addr:?}: {error}");
-                    }
-                });
-            }
-            Err(error) => tracing::error!("vsock accept error: {error}"),
-        }
-    }
-}
-
-#[cfg(not(all(feature = "vsock", target_os = "linux")))]
-async fn serve_vsock(_app: axum::Router, _port: u32) {
-    eprintln!("vsock support is only available in Linux builds with the vsock feature enabled.");
-    std::process::exit(1);
-}
-
-#[cfg(feature = "tcp")]
-async fn serve_tcp(app: axum::Router, addr: &str) {
-    info!("Listening on tcp://{addr}");
-    let listener = tokio::net::TcpListener::bind(addr)
-        .await
-        .expect("failed to bind TCP listener");
-    axum::serve(listener, app).await.expect("TCP server failed");
-}
-
-#[cfg(not(feature = "tcp"))]
-async fn serve_tcp(_app: axum::Router, _addr: &str) {
-    eprintln!("TCP listener support is disabled in public SmolVM guest-agent builds.");
-    std::process::exit(1);
+    server::serve_listen_addr(app, &args.listen).await;
 }

--- a/guest-agent/src/server.rs
+++ b/guest-agent/src/server.rs
@@ -1,0 +1,76 @@
+use axum::Router;
+use tracing::info;
+
+pub const DEFAULT_LISTEN: &str = "vsock://1024";
+
+pub async fn serve_listen_addr(app: Router, listen: &str) {
+    if let Some(port) = listen.strip_prefix("vsock://") {
+        let port: u32 = port.parse().expect("vsock port must be a number");
+        serve_vsock(app, port).await;
+    } else if let Some(addr) = listen.strip_prefix("tcp://") {
+        serve_tcp(app, addr).await;
+    } else {
+        eprintln!(
+            "Invalid listen address: {listen}. Use vsock://PORT{}.",
+            if cfg!(feature = "tcp") {
+                " or tcp://HOST:PORT"
+            } else {
+                ""
+            },
+        );
+        std::process::exit(1);
+    }
+}
+
+#[cfg(all(feature = "vsock", target_os = "linux"))]
+pub async fn serve_vsock(app: Router, port: u32) {
+    use tokio_vsock::{VsockAddr, VsockListener};
+    use tower::ServiceExt;
+
+    let addr = VsockAddr::new(u32::MAX, port);
+    let mut listener = VsockListener::bind(addr).expect("failed to bind vsock");
+    info!("Listening on vsock://{port}");
+
+    loop {
+        match listener.accept().await {
+            Ok((stream, addr)) => {
+                let app = app.clone();
+                tokio::spawn(async move {
+                    let io = hyper_util::rt::TokioIo::new(stream);
+                    let service = hyper::service::service_fn(move |req| {
+                        let app = app.clone();
+                        async move { app.oneshot(req).await.map_err(|e| match e {}) }
+                    });
+                    if let Err(error) = hyper::server::conn::http1::Builder::new()
+                        .serve_connection(io, service)
+                        .await
+                    {
+                        tracing::error!("vsock connection error from {addr:?}: {error}");
+                    }
+                });
+            }
+            Err(error) => tracing::error!("vsock accept error: {error}"),
+        }
+    }
+}
+
+#[cfg(not(all(feature = "vsock", target_os = "linux")))]
+pub async fn serve_vsock(_app: Router, _port: u32) {
+    eprintln!("vsock support is only available in Linux builds with the vsock feature enabled.");
+    std::process::exit(1);
+}
+
+#[cfg(feature = "tcp")]
+pub async fn serve_tcp(app: Router, addr: &str) {
+    info!("Listening on tcp://{addr}");
+    let listener = tokio::net::TcpListener::bind(addr)
+        .await
+        .expect("failed to bind TCP listener");
+    axum::serve(listener, app).await.expect("TCP server failed");
+}
+
+#[cfg(not(feature = "tcp"))]
+pub async fn serve_tcp(_app: Router, _addr: &str) {
+    eprintln!("TCP listener support is disabled in public SmolVM guest-agent builds.");
+    std::process::exit(1);
+}


### PR DESCRIPTION
## Summary

- split `guest-agent/` into a reusable Rust library plus the existing `smolvm-guest-agent` binary
- export the public router, protocol handlers/types, and TCP/vsock serving helpers
- add a non-conflicting extension router for private consumers that need shared public routes without taking SmolVM `/health` or `/exec`

## Validation

- `cargo test -p smolvm-guest-agent`
- `uv run pytest tests/test_rust_http_vsock_channel.py tests/test_guest_agent.py tests/test_guest_agent_image.py -q`

## Coordination

This is the public-core PR that `celesto-agent` pins to for the private prod guest-agent migration. Paired Celesto PR: https://github.com/CelestoAI/celesto-agent/pull/78.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Restructured guest-agent codebase into modular library format with unified server startup logic.
  * Exposed public APIs for handlers and server components to enable external extensibility.
  * Consolidated vsock and TCP connection handling into a single, unified listen address interface.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->