### PR TITLE
[codex] Track startup optimizations and defer Firecracker vsock networking

### DIFF
--- a/docs/benchmarks/startup-speedups.md
+++ b/docs/benchmarks/startup-speedups.md
@@ -1,0 +1,107 @@
+# SmolVM Startup Speedups
+
+This ledger records startup speed changes for the official published Ubuntu
+benchmark target. Each startup-related PR should add a row so we can see which
+changes moved user-visible latency.
+
+Primary target:
+
+- Image: official published Ubuntu preset.
+- Backends: QEMU and Firecracker.
+- Transports: SSH and vsock.
+- Statistic: warm-cache median unless noted otherwise.
+- Required headline fields: cold ready, first command, total first command, and
+  warm exec.
+- Fresh boot, snapshot restore, and warm-pool checkout must be reported
+  separately.
+
+## Summary Timeline
+
+| Date | PR / change | Backend | Transport | Before total ready | After total ready | Delta | Improvement | Notes |
+|---|---|---|---|---:|---:|---:|---:|---|
+| 2026-06-14 | #367 startup phase telemetry and early guest-agent path | QEMU | vsock | 1551.4 ms | 1073.9 ms | -477.5 ms | 30.8% faster | Published Ubuntu, Rust guest-agent, warm-cache medians. |
+| 2026-06-14 | #367 startup phase telemetry and early guest-agent path | Firecracker | vsock | 2598.8 ms | 1195.3 ms | -1403.5 ms | 54.0% faster | Published Ubuntu, Rust guest-agent, warm-cache medians. |
+| 2026-06-14 | Pending PR: Firecracker explicit-vsock lazy network setup | Firecracker | vsock | 1195.3 ms | 1098.3 ms | -97.0 ms | 8.1% faster | Current-init local run, 3 measured iterations; published artifact is still `images-2026.06.12.0`. |
+
+## Current Best Published Ubuntu Medians
+
+| Backend | Transport | Total ready | First command | Warm exec | Source |
+|---|---:|---:|---:|---:|---|
+| QEMU | SSH | 1455.6 ms | 9.3 ms | 42.9 ms | Pending PR current-init run |
+| QEMU | vsock | 1067.6 ms | 1.0 ms | 0.7 ms | Pending PR current-init run |
+| Firecracker | SSH | 1827.7 ms | 52.7 ms | 42.8 ms | Pending PR current-init run |
+| Firecracker | vsock | 1098.3 ms | 1.1 ms | 1.3 ms | Pending PR current-init run |
+
+The current best table uses `--rootfs-source current-init` because the latest
+published artifact observed locally is still `images-2026.06.12.0`.
+
+## Required Entry Format
+
+Add a short section for each PR that changes startup behavior or benchmark
+methodology.
+
+```markdown
+## YYYY-MM-DD - PR #NNN: short title
+
+- Commit: `SHA`
+- Image tag: `images-YYYY.MM.DD.N`
+- Command: `...`
+- Host: CPU, kernel, KVM/vsock notes
+- Method: warm-up count, measured iterations, median/mean policy
+- Behavior changed: one sentence
+
+| Backend | Transport | Before total ready | After total ready | Delta | Improvement |
+|---|---:|---:|---:|---:|---:|
+| QEMU | vsock | ... | ... | ... | ... |
+| Firecracker | vsock | ... | ... | ... | ... |
+```
+
+## 2026-06-14 - PR #367: Startup Phase Telemetry And Early Guest-Agent Path
+
+- Commit: `85a7e0a`
+- Image tag: current published Ubuntu image used by the local benchmark run.
+- Method: warm-cache medians from repeated published Ubuntu benchmark runs.
+- Behavior changed: the published Ubuntu path moved the Rust guest-agent earlier
+  in boot and benchmark output now separates startup phases more clearly.
+
+| Backend | Transport | Before total ready | After total ready | Delta | Improvement |
+|---|---:|---:|---:|---:|---:|
+| QEMU | vsock | 1551.4 ms | 1073.9 ms | -477.5 ms | 30.8% faster |
+| Firecracker | vsock | 2598.8 ms | 1195.3 ms | -1403.5 ms | 54.0% faster |
+
+Notes:
+
+- These numbers are fresh Ubuntu boot readiness, not snapshot restore.
+- QEMU VMM launch is already much lower than the total ready number; the
+  remaining time is dominated by guest boot and readiness detection.
+- The next benchmark update should fill in first-command and warm-exec columns
+  for the current best table using the full phase payload.
+
+## 2026-06-14 - Pending PR: Firecracker Explicit-vsock Lazy Network Setup
+
+- Commit: working tree based on `85a7e0a`
+- Image tag: `images-2026.06.12.0`
+- Command: `uv run python scripts/benchmarks/ubuntu_transport.py --iterations 3 --warm-exec-runs 5 --rootfs-source current-init --output /tmp/smolvm-ubuntu-transport-final-current-init.json`
+- Host: Linux with KVM; Firecracker networking used the unprivileged fallback path.
+- Method: one warm-up VM per variant, then three measured warm-cache iterations per variant.
+- Behavior changed: explicit Firecracker-vsock creates/configures the TAP for Firecracker, but defers route/NAT/egress setup until a network-backed operation needs it.
+
+| Backend | Transport | Before total ready | After total ready | Delta | Improvement |
+|---|---:|---:|---:|---:|---:|
+| QEMU | vsock | 1073.9 ms | 1067.6 ms | -6.3 ms | 0.6% faster |
+| Firecracker | vsock | 1195.3 ms | 1098.3 ms | -97.0 ms | 8.1% faster |
+
+Full current-init medians:
+
+| Backend | Transport | Host create | VMM start | Ready wait | Total ready | First command | Total first command | Warm exec |
+|---|---:|---:|---:|---:|---:|---:|---:|---:|
+| QEMU | SSH | 69.7 ms | 52.7 ms | 1325.5 ms | 1455.6 ms | 9.3 ms | 1464.8 ms | 42.9 ms |
+| QEMU | vsock | 76.6 ms | 52.4 ms | 935.1 ms | 1067.6 ms | 1.0 ms | 1068.5 ms | 0.7 ms |
+| Firecracker | SSH | 340.1 ms | 121.4 ms | 1365.6 ms | 1827.7 ms | 52.7 ms | 1880.4 ms | 42.8 ms |
+| Firecracker | vsock | 224.6 ms | 121.5 ms | 752.6 ms | 1098.3 ms | 1.1 ms | 1099.4 ms | 1.3 ms |
+
+Published-artifact check:
+
+- Command: `uv run python scripts/benchmarks/ubuntu_transport.py --iterations 2 --warm-exec-runs 3 --rootfs-source published --output /tmp/smolvm-ubuntu-transport-lazy-network.json -v`
+- Result: Firecracker-vsock used the deferred route/NAT path, but total ready was `2437.2 ms` because the locally published artifact was still `images-2026.06.12.0`.
+- Use the current-init numbers above for this PR's implementation signal until the published image is republished with the current init script.

--- a/docs/deep-dive/startup-time-optimization-plan.md
+++ b/docs/deep-dive/startup-time-optimization-plan.md
@@ -1,0 +1,188 @@
+# SmolVM Startup-Time Optimization Plan
+
+This plan tracks how we make the official published Ubuntu sandbox start faster.
+The goal is to improve the time from creating a sandbox to running the first
+command, while keeping the measurement honest about which phase became faster.
+
+OpenClaw and other presets are intentionally out of scope for this plan. They
+may share some runtime improvements, but they should not drive the benchmark or
+acceptance criteria here.
+
+## Primary Benchmark Target
+
+- Image: official published Ubuntu preset.
+- Backends: QEMU and Firecracker.
+- Transports: SSH and vsock.
+- Host state: warm image/runtime cache unless a run is explicitly marked cold.
+- Summary statistic: median of repeated runs.
+- Main user-facing metrics: cold ready, first command, total first command, and
+  warm exec.
+
+Track these fields for every optimization PR:
+
+| Field | Meaning |
+|---|---|
+| `host_create_ms` | Host-side VM object, disk, network, and runtime setup. |
+| `vmm_start_ms` | Hypervisor process/API launch time. |
+| `guest_ready_wait_ms` | Time spent waiting for SSH or the guest-agent to answer. |
+| `total_fresh_ready_ms` | Host create + VMM launch + readiness wait. |
+| `cold_ready_ms` | Ready time from a cold image/runtime cache, when explicitly measured. |
+| `first_command_ms` | First command latency after the control channel is ready. |
+| `total_first_command_ms` | End-to-end time from create to the first command result. |
+| `warm_exec_ms` | Median repeated command latency after the sandbox is ready. |
+| `guest_uptime_at_first_command_s` | Guest `/proc/uptime` when the first command ran, when available. |
+
+## Current Baseline
+
+The latest tracked improvement moved the published Ubuntu vsock path from the
+older warm-cache medians to the current measured medians:
+
+| Backend | Transport | Before total ready | After total ready | Delta | Improvement |
+|---|---:|---:|---:|---:|---:|
+| QEMU | vsock | 1551.4 ms | 1073.9 ms | -477.5 ms | 30.8% faster |
+| Firecracker | vsock | 2598.8 ms | 1195.3 ms | -1403.5 ms | 54.0% faster |
+
+These are fresh Ubuntu boot numbers, not snapshot restore numbers. A 50-120 ms
+VMM launch is already plausible today; the remaining latency is mostly Linux
+boot, init, and control-channel readiness.
+
+## Optimization Roadmap
+
+### Phase 1: Measurement Hygiene
+
+Keep improving the Ubuntu benchmark output before changing behavior. Every run
+should make it obvious whether time was spent in host setup, VMM launch, guest
+boot, control-channel probing, first command, or warm execution.
+
+Acceptance:
+
+- Benchmark output includes all fields listed above.
+- Reports label `total_fresh_ready_ms` clearly as fresh guest readiness.
+- The speed ledger is updated in the same PR when behavior or methodology
+  changes.
+
+### Phase 2: Explicit-vsock Fast Path
+
+For explicit vsock sandboxes, the guest-agent should become available before
+networking and SSH work that is not required for command execution.
+
+Keep:
+
+- Guest-agent startup before network and SSH setup in the published Ubuntu init
+  path.
+- SSH setup available after boot for users who explicitly use SSH.
+- Auto-mode SSH fallback behavior unchanged.
+
+Next work:
+
+- Keep network and SSH off the explicit-vsock critical path.
+- Defer Firecracker route/NAT/SSH forwarding work when no startup feature needs
+  SSH or network.
+- Keep QEMU slirp SSH host forwarding only where terminal compatibility requires
+  it.
+
+Current status:
+
+- Guest-agent startup already happens before network and SSH in the current
+  published Ubuntu init script.
+- Firecracker explicit-vsock now creates/configures the TAP needed by
+  Firecracker, but defers route/NAT/egress setup until SSH or port forwarding
+  needs host TCP/IP connectivity.
+
+Acceptance:
+
+- QEMU vsock and Firecracker vsock command execution still pass.
+- SSH variants still reach SSH and accept the injected key.
+- Explicit-vsock benchmarks do not wait for SSH readiness unless the requested
+  startup feature needs SSH.
+
+### Phase 3: QEMU Fast Machine Profile
+
+QEMU currently optimizes for broad compatibility. Add a measured fast profile
+for Linux direct-kernel vsock sandboxes before considering a default change.
+
+Approach:
+
+- Add an internal QEMU `microvm` experiment for Ubuntu direct-kernel vsock runs.
+- Avoid PCI/ACPI/SeaBIOS work where the fast profile supports the required
+  devices.
+- Fall back to the compatibility profile for SSH, workspace mounts, unsupported
+  host setups, or features that need the existing device model.
+
+Acceptance:
+
+- Unit tests prove the fast profile is selected only for eligible Ubuntu/vsock
+  runs.
+- QEMU vsock exec and file transfer pass.
+- Benchmarks report kernel-to-init and agent-ready deltas.
+
+### Phase 4: Kernel And Rootfs Trim
+
+Only trim kernel/rootfs work after phase telemetry shows the expensive stages.
+The target is a fast sandbox profile, not a general-purpose Ubuntu kernel.
+
+Candidates to test:
+
+- Boot args such as `raid=noautodetect`, `quiet`, `tsc=reliable`, and
+  `no_timer_check`.
+- `acpi=off` only inside a measured fast profile.
+- Less serial console output for explicit-vsock profiles.
+- Remove or modularize unused built-in paths such as sound, wireless regulatory
+  loading, RAID autodetect, and unused buses.
+
+Acceptance:
+
+- QEMU vsock and Firecracker vsock e2e tests pass.
+- SSH variants remain supported by the compatibility profile.
+- The speed ledger records both the measured win and any compatibility tradeoff.
+
+### Phase 5: Snapshot Or Warm Pool Path
+
+Fresh Ubuntu boot is unlikely to be the right path for sub-200 ms command-ready
+UX. Snapshot restore or a warm pool should be tracked separately because it
+skips kernel boot and most init work.
+
+Approach:
+
+- Create a base snapshot after the guest-agent is listening.
+- Restore and immediately repair mutable identity such as hostname, machine-id,
+  SSH keys when SSH is enabled, network identity, and agent session state.
+- Benchmark restore-to-first-command separately from fresh boot.
+
+Acceptance:
+
+- Restore-to-first-command e2e passes.
+- Isolation tests prove restored sandboxes do not share mutable identity.
+- Published reports separate fresh boot, snapshot restore, and warm-pool
+  checkout numbers.
+
+## Update Rules
+
+- Update `docs/benchmarks/startup-speedups.md` in every PR that changes startup
+  behavior, published Ubuntu image contents, runtime launch behavior, or
+  benchmark methodology.
+- Record the git SHA, image tag, benchmark command, host notes, before/after
+  medians, and what changed.
+- Do not compare fresh boot numbers to snapshot or warm-pool numbers in the
+  same headline row.
+- Keep OpenClaw and other presets out of the primary acceptance criteria until
+  they are explicitly added back.
+
+## Validation Rules
+
+- For docs-only changes, run `git diff --check`.
+- For benchmark code changes, run the focused pytest coverage for benchmark
+  payload shape and timeout handling, then `uv run ruff check` on changed Python
+  files.
+- For startup behavior changes, rerun published Ubuntu benchmarks across QEMU
+  SSH, QEMU vsock, Firecracker SSH, and Firecracker vsock.
+- Every benchmark update must record the command, git SHA, image tag, host
+  notes, and medians in `docs/benchmarks/startup-speedups.md`.
+
+## Assumptions
+
+- The official published Ubuntu image is the primary optimization target.
+- OpenClaw and other presets are out of scope for this plan.
+- Fresh boot, snapshot restore, and warm-pool numbers are tracked separately.
+- The speed ledger is updated by every PR that changes startup behavior or
+  benchmark methodology.

--- a/scripts/benchmarks/ubuntu_transport.py
+++ b/scripts/benchmarks/ubuntu_transport.py
@@ -174,7 +174,8 @@ def _run_one(
             rootfs_source=rootfs_source,
         )
         vm = SmolVM(config=config, ssh_key_path=ssh_key_path, comm_channel=transport)
-        record["create_ms"] = round((time.perf_counter() - started) * 1000, 1)
+        record["host_create_ms"] = round((time.perf_counter() - started) * 1000, 1)
+        record["create_ms"] = record["host_create_ms"]
         record["published_rootfs_path"] = str(published_rootfs)
         record["rootfs_path"] = str(config.rootfs_path)
         record["patched_rootfs_path"] = str(patched_rootfs) if patched_rootfs else None
@@ -185,11 +186,13 @@ def _run_one(
 
         started = time.perf_counter()
         vm.start()
-        record["start_ms"] = round((time.perf_counter() - started) * 1000, 1)
+        record["vmm_start_ms"] = round((time.perf_counter() - started) * 1000, 1)
+        record["start_ms"] = record["vmm_start_ms"]
 
         started = time.perf_counter()
         vm.wait_for_ready(timeout=60.0)
-        record["ready_wait_ms"] = round((time.perf_counter() - started) * 1000, 1)
+        record["guest_ready_wait_ms"] = round((time.perf_counter() - started) * 1000, 1)
+        record["ready_wait_ms"] = record["guest_ready_wait_ms"]
         record["control_kind"] = getattr(vm._control_channel, "kind", None)
 
         started = time.perf_counter()
@@ -211,12 +214,13 @@ def _run_one(
             uptime = vm.run("cat /proc/uptime", shell="raw", timeout=10.0)
             record["guest_uptime_after_ready_s"] = round(float(uptime.stdout.split()[0]), 3)
 
-        record["total_ready_ms"] = round(
-            record["create_ms"] + record["start_ms"] + record["ready_wait_ms"],
+        record["total_fresh_ready_ms"] = round(
+            record["host_create_ms"] + record["vmm_start_ms"] + record["guest_ready_wait_ms"],
             1,
         )
+        record["total_ready_ms"] = record["total_fresh_ready_ms"]
         record["total_first_command_ms"] = round(
-            record["total_ready_ms"] + record["first_command_ms"],
+            record["total_fresh_ready_ms"] + record["first_command_ms"],
             1,
         )
     finally:
@@ -226,14 +230,18 @@ def _run_one(
 
 def _summarize(records: list[dict[str, Any]]) -> dict[str, Any]:
     fields = [
-        "create_ms",
-        "start_ms",
-        "ready_wait_ms",
-        "total_ready_ms",
+        "host_create_ms",
+        "vmm_start_ms",
+        "guest_ready_wait_ms",
+        "total_fresh_ready_ms",
         "first_command_ms",
         "total_first_command_ms",
         "warm_exec_median_ms",
         "guest_uptime_after_ready_s",
+        "create_ms",
+        "start_ms",
+        "ready_wait_ms",
+        "total_ready_ms",
     ]
     return {
         field: _stats(

--- a/src/smolvm/facade.py
+++ b/src/smolvm/facade.py
@@ -2107,6 +2107,7 @@ class SmolVM:
                 "Cannot build SSH command: VM has no network configuration",
                 {"vm_id": self._vm_id},
             )
+        self._sdk.ensure_network_connectivity(self._info)
 
         # Reuse shared endpoint selection (prefers localhost forward, falls
         # back to guest IP).
@@ -2173,6 +2174,8 @@ class SmolVM:
             )
         if guest_port < 1 or guest_port > 65535:
             raise ValueError("guest_port must be 1-65535")
+
+        self._sdk.ensure_network_connectivity(self._info)
 
         requested_port = host_port
         if host_port is None:
@@ -3095,6 +3098,7 @@ modprobe 9pnet_virtio""".strip()
 
     def _wait_for_ssh_over_network(self, timeout: float, *, as_control: bool = False) -> None:
         """Wait for SSH across available network endpoints."""
+        self._sdk.ensure_network_connectivity(self._info)
         endpoints = self._ssh_endpoints()
 
         # Prefer the already selected client first, then try remaining candidates.

--- a/src/smolvm/vm.py
+++ b/src/smolvm/vm.py
@@ -1375,6 +1375,62 @@ class SmolVMManager:
 
         return backend == BACKEND_QEMU and config.qemu_network == "slirp"
 
+    def _should_setup_tap_connectivity_for_create(
+        self,
+        config: VMConfig,
+        backend: str,
+        *,
+        resolution: ChannelResolution,
+        ssh_forward_required: bool,
+    ) -> bool:
+        """Return whether TAP route/NAT rules are needed before first boot."""
+        if not self._uses_host_tap_networking(config, backend):
+            return False
+
+        if backend != BACKEND_FIRECRACKER:
+            return True
+
+        if ssh_forward_required:
+            return True
+
+        if (
+            config.internet_settings is not None
+            and not config.internet_settings.is_allow_all_domains
+        ):
+            return True
+
+        # Explicit Firecracker-vsock command paths do not need host TCP/IP
+        # connectivity before boot. The TAP still exists for Firecracker's
+        # network device, and connectivity is installed lazily if SSH/ports need it.
+        return not (resolution.kind == "vsock" and not resolution.allow_fallback)
+
+    def ensure_network_connectivity(self, vm_info: VMInfo) -> None:
+        """Ensure host-side TAP connectivity exists for network-backed operations."""
+        if vm_info.network is None:
+            return
+
+        backend = self._backend_for_vm(vm_info)
+        if not self._uses_host_tap_networking(vm_info.config, backend):
+            return
+
+        network = vm_info.network
+        self.network.add_route(network.guest_ip, network.tap_device)
+        self.network.setup_nat(network.tap_device)
+
+        if (
+            vm_info.config.internet_settings is not None
+            and not vm_info.config.internet_settings.is_allow_all_domains
+        ):
+            allowed_ips = resolve_domains_to_ips(vm_info.config.internet_settings.allowed_domains)
+            self.network.apply_egress_allowlist(network.tap_device, allowed_ips)
+
+        if network.ssh_host_port is not None:
+            self.network.setup_ssh_port_forward(
+                vm_id=vm_info.vm_id,
+                guest_ip=network.guest_ip,
+                host_port=network.ssh_host_port,
+            )
+
     def _maybe_enable_vsock(self, config: VMConfig, backend: str, vm_info: VMInfo) -> VMInfo:
         """Reserve a vsock CID and persist ``config.vsock`` when needed.
 
@@ -1641,31 +1697,44 @@ class SmolVMManager:
             # Update the lease with the real TAP name
             self.state.update_ip_lease_tap(effective_config.vm_id, tap_name)
 
+            tap_connectivity_required = self._should_setup_tap_connectivity_for_create(
+                effective_config,
+                backend,
+                resolution=channel_resolution,
+                ssh_forward_required=ssh_forward_required,
+            )
+
             # Create and configure TAP device
             user = os.environ.get("USER", "root")
             self.network.create_tap(tap_name, user)
 
             # Use /32 mask to avoid subnet conflicts between multiple TAPs
             self.network.configure_tap(tap_name, netmask="32")
-            self.network.add_route(guest_ip, tap_name)
 
-            self.network.setup_nat(tap_name)
+            if tap_connectivity_required:
+                self.network.add_route(guest_ip, tap_name)
+                self.network.setup_nat(tap_name)
 
-            # Apply domain allowlist if configured
-            if (
-                effective_config.internet_settings is not None
-                and not effective_config.internet_settings.is_allow_all_domains
-            ):
-                allowed_ips = resolve_domains_to_ips(
-                    effective_config.internet_settings.allowed_domains
-                )
-                self.network.apply_egress_allowlist(tap_name, allowed_ips)
+                # Apply domain allowlist if configured
+                if (
+                    effective_config.internet_settings is not None
+                    and not effective_config.internet_settings.is_allow_all_domains
+                ):
+                    allowed_ips = resolve_domains_to_ips(
+                        effective_config.internet_settings.allowed_domains
+                    )
+                    self.network.apply_egress_allowlist(tap_name, allowed_ips)
 
-            if ssh_host_port is not None:
-                self.network.setup_ssh_port_forward(
-                    vm_id=effective_config.vm_id,
-                    guest_ip=guest_ip,
-                    host_port=ssh_host_port,
+                if ssh_host_port is not None:
+                    self.network.setup_ssh_port_forward(
+                        vm_id=effective_config.vm_id,
+                        guest_ip=guest_ip,
+                        host_port=ssh_host_port,
+                    )
+            else:
+                logger.info(
+                    "VM %s: deferring Firecracker route/NAT setup until network is needed",
+                    effective_config.vm_id,
                 )
 
             # Generate MAC address from pool index
@@ -2979,28 +3048,40 @@ class SmolVMManager:
             vm_number = ip_to_pool_index(guest_ip)
             tap_name = f"tap{vm_number}"
             self.state.update_ip_lease_tap(effective_config.vm_id, tap_name)
+            tap_connectivity_required = self._should_setup_tap_connectivity_for_create(
+                effective_config,
+                backend,
+                resolution=channel_resolution,
+                ssh_forward_required=ssh_forward_required,
+            )
 
             user = os.environ.get("USER", "root")
             await self.network.async_create_tap(tap_name, user)
             await self.network.async_configure_tap(tap_name, netmask="32")
-            await self.network.async_add_route(guest_ip, tap_name)
-            await self.network.async_setup_nat(tap_name)
+            if tap_connectivity_required:
+                await self.network.async_add_route(guest_ip, tap_name)
+                await self.network.async_setup_nat(tap_name)
 
-            # Apply domain allowlist if configured
-            if (
-                effective_config.internet_settings is not None
-                and not effective_config.internet_settings.is_allow_all_domains
-            ):
-                allowed_ips = resolve_domains_to_ips(
-                    effective_config.internet_settings.allowed_domains
-                )
-                await self.network.async_apply_egress_allowlist(tap_name, allowed_ips)
+                # Apply domain allowlist if configured
+                if (
+                    effective_config.internet_settings is not None
+                    and not effective_config.internet_settings.is_allow_all_domains
+                ):
+                    allowed_ips = resolve_domains_to_ips(
+                        effective_config.internet_settings.allowed_domains
+                    )
+                    await self.network.async_apply_egress_allowlist(tap_name, allowed_ips)
 
-            if ssh_host_port is not None:
-                await self.network.async_setup_ssh_port_forward(
-                    vm_id=effective_config.vm_id,
-                    guest_ip=guest_ip,
-                    host_port=ssh_host_port,
+                if ssh_host_port is not None:
+                    await self.network.async_setup_ssh_port_forward(
+                        vm_id=effective_config.vm_id,
+                        guest_ip=guest_ip,
+                        host_port=ssh_host_port,
+                    )
+            else:
+                logger.info(
+                    "VM %s: deferring Firecracker route/NAT setup until network is needed",
+                    effective_config.vm_id,
                 )
 
             guest_mac = self.network.generate_mac(vm_number)

--- a/tests/test_facade.py
+++ b/tests/test_facade.py
@@ -15,7 +15,7 @@
 """Tests for SmolVM VM facade module."""
 
 from pathlib import Path
-from unittest.mock import MagicMock, call, patch
+from unittest.mock import ANY, MagicMock, call, patch
 
 import pytest
 
@@ -2039,12 +2039,20 @@ class TestVMRun:
 
         mock_ssh = MagicMock()
         mock_ssh_cls.return_value = mock_ssh
+        call_order = MagicMock()
+        call_order.attach_mock(
+            mock_sdk.ensure_network_connectivity,
+            "ensure_network_connectivity",
+        )
+        call_order.attach_mock(mock_ssh.wait_for_ssh, "wait_for_ssh")
 
         vm = SmolVM(sample_config)
         vm.wait_for_ssh(timeout=20.0)
 
-        mock_sdk.ensure_network_connectivity.assert_called_once_with(mock_info)
-        mock_ssh.wait_for_ssh.assert_called_once()
+        assert call_order.mock_calls == [
+            call.ensure_network_connectivity(mock_info),
+            call.wait_for_ssh(timeout=ANY),
+        ]
 
     @patch("smolvm.facade.SSHClient")
     @patch("smolvm.facade.SmolVMManager")

--- a/tests/test_facade.py
+++ b/tests/test_facade.py
@@ -2015,6 +2015,39 @@ class TestVMRun:
 
     @patch("smolvm.facade.SSHClient")
     @patch("smolvm.facade.SmolVMManager")
+    def test_wait_for_ssh_ensures_network_connectivity(
+        self,
+        mock_sdk_cls: MagicMock,
+        mock_ssh_cls: MagicMock,
+        sample_config: VMConfig,
+    ) -> None:
+        """Lazy Firecracker network setup must run before SSH endpoint probing."""
+        mock_network = MagicMock()
+        mock_network.guest_ip = "172.16.0.2"
+        mock_network.ssh_host_port = None
+
+        mock_info = MagicMock()
+        mock_info.vm_id = "vm001"
+        mock_info.status = VMState.RUNNING
+        mock_info.network = mock_network
+        mock_info.config = sample_config
+
+        mock_sdk = MagicMock()
+        mock_sdk.create.return_value = MagicMock(vm_id="vm001", status=VMState.CREATED)
+        mock_sdk.get.return_value = mock_info
+        mock_sdk_cls.return_value = mock_sdk
+
+        mock_ssh = MagicMock()
+        mock_ssh_cls.return_value = mock_ssh
+
+        vm = SmolVM(sample_config)
+        vm.wait_for_ssh(timeout=20.0)
+
+        mock_sdk.ensure_network_connectivity.assert_called_once_with(mock_info)
+        mock_ssh.wait_for_ssh.assert_called_once()
+
+    @patch("smolvm.facade.SSHClient")
+    @patch("smolvm.facade.SmolVMManager")
     def test_wait_for_ssh_falls_back_to_default_smolvm_key_when_no_key_configured(
         self,
         mock_sdk_cls: MagicMock,

--- a/tests/test_vm.py
+++ b/tests/test_vm.py
@@ -30,7 +30,7 @@ from smolvm.exceptions import (
     VMAlreadyExistsError,
     VMNotFoundError,
 )
-from smolvm.types import VMConfig, VMInfo, VMState, WorkspaceMount
+from smolvm.types import InternetSettings, VMConfig, VMInfo, VMState, WorkspaceMount
 from smolvm.vm import SmolVMManager
 
 
@@ -232,6 +232,36 @@ class TestSmolVMCreate:
         assert vm_info.network is not None
         assert vm_info.network.ssh_host_port is None
         assert vm_info.config.vsock is not None
+        mock_network.create_tap.assert_called_once()
+        mock_network.configure_tap.assert_called_once()
+        mock_network.add_route.assert_not_called()
+        mock_network.setup_nat.assert_not_called()
+        mock_network.setup_ssh_port_forward.assert_not_called()
+
+    @patch("smolvm.comm.select.platform.system", return_value="Linux")
+    def test_create_firecracker_explicit_vsock_lazy_network_can_be_activated(
+        self,
+        _mock_system: MagicMock,
+        smol_vm: SmolVMManager,
+        sample_config: VMConfig,
+    ) -> None:
+        """Deferred Firecracker network connectivity is installed before network use."""
+        mock_network = _attach_mock_network(smol_vm)
+        config = sample_config.model_copy(
+            update={"vm_id": "vm-vsock-lazy", "backend": "firecracker", "comm_channel": "vsock"}
+        )
+        vm_info = smol_vm.create(config)
+
+        mock_network.add_route.assert_not_called()
+        mock_network.setup_nat.assert_not_called()
+
+        smol_vm.ensure_network_connectivity(vm_info)
+
+        mock_network.add_route.assert_called_once_with(
+            vm_info.network.guest_ip,
+            vm_info.network.tap_device,
+        )
+        mock_network.setup_nat.assert_called_once_with(vm_info.network.tap_device)
         mock_network.setup_ssh_port_forward.assert_not_called()
 
     @patch("smolvm.comm.select.platform.system", return_value="Linux")
@@ -249,6 +279,8 @@ class TestSmolVMCreate:
 
         assert vm_info.network is not None
         assert vm_info.network.ssh_host_port is not None
+        mock_network.add_route.assert_called_once()
+        mock_network.setup_nat.assert_called_once()
         mock_network.setup_ssh_port_forward.assert_called_once()
 
     @patch("smolvm.comm.select.platform.system", return_value="Linux")
@@ -268,6 +300,8 @@ class TestSmolVMCreate:
 
         assert vm_info.network is not None
         assert vm_info.network.ssh_host_port is not None
+        mock_network.add_route.assert_called_once()
+        mock_network.setup_nat.assert_called_once()
         mock_network.setup_ssh_port_forward.assert_called_once()
 
     @patch("smolvm.comm.select.platform.system", return_value="Linux")
@@ -292,7 +326,41 @@ class TestSmolVMCreate:
 
         assert vm_info.network is not None
         assert vm_info.network.ssh_host_port is not None
+        mock_network.add_route.assert_called_once()
+        mock_network.setup_nat.assert_called_once()
         mock_network.setup_ssh_port_forward.assert_called_once()
+
+    @patch("smolvm.comm.select.platform.system", return_value="Linux")
+    @patch("smolvm.vm.resolve_domains_to_ips", return_value=["93.184.216.34"])
+    def test_create_firecracker_explicit_vsock_with_allowlist_keeps_tap_connectivity(
+        self,
+        _mock_resolve: MagicMock,
+        _mock_system: MagicMock,
+        smol_vm: SmolVMManager,
+        sample_config: VMConfig,
+    ) -> None:
+        """Network policy needs route/NAT before boot even with explicit vsock."""
+        mock_network = _attach_mock_network(smol_vm)
+        config = sample_config.model_copy(
+            update={
+                "vm_id": "vm-vsock-policy",
+                "backend": "firecracker",
+                "comm_channel": "vsock",
+                "internet_settings": InternetSettings(allowed_domains=["example.com"]),
+            }
+        )
+
+        vm_info = smol_vm.create(config)
+
+        assert vm_info.network is not None
+        assert vm_info.network.ssh_host_port is None
+        mock_network.add_route.assert_called_once()
+        mock_network.setup_nat.assert_called_once()
+        mock_network.apply_egress_allowlist.assert_called_once_with(
+            vm_info.network.tap_device,
+            ["93.184.216.34"],
+        )
+        mock_network.setup_ssh_port_forward.assert_not_called()
 
     @patch("smolvm.comm.select.host_supports_vsock", return_value=True)
     def test_create_qemu_slirp_explicit_vsock_keeps_ssh_hostfwd(
@@ -428,6 +496,8 @@ class TestSmolVMCreate:
 
         assert vm_info.network is not None
         assert vm_info.network.ssh_host_port is None
+        mock_network.async_add_route.assert_not_awaited()
+        mock_network.async_setup_nat.assert_not_awaited()
         mock_network.async_setup_ssh_port_forward.assert_not_awaited()
 
 


### PR DESCRIPTION
## Summary

- Add a tracked Ubuntu startup optimization roadmap and per-PR speed ledger.
- Defer Firecracker explicit-vsock route/NAT/egress setup until a network-backed operation needs it, while still creating/configuring the TAP required by Firecracker before launch.
- Lazily activate deferred TAP connectivity before SSH and localhost port-forward operations.
- Add canonical Ubuntu benchmark phase fields while keeping the old aliases for compatibility.

## Impact

Explicit Firecracker-vsock sandboxes avoid host route/NAT work on the command-ready critical path when SSH/network startup features are not needed. SSH, auto-fallback, env injection, workspace policy, and network allowlist paths keep pre-boot connectivity.

## Benchmark

Command:

```bash
uv run python scripts/benchmarks/ubuntu_transport.py \
  --iterations 3 \
  --warm-exec-runs 5 \
  --rootfs-source current-init \
  --output /tmp/smolvm-ubuntu-transport-final-current-init.json
```

| Backend | Transport | Host create | VMM start | Ready wait | Total ready | First command | Total first command | Warm exec |
|---|---:|---:|---:|---:|---:|---:|---:|---:|
| QEMU | SSH | 69.7 ms | 52.7 ms | 1325.5 ms | 1455.6 ms | 9.3 ms | 1464.8 ms | 42.9 ms |
| QEMU | vsock | 76.6 ms | 52.4 ms | 935.1 ms | 1067.6 ms | 1.0 ms | 1068.5 ms | 0.7 ms |
| Firecracker | SSH | 340.1 ms | 121.4 ms | 1365.6 ms | 1827.7 ms | 52.7 ms | 1880.4 ms | 42.8 ms |
| Firecracker | vsock | 224.6 ms | 121.5 ms | 752.6 ms | 1098.3 ms | 1.1 ms | 1099.4 ms | 1.3 ms |

Firecracker vsock moved from the prior ledger baseline of 1195.3 ms to 1098.3 ms total ready, a 97.0 ms improvement.

Note: the observed published tag was still `images-2026.06.12.0`, so the benchmark used `--rootfs-source current-init` to measure current init behavior without waiting for a republish.

## Validation

- `uv run pytest tests/test_vm.py tests/test_facade.py tests/test_rust_http_vsock_channel.py tests/test_benchmark_boot_telemetry.py -q`
- `uv run ruff check src/smolvm/vm.py src/smolvm/facade.py scripts/benchmarks/ubuntu_transport.py tests/test_vm.py tests/test_facade.py`
- `git diff --check`
- Ubuntu transport benchmark command above


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a startup-speed benchmark ledger tracking official Ubuntu median changes.
  * Added a startup-time optimization roadmap with measurement and update rules.
* **New Features**
  * Added finer-grained VM startup timing metrics (host create, VMM start, guest readiness wait) for benchmarks.
  * Improved network connectivity handling: conditional Firecracker TAP setup and explicit “lazy” connectivity activation when needed.
  * Ensured connectivity is verified automatically before SSH-related operations.
* **Tests**
  * Expanded coverage for network-connectivity validation and Firecracker explicit-vsock lazy behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->