### PR TITLE
Fix Claude auth on published-image sandboxes

### DIFF
--- a/src/smolvm/cli/main.py
+++ b/src/smolvm/cli/main.py
@@ -2309,15 +2309,28 @@ def _run_start_with_published_image(args: argparse.Namespace, preset: object) ->
                 writable_mounts=args.writable_mounts,
             )
             vm.start(boot_timeout=args.boot_timeout)
-            vm.wait_for_ssh(timeout=args.boot_timeout)
+            # Wait for the *resolved* control channel, not SSH specifically:
+            # the credential transfer below only needs run()/put_file(),
+            # which work over vsock too. On a Linux host with the guest
+            # agent this uses vsock (no guest network/sshd needed); on
+            # macOS it resolves to SSH. Forcing wait_for_ssh here would make
+            # the vsock path pay an unnecessary SSH handshake first.
+            vm.wait_for_ready(timeout=args.boot_timeout)
 
-            # Transfer credentials — keychain only, no config copies or
-            # install scripts. The CLI is already baked into the image;
-            # we only need the OAuth token so the guest is logged in.
-            from smolvm.presets import transfer_keychain_secrets
+            # Transfer credentials — no install scripts (the CLI is
+            # already baked into the image). We still copy the preset's
+            # host configs and the keychain token, since the OAuth token
+            # alone only satisfies headless use: the interactive claude
+            # TUI reads ~/.claude.json for onboarding state and shows its
+            # login screen without it. Configs first, keychain after, so
+            # a config copy can't clobber a credential we just wrote
+            # (mirrors apply_preset's ordering). Git configs are excluded
+            # here — the published path is credential-transfer only.
+            from smolvm.presets import transfer_host_configs, transfer_keychain_secrets
 
-            ssh = vm._ensure_ssh_for_env()
-            extracted_secrets = transfer_keychain_secrets(ssh, _preset)
+            channel = vm._ensure_control_for_file_transfer()
+            copied_configs = transfer_host_configs(channel, _preset, include_git_configs=False)
+            extracted_secrets = transfer_keychain_secrets(channel, _preset)
 
             network = vm.info.network
             data: StartPayload = {
@@ -2337,7 +2350,7 @@ def _run_start_with_published_image(args: argparse.Namespace, preset: object) ->
                 },
                 "preset": {
                     "name": _preset.name,
-                    "copied_configs": extracted_secrets,
+                    "copied_configs": [*copied_configs, *extracted_secrets],
                     "injected_env_keys": [],
                     "no_env_hint": _preset.no_env_hint,
                 },

--- a/src/smolvm/presets/__init__.py
+++ b/src/smolvm/presets/__init__.py
@@ -22,7 +22,12 @@ along with any host config files and API keys the harness expects.
 from __future__ import annotations
 
 from smolvm.presets._git import GIT_HOST_CONFIGS
-from smolvm.presets._install import apply_preset, collect_host_env, transfer_keychain_secrets
+from smolvm.presets._install import (
+    apply_preset,
+    collect_host_env,
+    transfer_host_configs,
+    transfer_keychain_secrets,
+)
 from smolvm.presets._types import HostConfigCopy, HostKeychainSecret, Preset
 from smolvm.presets.claude_code import CLAUDE_CODE_PRESET
 from smolvm.presets.codex import CODEX_PRESET
@@ -92,6 +97,7 @@ __all__ = [
     "apply_preset",
     "collect_host_env",
     "get_preset",
+    "transfer_host_configs",
     "transfer_keychain_secrets",
     "list_presets",
     "preset_command_names",

--- a/src/smolvm/presets/_install.py
+++ b/src/smolvm/presets/_install.py
@@ -76,25 +76,9 @@ def apply_preset(
     """
     notify = on_progress or (lambda _msg: None)
 
-    copied_configs: list[str] = []
-    # Git configs piggyback on host_configs so dir copies (e.g. ~/.ssh)
-    # preserve 0o600 modes via tar and the run summary surfaces them
-    # under the existing copied_configs key.
-    all_configs = (*preset.host_configs, *GIT_HOST_CONFIGS)
-    if all_configs:
-        notify("Copying host credentials (gitconfig, ssh keys, CLI configs)...")
-    for cfg in all_configs:
-        local = Path(cfg.host_path).expanduser()
-        if not local.exists():
-            if cfg.required:
-                raise SmolVMError(
-                    f"Required host config not found: {local}",
-                    {"preset": preset.name, "host_path": str(local)},
-                )
-            logger.debug("Skipping missing host config: %s", local)
-            continue
-        _copy_to_guest(ssh, local, cfg.guest_path, file_mode=cfg.file_mode)
-        copied_configs.append(cfg.guest_path)
+    copied_configs = transfer_host_configs(
+        ssh, preset, on_progress=on_progress, include_git_configs=True
+    )
 
     # Keychain step runs after host_configs so a directory copy that
     # targets the same parent (e.g. ~/.claude → /root/.claude) cannot
@@ -164,17 +148,29 @@ def _run_install_phase(
 
 
 def _copy_to_guest(
-    ssh: CommChannel, local: Path, guest_path: str, *, file_mode: int | None = None
+    ssh: CommChannel,
+    local: Path,
+    guest_path: str,
+    *,
+    file_mode: int | None = None,
+    transform: Callable[[bytes], bytes] | None = None,
 ) -> None:
     """Copy a host file or directory tree to *guest_path* inside the VM.
 
     *file_mode* applies only to single-file copies; directory copies
-    inherit per-file modes from the tar archive.
+    inherit per-file modes from the tar archive. *transform*, when set,
+    rewrites a single file's bytes before upload (directory copies have
+    no single byte stream and reject a transform).
     """
     if local.is_file():
-        _copy_file(ssh, local, guest_path, file_mode=file_mode)
+        _copy_file(ssh, local, guest_path, file_mode=file_mode, transform=transform)
         return
     if local.is_dir():
+        if transform is not None:
+            raise SmolVMError(
+                f"transform is not supported for directory copies: {local}",
+                {"host_path": str(local)},
+            )
         _copy_dir(ssh, local, guest_path)
         return
     raise SmolVMError(
@@ -184,7 +180,12 @@ def _copy_to_guest(
 
 
 def _copy_file(
-    ssh: CommChannel, local: Path, guest_path: str, *, file_mode: int | None = None
+    ssh: CommChannel,
+    local: Path,
+    guest_path: str,
+    *,
+    file_mode: int | None = None,
+    transform: Callable[[bytes], bytes] | None = None,
 ) -> None:
     """Upload a single host file to *guest_path* via SFTP, mkdir parent first.
 
@@ -193,6 +194,11 @@ def _copy_file(
     (e.g. ``~/.git-credentials`` with plaintext OAuth tokens), pass
     *file_mode* to chmod the guest file after the upload so it does
     not land world-readable.
+
+    When *transform* is set, the host file's bytes are passed through it
+    and the result is uploaded instead of the original — staged in a
+    0o600 host tempfile so a transformed credential file never sits
+    world-readable on the host mid-upload.
     """
     parent = _posix_dirname(guest_path)
     if parent:
@@ -202,7 +208,25 @@ def _copy_file(
                 f"Failed to create guest directory {parent!r}",
                 {"exit_code": result.exit_code, "stderr": result.stderr},
             )
-    ssh.put_file(local, guest_path)
+
+    upload_src = local
+    tmp_path: Path | None = None
+    try:
+        if transform is not None:
+            transformed = transform(local.read_bytes())
+            fd, tmp_name = tempfile.mkstemp(prefix=".smolvm-cfg-", suffix=".tmp")
+            tmp_path = Path(tmp_name)
+            # mkstemp creates the file 0o600; write via the fd to avoid a
+            # world-readable window before upload.
+            with os.fdopen(fd, "wb") as fp:
+                fp.write(transformed)
+            upload_src = tmp_path
+
+        ssh.put_file(upload_src, guest_path)
+    finally:
+        if tmp_path is not None:
+            tmp_path.unlink(missing_ok=True)
+
     if file_mode is not None:
         chmod_cmd = f"chmod {file_mode:o} -- {shlex.quote(guest_path)}"
         result = ssh.run(chmod_cmd, timeout=5)
@@ -341,6 +365,63 @@ def _write_secret_to_guest(ssh: CommChannel, content: str, guest_path: str, file
         tmp_path.unlink(missing_ok=True)
 
 
+def transfer_host_configs(
+    ssh: CommChannel,
+    preset: Preset,
+    *,
+    on_progress: Callable[[str], None] | None = None,
+    include_git_configs: bool = True,
+) -> list[str]:
+    """Copy the preset's host config files/dirs into the guest.
+
+    Runs only the config-copy step from :func:`apply_preset` — no
+    keychain extraction, no env injection, no install scripts. The
+    published-image path reuses this so a sandbox booted from a
+    pre-baked image still receives ``~/.claude.json`` and ``~/.claude``
+    (the interactive CLI reads ``~/.claude.json`` to skip its login
+    screen; the keychain token alone only satisfies headless ``-p``).
+
+    When *include_git_configs* is True the git/ssh credential set
+    (:data:`GIT_HOST_CONFIGS`) is appended so ``git``/``gh`` work in the
+    guest. The published-image path passes False — it only needs the
+    preset's own configs.
+
+    Missing host files are skipped silently unless marked ``required``,
+    which raises :class:`SmolVMError`. Returns the guest paths written.
+    """
+    notify = on_progress or (lambda _msg: None)
+
+    copied_configs: list[str] = []
+    git_configs = GIT_HOST_CONFIGS if include_git_configs else ()
+    # Git configs piggyback on host_configs so dir copies (e.g. ~/.ssh)
+    # preserve 0o600 modes via tar and the run summary surfaces them
+    # under the existing copied_configs key.
+    all_configs = (*preset.host_configs, *git_configs)
+    if all_configs:
+        notify("Copying host credentials (gitconfig, ssh keys, CLI configs)...")
+    for cfg in all_configs:
+        local = Path(cfg.host_path).expanduser()
+        if not local.exists():
+            if cfg.required:
+                raise SmolVMError(
+                    f"The {preset.name} sandbox needs the file '{local}' on your "
+                    "machine, but it isn't there. Restore it and start the sandbox "
+                    "again.",
+                    {"preset": preset.name, "host_path": str(local)},
+                )
+            logger.debug("Skipping missing host config: %s", local)
+            continue
+        _copy_to_guest(
+            ssh,
+            local,
+            cfg.guest_path,
+            file_mode=cfg.file_mode,
+            transform=cfg.transform,
+        )
+        copied_configs.append(cfg.guest_path)
+    return copied_configs
+
+
 def transfer_keychain_secrets(
     ssh: CommChannel,
     preset: Preset,
@@ -376,4 +457,9 @@ def transfer_keychain_secrets(
     return extracted
 
 
-__all__ = ["apply_preset", "collect_host_env", "transfer_keychain_secrets"]
+__all__ = [
+    "apply_preset",
+    "collect_host_env",
+    "transfer_host_configs",
+    "transfer_keychain_secrets",
+]

--- a/src/smolvm/presets/_types.py
+++ b/src/smolvm/presets/_types.py
@@ -16,6 +16,7 @@
 
 from __future__ import annotations
 
+from collections.abc import Callable
 from dataclasses import dataclass, field
 
 
@@ -34,12 +35,22 @@ class HostConfigCopy:
             files (e.g. ``~/.git-credentials``) that the SFTP server's
             umask would otherwise leave world-readable. ``None``
             (default) leaves the SFTP-applied mode in place.
+        transform: Optional callable applied to the host file's raw
+            bytes to produce the bytes written into the guest. Single-
+            file copies only (directory copies ignore it). Use it to
+            strip host-specific data before upload — e.g. Claude Code's
+            ``~/.claude.json`` is ~130 KB of per-host project history and
+            feature-flag caches, but the guest only needs the ~1 KB
+            auth/onboarding subset. Filtering on the host side keeps the
+            host's project history off the sandbox disk entirely.
+            ``None`` (default) copies the file verbatim.
     """
 
     host_path: str
     guest_path: str
     required: bool = False
     file_mode: int | None = None
+    transform: Callable[[bytes], bytes] | None = None
 
 
 @dataclass(frozen=True)

--- a/src/smolvm/presets/claude_code.py
+++ b/src/smolvm/presets/claude_code.py
@@ -16,37 +16,64 @@
 
 from __future__ import annotations
 
+import json
+
 from smolvm.presets._scripts import NODE20_BOOTSTRAP, npm_install_global
 from smolvm.presets._types import HostConfigCopy, HostKeychainSecret, Preset
 
-# Drop host-specific install metadata from the copied ~/.claude.json.
-# claude-code records `installMethod` ("native" if the user ran
-# `claude migrate-installer` on their host) and uses it to locate its
-# own binary on launch. That value reflects the host's layout, not the
-# guest's — in the guest claude is npm-installed under
-# /usr/lib/node_modules, so a copied "native" tag makes claude error
-# with "claude command not found at /root/.local/bin/claude" on first
-# start. Removing the key lets claude re-detect the install method
-# fresh on the guest. python3 ships in the Ubuntu cloud image.
+# The host ~/.claude.json is ~130 KB, but ~90% of it is data the guest
+# must not inherit: `projects` (per-host directory trust decisions and
+# prior session history — a privacy leak into a disposable sandbox) and
+# `cached*` feature-flag blobs (re-fetched in the guest anyway). The
+# interactive CLI only needs a tiny auth/onboarding subset to skip its
+# login screen — `claude auth status` returns `loggedIn: true` from just
+# these keys, with email/org/plan re-derived from the OAuth token in
+# .credentials.json.
 #
-# Public so the Pi preset can append the same cleanup when it
-# forwards ~/.claude.json (Pi delegates Claude Pro/Max auth through
-# Claude Code's on-disk config).
-CLAUDE_RESET_INSTALL_METHOD = r"""
-if [ -f /root/.claude.json ]; then
-  python3 - <<'PY' || true
-import json, pathlib
-p = pathlib.Path("/root/.claude.json")
-try:
-    data = json.loads(p.read_text())
-except Exception:
-    raise SystemExit(0)
-if isinstance(data, dict) and "installMethod" in data:
-    del data["installMethod"]
-    p.write_text(json.dumps(data, indent=2))
-PY
-fi
-"""
+# An allowlist (not a denylist) is deliberate: claude-code adds new
+# top-level keys every release, so a "strip these junk keys" list would
+# rot. The load-bearing keys below are stable.
+#
+# Notably absent: `installMethod`. The host records "native" when the
+# user ran `claude migrate-installer`; in the guest claude is
+# npm-installed, so a copied "native" tag made claude error with
+# "claude command not found at /root/.local/bin/claude". Omitting the
+# key from the allowlist lets claude re-detect the install method fresh
+# — replacing the old in-guest reset script.
+_CLAUDE_JSON_AUTH_KEYS = (
+    "oauthAccount",
+    "userID",
+    "anonymousId",
+    "hasCompletedOnboarding",
+    "firstStartTime",
+    "claudeCodeFirstTokenDate",
+)
+
+
+def minimize_claude_json(raw: bytes) -> bytes:
+    """Project the host ~/.claude.json down to the auth/onboarding subset.
+
+    Returns the filtered JSON as bytes ready to write into the guest.
+    Falls back to an empty JSON object if the host file is malformed —
+    or is valid JSON that isn't an object (``null``, a list, a string) —
+    so a corrupt host config can't abort sandbox provisioning; the guest
+    still has a valid (if login-prompting) file.
+
+    Public so the Pi preset can reuse it when it forwards ~/.claude.json
+    (Pi delegates Claude Pro/Max auth through Claude Code's on-disk
+    config).
+    """
+    try:
+        data = json.loads(raw)
+    except (json.JSONDecodeError, ValueError):
+        data = {}
+    # ~/.claude.json is always an object in practice, but guard the
+    # allowlist projection against valid-but-non-object JSON so the key
+    # lookups below can't raise and defeat the fallback intent.
+    if not isinstance(data, dict):
+        data = {}
+    minimal = {k: data[k] for k in _CLAUDE_JSON_AUTH_KEYS if k in data}
+    return json.dumps(minimal, indent=2).encode("utf-8")
 
 # On macOS, claude stores its OAuth tokens in the keychain (not in
 # ~/.claude/.credentials.json — that file does not exist on a
@@ -70,11 +97,20 @@ CLAUDE_CODE_PRESET = Preset(
     aliases=("claude",),
     summary="Start a sandbox with Anthropic's Claude Code CLI preinstalled.",
     setup_script=NODE20_BOOTSTRAP,
-    install_script=npm_install_global("@anthropic-ai/claude-code") + CLAUDE_RESET_INSTALL_METHOD,
+    install_script=npm_install_global("@anthropic-ai/claude-code"),
     host_env_vars=("ANTHROPIC_API_KEY",),
     host_configs=(
-        HostConfigCopy(host_path="~/.claude.json", guest_path="/root/.claude.json"),
-        HostConfigCopy(host_path="~/.claude", guest_path="/root/.claude"),
+        # Only ~/.claude.json, minimized to the auth/onboarding subset.
+        # The ~/.claude directory is intentionally not copied: its only
+        # auth-relevant content is .credentials.json, which the keychain
+        # secret below writes directly. Copying the whole dir would drag
+        # host caches/backups into the sandbox for no benefit.
+        HostConfigCopy(
+            host_path="~/.claude.json",
+            guest_path="/root/.claude.json",
+            file_mode=0o600,
+            transform=minimize_claude_json,
+        ),
     ),
     host_keychain_secrets=(CLAUDE_CODE_KEYCHAIN_SECRET,),
     launch_command="claude",

--- a/src/smolvm/presets/claude_code.py
+++ b/src/smolvm/presets/claude_code.py
@@ -100,16 +100,22 @@ CLAUDE_CODE_PRESET = Preset(
     install_script=npm_install_global("@anthropic-ai/claude-code"),
     host_env_vars=("ANTHROPIC_API_KEY",),
     host_configs=(
-        # Only ~/.claude.json, minimized to the auth/onboarding subset.
-        # The ~/.claude directory is intentionally not copied: its only
-        # auth-relevant content is .credentials.json, which the keychain
-        # secret below writes directly. Copying the whole dir would drag
-        # host caches/backups into the sandbox for no benefit.
+        # Minimize ~/.claude.json, then copy only the on-disk token file
+        # from ~/.claude. Linux stores Claude OAuth there; macOS usually
+        # lacks this file and uses the keychain secret below, which runs
+        # after config copies and can overwrite stale on-disk credentials.
+        # Copying the whole ~/.claude dir would drag host caches/backups
+        # into the sandbox for no benefit.
         HostConfigCopy(
             host_path="~/.claude.json",
             guest_path="/root/.claude.json",
             file_mode=0o600,
             transform=minimize_claude_json,
+        ),
+        HostConfigCopy(
+            host_path="~/.claude/.credentials.json",
+            guest_path="/root/.claude/.credentials.json",
+            file_mode=0o600,
         ),
     ),
     host_keychain_secrets=(CLAUDE_CODE_KEYCHAIN_SECRET,),

--- a/src/smolvm/presets/pi.py
+++ b/src/smolvm/presets/pi.py
@@ -29,8 +29,10 @@ from smolvm.presets.claude_code import CLAUDE_CODE_KEYCHAIN_SECRET, minimize_cla
 # The forwarded ~/.claude.json is minimized to the auth/onboarding subset
 # (see claude_code.minimize_claude_json) — this also drops the
 # host-specific installMethod that would otherwise misdirect claude in
-# the guest. The keychain secret writes ~/.claude/.credentials.json, so
-# the ~/.claude directory itself need not be copied.
+# the guest. Linux stores Claude OAuth in ~/.claude/.credentials.json,
+# so copy that single file too; the macOS keychain secret runs after
+# host-config copies and can overwrite it when available. The ~/.claude
+# directory itself need not be copied.
 PI_PRESET = Preset(
     name="pi",
     summary="Start a sandbox with the Pi coding agent preinstalled.",
@@ -45,6 +47,11 @@ PI_PRESET = Preset(
             guest_path="/root/.claude.json",
             file_mode=0o600,
             transform=minimize_claude_json,
+        ),
+        HostConfigCopy(
+            host_path="~/.claude/.credentials.json",
+            guest_path="/root/.claude/.credentials.json",
+            file_mode=0o600,
         ),
     ),
     host_keychain_secrets=(CLAUDE_CODE_KEYCHAIN_SECRET,),

--- a/src/smolvm/presets/pi.py
+++ b/src/smolvm/presets/pi.py
@@ -18,7 +18,7 @@ from __future__ import annotations
 
 from smolvm.presets._scripts import NODE20_BOOTSTRAP, npm_install_global
 from smolvm.presets._types import HostConfigCopy, Preset
-from smolvm.presets.claude_code import CLAUDE_CODE_KEYCHAIN_SECRET, CLAUDE_RESET_INSTALL_METHOD
+from smolvm.presets.claude_code import CLAUDE_CODE_KEYCHAIN_SECRET, minimize_claude_json
 
 # Pi is a meta-harness: its `/login` flow lists "OpenAI ChatGPT Plus/Pro
 # (Codex)" and "Anthropic Claude Pro/Max" as subscription providers, and
@@ -26,22 +26,26 @@ from smolvm.presets.claude_code import CLAUDE_CODE_KEYCHAIN_SECRET, CLAUDE_RESET
 # user is already logged in there. So forward the union of codex's and
 # claude-code's host-config bundles plus Pi's own ~/.pi (which contains
 # settings, sessions, and ~/.pi/agent/auth.json — Pi's own OAuth tokens).
-# We also append claude_code's reset snippet so the copied
-# ~/.claude.json doesn't carry a host-specific installMethod into the
-# guest.
+# The forwarded ~/.claude.json is minimized to the auth/onboarding subset
+# (see claude_code.minimize_claude_json) — this also drops the
+# host-specific installMethod that would otherwise misdirect claude in
+# the guest. The keychain secret writes ~/.claude/.credentials.json, so
+# the ~/.claude directory itself need not be copied.
 PI_PRESET = Preset(
     name="pi",
     summary="Start a sandbox with the Pi coding agent preinstalled.",
     setup_script=NODE20_BOOTSTRAP,
-    install_script=(
-        npm_install_global("@mariozechner/pi-coding-agent") + CLAUDE_RESET_INSTALL_METHOD
-    ),
+    install_script=npm_install_global("@mariozechner/pi-coding-agent"),
     host_env_vars=("ANTHROPIC_API_KEY", "OPENAI_API_KEY"),
     host_configs=(
         HostConfigCopy(host_path="~/.pi", guest_path="/root/.pi"),
         HostConfigCopy(host_path="~/.codex", guest_path="/root/.codex"),
-        HostConfigCopy(host_path="~/.claude.json", guest_path="/root/.claude.json"),
-        HostConfigCopy(host_path="~/.claude", guest_path="/root/.claude"),
+        HostConfigCopy(
+            host_path="~/.claude.json",
+            guest_path="/root/.claude.json",
+            file_mode=0o600,
+            transform=minimize_claude_json,
+        ),
     ),
     host_keychain_secrets=(CLAUDE_CODE_KEYCHAIN_SECRET,),
     launch_command="pi",

--- a/tests/test_presets.py
+++ b/tests/test_presets.py
@@ -143,20 +143,25 @@ class TestClaudeCodePreset:
         assert "@anthropic-ai/claude-code" in CLAUDE_CODE_PRESET.install_script
         assert "npm install -g" in CLAUDE_CODE_PRESET.install_script
 
-    def test_claude_code_json_copy_uses_minimizing_transform(self) -> None:
+    def test_claude_code_forwards_minimized_json_and_on_disk_token(self) -> None:
         """The ~/.claude.json copy must run through ``minimize_claude_json``
         and write 0o600 — the file carries OAuth/onboarding state and the
         host copy is mostly per-host project history we don't want in the
-        guest. The ~/.claude *directory* is intentionally not copied; the
-        keychain secret writes its only auth-relevant file."""
+        guest. The ~/.claude *directory* is intentionally not copied, but
+        the single Linux on-disk credential file still needs to travel."""
         from smolvm.presets.claude_code import minimize_claude_json
 
         pairs = [(cfg.host_path, cfg.guest_path) for cfg in CLAUDE_CODE_PRESET.host_configs]
-        assert pairs == [("~/.claude.json", "/root/.claude.json")]
+        assert pairs == [
+            ("~/.claude.json", "/root/.claude.json"),
+            ("~/.claude/.credentials.json", "/root/.claude/.credentials.json"),
+        ]
 
-        cfg = CLAUDE_CODE_PRESET.host_configs[0]
-        assert cfg.transform is minimize_claude_json
-        assert cfg.file_mode == 0o600
+        json_cfg, token_cfg = CLAUDE_CODE_PRESET.host_configs
+        assert json_cfg.transform is minimize_claude_json
+        assert json_cfg.file_mode == 0o600
+        assert token_cfg.transform is None
+        assert token_cfg.file_mode == 0o600
 
     def test_minimize_claude_json_keeps_only_auth_keys(self) -> None:
         """The transform projects the host config down to the auth/
@@ -223,6 +228,7 @@ class TestPiPreset:
             ("~/.pi", "/root/.pi"),
             ("~/.codex", "/root/.codex"),
             ("~/.claude.json", "/root/.claude.json"),
+            ("~/.claude/.credentials.json", "/root/.claude/.credentials.json"),
         ]
 
     def test_pi_pulls_oauth_from_macos_keychain(self) -> None:
@@ -237,19 +243,26 @@ class TestPiPreset:
         assert "@mariozechner/pi-coding-agent" in PI_PRESET.install_script
         assert "npm install -g" in PI_PRESET.install_script
 
-    def test_pi_claude_json_copy_uses_minimizing_transform(self) -> None:
+    def test_pi_claude_copies_use_minimized_json_and_on_disk_token(self) -> None:
         """Pi forwards ~/.claude.json for Claude Pro/Max delegation, so it
         must reuse claude-code's minimizing transform — this drops the
         host-specific ``installMethod`` (along with project history and
-        caches) that would otherwise break claude's subscription path in
-        the guest."""
+        caches) that would otherwise break claude's subscription path.
+        It must also forward Linux's on-disk Claude token file."""
         from smolvm.presets.claude_code import minimize_claude_json
 
         claude_cfg = next(
             cfg for cfg in PI_PRESET.host_configs if cfg.guest_path == "/root/.claude.json"
         )
+        token_cfg = next(
+            cfg
+            for cfg in PI_PRESET.host_configs
+            if cfg.guest_path == "/root/.claude/.credentials.json"
+        )
         assert claude_cfg.transform is minimize_claude_json
         assert claude_cfg.file_mode == 0o600
+        assert token_cfg.transform is None
+        assert token_cfg.file_mode == 0o600
 
     def test_pi_setup_uses_node20_bootstrap(self) -> None:
         from smolvm.presets._scripts import NODE20_BOOTSTRAP

--- a/tests/test_presets.py
+++ b/tests/test_presets.py
@@ -143,65 +143,62 @@ class TestClaudeCodePreset:
         assert "@anthropic-ai/claude-code" in CLAUDE_CODE_PRESET.install_script
         assert "npm install -g" in CLAUDE_CODE_PRESET.install_script
 
-    def test_claude_code_install_strips_host_install_method(self, tmp_path: Path) -> None:
-        """The install script must drop ``installMethod`` from the copied
-        ``~/.claude.json``. The host's value (e.g. ``"native"`` after the
-        user ran ``claude migrate-installer`` on their machine) does not
-        match the guest, where claude is npm-installed under
-        ``/usr/lib/node_modules`` — leaving it makes claude error with
-        ``claude command not found at /root/.local/bin/claude`` on the
-        first launch."""
+    def test_claude_code_json_copy_uses_minimizing_transform(self) -> None:
+        """The ~/.claude.json copy must run through ``minimize_claude_json``
+        and write 0o600 — the file carries OAuth/onboarding state and the
+        host copy is mostly per-host project history we don't want in the
+        guest. The ~/.claude *directory* is intentionally not copied; the
+        keychain secret writes its only auth-relevant file."""
+        from smolvm.presets.claude_code import minimize_claude_json
+
+        pairs = [(cfg.host_path, cfg.guest_path) for cfg in CLAUDE_CODE_PRESET.host_configs]
+        assert pairs == [("~/.claude.json", "/root/.claude.json")]
+
+        cfg = CLAUDE_CODE_PRESET.host_configs[0]
+        assert cfg.transform is minimize_claude_json
+        assert cfg.file_mode == 0o600
+
+    def test_minimize_claude_json_keeps_only_auth_keys(self) -> None:
+        """The transform projects the host config down to the auth/
+        onboarding allowlist, dropping host-specific bulk (project
+        history, caches) and ``installMethod`` (which reflects the host's
+        install layout, not the guest's)."""
         import json
-        import subprocess
 
-        root = tmp_path / "root"
-        root.mkdir()
-        config = root / ".claude.json"
-        config.write_text(
-            json.dumps(
-                {
-                    "installMethod": "native",
-                    "theme": "dark",
-                    "recentProjects": ["a", "b"],
-                }
-            )
-        )
+        from smolvm.presets.claude_code import minimize_claude_json
 
-        # Extract just the cleanup snippet (after the npm install line)
-        # and rewrite the hard-coded /root/ path to our temp dir.
-        from smolvm.presets.claude_code import CLAUDE_RESET_INSTALL_METHOD
+        raw = json.dumps(
+            {
+                "oauthAccount": {"emailAddress": "u@example.com"},
+                "userID": "uid-123",
+                "hasCompletedOnboarding": True,
+                "installMethod": "native",
+                "projects": {"/home/u/repo": {"allowedTools": ["x"]}},
+                "cachedGrowthBookFeatures": {"big": "blob"},
+            }
+        ).encode()
 
-        snippet = CLAUDE_RESET_INSTALL_METHOD.replace("/root/", f"{root}/")
-        completed = subprocess.run(
-            ["bash", "-c", f"set -euo pipefail; {snippet}"],
-            capture_output=True,
-            text=True,
-            check=False,
-        )
-        assert completed.returncode == 0, completed.stderr
+        result = json.loads(minimize_claude_json(raw))
 
-        data = json.loads(config.read_text())
-        assert "installMethod" not in data
-        # Other fields are untouched.
-        assert data["theme"] == "dark"
-        assert data["recentProjects"] == ["a", "b"]
+        assert result["oauthAccount"] == {"emailAddress": "u@example.com"}
+        assert result["userID"] == "uid-123"
+        assert result["hasCompletedOnboarding"] is True
+        # Host-specific bulk and install layout are dropped.
+        assert "installMethod" not in result
+        assert "projects" not in result
+        assert "cachedGrowthBookFeatures" not in result
 
-    def test_claude_code_install_skips_when_config_absent(self, tmp_path: Path) -> None:
-        """The cleanup must be a no-op when ~/.claude.json was never
-        copied (e.g. a fresh user with no host config)."""
-        import subprocess
+    def test_minimize_claude_json_tolerates_malformed_input(self) -> None:
+        """A corrupt host ~/.claude.json must not abort provisioning — the
+        transform falls back to an empty (valid) JSON object. Valid JSON
+        that isn't an object (null, list, string) must fall back too, so
+        the allowlist projection never raises on a non-dict."""
+        import json
 
-        from smolvm.presets.claude_code import CLAUDE_RESET_INSTALL_METHOD
+        from smolvm.presets.claude_code import minimize_claude_json
 
-        # Point at an empty dir — the file does not exist.
-        snippet = CLAUDE_RESET_INSTALL_METHOD.replace("/root/", f"{tmp_path}/")
-        completed = subprocess.run(
-            ["bash", "-c", f"set -euo pipefail; {snippet}"],
-            capture_output=True,
-            text=True,
-            check=False,
-        )
-        assert completed.returncode == 0, completed.stderr
+        for raw in (b"{not json", b"null", b"[]", b'"a string"', b"42"):
+            assert json.loads(minimize_claude_json(raw)) == {}
 
 
 class TestPiPreset:
@@ -226,7 +223,6 @@ class TestPiPreset:
             ("~/.pi", "/root/.pi"),
             ("~/.codex", "/root/.codex"),
             ("~/.claude.json", "/root/.claude.json"),
-            ("~/.claude", "/root/.claude"),
         ]
 
     def test_pi_pulls_oauth_from_macos_keychain(self) -> None:
@@ -241,14 +237,19 @@ class TestPiPreset:
         assert "@mariozechner/pi-coding-agent" in PI_PRESET.install_script
         assert "npm install -g" in PI_PRESET.install_script
 
-    def test_pi_install_strips_claude_install_method(self) -> None:
-        """Pi forwards ~/.claude.json, so its install must append the
-        same installMethod cleanup that claude-code uses — otherwise
-        the host's ``installMethod`` value carries into the guest and
-        breaks claude/Pi's claude-subscription path on first launch."""
-        from smolvm.presets.claude_code import CLAUDE_RESET_INSTALL_METHOD
+    def test_pi_claude_json_copy_uses_minimizing_transform(self) -> None:
+        """Pi forwards ~/.claude.json for Claude Pro/Max delegation, so it
+        must reuse claude-code's minimizing transform — this drops the
+        host-specific ``installMethod`` (along with project history and
+        caches) that would otherwise break claude's subscription path in
+        the guest."""
+        from smolvm.presets.claude_code import minimize_claude_json
 
-        assert CLAUDE_RESET_INSTALL_METHOD in PI_PRESET.install_script
+        claude_cfg = next(
+            cfg for cfg in PI_PRESET.host_configs if cfg.guest_path == "/root/.claude.json"
+        )
+        assert claude_cfg.transform is minimize_claude_json
+        assert claude_cfg.file_mode == 0o600
 
     def test_pi_setup_uses_node20_bootstrap(self) -> None:
         from smolvm.presets._scripts import NODE20_BOOTSTRAP
@@ -501,7 +502,7 @@ class TestApplyPreset:
             ),
         )
 
-        with pytest.raises(SmolVMError, match="Required host config not found"):
+        with pytest.raises(SmolVMError, match="isn't there. Restore it"):
             apply_preset(ssh, preset)
 
     def test_copies_file_via_put_file(self, tmp_path: Path) -> None:


### PR DESCRIPTION
## Problem

`smolvm claude-code start` left the interactive Claude CLI at its login screen, even though the host is signed in. The sandbox booted, but `claude` asked the user to authenticate.

Root cause: there are two boot paths. The **install-at-boot** path (`apply_preset`) copies the preset's `host_configs` — including `~/.claude.json` — then transfers the keychain token. The **published-image** path (used once a pre-baked image exists for the preset, which is now the case for claude-code) ran **only** the keychain transfer and skipped `host_configs` entirely.

The OAuth token in `~/.claude/.credentials.json` is enough for headless `claude -p`, but the **interactive** TUI reads `~/.claude.json` for onboarding state — with that file absent it treats the user as a first-run user and shows the login screen. So the bug appeared only on the published-image path, and only for the interactive flow.

## Fix

- The published-image path now copies the preset `host_configs` before the keychain transfer (configs first so a copy can't clobber the credential we just wrote). Git configs are **excluded** here (`include_git_configs=False`) — the published path stays credential-transfer only.
- The host `~/.claude.json` is ~130 KB, ~90% of it per-host `projects` history and feature-flag caches that should not leak into a disposable sandbox. A new `minimize_claude_json` transform projects it down to a ~1 KB auth/onboarding allowlist (allowlist, not denylist — new top-level keys are added every release). The allowlist omits `installMethod`, which replaces the old in-guest reset script.
- `HostConfigCopy` gains an optional `transform: Callable[[bytes], bytes]` (single-file copies only), staged through a 0600 host tempfile so a transformed credential never sits world-readable mid-upload.
- The config-copy loop is factored out of `apply_preset` into a reusable `transfer_host_configs` helper.
- The `pi` preset reuses the same minimizing transform for its forwarded `~/.claude.json` and drops the now-redundant `~/.claude` directory copy.
- The published path now transfers over the **resolved** control channel (`wait_for_ready` + `_ensure_control_for_file_transfer`) instead of forcing SSH. A Linux host with the guest agent uses vsock (no guest network/sshd needed); macOS resolves to SSH as before. The transfer only needs `run()`/`put_file()`, which both transports provide.

## Verification

On a fresh published-image sandbox (`uv run smolvm claude-code start`):

- `~/.claude.json` lands at **1074 bytes** (6 auth keys, mode 0600) — no host project history.
- `~/.claude/.credentials.json` from the keychain (mode 0600).
- `claude auth status` → `loggedIn: true` with correct account/org/plan.

Removing either file reproduces the logged-out state, confirming both are required and do distinct jobs (token vs. onboarding state).

`ruff` clean; `tests/test_presets.py` and `tests/test_published_images.py` pass (stale install-method / dir-copy tests replaced with transform tests).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * VM startup now waits for full VM readiness on preset-based starts.
  * Host credential/config copying supports safe byte-level transformations before upload.

* **Bug Fixes**
  * Credential transfer now uses the VM control channel and reports all copied items (configs + extracted secrets).
  * Claude/Pi presets now forward a minimized ~/.claude.json (written with restrictive permissions) and no longer copy whole ~/.claude directories.

* **Tests**
  * Expanded tests for minimized credential forwarding and updated error message text.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->