### PR TITLE
[codex] Tighten Rust guest agent followups

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -3,8 +3,8 @@
 # Unlike the unit suite (which mocks the hypervisor) and smoke-published-images
 # (which shells out to raw qemu), this boots actual micro-VMs *through the
 # SmolVM Python API* and walks their lifecycle — start, exec, file
-# upload/download, pause/resume, snapshot/restore, stop/cleanup. QEMU is
-# exercised over SSH and vsock; Firecracker is exercised over SSH.
+# upload/download, pause/resume, snapshot/restore, stop/cleanup. QEMU and
+# Firecracker are both exercised over SSH and vsock.
 #
 # GH-hosted ubuntu-latest (x86) exposes /dev/kvm, so this runs with hardware
 # acceleration. The suite gates review-ready PRs and pushes to main; the

--- a/docs/benchmarks/boot-latency-learnings.md
+++ b/docs/benchmarks/boot-latency-learnings.md
@@ -160,7 +160,7 @@ the default auto-config image could not start the old Python agent. The host
 then waited the full `_VSOCK_AUTO_PROBE_TIMEOUT = 8.0 s` before falling back to
 SSH:
 
-```
+```text
 QEMU auto-config (default), first command: 8066 ms   <- 8s vsock probe + SSH
 QEMU explicit comm_channel="ssh", first command: 1876 ms
 ```

--- a/docs/benchmarks/boot-latency-learnings.md
+++ b/docs/benchmarks/boot-latency-learnings.md
@@ -13,6 +13,10 @@ Numbers measured on one Linux host with KVM, 16 CPUs, an Alpine Linux guest
 (1 CPU / 512 MB), running `echo hello`. Scripts live under `scripts/`:
 `bench_backends.py`, `profile_boot.py`, `exp_vsock_trim.py`, `exp_userspace.py`.
 
+This report records the investigation as it happened. The blockers called out
+below were fixed later: published SmolVM images now start a standalone Rust
+guest agent, and both QEMU and Firecracker have vsock coverage.
+
 > **Methodology note.** SmolVM's `.start()` returns as soon as the hypervisor
 > *process* is up — it does **not** wait for the guest to finish booting. The
 > guest boot (kernel + init + sshd/agent) happens during the *first command*,
@@ -62,7 +66,7 @@ it emulates more devices the kernel must probe (biggest single stall:
 virtio-only model (`pci=off`, no SATA/VGA) avoids most of it — which is the
 whole point of a microVM.
 
-## Finding 3 — vsock helps, but is QEMU-only and needs python3 in the image
+## Finding 3 — vsock helps; the blockers here were historical
 
 `comm_channel="vsock"` uses a persistent guest agent instead of SSH.
 
@@ -72,20 +76,17 @@ whole point of a microVM.
   win for command-heavy workloads: SSH pays a fresh exec round-trip per command;
   the vsock agent is a kept-open connection.
 
-Two real blockers found:
+Two blockers were found and later fixed:
 
-1. **QEMU-only today.** `comm/select.py` gates vsock to the QEMU backend;
-   requesting it on Firecracker raises. QEMU uses native `AF_VSOCK` over the
-   host's `/dev/vhost-vsock`; Firecracker multiplexes vsock over a host Unix
-   socket whose host-side bridge client SmolVM hasn't implemented.
-2. **Default image can't run the agent.** The auto-config image
-   (`ImageBuilder.build_alpine_ssh_key`) installs `openssh iproute2 curl bash`
-   but **no `python3`**. The guest agent is a Python script that `/init` only
-   launches `if command -v python3`. No python3 → agent never starts → vsock
-   times out and (in auto mode) silently falls back to SSH. The password-auth
-   recipe (`build_alpine_ssh`) *does* install python3, which is what made vsock
-   measurable here. **This looks like a latent bug worth filing:** the default
-   image bakes the agent binary but omits its runtime.
+1. **Firecracker did not yet have the host-side bridge.** QEMU used native
+   `AF_VSOCK` over `/dev/vhost-vsock`, while Firecracker exposed vsock through
+   a host Unix socket that SmolVM did not yet speak to. The host now supports
+   the Firecracker UDS path.
+2. **The default image could not run the old agent.** At the time, the guest
+   agent was a Python script and the default image did not install `python3`,
+   so `/init` skipped the agent and auto mode fell back to SSH. Published
+   images now bake `/usr/local/bin/smolvm-guest-agent`, a standalone Rust
+   binary, so the control plane no longer depends on Python.
 
 Host requirement (present on this machine): `vhost_vsock` module loaded and
 `/dev/vhost-vsock` available.
@@ -151,27 +152,25 @@ becomes answerable the moment the agent starts (~0.9 s uptime). Guest-side
 userspace trims (baked keys) only pay off once the host-side wait is also tight
 or replaced by vsock.
 
-## Finding 6 — default QEMU auto-config has an 8-second vsock-probe penalty
+## Finding 6 — historical: default QEMU auto-config had an 8-second probe
 
-The most severe issue found. On the QEMU backend, the channel selector
-*auto-prefers* vsock with SSH fallback (`vsock_possible = is_qemu and …`). But
-the default auto-config image lacks python3, so the agent never answers. The
-host then waits the full `_VSOCK_AUTO_PROBE_TIMEOUT = 8.0 s` before falling back
-to SSH:
+This was the most severe issue found during the original investigation. On the
+QEMU backend, the channel selector auto-preferred vsock with SSH fallback, but
+the default auto-config image could not start the old Python agent. The host
+then waited the full `_VSOCK_AUTO_PROBE_TIMEOUT = 8.0 s` before falling back to
+SSH:
 
 ```
 QEMU auto-config (default), first command: 8066 ms   <- 8s vsock probe + SSH
 QEMU explicit comm_channel="ssh", first command: 1876 ms
 ```
 
-So the real out-of-box QEMU number is **~8.1 s to interact**, not ~1.9 s — the
-earlier ~1.9 s figures were taken with vsock-capable or explicit-SSH paths.
-Two independent bugs compound here:
+So the real out-of-box QEMU number at that point was **~8.1 s to interact**,
+not ~1.9 s. Two independent bugs compounded here:
 
-1. Default image bakes the agent but omits its python3 runtime (Finding 3).
+1. Default image baked the old Python agent but omitted its Python runtime.
 2. Auto-mode pays an 8 s timeout discovering that, every single boot.
 
-Mitigations (any one fixes it): ship python3 in the default image; or shorten
-the auto vsock probe; or have auto-mode skip vsock when the image has no agent;
-or default QEMU auto-config to `comm_channel="ssh"`.
+This is now addressed by baking the standalone Rust agent, shortening the auto
+probe, and keeping SSH fallback only for auto-selected channels.
 ```

--- a/docs/benchmarks/final-report.md
+++ b/docs/benchmarks/final-report.md
@@ -10,6 +10,10 @@ cell after an untimed warm-up; variance was small. Scripts: `scripts/exp_final.p
 (headline), plus `bench_backends.py`, `profile_boot.py`, `exp_vsock_trim.py`,
 `exp_userspace.py`. Full reasoning in `boot-latency-learnings.md`.
 
+This is a historical report. The old Python guest-agent and QEMU-only vsock
+limitations described below have since been replaced by the standalone Rust
+guest-agent and Firecracker vsock support.
+
 ---
 
 ## Before / After
@@ -28,10 +32,10 @@ runs so each builds its own image.
 
 All values milliseconds, mean of 5 runs.
 
-On `main`, QEMU "resolves" to vsock but the agent can't run (no python3 in the
-image), so it burns the full 8 s probe then silently falls back to SSH — hence
-`warm=42 ms` despite the channel reading vsock. On the branch, vsock genuinely
-works (`warm=1.0 ms`).
+At the time, `main` resolved QEMU to vsock but the old Python agent could not
+run in the image, so it burned the full 8 s probe then silently fell back to
+SSH — hence `warm=42 ms` despite the channel reading vsock. On the branch,
+vsock genuinely worked (`warm=1.0 ms`).
 
 > Firecracker ran on its unprivileged "slower networking path" in both runs (no
 > passwordless sudo), inflating its create/launch equally on both sides — the
@@ -43,16 +47,16 @@ works (`warm=1.0 ms`).
   default `SmolVM(backend="qemu")` no longer pays the 8-second vsock probe.
 - **Warm commands: 42 ms → 1.0 ms (~42×)** now that vsock is the working
   default — this dominates any multi-command (agentic) workload.
-- The SSH path that **Firecracker** still depends on also got faster:
+- The SSH path that **Firecracker** still depended on also got faster:
   **1645 ms → 1408 ms (1.17×)**, ~240 ms off first-command from the tightened
   poll (Q4) plus the boot trims (Q3). Its warm command stays ~42 ms because it's
-  still on SSH — the gap the (deferred) Firecracker-vsock bridge would close.
+  still on SSH. Current SmolVM also has Firecracker vsock coverage.
 
 ### What changed (4 commits)
 
 | # | Change | Effect measured |
 |---|---|---|
-| Q1 | python3 in auto-config image → vsock agent runs | first cmd 8066 → 1509 ms; warm 42 → 1.0 ms |
+| Q1 | guest-agent runtime present in auto-config image → vsock agent runs | first cmd 8066 → 1509 ms; warm 42 → 1.0 ms |
 | Q2 | vsock auto-probe 8s → 2.5s (guardrail for agent-less images) | agent-less fallback 8066 → 2567 ms |
 | Q3 | default safe boot trims (`tsc=reliable no_timer_check quiet`) | ~150–230 ms; `acpi=off` left opt-in |
 | Q4 | SSH wait loop 200ms fixed → 20ms exp backoff | SSH first cmd ~1878 → ~1669 ms |
@@ -87,7 +91,7 @@ answerable at ~0.9 s guest uptime.
 
 | Lever | Effect | Caveat |
 |---|---|---|
-| **vsock instead of SSH** | first cmd −370 ms; warm cmd 42 → 1 ms (~28–40×) | QEMU-only today; needs python3 in the image |
+| **vsock instead of SSH** | first cmd −370 ms; warm cmd 42 → 1 ms (~28–40×) | Was QEMU-only and Python-runtime dependent in this run; current images use the standalone Rust agent and Firecracker vsock is covered |
 | **Trim boot cmdline** (`acpi=off quiet …`) | ~230 ms off total (~70 ms real boot + console savings) | `acpi=off` not universally safe; validate per image |
 | **Bake SSH host keys** | guest ready ~100 ms sooner | **0 ms** end-to-end on SSH — host wait loop hides it |
 | (host) tighten SSH poll < 200 ms | ~240 ms off the SSH-path first command | shipped in Q4; the AFTER numbers include this change |
@@ -98,32 +102,31 @@ also tightened (or replaced by vsock).
 
 ---
 
-## Bugs found (worth filing)
+## Bugs found during this investigation
 
 1. **8-second vsock-probe penalty on QEMU defaults.** QEMU auto-config
-   auto-prefers vsock with SSH fallback, but the default image has no python3 to
-   run the agent, so every boot waits the full 8 s probe before falling back to
-   SSH. Out-of-box QEMU is ~8.1 s to interact, not ~1.9 s.
-2. **Default image ships the agent without its runtime.** `build_alpine_ssh_key`
-   (auto-config) bakes `/usr/local/bin/smolvm-guest-agent` but installs no
-   python3, so the agent can never start and vsock silently never works.
-3. **Firecracker can't use vsock at all** in this release (selector hard-gates
-   vsock to QEMU), despite the device being wired in the Firecracker adapter.
+   auto-preferred vsock with SSH fallback, but the default image could not run
+   the old Python agent, so every boot waited the full 8 s probe before falling
+   back to SSH.
+2. **Default image shipped the old agent without its runtime.** The image baked
+   a Python guest agent but did not install Python, so the agent could never
+   start.
+3. **Firecracker could not use vsock** in that release because the selector
+   hard-gated vsock to QEMU.
 
-Any one of these fixes for #1/#2 (ship python3, shorten the probe, skip vsock
-when no agent, or default QEMU to SSH) would restore QEMU's out-of-box number to
-the ~1.9 s SSH path; vsock + trim then takes it to ~1.35 s.
+These have since been addressed by the Rust guest-agent bake path, a shorter
+auto probe, and Firecracker vsock support.
 
 ---
 
-## Recommendations
+## Historical recommendations and current status
 
-1. **Fix the 8 s penalty first** — it is the single biggest real-world win
-   (6.8 s) and is pure bug, not tuning.
-2. **Ship python3 in the default image** so vsock works out of the box; then make
-   vsock the default channel on QEMU.
-3. **Adopt the trimmed boot cmdline** (after per-image validation of `acpi=off`).
-4. **Tighten the host-side SSH wait loop** (sub-200 ms cadence) for the SSH path
-   that Firecracker still depends on.
-5. **Implement the Firecracker vsock host bridge** to bring the warm-command and
-   first-command wins to the default Linux backend.
+1. **Fix the 8 s penalty first.** Done: the probe is shorter and published
+   images now start the Rust guest agent.
+2. **Make vsock work out of the box.** Done for published images without a
+   Python runtime dependency.
+3. **Adopt the trimmed boot cmdline.** Still image/profile-specific; keep
+   validating before broadening defaults.
+4. **Tighten the host-side SSH wait loop.** Done for the SSH fallback path.
+5. **Implement the Firecracker vsock host bridge.** Done, with E2E coverage for
+   Firecracker SSH and vsock.

--- a/guest-agent/src/exec.rs
+++ b/guest-agent/src/exec.rs
@@ -179,6 +179,13 @@ pub async fn run_command(req: ExecRequest) -> ExecResponse {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use once_cell::sync::Lazy;
+    use std::fs;
+    use std::path::{Path, PathBuf};
+    use std::sync::Mutex;
+    use tokio::time::{Duration, sleep};
+
+    static ENV_LOCK: Lazy<Mutex<()>> = Lazy::new(|| Mutex::new(()));
 
     #[tokio::test]
     async fn exec_success() {
@@ -222,5 +229,124 @@ mod tests {
         assert_eq!(res.exit_code, -1);
         assert_eq!(res.stderr, "");
         assert_eq!(res.error.as_deref(), Some("Command timed out after 1s"));
+    }
+
+    #[tokio::test]
+    async fn exec_rejects_missing_command() {
+        let res = run_command(ExecRequest {
+            command: "  \n\t  ".to_string(),
+            shell: ShellMode::Raw,
+            timeout_seconds: 5,
+            env: HashMap::new(),
+        })
+        .await;
+        assert!(!res.ok);
+        assert!(!res.timed_out);
+        assert_eq!(res.exit_code, -1);
+        assert_eq!(res.error.as_deref(), Some("missing command"));
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn exec_spawn_failure_reports_error() {
+        let _guard = ENV_LOCK.lock().unwrap();
+        let old_shell = std::env::var_os("SHELL");
+        unsafe {
+            std::env::set_var("SHELL", "/definitely/missing/smolvm-test-shell");
+        }
+
+        let res = run_command(ExecRequest {
+            command: "printf never-runs".to_string(),
+            shell: ShellMode::Login,
+            timeout_seconds: 5,
+            env: HashMap::new(),
+        })
+        .await;
+
+        unsafe {
+            match old_shell {
+                Some(value) => std::env::set_var("SHELL", value),
+                None => std::env::remove_var("SHELL"),
+            }
+        }
+
+        assert!(!res.ok);
+        assert!(!res.timed_out);
+        assert_eq!(res.exit_code, -1);
+        assert!(
+            res.error
+                .as_deref()
+                .unwrap_or("")
+                .starts_with("spawn failed:")
+        );
+    }
+
+    #[tokio::test]
+    async fn exec_timeout_kills_process_group() {
+        let dir = tempfile_dir();
+        let pid_file = dir.join("child.pid");
+        let command = format!(
+            "sleep 30 & echo $! > {}; printf parent-ready; wait",
+            pid_file.display()
+        );
+
+        let res = run_command(ExecRequest {
+            command,
+            shell: ShellMode::Raw,
+            timeout_seconds: 1,
+            env: HashMap::new(),
+        })
+        .await;
+
+        assert!(!res.ok);
+        assert!(res.timed_out);
+        assert_eq!(res.stdout, "parent-ready");
+
+        let child_pid = read_pid(&pid_file).await;
+        for _ in 0..50 {
+            if !process_is_running(child_pid) {
+                return;
+            }
+            sleep(Duration::from_millis(20)).await;
+        }
+        panic!("timed-out command left child process {child_pid} running");
+    }
+
+    async fn read_pid(path: &Path) -> i32 {
+        for _ in 0..50 {
+            if let Ok(raw) = fs::read_to_string(path) {
+                if let Ok(pid) = raw.trim().parse() {
+                    return pid;
+                }
+            }
+            sleep(Duration::from_millis(20)).await;
+        }
+        panic!("child pid was not written to {}", path.display());
+    }
+
+    #[cfg(target_os = "linux")]
+    fn process_is_running(pid: i32) -> bool {
+        let stat = match fs::read_to_string(format!("/proc/{pid}/stat")) {
+            Ok(stat) => stat,
+            Err(_) => return false,
+        };
+        !stat.contains(") Z ")
+    }
+
+    #[cfg(not(target_os = "linux"))]
+    fn process_is_running(pid: i32) -> bool {
+        unsafe { libc::kill(pid as libc::pid_t, 0) == 0 }
+    }
+
+    fn tempfile_dir() -> PathBuf {
+        let path = std::env::temp_dir().join(format!(
+            "smolvm-agent-exec-test-{}-{}",
+            std::process::id(),
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap_or_default()
+                .as_nanos()
+        ));
+        fs::create_dir(&path).unwrap();
+        path
     }
 }

--- a/guest-agent/src/files.rs
+++ b/guest-agent/src/files.rs
@@ -203,6 +203,56 @@ mod tests {
         assert!(put.error.unwrap().contains("directory"));
     }
 
+    #[tokio::test]
+    async fn put_rejects_invalid_directory_filename() {
+        let dir = tempfile_dir();
+        let put = put_file(FilePutRequest {
+            path: dir.to_string_lossy().to_string(),
+            name: Some("..".to_string()),
+            mode: None,
+            data_base64: base64::engine::general_purpose::STANDARD.encode(b"data"),
+        })
+        .await;
+        assert!(!put.ok);
+        assert!(
+            put.error
+                .unwrap()
+                .contains("destination filename is invalid")
+        );
+    }
+
+    #[tokio::test]
+    async fn put_rejects_invalid_base64() {
+        let dir = tempfile_dir();
+        let put = put_file(FilePutRequest {
+            path: dir.join("bad.bin").to_string_lossy().to_string(),
+            name: None,
+            mode: None,
+            data_base64: "%%%".to_string(),
+        })
+        .await;
+        assert!(!put.ok);
+        assert!(put.error.unwrap().contains("invalid base64 data"));
+    }
+
+    #[tokio::test]
+    async fn get_rejects_missing_and_non_regular_paths() {
+        let dir = tempfile_dir();
+        let missing = get_file(FileGetQuery {
+            path: dir.join("missing.bin").to_string_lossy().to_string(),
+        })
+        .await;
+        assert!(!missing.ok);
+        assert!(missing.error.unwrap().contains("No such file"));
+
+        let directory = get_file(FileGetQuery {
+            path: dir.to_string_lossy().to_string(),
+        })
+        .await;
+        assert!(!directory.ok);
+        assert_eq!(directory.error.as_deref(), Some("not a regular file"));
+    }
+
     fn tempfile_dir() -> PathBuf {
         let path = std::env::temp_dir().join(format!(
             "smolvm-agent-test-{}-{}",

--- a/guest-agent/src/handler.rs
+++ b/guest-agent/src/handler.rs
@@ -115,3 +115,116 @@ pub async fn handle_file_get(
 ) -> Json<FileGetResponse> {
     Json(files::get_file(query).await)
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use axum::{
+        body::{Body, to_bytes},
+        http::{Request, StatusCode},
+    };
+    use serde_json::{Value, json};
+    use tower::ServiceExt;
+
+    #[tokio::test]
+    async fn public_router_exposes_health_version_and_safe_capabilities() {
+        let health = request_json(router(), "GET", "/health", None).await;
+        assert_eq!(health.status, StatusCode::OK);
+        assert_eq!(health.body["status"], "ok");
+        assert_eq!(health.body["agent_version"], env!("CARGO_PKG_VERSION"));
+        assert_eq!(health.body["protocol"], "smolvm-http-vsock");
+        assert_eq!(health.body["protocol_version"], PROTOCOL_VERSION);
+
+        let version = request_json(router(), "GET", "/version", None).await;
+        assert_eq!(version.status, StatusCode::OK);
+        assert_eq!(version.body["agent_name"], "smolvm-guest-agent");
+        assert_eq!(version.body["protocol_version"], PROTOCOL_VERSION);
+
+        let capabilities = request_json(router(), "GET", "/capabilities", None).await;
+        assert_eq!(capabilities.status, StatusCode::OK);
+        assert_eq!(capabilities.body["protocol_version"], PROTOCOL_VERSION);
+        assert_eq!(capabilities.body["tcp_enabled"], cfg!(feature = "tcp"));
+        assert_eq!(capabilities.body["terminal_enabled"], false);
+        assert_eq!(capabilities.body["prod_metrics_enabled"], false);
+        let endpoints = capabilities.body["endpoints"].as_array().unwrap();
+        assert!(endpoints.contains(&json!("POST /exec")));
+        assert!(endpoints.contains(&json!("POST /files/put")));
+        assert!(endpoints.contains(&json!("GET /files/get")));
+    }
+
+    #[tokio::test]
+    async fn public_router_exec_maps_validation_errors_to_json() {
+        let response = request_json(
+            router(),
+            "POST",
+            "/exec",
+            Some(json!({
+                "command": "",
+                "shell": "raw",
+                "timeout_seconds": 5
+            })),
+        )
+        .await;
+
+        assert_eq!(response.status, StatusCode::OK);
+        assert_eq!(response.body["ok"], false);
+        assert_eq!(response.body["exit_code"], -1);
+        assert_eq!(response.body["timed_out"], false);
+        assert_eq!(response.body["error"], "missing command");
+    }
+
+    #[tokio::test]
+    async fn extension_router_leaves_private_health_and_exec_routes_to_consumer() {
+        let version = request_json(extension_router(), "GET", "/version", None).await;
+        assert_eq!(version.status, StatusCode::OK);
+
+        let health = raw_request(extension_router(), "GET", "/health", None).await;
+        assert_eq!(health.status(), StatusCode::NOT_FOUND);
+
+        let exec = raw_request(
+            extension_router(),
+            "POST",
+            "/exec",
+            Some(json!({"command": "printf no-op", "shell": "raw"})),
+        )
+        .await;
+        assert_eq!(exec.status(), StatusCode::NOT_FOUND);
+    }
+
+    struct JsonResponse {
+        status: StatusCode,
+        body: Value,
+    }
+
+    async fn request_json(
+        app: Router,
+        method: &str,
+        uri: &str,
+        body: Option<Value>,
+    ) -> JsonResponse {
+        let response = raw_request(app, method, uri, body).await;
+        let status = response.status();
+        let bytes = to_bytes(response.into_body(), usize::MAX).await.unwrap();
+        JsonResponse {
+            status,
+            body: serde_json::from_slice(&bytes).unwrap(),
+        }
+    }
+
+    async fn raw_request(
+        app: Router,
+        method: &str,
+        uri: &str,
+        body: Option<Value>,
+    ) -> axum::response::Response {
+        let mut builder = Request::builder().method(method).uri(uri);
+        let body = match body {
+            Some(value) => {
+                builder = builder.header("content-type", "application/json");
+                Body::from(serde_json::to_vec(&value).unwrap())
+            }
+            None => Body::empty(),
+        };
+        app.oneshot(builder.body(body).unwrap()).await.unwrap()
+    }
+}

--- a/src/smolvm/comm/__init__.py
+++ b/src/smolvm/comm/__init__.py
@@ -19,9 +19,10 @@ probe readiness. :class:`~smolvm.comm.base.CommChannel` is the small interface
 every consumer relies on; it has two implementations:
 
 - :class:`~smolvm.ssh.SSHClient` — SSH/paramiko (the default, works everywhere).
-- :class:`~smolvm.comm.vsock_channel.VsockChannel` — a guest agent reached over
-  ``AF_VSOCK`` (QEMU on Linux first), which works before the guest network or
-  sshd is up.
+- :class:`~smolvm.comm.rust_http_vsock_channel.RustHttpVsockChannel` — the
+  public Rust guest agent over HTTP/vsock, for QEMU CID and Firecracker UDS.
+- :class:`~smolvm.comm.vsock_channel.VsockChannel` — the legacy framed Python
+  guest-agent fallback kept for older images during the migration window.
 """
 
 from __future__ import annotations

--- a/src/smolvm/comm/protocol.py
+++ b/src/smolvm/comm/protocol.py
@@ -19,12 +19,13 @@ that many payload bytes. Control frames carry UTF-8 JSON; stream and file
 frames carry raw bytes, so command output and large files never pay base64
 overhead.
 
-This module is the host-side authority for the format. The guest agent
-(``smolvm/guest_agent/agent.py``) ships as a standalone, dependency-free file
-into the guest image — where the ``smolvm`` package is not installed — and
-embeds a byte-compatible copy of the framing below. ``tests/test_guest_agent.py``
-drives the agent with these host functions over a socketpair to prove the two
-ends interoperate, so the duplication can't drift silently.
+This module is the host-side authority for the legacy framed Python agent
+format. Current published images use the Rust HTTP/vsock agent; this framed
+protocol remains only as a migration fallback for older images. The Python
+agent (``smolvm/guest_agent/agent.py``) embeds a byte-compatible copy of the
+framing below. ``tests/test_guest_agent.py`` drives the agent with these host
+functions over a socketpair to prove the two ends interoperate while the
+fallback remains supported.
 
 Each request occupies its own connection: the host opens a connection, sends
 one request frame, consumes the response (which may stream many frames), and

--- a/src/smolvm/facade.py
+++ b/src/smolvm/facade.py
@@ -115,10 +115,10 @@ _DEFAULT_DISPLAY_SANDBOX_BOOT_TIMEOUT = 90.0
 # When auto-selecting the channel, how long to wait for the vsock agent before
 # falling back to SSH. Kept short: the agent binds its vsock port early in boot
 # (before sshd, ~0.9s guest uptime on Alpine), so if it hasn't answered by now
-# the image almost certainly can't run it (e.g. no python3) and SSH is the real
-# path. This is a guardrail — an agent-less image now costs ~2.5s of wasted
-# probe instead of 8s. (Images SmolVM builds ship the agent + python3, so they
-# answer well inside this window and never hit the fallback.)
+# the image is likely missing the agent or did not start it and SSH is the real
+# path. This is a guardrail: an agent-less image costs ~2.5s of wasted probe.
+# Images SmolVM builds ship the standalone Rust agent and should answer inside
+# this window.
 _VSOCK_AUTO_PROBE_TIMEOUT = 2.5
 _LOCAL_FORWARD_PROBE_TIMEOUT = 2.0
 _LOCAL_FORWARD_PROBE_INTERVAL = 0.2
@@ -594,7 +594,8 @@ def _build_auto_config(
             resolved_disk_size_mib = required_disk_size_mib
         elif resolved_disk_size_mib < required_disk_size_mib:
             raise ValueError(
-                f"Ubuntu needs at least {required_disk_size_mib} MiB for sandbox '{resolved_vm_name}'; "
+                f"Ubuntu needs at least {required_disk_size_mib} MiB for sandbox "
+                f"'{resolved_vm_name}'; "
                 f"recreate it with: smolvm create --name {resolved_vm_name} --os ubuntu "
                 f"--backend {resolved_backend} --disk-size {required_disk_size_mib}."
             )

--- a/src/smolvm/facade.py
+++ b/src/smolvm/facade.py
@@ -593,10 +593,11 @@ def _build_auto_config(
         if disk_size_mib is None:
             resolved_disk_size_mib = required_disk_size_mib
         elif resolved_disk_size_mib < required_disk_size_mib:
+            quoted_vm_name = shlex.quote(resolved_vm_name)
             raise ValueError(
                 f"Ubuntu needs at least {required_disk_size_mib} MiB for sandbox "
                 f"'{resolved_vm_name}'; "
-                f"recreate it with: smolvm create --name {resolved_vm_name} --os ubuntu "
+                f"recreate it with: smolvm create --name {quoted_vm_name} --os ubuntu "
                 f"--backend {resolved_backend} --disk-size {required_disk_size_mib}."
             )
         should_grow_filesystem = (

--- a/src/smolvm/images/builder.py
+++ b/src/smolvm/images/builder.py
@@ -403,8 +403,9 @@ FROM alpine:3.19
 
 ARG SSH_PASSWORD
 
-# Install SSH and networking utilities. python3 powers the SmolVM guest
-# agent (vsock control plane); the agent is stdlib-only, so no pip deps.
+# Install SSH, networking utilities, a shell, and python3. The SmolVM
+# guest agent is injected later as a standalone Rust binary, so python3 is
+# not required for the control plane.
 RUN apk add --no-cache \\
     openssh \\
     iproute2 \\
@@ -508,9 +509,9 @@ RUN chmod +x /init
         dockerfile_content = """
 FROM alpine:3.19
 
-# python3 powers the SmolVM guest agent (vsock control plane); the agent is
-# stdlib-only, so no pip deps. Without it /init silently skips the agent and the
-# host falls back to SSH after an 8s vsock probe (see _VSOCK_AUTO_PROBE_TIMEOUT).
+# Install SSH, networking utilities, a shell, and python3. The SmolVM
+# guest agent is injected later as a standalone Rust binary, so python3 is
+# not required for the control plane.
 RUN apk add --no-cache \
     openssh \
     iproute2 \

--- a/tests/test_facade.py
+++ b/tests/test_facade.py
@@ -258,16 +258,17 @@ class TestVMInit:
 
         with pytest.raises(ValueError) as exc_info:
             _build_auto_config(
-                vm_name="project-spacex",
+                vm_name="project spacex; rm -rf",
                 os="ubuntu",
                 backend="qemu",
                 disk_size_mib=512,
             )
 
         message = str(exc_info.value)
-        assert "Ubuntu needs at least 4096 MiB for sandbox 'project-spacex'" in message
+        assert "Ubuntu needs at least 4096 MiB for sandbox 'project spacex; rm -rf'" in message
         assert (
-            "smolvm create --name project-spacex --os ubuntu --backend qemu --disk-size 4096"
+            "smolvm create --name 'project spacex; rm -rf' --os ubuntu "
+            "--backend qemu --disk-size 4096"
             in message
         )
 

--- a/tests/test_guest_agent.py
+++ b/tests/test_guest_agent.py
@@ -12,13 +12,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Tests for the guest agent and the vsock wire protocol.
+"""Tests for the legacy framed Python guest agent and vsock wire protocol.
 
-The agent (``smolvm.guest_agent.agent``) ships into the guest as a standalone
-file and embeds its own copy of the framing in ``smolvm.comm.protocol``. These
-tests drive the agent's per-connection handler over an ``AF_UNIX`` socketpair
-using the *host-side* protocol helpers, so any drift between the two framings
-is caught immediately — without needing a real VM or AF_VSOCK.
+The Rust HTTP/vsock agent is the public default. This Python agent remains as a
+migration fallback for older images and embeds its own copy of the framing in
+``smolvm.comm.protocol``. These tests drive the agent's per-connection handler
+over an ``AF_UNIX`` socketpair using the *host-side* protocol helpers, so any
+drift between the two framings is caught immediately while the fallback exists.
 """
 
 import os

--- a/tests/test_vsock_channel.py
+++ b/tests/test_vsock_channel.py
@@ -12,11 +12,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Tests for the host-side VsockChannel.
+"""Tests for the legacy framed host-side VsockChannel.
 
 The channel's transport (AF_VSOCK / UDS) is exercised by pointing ``_open`` at
-a socketpair whose far end is served by the real guest agent, so these tests
-validate the full host↔agent round-trip without a VM.
+a socketpair whose far end is served by the legacy Python guest agent, so these
+tests validate the full host↔agent round-trip without a VM while the fallback
+exists.
 """
 
 import queue


### PR DESCRIPTION
## Summary

- Mark old Python-agent and QEMU-only vsock benchmark findings as historical now that the Rust agent and Firecracker vsock support are in place.
- Clarify that the framed Python agent/channel are legacy fallback paths for older images.
- Add Rust guest-agent tests for public endpoint metadata, safe default capabilities, extension-router behavior, exec validation/spawn failure/timeout process-group cleanup, and file error paths.
- Update the E2E workflow comment to reflect current QEMU and Firecracker SSH/vsock coverage.

## Validation

- `cargo test -p smolvm-guest-agent`
- `uv run pytest tests/test_facade_vsock.py tests/test_guest_agent_image.py tests/test_guest_agent.py tests/test_vsock_channel.py -q`
- `uv run ruff check src/smolvm/comm/__init__.py src/smolvm/comm/protocol.py src/smolvm/facade.py src/smolvm/images/builder.py tests/test_guest_agent.py tests/test_vsock_channel.py`
- `git diff --check`

## Notes

Full `uv run ruff check .` still reports existing unrelated lint debt elsewhere in the repo, mostly historical benchmark scripts and unrelated modules.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Expanded test coverage for guest-agent: exec command validation, timeout/process termination, file upload/download errors, and API endpoints; updated facade autoconfig test to validate sanitized VM names.

* **Documentation**
  * Clarified historical vs current agent/transport behavior across reports, benchmarks, and module docs; updated end-to-end workflow description to reflect micro‑VM lifecycle coverage and transport paths.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->