### PR TITLE
Add startup phase telemetry to benchmarks

### DIFF
--- a/scripts/benchmarks/README.md
+++ b/scripts/benchmarks/README.md
@@ -46,6 +46,23 @@ uv run python scripts/benchmarks/bench.py --backend qemu
 
 `-v` enables per-iteration progress logging.
 
+## Ubuntu Transport Comparison
+
+Use `ubuntu_transport.py` when comparing SSH vs vsock on the official Ubuntu
+preset across QEMU and Firecracker:
+
+```bash
+# Measure the currently published image bytes.
+uv run python scripts/benchmarks/ubuntu_transport.py --rootfs-source published -v
+
+# Pre-publish measurement: copy the published rootfs and replace /init with
+# scripts/ci/preset-init.sh from this checkout before booting.
+uv run python scripts/benchmarks/ubuntu_transport.py --rootfs-source current-init -v
+```
+
+`current-init` is for PR validation before a new image release exists. It avoids
+mistaking a stale published rootfs for the current branch's init behavior.
+
 ## What each benchmark means
 
 | Benchmark      | Metrics                                                         | What it measures |

--- a/scripts/benchmarks/README.md
+++ b/scripts/benchmarks/README.md
@@ -50,7 +50,7 @@ uv run python scripts/benchmarks/bench.py --backend qemu
 
 | Benchmark      | Metrics                                                         | What it measures |
 |----------------|-----------------------------------------------------------------|------------------|
-| `cold-start`   | `host_create_ms`, `vmm_start_ms`, `guest_ready_wait_ms`, `total_fresh_ready_ms`, `first_command_ms`, `total_first_command_ms` | First VM boot in this process. The image cache on disk is assumed already populated; "cold" means no warm SmolVM state in memory and no per-VM disk overlay yet. |
+| `cold-start`   | `host_create_ms`, `vmm_start_ms`, `guest_ready_wait_ms`, `total_fresh_ready_ms`, `first_command_ms`, `total_first_command_ms`, `boot_telemetry_stats` | First VM boot in this process. The image cache on disk is assumed already populated; "cold" means no warm SmolVM state in memory and no per-VM disk overlay yet. |
 | `tti`          | same as `cold-start`                                            | Subsequent boots — the steady-state experience. `tti` runs a warm-up boot first (excluded from stats), then takes `--iterations` measurements. Compare `results["tti"]["stats"]["total_fresh_ready_ms"]["p50"]` to `results["cold-start"]["raw"][0]["total_fresh_ready_ms"]` to see the one-time cost. |
 | `pause-resume` | `pause_ms`, `resume_ms`                                         | Freeze and unfreeze a long-lived VM. |
 | `snapshot`     | `snapshot_create_ms`, `snapshot_restore_ms`, `snapshot_restore_to_ssh_ms` | Persist VM state and bring it back. Each iteration uses a fresh source VM. |
@@ -63,6 +63,12 @@ startup. `total_fresh_ready_ms` is the user-facing fresh guest readiness
 metric: host create + VMM start + guest boot until SSH is ready. Use
 `total_first_command_ms` when comparing end-to-end "sandbox can run work"
 latency.
+
+For `cold-start` and `tti`, each raw record also includes `boot_telemetry`
+when the guest image emits `SMOLVM_TS` markers from `/init`. This reports guest
+uptime at each init stage, stage offsets from `init-start`, named phase
+durations, and the last kernel printk timestamp when the runtime log contains
+kernel messages.
 
 ## JSON shape
 
@@ -84,6 +90,15 @@ latency.
         "first_command_ms": { ... },
         "total_first_command_ms": { ... }
       },
+      "boot_telemetry_stats": {
+        "guest_init_offsets_ms": {
+          "sshd-invoked": {"p50": ..., "p95": ..., "mean": ..., "min": ..., "max": ..., "count": 5}
+        },
+        "guest_init_phases_ms": {
+          "ssh_hostkey_check_ms": {"p50": ..., "p95": ..., "mean": ..., "min": ..., "max": ..., "count": 5}
+        },
+        "kernel_last_printk_s": {"p50": ..., "p95": ..., "mean": ..., "min": ..., "max": ..., "count": 5}
+      },
       "raw": [{
         "iter": 0,
         "host_create_ms": ...,
@@ -92,7 +107,14 @@ latency.
         "total_fresh_ready_ms": ...,
         "first_command_ms": ...,
         "total_first_command_ms": ...,
-        "guest_uptime_at_first_command_s": ...
+        "guest_uptime_at_first_command_s": ...,
+        "boot_telemetry": {
+          "available": true,
+          "kernel_last_printk_s": ...,
+          "guest_init_markers_s": {"init-start": ..., "sshd-invoked": ...},
+          "guest_init_offsets_ms": {"sshd-invoked": ...},
+          "guest_init_phases_ms": {"ssh_hostkey_check_ms": ...}
+        }
       }, ...]
     },
     "tti": { ... },

--- a/scripts/benchmarks/bench.py
+++ b/scripts/benchmarks/bench.py
@@ -52,6 +52,7 @@ sys.path.insert(0, str(_REPO_ROOT / "src"))
 sys.path.insert(0, str(Path(__file__).resolve().parent))
 
 # Local sibling import — works whether invoked as a script or a module.
+from boot_telemetry import collect_boot_telemetry, summarize_boot_telemetry  # noqa: E402
 from metrics import Phase, stats  # noqa: E402
 
 logger = logging.getLogger("smolvm.bench")
@@ -182,6 +183,17 @@ def _is_unsupported_error(exc: BaseException) -> bool:
     return "does not support" in str(exc).lower()
 
 
+def _vm_log_path(vm) -> Path | None:
+    """Return the runtime log path for a benchmark VM."""
+    vm_id = getattr(vm, "_vm_id", None)
+    if not vm_id:
+        return None
+
+    from smolvm.vm import resolve_data_dir
+
+    return resolve_data_dir() / f"{vm_id}.log"
+
+
 # ── Individual benchmarks ────────────────────────────────────────────
 
 
@@ -201,9 +213,11 @@ def _bench_boot(backend: str, iterations: int, label: str) -> dict[str, Any]:
         logger.info("[%s] iter %d/%d", label, i + 1, iterations)
         vm: SmolVM | None = None
         record: dict[str, Any] = {"iter": i}
+        log_path: Path | None = None
         try:
             with Phase() as p_create:
                 vm = _new_vm(backend)
+                log_path = _vm_log_path(vm)
             record["host_create_ms"] = round(p_create.elapsed_ms, 1)
             host_create.append(record["host_create_ms"])
 
@@ -245,10 +259,13 @@ def _bench_boot(backend: str, iterations: int, label: str) -> dict[str, Any]:
             record["error"] = repr(e)
             logger.warning("[%s] iter %d failed: %s", label, i + 1, e)
         finally:
+            if log_path is None:
+                log_path = _vm_log_path(vm)
             _safe_teardown(vm)
+            record["boot_telemetry"] = collect_boot_telemetry(log_path)
             raw.append(record)
 
-    return {
+    result: dict[str, Any] = {
         "stats": {
             "host_create_ms": stats(host_create),
             "vmm_start_ms": stats(vmm_start),
@@ -259,6 +276,10 @@ def _bench_boot(backend: str, iterations: int, label: str) -> dict[str, Any]:
         },
         "raw": raw,
     }
+    boot_telemetry_stats = summarize_boot_telemetry(raw, stats)
+    if boot_telemetry_stats:
+        result["boot_telemetry_stats"] = boot_telemetry_stats
+    return result
 
 
 def bench_cold_start(backend: str, iterations: int) -> dict[str, Any]:
@@ -424,6 +445,12 @@ def _print_human(report: dict[str, Any]) -> None:
                 f"  {metric:30s} {s['p50']:8.1f}  {s['p95']:8.1f}  "
                 f"{s['mean']:8.1f}  {s['min']:8.1f}  {s['max']:8.1f}  {s['count']:4d}"
             )
+        phase_stats = result.get("boot_telemetry_stats", {}).get("guest_init_phases_ms", {})
+        if phase_stats:
+            print()
+            print("  guest init phase p50 (ms)")
+            for phase_name, s in phase_stats.items():
+                print(f"  {phase_name:30s} {s['p50']:8.1f}")
         print()
 
 

--- a/scripts/benchmarks/boot_telemetry.py
+++ b/scripts/benchmarks/boot_telemetry.py
@@ -1,0 +1,160 @@
+#!/usr/bin/env python3
+# Copyright 2026 Celesto AI
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Parse guest boot timing markers from SmolVM runtime logs."""
+
+from __future__ import annotations
+
+import re
+from collections.abc import Callable
+from pathlib import Path
+from typing import Any
+
+_SMOLVM_TS_RE = re.compile(
+    r"\bSMOLVM_TS\s+stage=(?P<stage>\S+)"
+    r"\s+epoch_s=(?P<epoch_s>\S+)"
+    r"\s+uptime_s=(?P<uptime_s>\S+)"
+)
+_PRINTK_RE = re.compile(r"\[\s*(?P<stamp>\d+\.\d+)\]")
+
+_PHASE_PAIRS: dict[str, tuple[str, str]] = {
+    "mount_filesystems_ms": ("init-start", "mounts-ready"),
+    "root_remount_ms": ("mounts-ready", "root-ready"),
+    "guest_agent_start_ms": ("guest-agent-start", "guest-agent-started"),
+    "network_config_ms": ("net-config-start", "net-ready"),
+    "clock_sync_setup_ms": ("clock-sync-start", "clock-sync-started"),
+    "ssh_hostkey_check_ms": ("ssh-hostkey-check-start", "ssh-hostkey-check-done"),
+    "ssh_authkey_inject_ms": ("ssh-authkey-inject-start", "ssh-authkey-inject-done"),
+    "sshd_start_ms": ("sshd-start", "sshd-invoked"),
+    "init_to_guest_agent_started_ms": ("init-start", "guest-agent-started"),
+    "init_to_network_ready_ms": ("init-start", "net-ready"),
+    "init_to_sshd_invoked_ms": ("init-start", "sshd-invoked"),
+    "init_to_complete_ms": ("init-start", "init-complete"),
+}
+
+_ALTERNATE_PHASE_ENDS: dict[str, tuple[str, ...]] = {
+    "clock_sync_setup_ms": ("clock-sync-started", "clock-sync-disabled"),
+}
+
+
+def parse_boot_telemetry_text(text: str) -> dict[str, Any]:
+    """Return guest boot telemetry parsed from one runtime log."""
+    markers: dict[str, float] = {}
+    marker_epochs: dict[str, float] = {}
+    marker_order: list[str] = []
+
+    for match in _SMOLVM_TS_RE.finditer(text):
+        stage = match.group("stage")
+        try:
+            uptime_s = float(match.group("uptime_s"))
+        except ValueError:
+            continue
+        try:
+            epoch_s = float(match.group("epoch_s"))
+        except ValueError:
+            epoch_s = 0.0
+
+        if stage not in markers:
+            marker_order.append(stage)
+        markers[stage] = round(uptime_s, 3)
+        marker_epochs[stage] = round(epoch_s, 3)
+
+    offsets_ms: dict[str, float] = {}
+    init_start = markers.get("init-start")
+    if init_start is not None:
+        offsets_ms = {
+            stage: round((markers[stage] - init_start) * 1000, 1) for stage in marker_order
+        }
+
+    phases_ms: dict[str, float] = {}
+    for phase_name, (start_stage, default_end_stage) in _PHASE_PAIRS.items():
+        end_stage = _resolve_phase_end(markers, phase_name, default_end_stage)
+        if start_stage in markers and end_stage in markers:
+            phases_ms[phase_name] = round((markers[end_stage] - markers[start_stage]) * 1000, 1)
+
+    printk_stamps = [float(match.group("stamp")) for match in _PRINTK_RE.finditer(text)]
+    kernel_last_printk_s = round(printk_stamps[-1], 3) if printk_stamps else None
+
+    return {
+        "available": bool(markers or kernel_last_printk_s is not None),
+        "log_lines": text.count("\n"),
+        "kernel_last_printk_s": kernel_last_printk_s,
+        "guest_init_markers_s": {stage: markers[stage] for stage in marker_order},
+        "guest_init_marker_epochs_s": {stage: marker_epochs[stage] for stage in marker_order},
+        "guest_init_offsets_ms": offsets_ms,
+        "guest_init_phases_ms": phases_ms,
+    }
+
+
+def collect_boot_telemetry(log_path: Path | None) -> dict[str, Any]:
+    """Read and parse boot telemetry from a runtime log path."""
+    if log_path is None:
+        return {"available": False, "reason": "vm log path unavailable"}
+    if not log_path.exists():
+        return {"available": False, "reason": "vm log missing"}
+
+    return parse_boot_telemetry_text(log_path.read_text(errors="replace"))
+
+
+def summarize_boot_telemetry(
+    records: list[dict[str, Any]],
+    stat_fn: Callable[[list[float]], dict[str, Any]],
+) -> dict[str, Any]:
+    """Summarize parsed boot telemetry attached to raw benchmark records."""
+    offsets: dict[str, list[float]] = {}
+    phases: dict[str, list[float]] = {}
+    kernel_last_printk_s: list[float] = []
+
+    for record in records:
+        telemetry = record.get("boot_telemetry")
+        if not isinstance(telemetry, dict):
+            continue
+        _collect_numeric_section(telemetry.get("guest_init_offsets_ms"), offsets)
+        _collect_numeric_section(telemetry.get("guest_init_phases_ms"), phases)
+        kernel_stamp = telemetry.get("kernel_last_printk_s")
+        if isinstance(kernel_stamp, int | float) and not isinstance(kernel_stamp, bool):
+            kernel_last_printk_s.append(float(kernel_stamp))
+
+    summary: dict[str, Any] = {}
+    if offsets:
+        summary["guest_init_offsets_ms"] = {
+            name: stat_fn(values) for name, values in sorted(offsets.items())
+        }
+    if phases:
+        summary["guest_init_phases_ms"] = {
+            name: stat_fn(values) for name, values in sorted(phases.items())
+        }
+    if kernel_last_printk_s:
+        summary["kernel_last_printk_s"] = stat_fn(kernel_last_printk_s)
+    return summary
+
+
+def _resolve_phase_end(
+    markers: dict[str, float],
+    phase_name: str,
+    default_end_stage: str,
+) -> str:
+    for stage in _ALTERNATE_PHASE_ENDS.get(phase_name, ()):
+        if stage in markers:
+            return stage
+    return default_end_stage
+
+
+def _collect_numeric_section(section: object, bucket: dict[str, list[float]]) -> None:
+    if not isinstance(section, dict):
+        return
+    for name, value in section.items():
+        if isinstance(value, int | float) and not isinstance(value, bool):
+            bucket.setdefault(str(name), []).append(float(value))

--- a/scripts/benchmarks/ubuntu_transport.py
+++ b/scripts/benchmarks/ubuntu_transport.py
@@ -104,7 +104,10 @@ def _current_init_fingerprint(rootfs_path: Path) -> str:
 def rootfs_with_current_init(rootfs_path: Path, *, cache_dir: Path | None = None) -> Path:
     """Return a copy of *rootfs_path* with this checkout's preset init baked in."""
     if shutil.which("debugfs") is None:
-        raise RuntimeError("debugfs is required for --rootfs-source current-init")
+        raise RuntimeError(
+            "debugfs is required for --rootfs-source current-init; "
+            "on Debian/Ubuntu install with: sudo apt install e2fsprogs"
+        )
 
     rootfs_path = rootfs_path.resolve()
     fingerprint = _current_init_fingerprint(rootfs_path)

--- a/scripts/benchmarks/ubuntu_transport.py
+++ b/scripts/benchmarks/ubuntu_transport.py
@@ -1,0 +1,351 @@
+#!/usr/bin/env python3
+# Copyright 2026 Celesto AI
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Benchmark published Ubuntu across QEMU/Firecracker and SSH/vsock.
+
+The default mode measures the currently published Ubuntu artifacts. Use
+``--rootfs-source current-init`` before an image release to copy the published
+Ubuntu rootfs and replace ``/init`` with this checkout's
+``scripts/ci/preset-init.sh``. That keeps pre-publish startup measurements from
+silently using stale remote image bytes.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import logging
+import platform
+import shutil
+import statistics
+import subprocess
+import sys
+import time
+import uuid
+from contextlib import suppress
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Literal
+
+_REPO_ROOT = Path(__file__).resolve().parent.parent.parent
+sys.path.insert(0, str(_REPO_ROOT / "src"))
+
+from smolvm.facade import SmolVM, _build_auto_config  # noqa: E402
+from smolvm.images.published import _images_release_tag  # noqa: E402
+
+logger = logging.getLogger("smolvm.bench.ubuntu_transport")
+
+RootfsSource = Literal["published", "current-init"]
+Transport = Literal["ssh", "vsock"]
+Backend = Literal["qemu", "firecracker"]
+
+
+def _median(values: list[float]) -> float | None:
+    if not values:
+        return None
+    return round(float(statistics.median(values)), 1)
+
+
+def _mean(values: list[float]) -> float | None:
+    if not values:
+        return None
+    return round(sum(values) / len(values), 1)
+
+
+def _stats(values: list[float]) -> dict[str, Any]:
+    if not values:
+        return {"median": None, "mean": None, "min": None, "max": None, "count": 0}
+    return {
+        "median": _median(values),
+        "mean": _mean(values),
+        "min": round(min(values), 1),
+        "max": round(max(values), 1),
+        "count": len(values),
+    }
+
+
+def _safe_teardown(vm: SmolVM | None) -> None:
+    if vm is None:
+        return
+    with suppress(Exception):
+        vm.stop(timeout=15.0)
+    with suppress(Exception):
+        vm.delete()
+
+
+def _current_init_path() -> Path:
+    return _REPO_ROOT / "scripts" / "ci" / "preset-init.sh"
+
+
+def _current_init_fingerprint(rootfs_path: Path) -> str:
+    init_path = _current_init_path()
+    hasher = hashlib.sha256()
+    hasher.update(init_path.read_bytes())
+    hasher.update(str(rootfs_path.resolve()).encode())
+    stat = rootfs_path.stat()
+    hasher.update(str(stat.st_size).encode())
+    hasher.update(str(int(stat.st_mtime_ns)).encode())
+    return hasher.hexdigest()[:16]
+
+
+def rootfs_with_current_init(rootfs_path: Path, *, cache_dir: Path | None = None) -> Path:
+    """Return a copy of *rootfs_path* with this checkout's preset init baked in."""
+    if shutil.which("debugfs") is None:
+        raise RuntimeError("debugfs is required for --rootfs-source current-init")
+
+    rootfs_path = rootfs_path.resolve()
+    fingerprint = _current_init_fingerprint(rootfs_path)
+    cache_root = cache_dir or (Path.home() / ".smolvm" / "benchmarks" / "current-init")
+    cache_root.mkdir(parents=True, exist_ok=True)
+
+    target = cache_root / f"{rootfs_path.parent.name}-{fingerprint}.ext4"
+    sidecar = target.with_suffix(target.suffix + ".fingerprint")
+    if target.is_file() and sidecar.is_file() and sidecar.read_text().strip() == fingerprint:
+        return target
+
+    tmp = target.with_suffix(target.suffix + ".tmp")
+    tmp.unlink(missing_ok=True)
+    subprocess.run(
+        ["cp", "--reflink=auto", "--sparse=always", str(rootfs_path), str(tmp)],
+        check=True,
+    )
+
+    init_copy = cache_root / f"preset-init-{fingerprint}.sh"
+    init_copy.write_bytes(_current_init_path().read_bytes())
+    init_copy.chmod(0o755)
+
+    subprocess.run(["debugfs", "-w", "-R", "rm /init", str(tmp)], check=False)
+    subprocess.run(["debugfs", "-w", "-R", f"write {init_copy} /init", str(tmp)], check=True)
+    subprocess.run(["debugfs", "-w", "-R", "sif /init mode 0100755", str(tmp)], check=True)
+
+    tmp.replace(target)
+    sidecar.write_text(fingerprint + "\n")
+    return target
+
+
+def _config_for_variant(
+    backend: Backend,
+    *,
+    vm_name: str,
+    rootfs_source: RootfsSource,
+) -> tuple[Any, str | None, Path, Path | None]:
+    config, ssh_key_path = _build_auto_config(os="ubuntu", backend=backend, vm_name=vm_name)
+    published_rootfs = Path(config.rootfs_path)
+    patched_rootfs = None
+    if rootfs_source == "current-init":
+        patched_rootfs = rootfs_with_current_init(published_rootfs)
+        config = config.model_copy(update={"rootfs_path": patched_rootfs})
+    return config, ssh_key_path, published_rootfs, patched_rootfs
+
+
+def _run_one(
+    backend: Backend,
+    transport: Transport,
+    iteration: int,
+    *,
+    rootfs_source: RootfsSource,
+    warm_exec_runs: int,
+    warmup: bool = False,
+) -> dict[str, Any]:
+    vm_name = f"bench-{backend[:2]}-{transport[:2]}-{uuid.uuid4().hex[:8]}"
+    record: dict[str, Any] = {"iter": iteration, "vm_id": vm_name, "warmup": warmup}
+    vm: SmolVM | None = None
+    try:
+        started = time.perf_counter()
+        config, ssh_key_path, published_rootfs, patched_rootfs = _config_for_variant(
+            backend,
+            vm_name=vm_name,
+            rootfs_source=rootfs_source,
+        )
+        vm = SmolVM(config=config, ssh_key_path=ssh_key_path, comm_channel=transport)
+        record["create_ms"] = round((time.perf_counter() - started) * 1000, 1)
+        record["published_rootfs_path"] = str(published_rootfs)
+        record["rootfs_path"] = str(config.rootfs_path)
+        record["patched_rootfs_path"] = str(patched_rootfs) if patched_rootfs else None
+        record["ssh_host_port"] = vm._info.network.ssh_host_port if vm._info.network else None
+        record["vsock_guest_cid"] = (
+            vm._info.config.vsock.guest_cid if vm._info.config.vsock else None
+        )
+
+        started = time.perf_counter()
+        vm.start()
+        record["start_ms"] = round((time.perf_counter() - started) * 1000, 1)
+
+        started = time.perf_counter()
+        vm.wait_for_ready(timeout=60.0)
+        record["ready_wait_ms"] = round((time.perf_counter() - started) * 1000, 1)
+        record["control_kind"] = getattr(vm._control_channel, "kind", None)
+
+        started = time.perf_counter()
+        first = vm.run("true", shell="raw", timeout=10.0)
+        record["first_command_ms"] = round((time.perf_counter() - started) * 1000, 1)
+        record["first_command_exit_code"] = first.exit_code
+
+        warm_exec_ms: list[float] = []
+        for _ in range(warm_exec_runs):
+            started = time.perf_counter()
+            result = vm.run("true", shell="raw", timeout=10.0)
+            warm_exec_ms.append(round((time.perf_counter() - started) * 1000, 1))
+            if result.exit_code != 0:
+                record.setdefault("warm_exec_errors", []).append(result.exit_code)
+        record["warm_exec_ms"] = warm_exec_ms
+        record["warm_exec_median_ms"] = _median(warm_exec_ms)
+
+        with suppress(Exception):
+            uptime = vm.run("cat /proc/uptime", shell="raw", timeout=10.0)
+            record["guest_uptime_after_ready_s"] = round(float(uptime.stdout.split()[0]), 3)
+
+        record["total_ready_ms"] = round(
+            record["create_ms"] + record["start_ms"] + record["ready_wait_ms"],
+            1,
+        )
+        record["total_first_command_ms"] = round(
+            record["total_ready_ms"] + record["first_command_ms"],
+            1,
+        )
+    finally:
+        _safe_teardown(vm)
+    return record
+
+
+def _summarize(records: list[dict[str, Any]]) -> dict[str, Any]:
+    fields = [
+        "create_ms",
+        "start_ms",
+        "ready_wait_ms",
+        "total_ready_ms",
+        "first_command_ms",
+        "total_first_command_ms",
+        "warm_exec_median_ms",
+        "guest_uptime_after_ready_s",
+    ]
+    return {
+        field: _stats(
+            [
+                float(record[field])
+                for record in records
+                if isinstance(record.get(field), int | float)
+            ]
+        )
+        for field in fields
+    }
+
+
+def run_benchmark(
+    *,
+    iterations: int,
+    warm_exec_runs: int,
+    rootfs_source: RootfsSource,
+) -> dict[str, Any]:
+    report: dict[str, Any] = {
+        "date": datetime.now(timezone.utc).isoformat(),
+        "host": {
+            "system": platform.system(),
+            "machine": platform.machine(),
+            "release": platform.release(),
+        },
+        "images_release_tag": _images_release_tag(),
+        "rootfs_source": rootfs_source,
+        "iterations": iterations,
+        "warm_exec_runs": warm_exec_runs,
+        "variants": {},
+    }
+
+    variants: tuple[tuple[Backend, Transport], ...] = (
+        ("qemu", "ssh"),
+        ("qemu", "vsock"),
+        ("firecracker", "ssh"),
+        ("firecracker", "vsock"),
+    )
+    for backend, transport in variants:
+        key = f"{backend}-{transport}"
+        logger.info("[%s] warm-up", key)
+        warmup_record: dict[str, Any] | None = None
+        with suppress(Exception):
+            warmup_record = _run_one(
+                backend,
+                transport,
+                -1,
+                rootfs_source=rootfs_source,
+                warm_exec_runs=warm_exec_runs,
+                warmup=True,
+            )
+
+        records: list[dict[str, Any]] = []
+        for iteration in range(iterations):
+            logger.info("[%s] measured %d/%d", key, iteration + 1, iterations)
+            try:
+                record = _run_one(
+                    backend,
+                    transport,
+                    iteration,
+                    rootfs_source=rootfs_source,
+                    warm_exec_runs=warm_exec_runs,
+                )
+            except Exception as exc:  # noqa: BLE001
+                logger.warning("[%s] iteration failed: %s", key, exc)
+                record = {"iter": iteration, "error": repr(exc)}
+            records.append(record)
+
+        report["variants"][key] = {
+            "backend": backend,
+            "transport": transport,
+            "warmup": warmup_record,
+            "raw": records,
+            "summary": _summarize(records),
+        }
+    return report
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--iterations", type=int, default=3)
+    parser.add_argument("--warm-exec-runs", type=int, default=5)
+    parser.add_argument(
+        "--rootfs-source",
+        choices=("published", "current-init"),
+        default="published",
+        help="Use published rootfs bytes, or patch /init from this checkout before booting.",
+    )
+    parser.add_argument("--output", type=Path, default=Path("/tmp/smolvm-ubuntu-transport.json"))
+    parser.add_argument("--json", action="store_true", help="Print the full JSON report.")
+    parser.add_argument("-v", "--verbose", action="store_true")
+    args = parser.parse_args()
+
+    if args.iterations < 1:
+        parser.error("--iterations must be >= 1")
+    if args.warm_exec_runs < 1:
+        parser.error("--warm-exec-runs must be >= 1")
+
+    logging.basicConfig(
+        level=logging.INFO if args.verbose else logging.WARNING,
+        format="%(message)s",
+    )
+    report = run_benchmark(
+        iterations=args.iterations,
+        warm_exec_runs=args.warm_exec_runs,
+        rootfs_source=args.rootfs_source,
+    )
+    payload = json.dumps(report, indent=2)
+    args.output.write_text(payload + "\n")
+    if args.json:
+        print(payload)
+    else:
+        print(f"Wrote {args.output}")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/ci/preset-init.sh
+++ b/scripts/ci/preset-init.sh
@@ -34,6 +34,22 @@ shutdown() {
 }
 trap shutdown INT TERM
 
+# ── Timestamp helpers (for host-side startup profiling) ──────
+ts_uptime() {
+    cut -d' ' -f1 /proc/uptime 2>/dev/null || echo "0.00"
+}
+
+ts_epoch() {
+    date +%s 2>/dev/null || echo "0"
+}
+
+log_ts() {
+    STAGE="$1"
+    echo "SMOLVM_TS stage=${STAGE} epoch_s=$(ts_epoch) uptime_s=$(ts_uptime)"
+}
+
+log_ts "init-start"
+
 # ── Mount essential filesystems ──────────────────────────────
 mount -t proc proc /proc
 mount -t sysfs sys /sys
@@ -45,24 +61,31 @@ mount -t tmpfs tmpfs /run
 # temporary writes, and a memory-sized tmpfs can fill up even when the disk
 # still has plenty of space.
 
+log_ts "mounts-ready"
+
 echo 0 > /proc/sys/kernel/ctrl-alt-del
 mount -o remount,rw /
 mkdir -p /run/sshd /var/log /tmp
 chmod 1777 /tmp
+
+log_ts "root-ready"
 
 # ── Guest agent (vsock control plane) ────────────────────────
 # Started before networking and sshd, so explicit-vsock sandboxes can become
 # ready without waiting for SSH host-key generation or network setup. Skipped
 # silently if the agent is missing (the host falls back to SSH in that case).
 # Mirrors _base_init_script() in src/smolvm/images/builder.py.
+log_ts "guest-agent-start"
 if [ -x /usr/local/bin/smolvm-guest-agent ]; then
     /usr/local/bin/smolvm-guest-agent --listen vsock://1024 >/var/log/smolvm-agent.log 2>&1 &
     echo "SmolVM init: guest agent started (PID=$!)"
 else
     echo "SmolVM init: guest agent not found, continuing without it" >&2
 fi
+log_ts "guest-agent-started"
 
 # ── Networking ───────────────────────────────────────────────
+log_ts "net-config-start"
 # Format: ip=<guest_ip>::<gateway>:<netmask>::eth0:off (kernel ip= param)
 netmask_to_prefix() {
     IFS=.
@@ -120,16 +143,20 @@ else
 fi
 
 hostname smolvm
+log_ts "net-ready"
 
 # ── SSH host keys ────────────────────────────────────────────
+log_ts "ssh-hostkey-check-start"
 if ! ls /etc/ssh/ssh_host_*_key >/dev/null 2>&1; then
     ssh-keygen -A 2>/dev/null
 fi
+log_ts "ssh-hostkey-check-done"
 
 # ── Pubkey injection from kernel cmdline ─────────────────────
 # Format: smolvm.authorized_key_b64=<base64-of-the-pubkey-line>.
 # Same mechanism as openclaw — published images don't bake keys at
 # build time, so each VM gets the launching user's key.
+log_ts "ssh-authkey-inject-start"
 AUTHKEY_B64=$(cat /proc/cmdline | tr ' ' '\n' \
     | grep '^smolvm\.authorized_key_b64=' | head -1 | cut -d= -f2-)
 if [ -n "$AUTHKEY_B64" ]; then
@@ -141,6 +168,7 @@ if [ -n "$AUTHKEY_B64" ]; then
         chmod 600 /root/.ssh/authorized_keys
     fi
 fi
+log_ts "ssh-authkey-inject-done"
 
 # ── Clock sync (host-sleep drift) ────────────────────────────
 # The guest's clocksource (the TSC under HVF/QEMU) stops advancing
@@ -150,6 +178,7 @@ fi
 # pinned to host wall-clock time (-rtc clock=host) — and step the
 # system clock to match. No-ops on backends with no RTC (Firecracker).
 # Mirrors _base_init_script() in src/smolvm/images/builder.py.
+log_ts "clock-sync-start"
 HWCLOCK=""
 for cand in hwclock /usr/sbin/hwclock /sbin/hwclock; do
     if HWCLOCK_PATH=$(command -v "$cand" 2>/dev/null); then
@@ -165,11 +194,17 @@ if [ -n "$HWCLOCK" ]; then
         done
     ) &
     echo "SmolVM init: clock-sync loop started (PID=$!)"
+    log_ts "clock-sync-started"
+else
+    log_ts "clock-sync-disabled"
 fi
 
+log_ts "sshd-start"
 /usr/sbin/sshd -e &
+log_ts "sshd-invoked"
 
 echo "SmolVM init complete: IP=${GUEST_IP}, SSH listening on port 22"
+log_ts "init-complete"
 
 # ── Keep PID 1 alive ────────────────────────────────────────
 # Use `wait` so signals are delivered promptly (plain `sleep` in a

--- a/scripts/ci/preset-init.sh
+++ b/scripts/ci/preset-init.sh
@@ -8,12 +8,13 @@
 # this minimal script that:
 #
 #   1. mounts the essential virtual filesystems
-#   2. brings up loopback + eth0 (DHCP-style static IP from kernel cmdline)
-#   3. generates SSH host keys on first boot
-#   4. injects the launching user's pubkey from the kernel cmdline param
+#   2. starts the vsock guest-agent control plane
+#   3. brings up loopback + eth0 (DHCP-style static IP from kernel cmdline)
+#   4. generates SSH host keys on first boot
+#   5. injects the launching user's pubkey from the kernel cmdline param
 #      smolvm.authorized_key_b64=<base64> (matches openclaw's mechanism)
-#   5. starts sshd
-#   6. parks PID 1 in a sleep loop, signal-handling Firecracker shutdown
+#   6. starts sshd
+#   7. parks PID 1 in a sleep loop, signal-handling Firecracker shutdown
 #
 # Mirrors `_base_init_script()` in src/smolvm/images/builder.py — keep
 # them in sync if either changes.

--- a/src/smolvm/comm/rust_http_vsock_channel.py
+++ b/src/smolvm/comm/rust_http_vsock_channel.py
@@ -20,6 +20,7 @@ import base64
 import http.client
 import json
 import logging
+import math
 import os
 import socket
 import stat
@@ -181,21 +182,22 @@ class RustHttpVsockChannel:
     def run(
         self,
         command: str,
-        timeout: int = 30,
+        timeout: float = 30,
         shell: ShellMode = "login",
     ) -> CommandResult:
         if not command or not command.strip():
             raise ValueError("command cannot be empty")
         if timeout < 1:
             raise ValueError("timeout must be >= 1")
+        timeout_seconds = math.ceil(timeout)
         resp = self._request_json(
             "POST",
             "/exec",
-            {"command": command, "shell": shell, "timeout_seconds": timeout},
-            timeout=float(timeout + self.connect_timeout),
+            {"command": command, "shell": shell, "timeout_seconds": timeout_seconds},
+            timeout=float(timeout_seconds + self.connect_timeout),
         )
         if resp.get("timed_out"):
-            raise OperationTimeoutError(f"vsock run: {command}", timeout)
+            raise OperationTimeoutError(f"vsock run: {command}", timeout_seconds)
         if not resp.get("ok"):
             raise SmolVMError(f"guest agent error during run: {resp.get('error', resp)}")
         return CommandResult(

--- a/tests/test_benchmark_boot_telemetry.py
+++ b/tests/test_benchmark_boot_telemetry.py
@@ -1,0 +1,104 @@
+# Copyright 2026 Celesto AI
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import annotations
+
+from pathlib import Path
+from types import SimpleNamespace
+
+from scripts.benchmarks import bench
+from scripts.benchmarks.boot_telemetry import parse_boot_telemetry_text, summarize_boot_telemetry
+from scripts.benchmarks.metrics import stats
+
+
+def _sample_log() -> str:
+    return """
+[    0.012345] Linux version 6.12.0
+SMOLVM_TS stage=init-start epoch_s=1781280000 uptime_s=0.10
+SMOLVM_TS stage=mounts-ready epoch_s=1781280000 uptime_s=0.12
+SMOLVM_TS stage=root-ready epoch_s=1781280000 uptime_s=0.15
+SMOLVM_TS stage=guest-agent-start epoch_s=1781280000 uptime_s=0.16
+SMOLVM_TS stage=guest-agent-started epoch_s=1781280000 uptime_s=0.18
+SMOLVM_TS stage=net-config-start epoch_s=1781280000 uptime_s=0.20
+SMOLVM_TS stage=net-ready epoch_s=1781280000 uptime_s=0.30
+SMOLVM_TS stage=ssh-hostkey-check-start epoch_s=1781280000 uptime_s=0.31
+SMOLVM_TS stage=ssh-hostkey-check-done epoch_s=1781280000 uptime_s=0.55
+SMOLVM_TS stage=ssh-authkey-inject-start epoch_s=1781280000 uptime_s=0.56
+SMOLVM_TS stage=ssh-authkey-inject-done epoch_s=1781280000 uptime_s=0.57
+SMOLVM_TS stage=sshd-start epoch_s=1781280000 uptime_s=0.58
+SMOLVM_TS stage=sshd-invoked epoch_s=1781280000 uptime_s=0.80
+SMOLVM_TS stage=init-complete epoch_s=1781280000 uptime_s=0.82
+[    0.901234] random: crng init done
+"""
+
+
+def test_parse_boot_telemetry_text_extracts_markers_offsets_and_phases() -> None:
+    telemetry = parse_boot_telemetry_text(_sample_log())
+
+    assert telemetry["available"] is True
+    assert telemetry["kernel_last_printk_s"] == 0.901
+    assert telemetry["guest_init_markers_s"]["init-start"] == 0.1
+    assert telemetry["guest_init_offsets_ms"]["sshd-invoked"] == 700.0
+    assert telemetry["guest_init_phases_ms"]["guest_agent_start_ms"] == 20.0
+    assert telemetry["guest_init_phases_ms"]["network_config_ms"] == 100.0
+    assert telemetry["guest_init_phases_ms"]["ssh_hostkey_check_ms"] == 240.0
+    assert telemetry["guest_init_phases_ms"]["init_to_complete_ms"] == 720.0
+
+
+def test_summarize_boot_telemetry_collects_numeric_sections() -> None:
+    telemetry = parse_boot_telemetry_text(_sample_log())
+
+    summary = summarize_boot_telemetry([{"boot_telemetry": telemetry}], stats)
+
+    assert summary["kernel_last_printk_s"]["p50"] == 0.9
+    assert summary["guest_init_offsets_ms"]["sshd-invoked"]["p50"] == 700.0
+    assert summary["guest_init_phases_ms"]["ssh_hostkey_check_ms"]["p50"] == 240.0
+
+
+def test_bench_boot_attaches_boot_telemetry(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    log_path = tmp_path / "bench-vm.log"
+    log_path.write_text(_sample_log())
+
+    class FakeVm:
+        _vm_id = "bench-vm"
+
+        def start(self) -> None:
+            pass
+
+        def wait_for_ssh(self) -> None:
+            pass
+
+        def run(self, command: str, *, shell: str) -> SimpleNamespace:
+            assert command == "cat /proc/uptime"
+            assert shell == "raw"
+            return SimpleNamespace(stdout="0.95 0.10\n")
+
+    monkeypatch.setattr(bench, "_new_vm", lambda backend: FakeVm())
+    monkeypatch.setattr(bench, "_safe_teardown", lambda vm: None)
+    monkeypatch.setattr(bench, "_vm_log_path", lambda vm: log_path)
+
+    result = bench._bench_boot("qemu", 1, "cold-start")
+
+    raw = result["raw"][0]
+    assert raw["guest_uptime_at_first_command_s"] == 0.95
+    assert raw["boot_telemetry"]["guest_init_offsets_ms"]["sshd-invoked"] == 700.0
+    assert (
+        result["boot_telemetry_stats"]["guest_init_phases_ms"]["init_to_sshd_invoked_ms"][
+            "p50"
+        ]
+        == 700.0
+    )

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -2336,7 +2336,7 @@ class TestCliUi:
         capsys: pytest.CaptureFixture,
     ) -> None:
         """Pre-release smolvm version should auto-enable beta UI assets."""
-        monkeypatch.setattr("smolvm.cli.main._current_version_is_prerelease", lambda: True)
+        monkeypatch.setitem(main.__globals__, "_current_version_is_prerelease", lambda: True)
         mock_uvicorn = MagicMock()
 
         def _run(*args: object, **kwargs: object) -> None:
@@ -2360,7 +2360,7 @@ class TestCliUi:
         capsys: pytest.CaptureFixture,
     ) -> None:
         """Stable smolvm version should NOT auto-enable beta UI assets."""
-        monkeypatch.setattr("smolvm.cli.main._current_version_is_prerelease", lambda: False)
+        monkeypatch.setitem(main.__globals__, "_current_version_is_prerelease", lambda: False)
         mock_uvicorn = MagicMock()
         mock_import.return_value = mock_uvicorn
 

--- a/tests/test_guest_agent_image.py
+++ b/tests/test_guest_agent_image.py
@@ -47,23 +47,56 @@ def _assert_guest_agent_starts_before_network_and_ssh(script: str) -> None:
 
 
 def _assert_startup_timestamp_markers(script: str) -> None:
-    ordered_stages = [
-        "init-start",
-        "mounts-ready",
-        "root-ready",
-        "guest-agent-start",
-        "guest-agent-started",
-        "net-config-start",
-        "net-ready",
-        "ssh-hostkey-check-start",
-        "ssh-hostkey-check-done",
-        "ssh-authkey-inject-start",
-        "ssh-authkey-inject-done",
-        "sshd-start",
-        "sshd-invoked",
-        "init-complete",
-    ]
-    positions = [script.index(f'log_ts "{stage}"') for stage in ordered_stages]
+    if script.index('log_ts "clock-sync-start"') > script.index(
+        'log_ts "ssh-authkey-inject-done"'
+    ):
+        ordered_stages = [
+            "init-start",
+            "mounts-ready",
+            "root-ready",
+            "guest-agent-start",
+            "guest-agent-started",
+            "net-config-start",
+            "net-ready",
+            "ssh-hostkey-check-start",
+            "ssh-hostkey-check-done",
+            "ssh-authkey-inject-start",
+            "ssh-authkey-inject-done",
+            "clock-sync-start",
+            "sshd-start",
+            "sshd-invoked",
+            "init-complete",
+        ]
+    else:
+        ordered_stages = [
+            "init-start",
+            "mounts-ready",
+            "root-ready",
+            "guest-agent-start",
+            "guest-agent-started",
+            "net-config-start",
+            "net-ready",
+            "clock-sync-start",
+            "ssh-hostkey-check-start",
+            "ssh-hostkey-check-done",
+            "ssh-authkey-inject-start",
+            "ssh-authkey-inject-done",
+            "sshd-start",
+            "sshd-invoked",
+            "init-complete",
+        ]
+
+    positions = []
+    for stage in ordered_stages:
+        positions.append(script.index(f'log_ts "{stage}"'))
+        if stage == "clock-sync-start":
+            clock_sync_done_positions = [
+                script.index(f'log_ts "{candidate}"')
+                for candidate in ("clock-sync-started", "clock-sync-disabled")
+                if f'log_ts "{candidate}"' in script
+            ]
+            assert clock_sync_done_positions
+            positions.extend(sorted(clock_sync_done_positions))
     assert positions == sorted(positions)
 
 

--- a/tests/test_guest_agent_image.py
+++ b/tests/test_guest_agent_image.py
@@ -46,6 +46,27 @@ def _assert_guest_agent_starts_before_network_and_ssh(script: str) -> None:
     assert agent_start < script.index("/usr/sbin/sshd")
 
 
+def _assert_startup_timestamp_markers(script: str) -> None:
+    ordered_stages = [
+        "init-start",
+        "mounts-ready",
+        "root-ready",
+        "guest-agent-start",
+        "guest-agent-started",
+        "net-config-start",
+        "net-ready",
+        "ssh-hostkey-check-start",
+        "ssh-hostkey-check-done",
+        "ssh-authkey-inject-start",
+        "ssh-authkey-inject-done",
+        "sshd-start",
+        "sshd-invoked",
+        "init-complete",
+    ]
+    positions = [script.index(f'log_ts "{stage}"') for stage in ordered_stages]
+    assert positions == sorted(positions)
+
+
 def test_ci_preset_init_launches_guest_agent_before_sshd() -> None:
     """The CI publish pipeline's /init must launch the agent before sshd,
     mirroring the Python builder. These two init paths have to stay in sync —
@@ -55,6 +76,7 @@ def test_ci_preset_init_launches_guest_agent_before_sshd() -> None:
     assert "/usr/local/bin/smolvm-guest-agent --listen vsock://1024" in script
     assert "python3 /usr/local/bin/smolvm-guest-agent" not in script
     _assert_guest_agent_starts_before_network_and_ssh(script)
+    _assert_startup_timestamp_markers(script)
 
 
 def test_ci_build_preset_bakes_guest_agent() -> None:
@@ -125,6 +147,7 @@ def test_base_init_script_launches_guest_agent_before_sshd() -> None:
     assert "python3 /usr/local/bin/smolvm-guest-agent" not in script
     # The agent must start before sshd so the channel is up independent of it.
     _assert_guest_agent_starts_before_network_and_ssh(script)
+    _assert_startup_timestamp_markers(script)
 
 
 def test_base_init_script_runs_clock_sync_loop() -> None:

--- a/tests/test_rust_http_vsock_channel.py
+++ b/tests/test_rust_http_vsock_channel.py
@@ -166,6 +166,19 @@ def test_run_maps_command_result() -> None:
     assert result.stdout == "ok"
 
 
+def test_run_serializes_float_timeout_as_integer_seconds() -> None:
+    def _handler(method: str, path: str, body: bytes) -> dict:
+        assert method == "POST"
+        assert path == "/exec"
+        request = json.loads(body)
+        assert request["timeout_seconds"] == 10
+        assert isinstance(request["timeout_seconds"], int)
+        return {"ok": True, "exit_code": 0, "stdout": "", "stderr": "", "timed_out": False}
+
+    result = FakeRustChannel([_handler]).run("true", timeout=10.0, shell="raw")
+    assert result.exit_code == 0
+
+
 def test_run_timeout_maps_to_operation_timeout() -> None:
     channel = FakeRustChannel(
         [

--- a/tests/test_rust_http_vsock_channel.py
+++ b/tests/test_rust_http_vsock_channel.py
@@ -167,15 +167,21 @@ def test_run_maps_command_result() -> None:
 
 
 def test_run_serializes_float_timeout_as_integer_seconds() -> None:
-    def _handler(method: str, path: str, body: bytes) -> dict:
-        assert method == "POST"
-        assert path == "/exec"
-        request = json.loads(body)
-        assert request["timeout_seconds"] == 10
-        assert isinstance(request["timeout_seconds"], int)
-        return {"ok": True, "exit_code": 0, "stdout": "", "stderr": "", "timed_out": False}
+    def _handler(expected_timeout_seconds: int):
+        def handle(method: str, path: str, body: bytes) -> dict:
+            assert method == "POST"
+            assert path == "/exec"
+            request = json.loads(body)
+            assert request["timeout_seconds"] == expected_timeout_seconds
+            assert isinstance(request["timeout_seconds"], int)
+            return {"ok": True, "exit_code": 0, "stdout": "", "stderr": "", "timed_out": False}
 
-    result = FakeRustChannel([_handler]).run("true", timeout=10.0, shell="raw")
+        return handle
+
+    result = FakeRustChannel([_handler(10)]).run("true", timeout=10.0, shell="raw")
+    assert result.exit_code == 0
+
+    result = FakeRustChannel([_handler(11)]).run("true", timeout=10.1, shell="raw")
     assert result.exit_code == 0
 
 


### PR DESCRIPTION
## Summary
- parse SMOLVM_TS and kernel printk timestamps from runtime logs
- attach boot telemetry to cold-start/TTI benchmark raw records and aggregate phase stats
- add SMOLVM_TS markers to the CI preset init path used by published images

## Validation
- uv run --extra dev ruff check scripts/benchmarks/boot_telemetry.py scripts/benchmarks/bench.py tests/test_benchmark_boot_telemetry.py tests/test_guest_agent_image.py
- uv run --extra dev pytest tests/test_benchmark_boot_telemetry.py tests/test_guest_agent_image.py -q
- git diff --check
- uv run --extra dev python scripts/benchmarks/bench.py --backend qemu --only cold-start --iterations 1 --json --output /tmp/smolvm-startup-telemetry-smoke.json -v

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Benchmarks now capture guest boot/init telemetry (phase timings, offsets) and report aggregated statistics (including p50) in both JSON output and the human-readable report.
  * Added an Ubuntu Transport benchmark to compare QEMU/Firecracker with SSH vs vsock, including configurable rootfs modes.

* **Bug Fixes**
  * vsock guest command timeouts are rounded for consistent guest-agent timeout handling.

* **Documentation**
  * Expanded the benchmark README with Ubuntu transport usage and detailed cold-start telemetry/JSON examples.

* **Tests**
  * Added coverage for boot-telemetry parsing/summarization and benchmark integration, plus deterministic init marker ordering and float timeout serialization.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->