### PR TITLE
[codex] Improve startup timing and vsock readiness

### DIFF
--- a/scripts/benchmarks/README.md
+++ b/scripts/benchmarks/README.md
@@ -50,13 +50,19 @@ uv run python scripts/benchmarks/bench.py --backend qemu
 
 | Benchmark      | Metrics                                                         | What it measures |
 |----------------|-----------------------------------------------------------------|------------------|
-| `cold-start`   | `construct_ms`, `boot_to_ssh_ms`, `total_ms`                    | First VM boot in this process. The image cache on disk is assumed already populated; "cold" means no warm SmolVM state in memory and no per-VM disk overlay yet. |
-| `tti`          | same as `cold-start`                                            | Subsequent boots — the steady-state experience. `tti` runs a warm-up boot first (excluded from stats), then takes `--iterations` measurements. Compare `results["tti"]["stats"]["total_ms"]["p50"]` to `results["cold-start"]["raw"][0]["total_ms"]` to see the one-time cost. |
+| `cold-start`   | `host_create_ms`, `vmm_start_ms`, `guest_ready_wait_ms`, `total_fresh_ready_ms`, `first_command_ms`, `total_first_command_ms` | First VM boot in this process. The image cache on disk is assumed already populated; "cold" means no warm SmolVM state in memory and no per-VM disk overlay yet. |
+| `tti`          | same as `cold-start`                                            | Subsequent boots — the steady-state experience. `tti` runs a warm-up boot first (excluded from stats), then takes `--iterations` measurements. Compare `results["tti"]["stats"]["total_fresh_ready_ms"]["p50"]` to `results["cold-start"]["raw"][0]["total_fresh_ready_ms"]` to see the one-time cost. |
 | `pause-resume` | `pause_ms`, `resume_ms`                                         | Freeze and unfreeze a long-lived VM. |
 | `snapshot`     | `snapshot_create_ms`, `snapshot_restore_ms`, `snapshot_restore_to_ssh_ms` | Persist VM state and bring it back. Each iteration uses a fresh source VM. |
 
 All timings are wall-clock milliseconds via `time.monotonic()`.
 Each benchmark reports `{p50, p95, mean, min, max, count}` plus the raw per-iteration values.
+
+For `cold-start` and `tti`, `vmm_start_ms` is only the host VMM process/API
+startup. `total_fresh_ready_ms` is the user-facing fresh guest readiness
+metric: host create + VMM start + guest boot until SSH is ready. Use
+`total_first_command_ms` when comparing end-to-end "sandbox can run work"
+latency.
 
 ## JSON shape
 
@@ -71,11 +77,14 @@ Each benchmark reports `{p50, p95, mean, min, max, count}` plus the raw per-iter
   "results": {
     "cold-start": {
       "stats": {
-        "construct_ms": {"p50": ..., "p95": ..., "mean": ..., "min": ..., "max": ..., "count": 5},
-        "boot_to_ssh_ms": { ... },
-        "total_ms": { ... }
+        "host_create_ms": {"p50": ..., "p95": ..., "mean": ..., "min": ..., "max": ..., "count": 5},
+        "vmm_start_ms": { ... },
+        "guest_ready_wait_ms": { ... },
+        "total_fresh_ready_ms": { ... },
+        "first_command_ms": { ... },
+        "total_first_command_ms": { ... }
       },
-      "raw": [{"iter": 0, "construct_ms": ..., "boot_to_ssh_ms": ..., "total_ms": ...}, ...]
+      "raw": [{"iter": 0, "host_create_ms": ..., "vmm_start_ms": ..., "guest_ready_wait_ms": ..., "total_fresh_ready_ms": ...}, ...]
     },
     "tti": { ... },
     "pause-resume": { "stats": {"pause_ms": ..., "resume_ms": ...}, "raw": [...] },

--- a/scripts/benchmarks/README.md
+++ b/scripts/benchmarks/README.md
@@ -84,7 +84,16 @@ latency.
         "first_command_ms": { ... },
         "total_first_command_ms": { ... }
       },
-      "raw": [{"iter": 0, "host_create_ms": ..., "vmm_start_ms": ..., "guest_ready_wait_ms": ..., "total_fresh_ready_ms": ...}, ...]
+      "raw": [{
+        "iter": 0,
+        "host_create_ms": ...,
+        "vmm_start_ms": ...,
+        "guest_ready_wait_ms": ...,
+        "total_fresh_ready_ms": ...,
+        "first_command_ms": ...,
+        "total_first_command_ms": ...,
+        "guest_uptime_at_first_command_s": ...
+      }, ...]
     },
     "tti": { ... },
     "pause-resume": { "stats": {"pause_ms": ..., "resume_ms": ...}, "raw": [...] },

--- a/scripts/benchmarks/bench.py
+++ b/scripts/benchmarks/bench.py
@@ -16,8 +16,8 @@
 """SmolVM benchmark suite — drives the public SDK and measures real lifecycle timings.
 
 Benchmarks:
-    cold-start    Time from SmolVM(...) to a booted, SSH-reachable VM (first time, no warm caches).
-    tti           Time-to-interactive on subsequent boots (image cache warm).
+    cold-start    Fresh guest readiness split into host, VMM, guest, and command phases.
+    tti           Same split on subsequent boots (image cache warm).
     pause-resume  How fast we can freeze and unfreeze a running VM.
     snapshot      How fast we can persist VM state and bring it back.
 
@@ -189,9 +189,12 @@ def _bench_boot(backend: str, iterations: int, label: str) -> dict[str, Any]:
     """Shared implementation for cold-start and tti — they differ only in cache state."""
     from smolvm.facade import SmolVM
 
-    construct: list[float] = []
-    boot_to_ssh: list[float] = []
-    totals: list[float] = []
+    host_create: list[float] = []
+    vmm_start: list[float] = []
+    guest_ready_wait: list[float] = []
+    first_command: list[float] = []
+    total_fresh_ready: list[float] = []
+    total_first_command: list[float] = []
     raw: list[dict[str, Any]] = []
 
     for i in range(iterations):
@@ -199,19 +202,45 @@ def _bench_boot(backend: str, iterations: int, label: str) -> dict[str, Any]:
         vm: SmolVM | None = None
         record: dict[str, Any] = {"iter": i}
         try:
-            with Phase() as p_construct:
+            with Phase() as p_create:
                 vm = _new_vm(backend)
-            record["construct_ms"] = round(p_construct.elapsed_ms, 1)
-            construct.append(record["construct_ms"])
+            record["host_create_ms"] = round(p_create.elapsed_ms, 1)
+            host_create.append(record["host_create_ms"])
 
-            with Phase() as p_boot:
+            with Phase() as p_start:
                 vm.start()
-                vm.wait_for_ssh()
-            record["boot_to_ssh_ms"] = round(p_boot.elapsed_ms, 1)
-            boot_to_ssh.append(record["boot_to_ssh_ms"])
+            record["vmm_start_ms"] = round(p_start.elapsed_ms, 1)
+            vmm_start.append(record["vmm_start_ms"])
 
-            record["total_ms"] = round(record["construct_ms"] + record["boot_to_ssh_ms"], 1)
-            totals.append(record["total_ms"])
+            with Phase() as p_ready:
+                vm.wait_for_ssh()
+            record["guest_ready_wait_ms"] = round(p_ready.elapsed_ms, 1)
+            guest_ready_wait.append(record["guest_ready_wait_ms"])
+
+            with Phase() as p_first_command:
+                result = vm.run("cat /proc/uptime", shell="raw")
+            record["first_command_ms"] = round(p_first_command.elapsed_ms, 1)
+            first_command.append(record["first_command_ms"])
+            try:
+                record["guest_uptime_at_first_command_s"] = round(
+                    float(result.stdout.split()[0]),
+                    3,
+                )
+            except (IndexError, TypeError, ValueError):
+                record["guest_uptime_at_first_command_s"] = None
+
+            record["total_fresh_ready_ms"] = round(
+                record["host_create_ms"]
+                + record["vmm_start_ms"]
+                + record["guest_ready_wait_ms"],
+                1,
+            )
+            total_fresh_ready.append(record["total_fresh_ready_ms"])
+            record["total_first_command_ms"] = round(
+                record["total_fresh_ready_ms"] + record["first_command_ms"],
+                1,
+            )
+            total_first_command.append(record["total_first_command_ms"])
         except Exception as e:  # noqa: BLE001
             record["error"] = repr(e)
             logger.warning("[%s] iter %d failed: %s", label, i + 1, e)
@@ -221,9 +250,12 @@ def _bench_boot(backend: str, iterations: int, label: str) -> dict[str, Any]:
 
     return {
         "stats": {
-            "construct_ms": stats(construct),
-            "boot_to_ssh_ms": stats(boot_to_ssh),
-            "total_ms": stats(totals),
+            "host_create_ms": stats(host_create),
+            "vmm_start_ms": stats(vmm_start),
+            "guest_ready_wait_ms": stats(guest_ready_wait),
+            "total_fresh_ready_ms": stats(total_fresh_ready),
+            "first_command_ms": stats(first_command),
+            "total_first_command_ms": stats(total_first_command),
         },
         "raw": raw,
     }

--- a/scripts/ci/preset-init.sh
+++ b/scripts/ci/preset-init.sh
@@ -50,6 +50,16 @@ mount -o remount,rw /
 mkdir -p /run/sshd /var/log /tmp
 chmod 1777 /tmp
 
+# ── Guest agent (vsock control plane) ────────────────────────
+# Started before networking and sshd, so explicit-vsock sandboxes can become
+# ready without waiting for SSH host-key generation or network setup. Skipped
+# silently if the agent is missing (the host falls back to SSH in that case).
+# Mirrors _base_init_script() in src/smolvm/images/builder.py.
+if [ -x /usr/local/bin/smolvm-guest-agent ]; then
+    /usr/local/bin/smolvm-guest-agent --listen vsock://1024 >/var/log/smolvm-agent.log 2>&1 &
+    echo "SmolVM init: guest agent started (PID=$!)"
+fi
+
 # ── Networking ───────────────────────────────────────────────
 # Format: ip=<guest_ip>::<gateway>:<netmask>::eth0:off (kernel ip= param)
 netmask_to_prefix() {
@@ -128,16 +138,6 @@ if [ -n "$AUTHKEY_B64" ]; then
         echo "$DECODED" > /root/.ssh/authorized_keys
         chmod 600 /root/.ssh/authorized_keys
     fi
-fi
-
-# ── Guest agent (vsock control plane) ────────────────────────
-# Started before sshd and independent of networking, so the host can drive
-# the guest over vsock the moment the kernel is up. Skipped silently if
-# the agent is missing (the host falls back to SSH in that case).
-# Mirrors _base_init_script() in src/smolvm/images/builder.py.
-if [ -x /usr/local/bin/smolvm-guest-agent ]; then
-    /usr/local/bin/smolvm-guest-agent --listen vsock://1024 >/var/log/smolvm-agent.log 2>&1 &
-    echo "SmolVM init: guest agent started (PID=$!)"
 fi
 
 # ── Clock sync (host-sleep drift) ────────────────────────────

--- a/scripts/ci/preset-init.sh
+++ b/scripts/ci/preset-init.sh
@@ -58,6 +58,8 @@ chmod 1777 /tmp
 if [ -x /usr/local/bin/smolvm-guest-agent ]; then
     /usr/local/bin/smolvm-guest-agent --listen vsock://1024 >/var/log/smolvm-agent.log 2>&1 &
     echo "SmolVM init: guest agent started (PID=$!)"
+else
+    echo "SmolVM init: guest agent not found, continuing without it" >&2
 fi
 
 # ── Networking ───────────────────────────────────────────────

--- a/src/smolvm/comm/rust_http_vsock_channel.py
+++ b/src/smolvm/comm/rust_http_vsock_channel.py
@@ -36,6 +36,9 @@ from smolvm.types import CommandResult
 
 logger = logging.getLogger(__name__)
 
+_READY_FAST_POLL_WINDOW = 1.0
+_READY_FAST_POLL_INTERVAL = 0.02
+
 
 class _SocketHTTPConnection(http.client.HTTPConnection):
     """HTTPConnection that uses a caller-supplied connected socket."""
@@ -249,14 +252,21 @@ class RustHttpVsockChannel:
     def wait_ready(self, timeout: float = 60.0, interval: float = 0.1) -> None:
         if timeout <= 0:
             raise ValueError("timeout must be > 0")
+        if interval <= 0:
+            raise ValueError("interval must be > 0")
+        started_at = time.monotonic()
         deadline = time.monotonic() + timeout
         last_error = ""
         target = self.uds_path if self.uds_path is not None else f"cid={self.guest_cid}"
         logger.info("Waiting for Rust guest agent on vsock %s (timeout=%.0fs)", target, timeout)
 
         while time.monotonic() < deadline:
+            elapsed = time.monotonic() - started_at
+            poll_interval = interval
+            if elapsed < _READY_FAST_POLL_WINDOW:
+                poll_interval = min(interval, _READY_FAST_POLL_INTERVAL)
             try:
-                resp = self._request_json("GET", "/health", timeout=max(1.0, interval))
+                resp = self._request_json("GET", "/health", timeout=max(1.0, poll_interval))
                 if resp.get("status") == "ok":
                     self._ready = True
                     logger.info("Rust guest agent is ready on vsock %s", target)
@@ -267,7 +277,7 @@ class RustHttpVsockChannel:
             remaining = deadline - time.monotonic()
             if remaining <= 0:
                 break
-            time.sleep(min(interval, remaining))
+            time.sleep(min(poll_interval, remaining))
 
         raise OperationTimeoutError(
             f"wait_ready(rust-vsock {target}): last error: {last_error}", timeout

--- a/src/smolvm/images/builder.py
+++ b/src/smolvm/images/builder.py
@@ -1394,6 +1394,20 @@ chmod 1777 /tmp
 
 log_ts "root-ready"
 
+# ── Guest agent (vsock control plane) ───────────────────────
+# Started before networking and sshd, so explicit-vsock sandboxes can become
+# ready without waiting for SSH host-key generation or network setup. Skipped
+# silently if the agent wasn't baked in — the host falls back to SSH in that
+# case.
+log_ts "guest-agent-start"
+if [ -x /usr/local/bin/smolvm-guest-agent ]; then
+    /usr/local/bin/smolvm-guest-agent --listen vsock://1024 >/var/log/smolvm-agent.log 2>&1 &
+    echo "SmolVM init: guest agent started (PID=$!)"
+else
+    echo "SmolVM init: guest agent not started (agent missing)"
+fi
+log_ts "guest-agent-started"
+
 # ── Networking ───────────────────────────────────────────────
 log_ts "net-config-start"
 # Configure from kernel command line ip= parameter
@@ -1456,20 +1470,6 @@ fi
 
 hostname {custom_hostname}
 log_ts "net-ready"
-
-# ── Guest agent (vsock control plane) ───────────────────────
-# Started before sshd and independent of networking, so the host can
-# drive the guest over vsock the moment the kernel is up. Skipped
-# silently if the agent wasn't baked in — the host falls back to SSH in
-# that case.
-log_ts "guest-agent-start"
-if [ -x /usr/local/bin/smolvm-guest-agent ]; then
-    /usr/local/bin/smolvm-guest-agent --listen vsock://1024 >/var/log/smolvm-agent.log 2>&1 &
-    echo "SmolVM init: guest agent started (PID=$!)"
-else
-    echo "SmolVM init: guest agent not started (agent missing)"
-fi
-log_ts "guest-agent-started"
 
 # ── Clock sync (host-sleep drift) ────────────────────────────
 # The guest tracks time with its own clocksource (the TSC under

--- a/tests/test_guest_agent_image.py
+++ b/tests/test_guest_agent_image.py
@@ -34,6 +34,13 @@ def _assert_clock_sync_loop_before_sshd(script: str) -> None:
     assert script.index('"$HWCLOCK" -s -u') < script.index("/usr/sbin/sshd")
 
 
+def _assert_guest_agent_starts_before_network_and_ssh(script: str) -> None:
+    agent_start = script.index("/usr/local/bin/smolvm-guest-agent --listen vsock://1024")
+    assert agent_start < script.index("Networking")
+    assert agent_start < script.index("ssh-keygen -A")
+    assert agent_start < script.index("/usr/sbin/sshd")
+
+
 def test_ci_preset_init_launches_guest_agent_before_sshd() -> None:
     """The CI publish pipeline's /init must launch the agent before sshd,
     mirroring the Python builder. These two init paths have to stay in sync —
@@ -42,7 +49,7 @@ def test_ci_preset_init_launches_guest_agent_before_sshd() -> None:
     script = (_REPO_ROOT / "scripts" / "ci" / "preset-init.sh").read_text()
     assert "/usr/local/bin/smolvm-guest-agent --listen vsock://1024" in script
     assert "python3 /usr/local/bin/smolvm-guest-agent" not in script
-    assert script.index("smolvm-guest-agent") < script.index("/usr/sbin/sshd")
+    _assert_guest_agent_starts_before_network_and_ssh(script)
 
 
 def test_ci_build_preset_bakes_guest_agent() -> None:
@@ -112,7 +119,7 @@ def test_base_init_script_launches_guest_agent_before_sshd() -> None:
     assert "/usr/local/bin/smolvm-guest-agent --listen vsock://1024" in script
     assert "python3 /usr/local/bin/smolvm-guest-agent" not in script
     # The agent must start before sshd so the channel is up independent of it.
-    assert script.index("smolvm-guest-agent") < script.index("/usr/sbin/sshd")
+    _assert_guest_agent_starts_before_network_and_ssh(script)
 
 
 def test_base_init_script_runs_clock_sync_loop() -> None:

--- a/tests/test_guest_agent_image.py
+++ b/tests/test_guest_agent_image.py
@@ -36,7 +36,12 @@ def _assert_clock_sync_loop_before_sshd(script: str) -> None:
 
 def _assert_guest_agent_starts_before_network_and_ssh(script: str) -> None:
     agent_start = script.index("/usr/local/bin/smolvm-guest-agent --listen vsock://1024")
-    assert agent_start < script.index("Networking")
+    network_ready = (
+        script.index('log_ts "net-ready"')
+        if 'log_ts "net-ready"' in script
+        else script.index("hostname smolvm")
+    )
+    assert agent_start < network_ready
     assert agent_start < script.index("ssh-keygen -A")
     assert agent_start < script.index("/usr/sbin/sshd")
 

--- a/tests/test_rust_http_vsock_channel.py
+++ b/tests/test_rust_http_vsock_channel.py
@@ -99,6 +99,26 @@ def test_wait_ready_uses_health() -> None:
     assert channel.requests[0][0:2] == ("GET", "/health")
 
 
+def test_wait_ready_polls_quickly_during_early_boot(monkeypatch: pytest.MonkeyPatch) -> None:
+    channel = FakeRustChannel(
+        [
+            lambda method, path, body: {"status": "starting"},
+            lambda method, path, body: {"status": "starting"},
+            lambda method, path, body: {"status": "ok", "agent_version": "0.1.0"},
+        ]
+    )
+    sleeps: list[float] = []
+    monkeypatch.setattr(
+        "smolvm.comm.rust_http_vsock_channel.time.sleep",
+        lambda duration: sleeps.append(duration),
+    )
+
+    channel.wait_ready(timeout=1, interval=0.1)
+
+    assert channel.connected is True
+    assert sleeps == [0.02, 0.02]
+
+
 def test_from_uds_closes_socket_when_connect_rejected(tmp_path: Path) -> None:
     uds = str(tmp_path / "vsock.sock")
     server = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)


### PR DESCRIPTION
## Summary

- split benchmark startup reporting into host-create, VMM-start, guest-ready, first-command, and total-to-command phases
- start the Rust guest agent earlier in both published-image and local-builder init scripts, before networking and SSH key generation
- tighten early Rust vsock readiness polling to reduce detection jitter while preserving existing timeout/fallback behavior

## Validation

- uv run --extra dev ruff check src/smolvm/comm/rust_http_vsock_channel.py src/smolvm/images/builder.py scripts/benchmarks/bench.py tests/test_guest_agent_image.py tests/test_rust_http_vsock_channel.py
- uv run --extra dev pytest tests/test_guest_agent_image.py tests/test_rust_http_vsock_channel.py tests/test_build.py -q
- uv run --extra dev pytest tests/test_facade_vsock.py tests/test_vsock_channel.py tests/test_comm_select.py -q
- uv run --extra dev pytest -m "not e2e" -q
- uv run --extra dev pytest -m e2e tests/e2e -v --e2e-backend qemu
- uv run --extra dev pytest -m e2e tests/e2e -v --e2e-backend firecracker
- uv run --extra dev python scripts/benchmarks/bench.py --backend qemu --only cold-start --iterations 1 --json

## Notes

The earlier published-init ordering change will affect newly baked/published rootfs artifacts. The one-iteration QEMU benchmark validates the new benchmark fields, but it still uses the currently published rootfs until image CI bakes this init change.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * More granular benchmark metrics for cold-start and time-to-interactive, with clarified metric definitions and example payloads including guest uptime at first command.

* **Performance**
  * Guest agent startup moved earlier in the boot flow (before networking and SSH).
  * Readiness polling now uses a faster cadence during early boot for quicker detection.

* **Tests**
  * Added/expanded tests for early-boot polling behavior and guest-agent startup ordering.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->