### PR TITLE
[codex] Use published Ubuntu for QEMU and trim vsock forwarding

### DIFF
--- a/docs/deep-dive/microvm-from-first-principles.md
+++ b/docs/deep-dive/microvm-from-first-principles.md
@@ -591,11 +591,11 @@ Lesson: when you generalize a code path that used to be single-purpose, audit th
 
 A few open threads, in the order I'd tackle them.
 
-### `smolvm create` should use our base rootfs (#273)
+### `smolvm create` uses our base rootfs (#273)
 
-Right now `smolvm create` (no preset) downloads Ubuntu's official cloud image from `cloud-images.ubuntu.com`. That's the last external CDN in the boot path. The base rootfs we built for layered presets is a strict improvement: smaller (150 MB vs 227 MB compressed), faster boot (no cloud-init wait), pinnable SHAs.
+`smolvm create` now uses the published Ubuntu base rootfs from the SmolVM image release instead of downloading Ubuntu's official cloud image from `cloud-images.ubuntu.com`. That removes the last external CDN from the boot path and keeps the default image pinned by SHA.
 
-The work: publish the base ext4 as a release asset alongside the preset ones, bake `/init` into the base Dockerfile (so layered presets inherit it instead of the build script copying it), rewire `_build_auto_config` to download from our release.
+The remaining work is operational: keep the base ext4 published alongside preset images, keep `/init` in the base Dockerfile, and bump the image release tag when those bytes change.
 
 ### Drift smoke test (#265)
 

--- a/src/smolvm/facade.py
+++ b/src/smolvm/facade.py
@@ -594,11 +594,9 @@ def _build_auto_config(
             resolved_disk_size_mib = required_disk_size_mib
         elif resolved_disk_size_mib < required_disk_size_mib:
             raise ValueError(
-                f"ubuntu auto-config requires disk_size_mib >= {required_disk_size_mib} "
-                f"(got {resolved_disk_size_mib}; default floor {default_disk_size_mib}); "
-                "fix by running: "
-                f"smolvm create --name {resolved_vm_name} --os ubuntu "
-                f"--backend {resolved_backend} --disk-size {required_disk_size_mib}"
+                f"Ubuntu needs at least {required_disk_size_mib} MiB for sandbox '{resolved_vm_name}'; "
+                f"recreate it with: smolvm create --name {resolved_vm_name} --os ubuntu "
+                f"--backend {resolved_backend} --disk-size {required_disk_size_mib}."
             )
         should_grow_filesystem = (
             disk_size_mib is not None and resolved_disk_size_mib > base_rootfs_size_mib
@@ -621,7 +619,7 @@ def _build_auto_config(
             ssh_capable=True,
             backend=resolved_backend,
             ssh_public_key=public_key_value,
-            disk_size_mib=resolved_disk_size_mib if disk_size_mib is not None else None,
+            disk_size_mib=resolved_disk_size_mib,
             grow_filesystem=should_grow_filesystem,
         )
         logger.info(

--- a/src/smolvm/facade.py
+++ b/src/smolvm/facade.py
@@ -32,11 +32,9 @@ import json
 import logging
 import platform
 import shlex
-import shutil
 import socket
 import subprocess
 import time
-import uuid
 from collections.abc import Callable
 from contextlib import suppress
 from dataclasses import dataclass
@@ -84,7 +82,6 @@ from smolvm.runtime.backends import (
 from smolvm.runtime.boot_profiles import (
     KernelBootProfile,
     get_boot_profile_spec,
-    normalize_arch,
     to_published_arch,
 )
 from smolvm.ssh import ShellKind, SSHClient
@@ -139,21 +136,6 @@ _AUTO_CONFIG_DEFAULT_DISK_SIZE_MIB = {
     # WINDOWS: not used. The Windows path always supplies a pre-built
     # qcow2 in Phase 1, so we don't size or grow a disk for it.
 }
-_UBUNTU_CURRENT_RELEASE_DATE = "20260406"
-# Ubuntu cloud-images rootfs URLs. Post-0.0.14a0 we no longer fetch Ubuntu's
-# vmlinuz/initrd alongside — the SmolVM-built base kernel boots the rootfs
-# directly (CONFIG_ISO9660_FS=y enables the cloud-init NoCloud seed). Only
-# the qcow2 rootfs is fetched from cloud-images.ubuntu.com.
-_QEMU_UBUNTU_AUTO_IMAGES: dict[str, str] = {
-    "ubuntu-noble-minimal-qemu-x86_64": (
-        "https://cloud-images.ubuntu.com/minimal/releases/noble/release/"
-        "ubuntu-24.04-minimal-cloudimg-amd64.img"
-    ),
-    "ubuntu-noble-minimal-qemu-aarch64": (
-        "https://cloud-images.ubuntu.com/minimal/releases/noble/release/"
-        "ubuntu-24.04-minimal-cloudimg-arm64.img"
-    ),
-}
 
 
 def _vsock_not_supported_message(vm_id: str, error: VsockNotSupportedError) -> str:
@@ -184,17 +166,8 @@ def _default_guest_os_for_backend(backend: str) -> GuestOS:
     return GuestOS.ALPINE
 
 
-def _qemu_auto_config_image_name(guest_os: GuestOS = GuestOS.UBUNTU) -> str:
-    """Return the prebuilt QEMU image cache key for *guest_os* on this host."""
-    arch = platform.machine().lower()
-    image_arch = "aarch64" if arch in {"arm64", "aarch64"} else "x86_64"
-    if guest_os is GuestOS.UBUNTU:
-        return f"ubuntu-noble-minimal-qemu-{image_arch}"
-    raise ValueError(f"No prebuilt QEMU auto-config image for guest OS: {guest_os}")
-
-
 def _qcow2_virtual_size_mib(qcow2_path: Path) -> int:
-    """Return the virtual size of a qcow2 image in MiB."""
+    """Return the guest-visible virtual size of a qcow2 image in MiB."""
     result = subprocess.run(
         ["qemu-img", "info", "--output=json", str(qcow2_path)],
         check=True,
@@ -203,74 +176,6 @@ def _qcow2_virtual_size_mib(qcow2_path: Path) -> int:
     )
     info = json.loads(result.stdout)
     return int(info["virtual-size"]) // (1024 * 1024)
-
-
-def _prepare_sized_qcow2(
-    *,
-    cache_dir: Path,
-    base_image_name: str,
-    source_qcow2: Path,
-    target_mib: int,
-) -> tuple[Path, int]:
-    """Return a qcow2 rootfs sized to at least *target_mib*.
-
-    The pristine downloaded image is never mutated. When the requested size
-    exceeds the cached image's virtual size, this copies the qcow2 into a
-    size-specific cache directory (``{base_image_name}-{target_mib}m``) and
-    runs ``qemu-img resize`` on the copy. The sized copy is shared across
-    VMs of the same size; per-VM isolation still happens via
-    ``disk_mode="isolated"`` cloning later.
-
-    Returns a tuple of ``(rootfs_path, resolved_target_mib)`` where
-    ``resolved_target_mib`` is the actual virtual size of the returned image
-    (equal to ``target_mib`` for a fresh resize, or the existing cached size
-    for the default-size passthrough).
-    """
-    current_mib = _qcow2_virtual_size_mib(source_qcow2)
-    if target_mib <= current_mib:
-        # Use the pristine cached image. Cloud images ship at their minimum
-        # viable size; we refuse to shrink below that to avoid breaking the
-        # filesystem. Callers should enforce target_mib >= default upstream
-        # and surface a clear error instead of silently falling back here.
-        return source_qcow2, current_mib
-
-    sized_dir = cache_dir / f"{base_image_name}-{target_mib}m"
-    sized_qcow2 = sized_dir / source_qcow2.name
-    if sized_qcow2.is_file():
-        try:
-            existing_mib = _qcow2_virtual_size_mib(sized_qcow2)
-        except subprocess.CalledProcessError:
-            existing_mib = -1
-        if existing_mib == target_mib:
-            return sized_qcow2, existing_mib
-        logger.warning(
-            "Cached resized image %s has unexpected size (%d MiB), rebuilding",
-            sized_qcow2,
-            existing_mib,
-        )
-        sized_qcow2.unlink(missing_ok=True)
-
-    sized_dir.mkdir(parents=True, exist_ok=True)
-    temp_qcow2 = sized_qcow2.with_name(f".{sized_qcow2.name}.{uuid.uuid4().hex}.tmp")
-    try:
-        shutil.copy2(source_qcow2, temp_qcow2)
-        subprocess.run(
-            ["qemu-img", "resize", str(temp_qcow2), f"{target_mib}M"],
-            check=True,
-            capture_output=True,
-            text=True,
-        )
-        temp_qcow2.replace(sized_qcow2)
-    except Exception:
-        temp_qcow2.unlink(missing_ok=True)
-        raise
-    logger.info(
-        "Prepared resized rootfs at %s (%d MiB -> %d MiB)",
-        sized_qcow2,
-        current_mib,
-        target_mib,
-    )
-    return sized_qcow2, target_mib
 
 
 def _existing_vm_ids() -> set[str]:
@@ -644,8 +549,6 @@ def _build_auto_config(
     on_download: Callable[[str, int, int | None], None] | None = None,
 ) -> tuple[VMConfig, str | None]:
     """Build the default SSH-ready VM config used by zero-config flows."""
-    from smolvm.images.builder import ImageBuilder
-
     resolved_backend = resolve_backend(backend)
     resolved_os = _normalize_guest_os(os or _default_guest_os_for_backend(resolved_backend))
     if resolved_os is GuestOS.WINDOWS:
@@ -668,30 +571,21 @@ def _build_auto_config(
     if resolved_disk_size_mib < 64:
         raise ValueError("disk_size_mib must be >= 64")
 
-    if resolved_os is GuestOS.UBUNTU and resolved_backend != BACKEND_QEMU:
-        # Firecracker / libkrun can't boot the Ubuntu cloud qcow2 (no qcow2
-        # support, no firmware/bootloader). Pull the published bare-Ubuntu
-        # raw-ext4 rootfs + ELF kernel and boot it direct-kernel, exactly like
-        # the alpine/published path below. The SSH key rides the kernel cmdline
-        # (parsed by the image's /init), not a cloud-init seed.
-        from smolvm.images.published import (
-            Vmm,
-            ensure_published_image,
-            is_preset_published,
-        )
-
-        vmm: Vmm = "libkrun" if resolved_backend == BACKEND_LIBKRUN else "firecracker"
-        arch = to_published_arch(platform.machine())
-        if not is_preset_published("ubuntu", arch, vmm, "ubuntu"):
-            # Manifest has no bare-Ubuntu row for this host yet — steer the user
-            # to the qemu path. A *published* image that then fails to download
-            # or verify raises ImageError from ensure_published_image below,
-            # which we deliberately let surface unchanged.
-            sandbox_name = vm_name or "<name>"
-            raise SmolVMError(
-                "No bare-Ubuntu image is published for this backend yet; "
-                f"run: smolvm create --name {sandbox_name} --os ubuntu --backend qemu"
+    if resolved_os is GuestOS.UBUNTU:
+        if resolved_disk_size_mib < default_disk_size_mib:
+            raise ValueError(
+                f"ubuntu auto-config requires disk_size_mib >= {default_disk_size_mib} "
+                f"(got {resolved_disk_size_mib})"
             )
+        from smolvm.images.published import Vmm, ensure_published_image
+
+        vmm_by_backend: dict[str, Vmm] = {
+            BACKEND_QEMU: "qemu",
+            BACKEND_FIRECRACKER: "firecracker",
+            BACKEND_LIBKRUN: "libkrun",
+        }
+        vmm = vmm_by_backend[resolved_backend]
+        arch = to_published_arch(platform.machine())
         local_image = ensure_published_image("ubuntu", arch, vmm, "ubuntu")
 
         kernel_profile = KernelBootProfile.MICROVM_DIRECT
@@ -706,107 +600,17 @@ def _build_auto_config(
             memory=resolved_memory,
             kernel_path=local_image.kernel_path,
             rootfs_path=local_image.rootfs_path,
+            rootfs_format="raw-ext4",
             boot_args=boot_args,
+            guest_os=GuestOS.UBUNTU,
+            ssh_capable=True,
             backend=resolved_backend,
             ssh_public_key=public_key_value,
+            disk_size_mib=resolved_disk_size_mib if disk_size_mib is not None else None,
         )
         logger.info(
             "Auto-configured VM: %s (os=ubuntu, backend=%s, source=published-bare-ubuntu)",
             resolved_vm_name,
-            resolved_backend,
-        )
-        return config, resolved_ssh_key_path
-
-    if resolved_os is GuestOS.UBUNTU:
-        if resolved_disk_size_mib < default_disk_size_mib:
-            raise ValueError(
-                f"ubuntu auto-config requires disk_size_mib >= {default_disk_size_mib} "
-                f"(got {resolved_disk_size_mib})"
-            )
-        from smolvm.images.published import ensure_base_kernel
-
-        image_name = _qemu_auto_config_image_name(GuestOS.UBUNTU)
-        rootfs_url = _QEMU_UBUNTU_AUTO_IMAGES.get(image_name)
-        if rootfs_url is None:
-            raise SmolVMError(
-                "No prebuilt Ubuntu rootfs registered for this host architecture",
-                {"image_name": image_name},
-            )
-        image_manager = ImageManager()
-        pristine_rootfs = image_manager.ensure_rootfs_only(
-            image_name,
-            url=rootfs_url,
-            filename="rootfs.qcow2",
-            on_download=on_download,
-        )
-        # Pull the SmolVM-built base kernel — Image format for QEMU
-        # (Firecracker would use the ELF; this branch is QEMU-only).
-        host_arch = platform.machine()
-        kernel_path = ensure_base_kernel(
-            to_published_arch(host_arch),
-            "image",
-            cache_dir=image_manager.cache_dir,
-        )
-
-        if resolved_disk_size_mib > default_disk_size_mib:
-            rootfs_path, _resolved_size = _prepare_sized_qcow2(
-                cache_dir=image_manager.cache_dir,
-                base_image_name=image_name,
-                source_qcow2=pristine_rootfs,
-                target_mib=resolved_disk_size_mib,
-            )
-        else:
-            rootfs_path = pristine_rootfs
-
-        # Direct kernel boot, no initrd. Ubuntu's cloud qcow2 has a 3-partition
-        # GPT layout (vda1=rootfs, vda15=ESP, vda16=/boot); without an initrd
-        # to resolve `LABEL=cloudimg-rootfs` we point at the partition directly.
-        # cloud-init userspace then reads the seed ISO at /dev/vdb
-        # (CONFIG_ISO9660_FS=y) and provisions sshd.
-        #
-        # We deliberately don't use the MICROVM_DIRECT boot-profile string here
-        # because it bakes in `init=/init` (the SmolVM-built Alpine/Debian images
-        # ship a custom /init shell script). Ubuntu's rootfs has no /init —
-        # init lives at /sbin/init (systemd). Letting the kernel pick its
-        # default search path lands on systemd, which kicks cloud-init.
-        console = "ttyAMA0" if normalize_arch(host_arch) == "aarch64" else "ttyS0"
-        boot_args = f"console={console} reboot=k panic=1 root=/dev/vda1 rw"
-
-        user_data = default_user_data(public_key_value)
-        seed_key = seed_cache_key(
-            ssh_public_key=public_key_value,
-            instance_id=f"smolvm-{_UBUNTU_CURRENT_RELEASE_DATE}",
-            hostname="smolvm",
-            user_data=user_data,
-        )
-        seed_dir = image_manager.cache_dir / "cloud-init-seeds"
-        seed_path = seed_dir / f"{seed_key}.iso"
-        if not seed_path.exists():
-            build_seed_iso(
-                seed_path,
-                user_data=user_data,
-                meta_data=default_meta_data(
-                    instance_id=f"smolvm-{_UBUNTU_CURRENT_RELEASE_DATE}",
-                    hostname="smolvm",
-                ),
-            )
-
-        resolved_vm_name = _resolve_vm_name(vm_name, prefix=name_prefix)
-        config = VMConfig(
-            vm_id=resolved_vm_name,
-            vcpu_count=1,
-            memory=resolved_memory,
-            kernel_path=kernel_path,
-            rootfs_path=rootfs_path,
-            extra_drives=[seed_path],
-            boot_args=boot_args,
-            ssh_capable=True,
-            backend=resolved_backend,
-        )
-        logger.info(
-            "Auto-configured VM: %s (os=%s, backend=%s, source=prebuilt-qemu-image)",
-            resolved_vm_name,
-            resolved_os.value,
             resolved_backend,
         )
         return config, resolved_ssh_key_path
@@ -816,6 +620,8 @@ def _build_auto_config(
         resolved_backend,
         platform.machine(),
     )
+    from smolvm.images.builder import ImageBuilder
+
     builder = ImageBuilder()
     image_name = _build_auto_config_image_name(
         resolved_os,

--- a/src/smolvm/facade.py
+++ b/src/smolvm/facade.py
@@ -178,6 +178,11 @@ def _qcow2_virtual_size_mib(qcow2_path: Path) -> int:
     return int(info["virtual-size"]) // (1024 * 1024)
 
 
+def _path_size_mib(path: Path) -> int:
+    """Return a path size rounded up to MiB."""
+    return (path.stat().st_size + (1024 * 1024) - 1) // (1024 * 1024)
+
+
 def _existing_vm_ids() -> set[str]:
     """Best-effort lookup of existing VM IDs for collision-free auto-naming.
 
@@ -572,11 +577,6 @@ def _build_auto_config(
         raise ValueError("disk_size_mib must be >= 64")
 
     if resolved_os is GuestOS.UBUNTU:
-        if resolved_disk_size_mib < default_disk_size_mib:
-            raise ValueError(
-                f"ubuntu auto-config requires disk_size_mib >= {default_disk_size_mib} "
-                f"(got {resolved_disk_size_mib})"
-            )
         from smolvm.images.published import Vmm, ensure_published_image
 
         vmm_by_backend: dict[str, Vmm] = {
@@ -586,14 +586,29 @@ def _build_auto_config(
         }
         vmm = vmm_by_backend[resolved_backend]
         arch = to_published_arch(platform.machine())
+        resolved_vm_name = _resolve_vm_name(vm_name, prefix=name_prefix)
         local_image = ensure_published_image("ubuntu", arch, vmm, "ubuntu")
+        base_rootfs_size_mib = _path_size_mib(local_image.rootfs_path)
+        required_disk_size_mib = max(default_disk_size_mib, base_rootfs_size_mib)
+        if disk_size_mib is None:
+            resolved_disk_size_mib = required_disk_size_mib
+        elif resolved_disk_size_mib < required_disk_size_mib:
+            raise ValueError(
+                f"ubuntu auto-config requires disk_size_mib >= {required_disk_size_mib} "
+                f"(got {resolved_disk_size_mib}; default floor {default_disk_size_mib}); "
+                "fix by running: "
+                f"smolvm create --name {resolved_vm_name} --os ubuntu "
+                f"--backend {resolved_backend} --disk-size {required_disk_size_mib}"
+            )
+        should_grow_filesystem = (
+            disk_size_mib is not None and resolved_disk_size_mib > base_rootfs_size_mib
+        )
 
         kernel_profile = KernelBootProfile.MICROVM_DIRECT
         boot_args = get_boot_profile_spec(kernel_profile).base_boot_args_for_backend(
             resolved_backend,
             platform.machine(),
         )
-        resolved_vm_name = _resolve_vm_name(vm_name, prefix=name_prefix)
         config = VMConfig(
             vm_id=resolved_vm_name,
             vcpu_count=1,
@@ -607,6 +622,7 @@ def _build_auto_config(
             backend=resolved_backend,
             ssh_public_key=public_key_value,
             disk_size_mib=resolved_disk_size_mib if disk_size_mib is not None else None,
+            grow_filesystem=should_grow_filesystem,
         )
         logger.info(
             "Auto-configured VM: %s (os=ubuntu, backend=%s, source=published-bare-ubuntu)",

--- a/src/smolvm/images/published.py
+++ b/src/smolvm/images/published.py
@@ -310,8 +310,8 @@ MANIFEST: dict[ManifestKey, PublishedImage] = {
     **_preset_rows("hermes", _HERMES_AMD64_ROOTFS_SHA, _HERMES_ARM64_ROOTFS_SHA),
     **_preset_rows("pi", _PI_AMD64_ROOTFS_SHA, _PI_ARM64_ROOTFS_SHA),
     # Bare Ubuntu base image (raw-ext4, agent baked in) — powers
-    # ``create --os ubuntu`` on firecracker/libkrun (the qemu path keeps its
-    # qcow2 cloud image). Same rootfs shared across vmms; only the kernel differs.
+    # ``create --os ubuntu`` on every supported VMM. Same rootfs shared
+    # across vmms; only the kernel differs.
     **_preset_rows("ubuntu", _UBUNTU_AMD64_ROOTFS_SHA, _UBUNTU_ARM64_ROOTFS_SHA),
     # Alpine rows — add once CI publishes ``<preset>-<arch>-alpine-rootfs.ext4.zst``
     # under :data:`IMAGES_RELEASE_TAG` and we have SHAs to pin against.

--- a/src/smolvm/vm.py
+++ b/src/smolvm/vm.py
@@ -40,7 +40,7 @@ from pathlib import Path
 from typing import Any, TextIO
 from uuid import uuid4
 
-from smolvm.comm.select import VsockNotSupportedError, resolve_comm_channel
+from smolvm.comm.select import ChannelResolution, VsockNotSupportedError, resolve_comm_channel
 from smolvm.exceptions import (
     NetworkError,
     SmolVMError,
@@ -1313,16 +1313,14 @@ class SmolVMManager:
 
         return errors
 
-    def _maybe_enable_vsock(self, config: VMConfig, backend: str, vm_info: VMInfo) -> VMInfo:
-        """Reserve a vsock CID and persist ``config.vsock`` when needed.
-
-        Auto/explicit vsock control channels need a reserved CID. QEMU uses the
-        CID directly from the host. Firecracker exposes the same guest CID via a
-        host-side Unix socket, so the generated UDS path is also persisted in
-        ``config.vsock`` for the facade to dial.
-        """
+    def _resolve_control_channel_for_config(
+        self,
+        config: VMConfig,
+        backend: str,
+    ) -> ChannelResolution:
+        """Resolve the create-time control channel for *config*."""
         try:
-            resolution = resolve_comm_channel(
+            return resolve_comm_channel(
                 requested=None,
                 config_channel=config.comm_channel,
                 backend=backend,
@@ -1333,6 +1331,35 @@ class SmolVMManager:
                 _vsock_not_supported_message(config.vm_id, exc),
                 {"vm_id": config.vm_id, **exc.details},
             ) from exc
+
+    def _should_reserve_ssh_forward(
+        self,
+        config: VMConfig,
+        backend: str,
+        *,
+        resolution: ChannelResolution | None = None,
+    ) -> bool:
+        """Return whether create-time networking must expose guest SSH."""
+        if config.env_vars or config.workspace_mounts:
+            return True
+
+        resolution = resolution or self._resolve_control_channel_for_config(config, backend)
+        if resolution.kind == "ssh":
+            return True
+        if resolution.allow_fallback:
+            return True
+
+        return backend == BACKEND_QEMU and config.qemu_network == "slirp"
+
+    def _maybe_enable_vsock(self, config: VMConfig, backend: str, vm_info: VMInfo) -> VMInfo:
+        """Reserve a vsock CID and persist ``config.vsock`` when needed.
+
+        Auto/explicit vsock control channels need a reserved CID. QEMU uses the
+        CID directly from the host. Firecracker exposes the same guest CID via a
+        host-side Unix socket, so the generated UDS path is also persisted in
+        ``config.vsock`` for the facade to dial.
+        """
+        resolution = self._resolve_control_channel_for_config(config, backend)
         requested_vsock = config.vsock
         should_reserve_device = (
             backend in {BACKEND_QEMU, BACKEND_FIRECRACKER} and requested_vsock is not None
@@ -1532,7 +1559,17 @@ class SmolVMManager:
                 raise
 
         try:
-            ssh_host_port = self._reserve_available_ssh_port(effective_config.vm_id)
+            channel_resolution = self._resolve_control_channel_for_config(effective_config, backend)
+            ssh_forward_required = self._should_reserve_ssh_forward(
+                effective_config,
+                backend,
+                resolution=channel_resolution,
+            )
+            ssh_host_port = (
+                self._reserve_available_ssh_port(effective_config.vm_id)
+                if ssh_forward_required
+                else None
+            )
 
             if not self._uses_host_tap_networking(effective_config, backend):
                 if (
@@ -1544,7 +1581,7 @@ class SmolVMManager:
                         "with the %s backend (user-mode networking)",
                         backend,
                     )
-                mac_seed = (ssh_host_port % 65534) + 1
+                mac_seed = ((ssh_host_port or SSH_PORT_START) % 65534) + 1
                 guest_mac = self.network.generate_mac(mac_seed)
                 network_config = NetworkConfig(
                     guest_ip=QEMU_GUEST_IP,
@@ -1556,12 +1593,19 @@ class SmolVMManager:
                 )
                 vm_info = self.state.update_vm(effective_config.vm_id, network=network_config)
                 vm_info = self._maybe_enable_vsock(effective_config, backend, vm_info)
-                logger.info(
-                    "VM created: %s (backend=%s, ssh localhost:%d)",
-                    effective_config.vm_id,
-                    backend,
-                    ssh_host_port,
-                )
+                if ssh_host_port is not None:
+                    logger.info(
+                        "VM created: %s (backend=%s, ssh localhost:%d)",
+                        effective_config.vm_id,
+                        backend,
+                        ssh_host_port,
+                    )
+                else:
+                    logger.info(
+                        "VM created: %s (backend=%s, ssh forwarding disabled)",
+                        effective_config.vm_id,
+                        backend,
+                    )
                 return vm_info
 
             # Firecracker networking: allocate an IP first, then derive
@@ -1593,11 +1637,12 @@ class SmolVMManager:
                 )
                 self.network.apply_egress_allowlist(tap_name, allowed_ips)
 
-            self.network.setup_ssh_port_forward(
-                vm_id=effective_config.vm_id,
-                guest_ip=guest_ip,
-                host_port=ssh_host_port,
-            )
+            if ssh_host_port is not None:
+                self.network.setup_ssh_port_forward(
+                    vm_id=effective_config.vm_id,
+                    guest_ip=guest_ip,
+                    host_port=ssh_host_port,
+                )
 
             # Generate MAC address from pool index
             guest_mac = self.network.generate_mac(vm_number)
@@ -2869,7 +2914,17 @@ class SmolVMManager:
                 raise
 
         try:
-            ssh_host_port = self._reserve_available_ssh_port(effective_config.vm_id)
+            channel_resolution = self._resolve_control_channel_for_config(effective_config, backend)
+            ssh_forward_required = self._should_reserve_ssh_forward(
+                effective_config,
+                backend,
+                resolution=channel_resolution,
+            )
+            ssh_host_port = (
+                self._reserve_available_ssh_port(effective_config.vm_id)
+                if ssh_forward_required
+                else None
+            )
 
             if not self._uses_host_tap_networking(effective_config, backend):
                 if (
@@ -2881,7 +2936,7 @@ class SmolVMManager:
                         "with the %s backend (user-mode networking)",
                         backend,
                     )
-                mac_seed = (ssh_host_port % 65534) + 1
+                mac_seed = ((ssh_host_port or SSH_PORT_START) % 65534) + 1
                 guest_mac = self.network.generate_mac(mac_seed)
                 network_config = NetworkConfig(
                     guest_ip=QEMU_GUEST_IP,
@@ -2917,11 +2972,12 @@ class SmolVMManager:
                 )
                 await self.network.async_apply_egress_allowlist(tap_name, allowed_ips)
 
-            await self.network.async_setup_ssh_port_forward(
-                vm_id=effective_config.vm_id,
-                guest_ip=guest_ip,
-                host_port=ssh_host_port,
-            )
+            if ssh_host_port is not None:
+                await self.network.async_setup_ssh_port_forward(
+                    vm_id=effective_config.vm_id,
+                    guest_ip=guest_ip,
+                    host_port=ssh_host_port,
+                )
 
             guest_mac = self.network.generate_mac(vm_number)
             network_config = NetworkConfig(

--- a/src/smolvm/vm.py
+++ b/src/smolvm/vm.py
@@ -244,11 +244,30 @@ def _crashed_message(vm_id: str) -> str:
     )
 
 
-def _vsock_not_supported_message(vm_id: str, error: VsockNotSupportedError) -> str:
+def _vsock_recovery_command(vm_id: str, backend: str) -> str:
+    """Return a CLI recovery command for an explicit-vsock create failure."""
+    return f"smolvm create --name {vm_id} --backend {backend}"
+
+
+def _vsock_not_supported_message(
+    vm_id: str,
+    error: VsockNotSupportedError,
+    *,
+    recovery_command: str,
+) -> str:
     """Format a user-facing explicit-vsock failure at the VM boundary."""
+    reason_by_code = {
+        "vsock_not_supported_for_windows": "Windows guests use SSH in this release",
+        "vsock_not_supported_for_backend": "this backend does not support vsock in this release",
+        "vsock_host_device_missing": "this host is missing QEMU vsock support",
+        "vsock_not_supported_for_firecracker_host": (
+            "Firecracker vsock is only available on Linux"
+        ),
+    }
+    reason = reason_by_code.get(error.code, "vsock is not available for this sandbox")
     return (
-        f"Cannot use vsock for sandbox '{vm_id}': {error.reason}; "
-        "create it with comm_channel='ssh'."
+        f"Cannot use vsock for sandbox '{vm_id}': {reason}; "
+        f"create it with SSH by running: {recovery_command}."
     )
 
 
@@ -1327,9 +1346,14 @@ class SmolVMManager:
                 guest_os=config.guest_os,
             )
         except VsockNotSupportedError as exc:
+            recovery_command = _vsock_recovery_command(config.vm_id, backend)
             raise SmolVMError(
-                _vsock_not_supported_message(config.vm_id, exc),
-                {"vm_id": config.vm_id, **exc.details},
+                _vsock_not_supported_message(
+                    config.vm_id,
+                    exc,
+                    recovery_command=recovery_command,
+                ),
+                {"vm_id": config.vm_id, "recovery_command": recovery_command},
             ) from exc
 
     def _should_reserve_ssh_forward(

--- a/tests/e2e/conftest.py
+++ b/tests/e2e/conftest.py
@@ -86,11 +86,10 @@ def vm(e2e_variant: E2EVariant):
             "(load it via `sudo modprobe vhost_vsock`)"
         )
 
-    # Pin to Alpine: the SmolVM-*built* image (vsock guest agent + python3 baked
-    # in by ImageBuilder, SSH key injected on the kernel cmdline, no cloud-init
-    # seed ISO). The QEMU default is Ubuntu, whose cloud qcow2 carries a seed
-    # ISO as an extra drive (snapshot then rejects it) and lacks the baked-in
-    # agent (vsock never answers) — neither of which is what we want to smoke.
+    # Pin to Alpine for these lifecycle smoke tests: it is the small local
+    # ImageBuilder path, with the agent and SSH key injected through /init.
+    # Published Ubuntu has separate e2e coverage so this fixture stays stable
+    # when the default OS image changes.
     sandbox = SmolVM(
         backend=e2e_variant.backend,
         os="alpine",

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -30,8 +30,10 @@ from smolvm.cli.main import (
 )
 from smolvm.types import (
     BrowserSessionState,
+    GuestOS,
     NetworkConfig,
     SnapshotType,
+    VMConfig,
     VMState,
     WorkspaceMount,
 )
@@ -815,6 +817,73 @@ class TestCliCreate:
         assert payload["data"]["vm"]["started_at"]
         assert payload["data"]["next"]["ssh_command"] == "smolvm ssh project-spacex"
         assert payload["data"]["next"]["info_command"] == "smolvm info project-spacex"
+
+    @patch("smolvm.facade.platform.machine", return_value="x86_64")
+    @patch("smolvm.facade.build_seed_iso")
+    @patch("smolvm.facade.ImageManager")
+    @patch("smolvm.facade.SmolVM")
+    @patch("smolvm.utils.ensure_ssh_key")
+    @patch("smolvm.images.published.ensure_published_image")
+    def test_create_ubuntu_qemu_uses_published_image_config(
+        self,
+        mock_ensure_published: MagicMock,
+        mock_ensure_ssh_key: MagicMock,
+        mock_vm_cls: MagicMock,
+        mock_image_manager_cls: MagicMock,
+        mock_build_seed_iso: MagicMock,
+        _mock_machine: MagicMock,
+        tmp_path: Path,
+    ) -> None:
+        """`create --os ubuntu --backend qemu` should use the published Ubuntu rootfs."""
+        from smolvm.images.manager import LocalImage
+
+        kernel = tmp_path / "vmlinuz.image"
+        rootfs = tmp_path / "ubuntu-rootfs.ext4"
+        private_key = tmp_path / "id_ed25519"
+        public_key = tmp_path / "id_ed25519.pub"
+        kernel.touch()
+        rootfs.touch()
+        private_key.touch()
+        public_key.write_text("ssh-ed25519 AAAAExampleKey test@host\n")
+        mock_ensure_ssh_key.return_value = (private_key, public_key)
+        mock_ensure_published.return_value = LocalImage(
+            name="ubuntu-qemu", kernel_path=kernel, rootfs_path=rootfs
+        )
+
+        vm = MagicMock()
+        vm.vm_id = "project-spacex"
+        vm.info.config.backend = "qemu"
+        vm.info.network = MagicMock(spec=NetworkConfig)
+        vm.info.network.guest_ip = "172.16.0.2"
+        vm.info.network.ssh_host_port = 2200
+        mock_vm_cls.return_value = vm
+
+        ret = main(
+            [
+                "create",
+                "--name",
+                "project-spacex",
+                "--os",
+                "ubuntu",
+                "--backend",
+                "qemu",
+                "--json",
+            ]
+        )
+
+        assert ret == 0
+        preset, arch, vmm, os_ = mock_ensure_published.call_args.args
+        assert (preset, arch, vmm, os_) == ("ubuntu", "amd64", "qemu", "ubuntu")
+        created_config = mock_vm_cls.call_args.args[0]
+        assert isinstance(created_config, VMConfig)
+        assert created_config.guest_os is GuestOS.UBUNTU
+        assert created_config.kernel_path == kernel
+        assert created_config.rootfs_path == rootfs
+        assert created_config.rootfs_format == "raw-ext4"
+        assert created_config.extra_drives == []
+        assert "init=/init" in created_config.boot_args
+        mock_image_manager_cls.assert_not_called()
+        mock_build_seed_iso.assert_not_called()
 
     @patch("smolvm.facade._build_auto_config")
     @patch("smolvm.facade.SmolVM")
@@ -2757,7 +2826,7 @@ class TestCliInfo:
         tmp_path: Path,
         capsys: pytest.CaptureFixture,
     ) -> None:
-        """For qcow2 rootfs, disk size should report the guest-visible virtual size, not the host file footprint."""
+        """For qcow2 rootfs, disk size should report the guest-visible virtual size."""
         rootfs = tmp_path / "ubuntu" / "rootfs.qcow2"
         rootfs.parent.mkdir(parents=True)
         rootfs.write_bytes(b"\0" * (1 * 1024 * 1024))  # 1 MiB on disk

--- a/tests/test_facade.py
+++ b/tests/test_facade.py
@@ -230,27 +230,48 @@ class TestVMInit:
         created_config = mock_sdk.create.call_args[0][0]
         assert created_config.ssh_public_key == pubkey_value
 
+    @patch("smolvm.images.published.ensure_published_image")
     @patch("smolvm.utils.ensure_ssh_key")
     def test_autoconfigure_ubuntu_rejects_undersized_disk(
         self,
         mock_ensure_ssh_key: MagicMock,
+        mock_ensure_published: MagicMock,
         tmp_path: Path,
     ) -> None:
-        """Ubuntu should reject --disk-size below the default.
+        """Ubuntu should reject --disk-size below the published rootfs size."""
+        from smolvm.images.manager import LocalImage
 
-        ``ensure_ssh_key`` is mocked because the validation we're checking
-        runs after key resolution today; without the mock the test fails
-        early on hosts where ssh-keygen isn't on PATH (CI sandboxes,
-        minimal containers) and never reaches the disk-size check.
-        """
         priv = tmp_path / "id_ed25519"
         pub = tmp_path / "id_ed25519.pub"
         priv.touch()
         pub.write_text("ssh-ed25519 AAAAExampleKey test@host\n")
         mock_ensure_ssh_key.return_value = (priv, pub)
 
-        with pytest.raises(ValueError, match="disk_size_mib >= 2048"):
-            _build_auto_config(os="ubuntu", backend="qemu", disk_size_mib=512)
+        kernel = tmp_path / "vmlinux.bin"
+        rootfs = tmp_path / "rootfs.ext4"
+        kernel.touch()
+        with rootfs.open("wb") as rootfs_file:
+            rootfs_file.truncate(4096 * 1024 * 1024)
+        mock_ensure_published.return_value = LocalImage(
+            name="ubuntu-qemu", kernel_path=kernel, rootfs_path=rootfs
+        )
+
+        with pytest.raises(ValueError) as exc_info:
+            _build_auto_config(
+                vm_name="project-spacex",
+                os="ubuntu",
+                backend="qemu",
+                disk_size_mib=512,
+            )
+
+        message = str(exc_info.value)
+        assert "disk_size_mib >= 4096" in message
+        assert "got 512" in message
+        assert "default floor 2048" in message
+        assert (
+            "smolvm create --name project-spacex --os ubuntu --backend qemu --disk-size 4096"
+            in message
+        )
 
     @pytest.mark.parametrize(
         ("backend", "expected_vmm"),
@@ -301,6 +322,8 @@ class TestVMInit:
         assert "init=/init" in config.boot_args
         assert config.ssh_capable is True
         assert config.ssh_public_key == "ssh-ed25519 AAAAExampleKey test@host"
+        assert config.disk_size_mib is None
+        assert config.grow_filesystem is False
         assert not config.extra_drives
 
     @patch("smolvm.images.published.ensure_published_image")
@@ -476,6 +499,7 @@ class TestVMInit:
         assert config.initrd_path is None
         assert config.ssh_capable is True
         assert config.disk_size_mib == 8192
+        assert config.grow_filesystem is True
         assert "init=/init" in config.boot_args
         assert not config.extra_drives
         mock_image_manager_cls.assert_not_called()

--- a/tests/test_facade.py
+++ b/tests/test_facade.py
@@ -26,7 +26,6 @@ from smolvm.exceptions import (
 )
 from smolvm.facade import SmolVM, _build_auto_config
 from smolvm.images import BootImage, DirectKernelBoot, FirmwareBoot
-from smolvm.images.cloud_init import seed_cache_key
 from smolvm.types import (
     CommandResult,
     GuestOS,
@@ -253,18 +252,25 @@ class TestVMInit:
         with pytest.raises(ValueError, match="disk_size_mib >= 2048"):
             _build_auto_config(os="ubuntu", backend="qemu", disk_size_mib=512)
 
-    @patch("smolvm.images.published.ensure_published_image")
-    @patch("smolvm.images.published.is_preset_published", return_value=True)
+    @pytest.mark.parametrize(
+        ("backend", "expected_vmm"),
+        [
+            ("qemu", "qemu"),
+            ("firecracker", "firecracker"),
+            ("libkrun", "libkrun"),
+        ],
+    )
     @patch("smolvm.utils.ensure_ssh_key")
-    def test_autoconfigure_ubuntu_firecracker_uses_published_rootfs(
+    @patch("smolvm.images.published.ensure_published_image")
+    def test_autoconfigure_ubuntu_uses_published_rootfs(
         self,
-        mock_ensure_ssh_key: MagicMock,
-        _mock_is_published: MagicMock,
         mock_ensure_published: MagicMock,
+        mock_ensure_ssh_key: MagicMock,
+        backend: str,
+        expected_vmm: str,
         tmp_path: Path,
     ) -> None:
-        """Ubuntu on firecracker pulls the published raw-ext4 image and boots
-        it direct-kernel (no qcow2, no cloud-init seed)."""
+        """Ubuntu pulls the published raw-ext4 image and boots direct-kernel."""
         from smolvm.images.manager import LocalImage
 
         priv = tmp_path / "id_ed25519"
@@ -278,64 +284,34 @@ class TestVMInit:
         kernel.touch()
         rootfs.touch()
         mock_ensure_published.return_value = LocalImage(
-            name="ubuntu-fc", kernel_path=kernel, rootfs_path=rootfs
+            name=f"ubuntu-{expected_vmm}", kernel_path=kernel, rootfs_path=rootfs
         )
 
-        config, _ = _build_auto_config(os="ubuntu", backend="firecracker")
+        config, _ = _build_auto_config(os="ubuntu", backend=backend)
 
-        # Resolved the bare-Ubuntu published image for the firecracker vmm.
         preset, _arch, vmm, os_ = mock_ensure_published.call_args.args
-        assert (preset, vmm, os_) == ("ubuntu", "firecracker", "ubuntu")
+        assert (preset, vmm, os_) == ("ubuntu", expected_vmm, "ubuntu")
 
-        # Raw-ext4 direct-kernel boot, SSH key via cmdline, no cloud-init seed.
-        assert config.backend == "firecracker"
+        assert config.backend == backend
+        assert config.guest_os is GuestOS.UBUNTU
         assert config.rootfs_path == rootfs
+        assert config.rootfs_format == "raw-ext4"
         assert config.kernel_path == kernel
         assert config.boot_mode == "direct_kernel"
         assert "init=/init" in config.boot_args
+        assert config.ssh_capable is True
         assert config.ssh_public_key == "ssh-ed25519 AAAAExampleKey test@host"
         assert not config.extra_drives
 
     @patch("smolvm.images.published.ensure_published_image")
-    @patch("smolvm.images.published.is_preset_published", return_value=False)
     @patch("smolvm.utils.ensure_ssh_key")
-    def test_autoconfigure_ubuntu_firecracker_unpublished_is_clear(
+    def test_autoconfigure_ubuntu_download_error_propagates(
         self,
         mock_ensure_ssh_key: MagicMock,
-        _mock_is_published: MagicMock,
         mock_ensure_published: MagicMock,
         tmp_path: Path,
     ) -> None:
-        """When no bare-Ubuntu row is published, fail with a single-line recovery
-        command that names the sandbox — without invoking the downloader, so
-        genuine download/integrity errors stay a separate signal."""
-        from smolvm.exceptions import SmolVMError
-
-        priv = tmp_path / "id_ed25519"
-        pub = tmp_path / "id_ed25519.pub"
-        priv.touch()
-        pub.write_text("ssh-ed25519 AAAAExampleKey test@host\n")
-        mock_ensure_ssh_key.return_value = (priv, pub)
-
-        with pytest.raises(
-            SmolVMError,
-            match="smolvm create --name myvm --os ubuntu --backend qemu",
-        ):
-            _build_auto_config(os="ubuntu", backend="firecracker", vm_name="myvm")
-        mock_ensure_published.assert_not_called()
-
-    @patch("smolvm.images.published.ensure_published_image")
-    @patch("smolvm.images.published.is_preset_published", return_value=True)
-    @patch("smolvm.utils.ensure_ssh_key")
-    def test_autoconfigure_ubuntu_firecracker_download_error_propagates(
-        self,
-        mock_ensure_ssh_key: MagicMock,
-        _mock_is_published: MagicMock,
-        mock_ensure_published: MagicMock,
-        tmp_path: Path,
-    ) -> None:
-        """A published-but-broken image (download / SHA-256 failure) surfaces as
-        the original ImageError, not the friendly 'not published' message."""
+        """A published-but-broken image surfaces the original ImageError."""
         from smolvm.exceptions import ImageError
 
         priv = tmp_path / "id_ed25519"
@@ -455,23 +431,23 @@ class TestVMInit:
         assert "init=/init" in config.boot_args
         mock_builder.build_alpine_ssh_key.assert_called_once()
 
-    @patch("smolvm.facade.platform.machine", return_value="arm64")
     @patch("smolvm.facade.build_seed_iso")
     @patch("smolvm.facade.ImageManager")
     @patch("smolvm.utils.ensure_ssh_key")
-    @patch("smolvm.images.published.ensure_base_kernel")
-    def test_named_auto_config_qemu_keeps_backend_specific_settings(
+    @patch("smolvm.images.published.ensure_published_image")
+    def test_named_auto_config_qemu_uses_published_ubuntu(
         self,
-        mock_ensure_base_kernel: MagicMock,
+        mock_ensure_published: MagicMock,
         mock_ensure_ssh_key: MagicMock,
         mock_image_manager_cls: MagicMock,
         mock_build_seed_iso: MagicMock,
-        _: MagicMock,
         tmp_path: Path,
     ) -> None:
-        """QEMU auto-config should use the prebuilt rootfs + SmolVM base kernel."""
+        """QEMU auto-config should use the public published Ubuntu image."""
+        from smolvm.images.manager import LocalImage
+
         kernel = tmp_path / "vmlinux.bin"
-        rootfs = tmp_path / "rootfs.qcow2"
+        rootfs = tmp_path / "rootfs.ext4"
         private_key = tmp_path / "id_ed25519"
         public_key = tmp_path / "id_ed25519.pub"
         kernel.touch()
@@ -480,65 +456,55 @@ class TestVMInit:
         public_key.write_text("ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIMockKey user@test\n")
 
         mock_ensure_ssh_key.return_value = (private_key, public_key)
-        mock_build_seed_iso.side_effect = lambda path, **kwargs: (
-            path.parent.mkdir(parents=True, exist_ok=True),
-            path.touch(),
-        )[-1]
-        mock_image_manager = MagicMock()
-        mock_image_manager.cache_dir = tmp_path
-        mock_image_manager.ensure_rootfs_only.return_value = rootfs
-        mock_image_manager_cls.return_value = mock_image_manager
-        mock_ensure_base_kernel.return_value = kernel
+        mock_ensure_published.return_value = LocalImage(
+            name="ubuntu-qemu", kernel_path=kernel, rootfs_path=rootfs
+        )
 
-        config, _ = _build_auto_config(vm_name="project-spacex", backend="qemu")
+        config, _ = _build_auto_config(
+            vm_name="project-spacex",
+            backend="qemu",
+            disk_size_mib=8192,
+        )
 
+        preset, _arch, vmm, os_ = mock_ensure_published.call_args.args
+        assert (preset, vmm, os_) == ("ubuntu", "qemu", "ubuntu")
         assert config.backend == "qemu"
         assert config.kernel_path == kernel
-        assert config.initrd_path is None  # direct kernel boot, no initrd
+        assert config.rootfs_path == rootfs
+        assert config.rootfs_format == "raw-ext4"
+        assert config.guest_os is GuestOS.UBUNTU
+        assert config.initrd_path is None
         assert config.ssh_capable is True
-        assert "root=/dev/vda1" in config.boot_args
-        assert config.extra_drives[0].suffix == ".iso"
-        mock_image_manager.ensure_rootfs_only.assert_called_once()
-        mock_ensure_base_kernel.assert_called_once()
+        assert config.disk_size_mib == 8192
+        assert "init=/init" in config.boot_args
+        assert not config.extra_drives
+        mock_image_manager_cls.assert_not_called()
+        mock_build_seed_iso.assert_not_called()
 
-    @patch("smolvm.facade.platform.machine", return_value="arm64")
     @patch("smolvm.facade.build_seed_iso")
     @patch("smolvm.facade.ImageManager")
-    @patch("smolvm.utils.ensure_ssh_key")
-    @patch("smolvm.images.published.ensure_base_kernel")
-    def test_named_auto_config_qemu_uses_explicit_ssh_key_for_seed(
+    @patch("smolvm.images.published.ensure_published_image")
+    def test_named_auto_config_qemu_uses_explicit_ssh_key(
         self,
-        mock_ensure_base_kernel: MagicMock,
-        mock_ensure_ssh_key: MagicMock,
+        mock_ensure_published: MagicMock,
         mock_image_manager_cls: MagicMock,
         mock_build_seed_iso: MagicMock,
-        _: MagicMock,
         tmp_path: Path,
     ) -> None:
-        """QEMU auto-config should honor an explicit SSH key when building the seed ISO."""
+        """QEMU auto-config should put the explicit SSH key on the config."""
+        from smolvm.images.manager import LocalImage
+
         kernel = tmp_path / "vmlinux.bin"
-        rootfs = tmp_path / "rootfs.qcow2"
-        default_private = tmp_path / "id_ed25519"
-        default_public = tmp_path / "id_ed25519.pub"
+        rootfs = tmp_path / "rootfs.ext4"
         custom_private = tmp_path / "custom_id_ed25519"
         custom_public = tmp_path / "custom_id_ed25519.pub"
         kernel.touch()
         rootfs.touch()
-        default_private.touch()
-        default_public.write_text("ssh-ed25519 AAAAC3NzaDefault user@test\n")
         custom_private.touch()
         custom_public.write_text("ssh-ed25519 AAAAC3NzaCustom user@test\n")
-
-        mock_ensure_ssh_key.return_value = (default_private, default_public)
-        mock_build_seed_iso.side_effect = lambda path, **kwargs: (
-            path.parent.mkdir(parents=True, exist_ok=True),
-            path.touch(),
-        )[-1]
-        mock_image_manager = MagicMock()
-        mock_image_manager.cache_dir = tmp_path
-        mock_image_manager.ensure_rootfs_only.return_value = rootfs
-        mock_image_manager_cls.return_value = mock_image_manager
-        mock_ensure_base_kernel.return_value = kernel
+        mock_ensure_published.return_value = LocalImage(
+            name="ubuntu-qemu", kernel_path=kernel, rootfs_path=rootfs
+        )
 
         config, ssh_key_path = _build_auto_config(
             vm_name="project-spacex",
@@ -546,21 +512,12 @@ class TestVMInit:
             ssh_key_path=str(custom_private),
         )
 
-        actual_user_data = mock_build_seed_iso.call_args.kwargs["user_data"]
-        expected_seed_name = (
-            seed_cache_key(
-                ssh_public_key=custom_public.read_text().strip(),
-                instance_id="smolvm-20260406",
-                hostname="smolvm",
-                user_data=actual_user_data,
-            )
-            + ".iso"
-        )
         assert ssh_key_path == str(custom_private)
-        assert config.extra_drives[0].name == expected_seed_name
+        assert config.ssh_public_key == "ssh-ed25519 AAAAC3NzaCustom user@test"
         assert config.ssh_capable is True
-        assert "AAAAC3NzaCustom" in actual_user_data
-        mock_ensure_ssh_key.assert_not_called()
+        assert not config.extra_drives
+        mock_image_manager_cls.assert_not_called()
+        mock_build_seed_iso.assert_not_called()
 
     @patch("smolvm.facade.SmolVMManager")
     def test_from_id(self, mock_sdk_cls: MagicMock) -> None:

--- a/tests/test_facade.py
+++ b/tests/test_facade.py
@@ -265,9 +265,7 @@ class TestVMInit:
             )
 
         message = str(exc_info.value)
-        assert "disk_size_mib >= 4096" in message
-        assert "got 512" in message
-        assert "default floor 2048" in message
+        assert "Ubuntu needs at least 4096 MiB for sandbox 'project-spacex'" in message
         assert (
             "smolvm create --name project-spacex --os ubuntu --backend qemu --disk-size 4096"
             in message
@@ -322,7 +320,7 @@ class TestVMInit:
         assert "init=/init" in config.boot_args
         assert config.ssh_capable is True
         assert config.ssh_public_key == "ssh-ed25519 AAAAExampleKey test@host"
-        assert config.disk_size_mib is None
+        assert config.disk_size_mib == 2048
         assert config.grow_filesystem is False
         assert not config.extra_drives
 

--- a/tests/test_published_images.py
+++ b/tests/test_published_images.py
@@ -62,6 +62,15 @@ def test_ubuntu_rows_share_one_rootfs_across_vmms() -> None:
     assert qemu.kernel_url.endswith(".image")
 
 
+def test_published_ubuntu_manifest_shares_rootfs_for_qemu_and_firecracker() -> None:
+    """The live manifest keeps QEMU and Firecracker on the same Ubuntu rootfs."""
+    qemu = MANIFEST[("ubuntu", "amd64", "qemu", "ubuntu")]
+    firecracker = MANIFEST[("ubuntu", "amd64", "firecracker", "ubuntu")]
+
+    assert qemu.rootfs_url == firecracker.rootfs_url
+    assert qemu.rootfs_sha256 == firecracker.rootfs_sha256
+
+
 @pytest.fixture
 def sample_entry() -> PublishedImage:
     """A manifest entry pointing at an UNCOMPRESSED rootfs.

--- a/tests/test_vm.py
+++ b/tests/test_vm.py
@@ -20,16 +20,17 @@ import time
 from contextlib import suppress
 from pathlib import Path
 from types import SimpleNamespace
-from unittest.mock import MagicMock, call, patch
+from unittest.mock import AsyncMock, MagicMock, call, patch
 
 import pytest
 
+from smolvm.comm.select import ChannelResolution
 from smolvm.exceptions import (
     SmolVMError,
     VMAlreadyExistsError,
     VMNotFoundError,
 )
-from smolvm.types import VMConfig, VMInfo, VMState
+from smolvm.types import VMConfig, VMInfo, VMState, WorkspaceMount
 from smolvm.vm import SmolVMManager
 
 
@@ -58,6 +59,21 @@ def sample_config(tmp_path: Path) -> VMConfig:
         kernel_path=kernel,
         rootfs_path=rootfs,
     )
+
+
+def _attach_mock_network(manager: SmolVMManager) -> MagicMock:
+    """Attach a network mock that supports sync and async create paths."""
+    mock_network = MagicMock()
+    mock_network.host_ip = "172.16.0.1"
+    mock_network.generate_mac.return_value = "AA:FC:00:00:00:01"
+    mock_network.async_create_tap = AsyncMock()
+    mock_network.async_configure_tap = AsyncMock()
+    mock_network.async_add_route = AsyncMock()
+    mock_network.async_setup_nat = AsyncMock()
+    mock_network.async_apply_egress_allowlist = AsyncMock()
+    mock_network.async_setup_ssh_port_forward = AsyncMock()
+    manager.network = mock_network
+    return mock_network
 
 
 class TestSmolVMCreate:
@@ -197,6 +213,194 @@ class TestSmolVMCreate:
             patch.object(smol_vm, "_find_qemu_img_binary", return_value=None),
         ):
             assert smol_vm.check_prerequisites() == []
+
+    @patch("smolvm.comm.select.platform.system", return_value="Linux")
+    def test_create_firecracker_explicit_vsock_skips_ssh_forward(
+        self,
+        _mock_system: MagicMock,
+        smol_vm: SmolVMManager,
+        sample_config: VMConfig,
+    ) -> None:
+        """Explicit Firecracker vsock without SSH-backed startup should not add DNAT."""
+        mock_network = _attach_mock_network(smol_vm)
+        config = sample_config.model_copy(
+            update={"vm_id": "vm-vsock", "backend": "firecracker", "comm_channel": "vsock"}
+        )
+
+        vm_info = smol_vm.create(config)
+
+        assert vm_info.network is not None
+        assert vm_info.network.ssh_host_port is None
+        assert vm_info.config.vsock is not None
+        mock_network.setup_ssh_port_forward.assert_not_called()
+
+    @patch("smolvm.comm.select.platform.system", return_value="Linux")
+    def test_create_firecracker_auto_keeps_ssh_forward_for_fallback(
+        self,
+        _mock_system: MagicMock,
+        smol_vm: SmolVMManager,
+        sample_config: VMConfig,
+    ) -> None:
+        """Auto channel keeps SSH forwarding so vsock probe fallback still works."""
+        mock_network = _attach_mock_network(smol_vm)
+        config = sample_config.model_copy(update={"vm_id": "vm-auto", "backend": "firecracker"})
+
+        vm_info = smol_vm.create(config)
+
+        assert vm_info.network is not None
+        assert vm_info.network.ssh_host_port is not None
+        mock_network.setup_ssh_port_forward.assert_called_once()
+
+    @patch("smolvm.comm.select.platform.system", return_value="Linux")
+    def test_create_firecracker_explicit_ssh_keeps_ssh_forward(
+        self,
+        _mock_system: MagicMock,
+        smol_vm: SmolVMManager,
+        sample_config: VMConfig,
+    ) -> None:
+        """Explicit SSH must reserve and expose a host SSH port."""
+        mock_network = _attach_mock_network(smol_vm)
+        config = sample_config.model_copy(
+            update={"vm_id": "vm-ssh", "backend": "firecracker", "comm_channel": "ssh"}
+        )
+
+        vm_info = smol_vm.create(config)
+
+        assert vm_info.network is not None
+        assert vm_info.network.ssh_host_port is not None
+        mock_network.setup_ssh_port_forward.assert_called_once()
+
+    @patch("smolvm.comm.select.platform.system", return_value="Linux")
+    def test_create_firecracker_explicit_vsock_with_env_keeps_ssh_forward(
+        self,
+        _mock_system: MagicMock,
+        smol_vm: SmolVMManager,
+        sample_config: VMConfig,
+    ) -> None:
+        """Env injection is still SSH-backed at startup, so keep forwarding."""
+        mock_network = _attach_mock_network(smol_vm)
+        config = sample_config.model_copy(
+            update={
+                "vm_id": "vm-vsock-env",
+                "backend": "firecracker",
+                "comm_channel": "vsock",
+                "env_vars": {"SMOLVM_TEST": "1"},
+            }
+        )
+
+        vm_info = smol_vm.create(config)
+
+        assert vm_info.network is not None
+        assert vm_info.network.ssh_host_port is not None
+        mock_network.setup_ssh_port_forward.assert_called_once()
+
+    @patch("smolvm.comm.select.host_supports_vsock", return_value=True)
+    def test_create_qemu_slirp_explicit_vsock_keeps_ssh_hostfwd(
+        self,
+        _mock_host_vsock: MagicMock,
+        tmp_path: Path,
+        sample_config: VMConfig,
+    ) -> None:
+        """QEMU slirp keeps hostfwd for terminal compatibility under explicit vsock."""
+        smol_vm = SmolVMManager(
+            data_dir=tmp_path / "data-qemu-vsock",
+            socket_dir=tmp_path / "sockets-qemu-vsock",
+            backend="qemu",
+        )
+        mock_network = _attach_mock_network(smol_vm)
+        config = sample_config.model_copy(
+            update={
+                "vm_id": "vm-qemu-vsock",
+                "backend": "qemu",
+                "comm_channel": "vsock",
+                "qemu_network": "slirp",
+            }
+        )
+
+        vm_info = smol_vm.create(config)
+
+        assert vm_info.network is not None
+        assert vm_info.network.tap_device == "usernet"
+        assert vm_info.network.ssh_host_port is not None
+        mock_network.setup_ssh_port_forward.assert_not_called()
+
+    def test_qemu_tap_workspace_policy_keeps_ssh_forward(
+        self,
+        tmp_path: Path,
+        sample_config: VMConfig,
+    ) -> None:
+        """Workspace startup remains SSH-backed even when the control channel is vsock."""
+        smol_vm = SmolVMManager(
+            data_dir=tmp_path / "data-qemu-workspace",
+            socket_dir=tmp_path / "sockets-qemu-workspace",
+            backend="qemu",
+        )
+        workspace = tmp_path / "workspace"
+        workspace.mkdir()
+        config = sample_config.model_copy(
+            update={
+                "vm_id": "vm-qemu-workspace",
+                "backend": "qemu",
+                "comm_channel": "vsock",
+                "qemu_network": "tap",
+                "workspace_mounts": [WorkspaceMount(host_path=workspace)],
+            }
+        )
+
+        assert smol_vm._should_reserve_ssh_forward(
+            config,
+            "qemu",
+            resolution=ChannelResolution(kind="vsock", allow_fallback=False),
+        )
+
+    def test_firecracker_workspace_policy_keeps_ssh_forward(
+        self,
+        tmp_path: Path,
+        smol_vm: SmolVMManager,
+        sample_config: VMConfig,
+    ) -> None:
+        """Workspace startup is SSH-backed by policy even before backend validation."""
+        workspace = tmp_path / "workspace-firecracker"
+        workspace.mkdir()
+        config = sample_config.model_copy(
+            update={
+                "vm_id": "vm-fc-workspace",
+                "backend": "firecracker",
+                "comm_channel": "vsock",
+                "workspace_mounts": [WorkspaceMount(host_path=workspace)],
+            }
+        )
+
+        assert smol_vm._should_reserve_ssh_forward(
+            config,
+            "firecracker",
+            resolution=ChannelResolution(kind="vsock", allow_fallback=False),
+        )
+
+    @pytest.mark.asyncio
+    @patch("smolvm.comm.select.platform.system", return_value="Linux")
+    async def test_async_create_firecracker_explicit_vsock_skips_ssh_forward(
+        self,
+        _mock_system: MagicMock,
+        tmp_path: Path,
+        sample_config: VMConfig,
+    ) -> None:
+        """Async create should mirror the Firecracker explicit-vsock no-forward policy."""
+        smol_vm = SmolVMManager(
+            data_dir=tmp_path / "data-async-vsock",
+            socket_dir=tmp_path / "sockets-async-vsock",
+            backend="firecracker",
+        )
+        mock_network = _attach_mock_network(smol_vm)
+        config = sample_config.model_copy(
+            update={"vm_id": "vm-async-vsock", "backend": "firecracker", "comm_channel": "vsock"}
+        )
+
+        vm_info = await smol_vm.async_create(config)
+
+        assert vm_info.network is not None
+        assert vm_info.network.ssh_host_port is None
+        mock_network.async_setup_ssh_port_forward.assert_not_awaited()
 
 
 class TestSmolVMDiskLifecycle:

--- a/tests/test_vm.py
+++ b/tests/test_vm.py
@@ -381,6 +381,30 @@ class TestSmolVMCreate:
             resolution=ChannelResolution(kind="vsock", allow_fallback=False),
         )
 
+    def test_explicit_vsock_error_uses_recovery_payload(
+        self,
+        smol_vm: SmolVMManager,
+        sample_config: VMConfig,
+    ) -> None:
+        """Explicit-vsock create errors should not expose selector internals."""
+        config = sample_config.model_copy(
+            update={"vm_id": "vm-vsock-bad", "backend": "libkrun", "comm_channel": "vsock"}
+        )
+
+        with pytest.raises(SmolVMError) as exc_info:
+            smol_vm._resolve_control_channel_for_config(config, "libkrun")
+
+        assert (
+            str(exc_info.value)
+            == "Cannot use vsock for sandbox 'vm-vsock-bad': this backend does not support "
+            "vsock in this release; create it with SSH by running: "
+            "smolvm create --name vm-vsock-bad --backend libkrun."
+        )
+        assert exc_info.value.details == {
+            "vm_id": "vm-vsock-bad",
+            "recovery_command": "smolvm create --name vm-vsock-bad --backend libkrun",
+        }
+
     @pytest.mark.asyncio
     @patch("smolvm.comm.select.platform.system", return_value="Linux")
     async def test_async_create_firecracker_explicit_vsock_skips_ssh_forward(

--- a/tests/test_vm.py
+++ b/tests/test_vm.py
@@ -314,15 +314,18 @@ class TestSmolVMCreate:
                 "backend": "qemu",
                 "comm_channel": "vsock",
                 "qemu_network": "slirp",
+                "disk_mode": "shared",
                 "rootfs_format": "raw-ext4",
             }
         )
 
-        vm_info = smol_vm.create(config)
+        with patch.object(smol_vm, "_create_qemu_overlay_disk") as mock_overlay:
+            vm_info = smol_vm.create(config)
 
         assert vm_info.network is not None
         assert vm_info.network.tap_device == "usernet"
         assert vm_info.network.ssh_host_port is not None
+        mock_overlay.assert_not_called()
         mock_network.setup_ssh_port_forward.assert_not_called()
 
     def test_qemu_tap_workspace_policy_keeps_ssh_forward(

--- a/tests/test_vm.py
+++ b/tests/test_vm.py
@@ -314,6 +314,7 @@ class TestSmolVMCreate:
                 "backend": "qemu",
                 "comm_channel": "vsock",
                 "qemu_network": "slirp",
+                "rootfs_format": "raw-ext4",
             }
         )
 


### PR DESCRIPTION
## Summary

- Route `SmolVM(os="ubuntu", backend="qemu")` and CLI `smolvm create --os ubuntu --backend qemu` through the public published `ubuntu` preset instead of the legacy Ubuntu cloud qcow2 path.
- Keep published Ubuntu direct-kernel/raw-ext4 behavior consistent across QEMU, Firecracker, and libkrun.
- Add a create-time SSH forwarding policy so explicit Firecracker vsock skips SSH DNAT when startup does not need SSH, while QEMU slirp still keeps SSH hostfwd for `smolvm ssh` compatibility.
- Update tests/docs around published Ubuntu and forwarding behavior.

## Why

QEMU Ubuntu auto-config was still using the old cloud-image qcow2 + seed ISO path, which made it differ from the published bare Ubuntu image used for other VMMs. Firecracker explicit-vsock sandboxes also still reserved SSH ports and installed tap DNAT rules even when no SSH-backed startup feature needed them, which kept stale-port failures in the vsock path.

## Validation

- `uv run --extra dev ruff check src/smolvm/facade.py src/smolvm/vm.py src/smolvm/images/published.py tests/test_facade.py tests/test_cli.py tests/test_published_images.py tests/test_vm.py tests/e2e/conftest.py docs/deep-dive/microvm-from-first-principles.md`
- `uv run --extra dev pytest tests/test_vm.py::TestSmolVMCreate::test_create_qemu_slirp_explicit_vsock_keeps_ssh_hostfwd -q`
- `uv run --extra dev pytest -m "not e2e" -q` (`1322 passed, 13 skipped, 26 deselected`)
- `uv run --extra dev pytest -m e2e tests/e2e -v` (`26 passed`)
- Published Ubuntu cache check: QEMU and Firecracker rootfs are both 4096 MiB.

## Local Benchmark

Warm-cache medians on published Ubuntu, 3 measured iterations per variant:

| Backend | Transport | Total ready | First command | Warm exec |
|---|---:|---:|---:|---:|
| QEMU | SSH | 1342.3 ms | 10.4 ms | 42.1 ms |
| QEMU | vsock | 1408.2 ms | 1.1 ms | 0.8 ms |
| Firecracker | SSH | 2879.0 ms | 53.9 ms | 42.8 ms |
| Firecracker | vsock | 2334.0 ms | 1.3 ms | 1.0 ms |

The local benchmark note remains uncommitted as `tmp-published-ubuntu-benchmark.md`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Default Ubuntu base images now use the published, SHA‑pinned rootfs across all supported backends; external CDN downloads removed.
  * VM creation reserves SSH forwarding only when required; logs explicitly note when forwarding is disabled.
  * Vsock-related errors include a concise recovery command for user guidance.

* **Tests**
  * Added and expanded tests for published-Ubuntu image usage, disk-size validation, and SSH-forwarding reservation across backends.

* **Documentation**
  * Clarified Ubuntu rootfs usage, image pinning, and follow-up operational notes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->