### PR TITLE
Preserve sparse published rootfs caches

### DIFF
--- a/docs/benchmarks/startup-speedups.md
+++ b/docs/benchmarks/startup-speedups.md
@@ -22,20 +22,20 @@ Primary target:
 | 2026-06-14 | #367 startup phase telemetry and early guest-agent path | QEMU | vsock | 1551.4 ms | 1073.9 ms | -477.5 ms | 30.8% faster | Published Ubuntu, Rust guest-agent, warm-cache medians. |
 | 2026-06-14 | #367 startup phase telemetry and early guest-agent path | Firecracker | vsock | 2598.8 ms | 1195.3 ms | -1403.5 ms | 54.0% faster | Published Ubuntu, Rust guest-agent, warm-cache medians. |
 | 2026-06-14 | #371 Firecracker explicit-vsock lazy network setup | Firecracker | vsock | 1195.3 ms | 1098.3 ms | -97.0 ms | 8.1% faster | Current-init local run, 3 measured iterations; published artifact was still `images-2026.06.12.0`. |
-| 2026-06-14 | Sparse published rootfs cache and raw disk copy | Firecracker | SSH | 2500.2 ms | 1797.9 ms | -702.3 ms | 28.1% faster | Published `images-2026.06.14.0`; avoids copying fully allocated zero regions during Firecracker disk materialization. |
-| 2026-06-14 | Sparse published rootfs cache and raw disk copy | Firecracker | vsock | 1979.1 ms | 1057.4 ms | -921.7 ms | 46.6% faster | Published `images-2026.06.14.0`; host create dropped from 1123.6 ms to 200.5 ms. |
+| 2026-06-14 | #373 sparse published rootfs cache and raw disk copy | Firecracker | SSH | 2500.2 ms | 1797.9 ms | -702.3 ms | 28.1% faster | Published `images-2026.06.14.0`; avoids copying fully allocated zero regions during Firecracker disk materialization. |
+| 2026-06-14 | #373 sparse published rootfs cache and raw disk copy | Firecracker | vsock | 1979.1 ms | 1057.4 ms | -921.7 ms | 46.6% faster | Published `images-2026.06.14.0`; host create dropped from 1123.6 ms to 200.5 ms. |
 
 ## Current Published Ubuntu Medians
 
 | Backend | Transport | Total ready | First command | Warm exec | Source |
 |---|---:|---:|---:|---:|---|
-| QEMU | SSH | 1751.6 ms | 9.9 ms | 43.0 ms | Sparse-cache branch, published run |
-| QEMU | vsock | 1059.7 ms | 1.1 ms | 0.8 ms | Sparse-cache branch, published run |
-| Firecracker | SSH | 1797.9 ms | 53.0 ms | 43.0 ms | Sparse-cache branch, published run |
-| Firecracker | vsock | 1057.4 ms | 1.1 ms | 1.0 ms | Sparse-cache branch, published run |
+| QEMU | SSH | 1751.6 ms | 9.9 ms | 43.0 ms | #373 published run |
+| QEMU | vsock | 1059.7 ms | 1.1 ms | 0.8 ms | #373 published run |
+| Firecracker | SSH | 1797.9 ms | 53.0 ms | 43.0 ms | #373 published run |
+| Firecracker | vsock | 1057.4 ms | 1.1 ms | 1.0 ms | #373 published run |
 
-The current best table uses the public `images-2026.06.14.0` release with this
-branch's sparse-cache behavior.
+The current best table uses the public `images-2026.06.14.0` release with #373
+sparse-cache behavior.
 
 ## Required Entry Format
 
@@ -133,9 +133,9 @@ Finding:
   file. On this ext4 host, Firecracker isolated-disk materialization then copied
   gigabytes of zeros before boot.
 
-## 2026-06-14 - Pending PR: Sparse Published Rootfs Cache
+## 2026-06-14 - PR #373: Sparse Published Rootfs Cache
 
-- Commit: pending
+- Commit: `2ef22c3`
 - Image tag: `images-2026.06.14.0`
 - Command: `uv run python scripts/benchmarks/ubuntu_transport.py --iterations 3 --warm-exec-runs 5 --rootfs-source published --output /tmp/smolvm-benchmarks/ubuntu-transport-published-sparse-2026-06-14.json -v`
 - Host: Linux x86_64, kernel `7.0.0-15-generic`, KVM available.

--- a/docs/benchmarks/startup-speedups.md
+++ b/docs/benchmarks/startup-speedups.md
@@ -37,6 +37,11 @@ Primary target:
 The current best table uses the public `images-2026.06.14.0` release with #373
 sparse-cache behavior.
 
+Snapshot restore metrics are now instrumented separately by
+`scripts/benchmarks/ubuntu_transport.py --include-snapshot`. Add snapshot
+restore rows only after running that lane; do not mix them with the fresh-boot
+summary timeline above.
+
 ## Required Entry Format
 
 Add a short section for each PR that changes startup behavior or benchmark
@@ -160,3 +165,30 @@ Cache size check:
 
 - Before sparse cache refresh: decompressed Ubuntu rootfs used about `4.1G` on disk.
 - After sparse cache refresh: decompressed Ubuntu rootfs used about `423M` on disk.
+
+## 2026-06-14 - Snapshot Restore Probe: QEMU Vsock Snapshot
+
+- Commit: current working tree on top of `ad560f1`.
+- Image tag: `images-2026.06.14.0`.
+- Command: `uv run python scripts/benchmarks/ubuntu_transport.py --iterations 1 --warm-exec-runs 1 --rootfs-source published --variants qemu-vsock --include-snapshot --output /tmp/smolvm-ubuntu-qemu-vsock-snapshot-probe.json -v`
+- Host: Linux x86_64, kernel `7.0.0-15-generic`, KVM available.
+- Method: one warm-up plus one measured QEMU-vsock source VM, snapshot after guest-agent readiness, restore with `comm_channel="vsock"`, then first `true` command.
+- Behavior changed: the Ubuntu transport benchmark can now measure snapshot restore separately from fresh boot and skips live QEMU CIDs that are not present in local state.
+
+Fresh-boot result from the same filtered run:
+
+| Backend | Transport | Host create | VMM start | Ready wait | Total ready | First command | Warm exec |
+|---|---|---:|---:|---:|---:|---:|---:|
+| QEMU | vsock | 83.4 ms | 54.1 ms | 922.9 ms | 1060.4 ms | 1.0 ms | 0.8 ms |
+
+Snapshot result:
+
+| Backend | Transport | Snapshot request | Effective snapshot | Source fresh ready | Snapshot create | Restore | Restore ready wait | Restore to first command | Warm exec |
+|---|---|---|---|---:|---:|---:|---:|---:|---:|
+| QEMU | vsock | diff | full fallback | 1105.4 ms | 1294.2 ms | 193.5 ms | 0.6 ms | 195.0 ms | 0.8 ms |
+
+Firecracker note:
+
+- Firecracker-vsock full/diff snapshot restore is not reported yet. Stale vsock
+  UDS cleanup is fixed, but the restored guest still panics in
+  `restore_fpregs_from_fpstate` on this host before the guest-agent can answer.

--- a/docs/benchmarks/startup-speedups.md
+++ b/docs/benchmarks/startup-speedups.md
@@ -22,18 +22,20 @@ Primary target:
 | 2026-06-14 | #367 startup phase telemetry and early guest-agent path | QEMU | vsock | 1551.4 ms | 1073.9 ms | -477.5 ms | 30.8% faster | Published Ubuntu, Rust guest-agent, warm-cache medians. |
 | 2026-06-14 | #367 startup phase telemetry and early guest-agent path | Firecracker | vsock | 2598.8 ms | 1195.3 ms | -1403.5 ms | 54.0% faster | Published Ubuntu, Rust guest-agent, warm-cache medians. |
 | 2026-06-14 | #371 Firecracker explicit-vsock lazy network setup | Firecracker | vsock | 1195.3 ms | 1098.3 ms | -97.0 ms | 8.1% faster | Current-init local run, 3 measured iterations; published artifact was still `images-2026.06.12.0`. |
+| 2026-06-14 | Sparse published rootfs cache and raw disk copy | Firecracker | SSH | 2500.2 ms | 1797.9 ms | -702.3 ms | 28.1% faster | Published `images-2026.06.14.0`; avoids copying fully allocated zero regions during Firecracker disk materialization. |
+| 2026-06-14 | Sparse published rootfs cache and raw disk copy | Firecracker | vsock | 1979.1 ms | 1057.4 ms | -921.7 ms | 46.6% faster | Published `images-2026.06.14.0`; host create dropped from 1123.6 ms to 200.5 ms. |
 
-## Current Best Published Ubuntu Medians
+## Current Published Ubuntu Medians
 
 | Backend | Transport | Total ready | First command | Warm exec | Source |
 |---|---:|---:|---:|---:|---|
-| QEMU | SSH | 1455.6 ms | 9.3 ms | 42.9 ms | #371 current-init run |
-| QEMU | vsock | 1067.6 ms | 1.0 ms | 0.7 ms | #371 current-init run |
-| Firecracker | SSH | 1827.7 ms | 52.7 ms | 42.8 ms | #371 current-init run |
-| Firecracker | vsock | 1098.3 ms | 1.1 ms | 1.3 ms | #371 current-init run |
+| QEMU | SSH | 1751.6 ms | 9.9 ms | 43.0 ms | Sparse-cache branch, published run |
+| QEMU | vsock | 1059.7 ms | 1.1 ms | 0.8 ms | Sparse-cache branch, published run |
+| Firecracker | SSH | 1797.9 ms | 53.0 ms | 43.0 ms | Sparse-cache branch, published run |
+| Firecracker | vsock | 1057.4 ms | 1.1 ms | 1.0 ms | Sparse-cache branch, published run |
 
-The current best table uses `--rootfs-source current-init` because the latest
-published artifact observed locally was still `images-2026.06.12.0`.
+The current best table uses the public `images-2026.06.14.0` release with this
+branch's sparse-cache behavior.
 
 ## Required Entry Format
 
@@ -105,3 +107,56 @@ Published-artifact check:
 - Command: `uv run python scripts/benchmarks/ubuntu_transport.py --iterations 2 --warm-exec-runs 3 --rootfs-source published --output /tmp/smolvm-ubuntu-transport-lazy-network.json -v`
 - Result: Firecracker-vsock used the deferred route/NAT path, but total ready was `2437.2 ms` because the locally published artifact was still `images-2026.06.12.0`.
 - Use the current-init numbers above for this PR's implementation signal until the published image is republished with the current init script.
+
+## 2026-06-14 - PR #372: Published Image Release `images-2026.06.14.0`
+
+- Commit: `269c1a5`
+- Image tag: `images-2026.06.14.0`
+- Command: `uv run python scripts/benchmarks/ubuntu_transport.py --iterations 3 --warm-exec-runs 5 --rootfs-source published --output /tmp/smolvm-benchmarks/ubuntu-transport-published-2026-06-14.json -v`
+- Host: Linux x86_64, kernel `7.0.0-15-generic`, KVM available.
+- Method: one warm-up VM per variant, then three measured warm-cache iterations per variant.
+- Behavior changed: the official published Ubuntu image now contains the current init path and Rust guest-agent startup order from #367/#371.
+
+Published medians before the sparse-cache fix:
+
+| Backend | Transport | Host create | VMM start | Ready wait | Total ready | First command | Total first command | Warm exec |
+|---|---:|---:|---:|---:|---:|---:|---:|---:|
+| QEMU | SSH | 82.6 ms | 54.6 ms | 1527.4 ms | 1663.8 ms | 9.7 ms | 1673.5 ms | 42.1 ms |
+| QEMU | vsock | 80.3 ms | 52.7 ms | 921.2 ms | 1055.1 ms | 1.0 ms | 1056.0 ms | 0.9 ms |
+| Firecracker | SSH | 1207.0 ms | 118.6 ms | 1150.6 ms | 2500.2 ms | 52.4 ms | 2552.0 ms | 42.4 ms |
+| Firecracker | vsock | 1123.6 ms | 121.8 ms | 734.1 ms | 1979.1 ms | 1.2 ms | 1980.4 ms | 1.0 ms |
+
+Finding:
+
+- QEMU matched the current-init expectation, but Firecracker regressed because
+  the zstd decompression cache stored `rootfs.ext4` as a fully allocated 4 GiB
+  file. On this ext4 host, Firecracker isolated-disk materialization then copied
+  gigabytes of zeros before boot.
+
+## 2026-06-14 - Pending PR: Sparse Published Rootfs Cache
+
+- Commit: pending
+- Image tag: `images-2026.06.14.0`
+- Command: `uv run python scripts/benchmarks/ubuntu_transport.py --iterations 3 --warm-exec-runs 5 --rootfs-source published --output /tmp/smolvm-benchmarks/ubuntu-transport-published-sparse-2026-06-14.json -v`
+- Host: Linux x86_64, kernel `7.0.0-15-generic`, KVM available.
+- Method: one warm-up VM per variant, then three measured warm-cache iterations per variant.
+- Behavior changed: published zstd rootfs decompression now preserves sparse zero regions and raw isolated-disk copies pass `cp --sparse=always`.
+
+| Backend | Transport | Before total ready | After total ready | Delta | Improvement |
+|---|---:|---:|---:|---:|---:|
+| Firecracker | SSH | 2500.2 ms | 1797.9 ms | -702.3 ms | 28.1% faster |
+| Firecracker | vsock | 1979.1 ms | 1057.4 ms | -921.7 ms | 46.6% faster |
+
+Full published medians after sparse-cache fix:
+
+| Backend | Transport | Host create | VMM start | Ready wait | Total ready | First command | Total first command | Warm exec |
+|---|---:|---:|---:|---:|---:|---:|---:|---:|
+| QEMU | SSH | 73.7 ms | 52.7 ms | 1623.1 ms | 1751.6 ms | 9.9 ms | 1761.0 ms | 43.0 ms |
+| QEMU | vsock | 80.6 ms | 54.6 ms | 924.0 ms | 1059.7 ms | 1.1 ms | 1061.4 ms | 0.8 ms |
+| Firecracker | SSH | 310.0 ms | 121.7 ms | 1362.3 ms | 1797.9 ms | 53.0 ms | 1850.7 ms | 43.0 ms |
+| Firecracker | vsock | 200.5 ms | 120.9 ms | 736.6 ms | 1057.4 ms | 1.1 ms | 1058.5 ms | 1.0 ms |
+
+Cache size check:
+
+- Before sparse cache refresh: decompressed Ubuntu rootfs used about `4.1G` on disk.
+- After sparse cache refresh: decompressed Ubuntu rootfs used about `423M` on disk.

--- a/docs/deep-dive/startup-time-optimization-plan.md
+++ b/docs/deep-dive/startup-time-optimization-plan.md
@@ -161,6 +161,28 @@ Approach:
   SSH keys when SSH is enabled, network identity, and agent session state.
 - Benchmark restore-to-first-command separately from fresh boot.
 
+Current status:
+
+- The Ubuntu transport benchmark has an opt-in `--include-snapshot` lane that
+  reports snapshot restore-to-ready and restore-to-first-command separately from
+  fresh boot.
+- `SmolVM.from_snapshot(..., comm_channel=...)` can reattach to restored VMs
+  with the same SSH or vsock transport selected by the benchmark variant.
+- The benchmark defaults snapshot measurement to requesting diff snapshots; QEMU
+  may fall back to a full snapshot when the active disk has no backing file.
+- QEMU vsock CID allocation skips CIDs already visible in live QEMU process
+  arguments, so stale/out-of-band QEMU processes do not break benchmark runs.
+- A CLI-validated QEMU-vsock snapshot probe restored to first command in
+  `195.0 ms` (`snapshot_restore_ms=193.5`, ready wait `0.6 ms`, first command
+  `0.9 ms`).
+- QEMU published Ubuntu currently falls back to a full snapshot artifact for
+  the measured diff request because the managed qcow2 has no backing file; a
+  follow-up should evaluate raw-backed qcow2 overlays for the published raw
+  rootfs path.
+- Firecracker full/diff snapshot restore needs follow-up before we can report
+  warm numbers: stale vsock UDS cleanup is fixed, but the restored guest still
+  panics in `restore_fpregs_from_fpstate` on the local benchmark host.
+
 Acceptance:
 
 - Restore-to-first-command e2e passes.

--- a/docs/deep-dive/startup-time-optimization-plan.md
+++ b/docs/deep-dive/startup-time-optimization-plan.md
@@ -46,6 +46,13 @@ These are fresh Ubuntu boot numbers, not snapshot restore numbers. A 50-120 ms
 VMM launch is already plausible today; the remaining latency is mostly Linux
 boot, init, and control-channel readiness.
 
+After publishing `images-2026.06.14.0`, phase telemetry exposed a separate
+host-side Firecracker issue: the decompressed raw ext4 cache was fully
+allocated, so isolated Firecracker starts copied gigabytes of zeros on
+non-reflink filesystems. Preserving sparse holes in the published rootfs cache
+and raw disk copy path brought Firecracker-vsock published total ready to
+`1057.4 ms` on the local benchmark host.
+
 ## Optimization Roadmap
 
 ### Phase 1: Measurement Hygiene
@@ -88,6 +95,9 @@ Current status:
 - Firecracker explicit-vsock now creates/configures the TAP needed by
   Firecracker, but defers route/NAT/egress setup until SSH or port forwarding
   needs host TCP/IP connectivity.
+- Published zstd rootfs decompression preserves sparse zero regions, and raw
+  isolated-disk copies preserve those holes. This removes the accidental
+  4 GiB copy from the Firecracker critical path on non-reflink filesystems.
 
 Acceptance:
 
@@ -95,6 +105,8 @@ Acceptance:
 - SSH variants still reach SSH and accept the injected key.
 - Explicit-vsock benchmarks do not wait for SSH readiness unless the requested
   startup feature needs SSH.
+- Firecracker host-create time stays near the measured TAP/setup cost instead
+  of scaling with the apparent raw rootfs size.
 
 ### Phase 3: QEMU Fast Machine Profile
 

--- a/docs/deep-dive/startup-time-optimization-plan.md
+++ b/docs/deep-dive/startup-time-optimization-plan.md
@@ -175,10 +175,15 @@ Current status:
 - A CLI-validated QEMU-vsock snapshot probe restored to first command in
   `195.0 ms` (`snapshot_restore_ms=193.5`, ready wait `0.6 ms`, first command
   `0.9 ms`).
-- QEMU published Ubuntu currently falls back to a full snapshot artifact for
-  the measured diff request because the managed qcow2 has no backing file; a
-  follow-up should evaluate raw-backed qcow2 overlays for the published raw
-  rootfs path.
+- QEMU published Ubuntu restores fast enough to show the snapshot path is
+  useful, but it is not using the smallest possible snapshot artifact yet. The
+  current run asks for a diff snapshot, which should save only changed disk
+  blocks, but QEMU falls back to a full disk artifact because the managed
+  `qcow2` disk has no backing file. `qcow2` is QEMU's copy-on-write disk
+  format, a backing file is the unchanged base image it can refer back to, and
+  a raw-backed overlay would let the per-sandbox disk point at the published
+  raw rootfs while storing only sandbox changes. A follow-up should evaluate
+  raw-backed `qcow2` overlays for the published raw rootfs path.
 - Firecracker full/diff snapshot restore needs follow-up before we can report
   warm numbers: stale vsock UDS cleanup is fixed, but the restored guest still
   panics in `restore_fpregs_from_fpstate` on the local benchmark host.

--- a/scripts/benchmarks/README.md
+++ b/scripts/benchmarks/README.md
@@ -63,6 +63,15 @@ uv run python scripts/benchmarks/ubuntu_transport.py --rootfs-source current-ini
 `current-init` is for PR validation before a new image release exists. It avoids
 mistaking a stale published rootfs for the current branch's init behavior.
 
+Add `--include-snapshot` to measure a separate snapshot lane for the same Ubuntu
+variants. The fresh-boot results stay under `variants`; snapshot restore results
+are reported under `snapshot_variants` with `snapshot_restore_to_ready_ms` and
+`snapshot_restore_to_first_command_ms`. The default `--snapshot-type auto` uses
+diff snapshots when the runtime can store them safely; QEMU may fall back to a
+full snapshot when the active disk has no backing file.
+Use `--variants qemu-vsock` or a comma-separated list such as
+`--variants qemu-vsock,firecracker-vsock` when you want a focused run.
+
 ## What each benchmark means
 
 | Benchmark      | Metrics                                                         | What it measures |

--- a/scripts/benchmarks/ubuntu_transport.py
+++ b/scripts/benchmarks/ubuntu_transport.py
@@ -45,12 +45,22 @@ sys.path.insert(0, str(_REPO_ROOT / "src"))
 
 from smolvm.facade import SmolVM, _build_auto_config  # noqa: E402
 from smolvm.images.published import _images_release_tag  # noqa: E402
+from smolvm.types import SnapshotType  # noqa: E402
+from smolvm.vm import SmolVMManager  # noqa: E402
 
 logger = logging.getLogger("smolvm.bench.ubuntu_transport")
 
 RootfsSource = Literal["published", "current-init"]
 Transport = Literal["ssh", "vsock"]
 Backend = Literal["qemu", "firecracker"]
+SnapshotChoice = Literal["auto", "full", "diff", "disk"]
+Variant = tuple[Backend, Transport]
+ALL_VARIANTS: tuple[Variant, ...] = (
+    ("qemu", "ssh"),
+    ("qemu", "vsock"),
+    ("firecracker", "ssh"),
+    ("firecracker", "vsock"),
+)
 
 
 def _median(values: list[float]) -> float | None:
@@ -84,6 +94,11 @@ def _safe_teardown(vm: SmolVM | None) -> None:
         vm.stop(timeout=15.0)
     with suppress(Exception):
         vm.delete()
+
+
+def _safe_delete_snapshot(snapshot_id: str) -> None:
+    with suppress(Exception), SmolVMManager() as sdk:
+        sdk.delete_snapshot(snapshot_id)
 
 
 def _current_init_path() -> Path:
@@ -228,21 +243,7 @@ def _run_one(
     return record
 
 
-def _summarize(records: list[dict[str, Any]]) -> dict[str, Any]:
-    fields = [
-        "host_create_ms",
-        "vmm_start_ms",
-        "guest_ready_wait_ms",
-        "total_fresh_ready_ms",
-        "first_command_ms",
-        "total_first_command_ms",
-        "warm_exec_median_ms",
-        "guest_uptime_after_ready_s",
-        "create_ms",
-        "start_ms",
-        "ready_wait_ms",
-        "total_ready_ms",
-    ]
+def _summarize_fields(records: list[dict[str, Any]], fields: list[str]) -> dict[str, Any]:
     return {
         field: _stats(
             [
@@ -255,11 +256,264 @@ def _summarize(records: list[dict[str, Any]]) -> dict[str, Any]:
     }
 
 
+def _summarize(records: list[dict[str, Any]]) -> dict[str, Any]:
+    return _summarize_fields(
+        records,
+        [
+            "host_create_ms",
+            "vmm_start_ms",
+            "guest_ready_wait_ms",
+            "total_fresh_ready_ms",
+            "first_command_ms",
+            "total_first_command_ms",
+            "warm_exec_median_ms",
+            "guest_uptime_after_ready_s",
+            "create_ms",
+            "start_ms",
+            "ready_wait_ms",
+            "total_ready_ms",
+        ],
+    )
+
+
+def _snapshot_type_for_choice(choice: SnapshotChoice) -> SnapshotType:
+    if choice == "auto":
+        return SnapshotType.DIFF
+    return SnapshotType(choice)
+
+
+def _variant_key(variant: Variant) -> str:
+    backend, transport = variant
+    return f"{backend}-{transport}"
+
+
+def _parse_variants(raw: str) -> tuple[Variant, ...]:
+    if raw == "all":
+        return ALL_VARIANTS
+
+    by_key = {_variant_key(variant): variant for variant in ALL_VARIANTS}
+    selected: list[Variant] = []
+    invalid: list[str] = []
+    for item in (part.strip() for part in raw.split(",")):
+        if not item:
+            continue
+        variant = by_key.get(item)
+        if variant is None:
+            invalid.append(item)
+            continue
+        if variant not in selected:
+            selected.append(variant)
+    if invalid or not selected:
+        allowed = ", ".join(["all", *by_key])
+        requested = ", ".join(invalid) if invalid else raw
+        raise ValueError(f"Unknown variant {requested!r}; choose one of: {allowed}")
+    return tuple(selected)
+
+
+def _run_snapshot_one(
+    backend: Backend,
+    transport: Transport,
+    iteration: int,
+    *,
+    rootfs_source: RootfsSource,
+    warm_exec_runs: int,
+    snapshot_choice: SnapshotChoice,
+    warmup: bool = False,
+) -> dict[str, Any]:
+    vm_name = f"bench-snap-{backend[:2]}-{transport[:2]}-{uuid.uuid4().hex[:8]}"
+    snapshot_id = f"{vm_name}-snap"
+    snapshot_type = _snapshot_type_for_choice(snapshot_choice)
+    record: dict[str, Any] = {
+        "iter": iteration,
+        "vm_id": vm_name,
+        "snapshot_id": snapshot_id,
+        "snapshot_type": snapshot_type.value,
+        "warmup": warmup,
+    }
+    source_vm: SmolVM | None = None
+    restored_vm: SmolVM | None = None
+    try:
+        started = time.perf_counter()
+        config, ssh_key_path, published_rootfs, patched_rootfs = _config_for_variant(
+            backend,
+            vm_name=vm_name,
+            rootfs_source=rootfs_source,
+        )
+        source_vm = SmolVM(config=config, ssh_key_path=ssh_key_path, comm_channel=transport)
+        record["snapshot_source_host_create_ms"] = round(
+            (time.perf_counter() - started) * 1000, 1
+        )
+        record["published_rootfs_path"] = str(published_rootfs)
+        record["rootfs_path"] = str(config.rootfs_path)
+        record["patched_rootfs_path"] = str(patched_rootfs) if patched_rootfs else None
+        record["ssh_host_port"] = (
+            source_vm._info.network.ssh_host_port if source_vm._info.network else None
+        )
+        record["vsock_guest_cid"] = (
+            source_vm._info.config.vsock.guest_cid if source_vm._info.config.vsock else None
+        )
+
+        started = time.perf_counter()
+        source_vm.start()
+        record["snapshot_source_vmm_start_ms"] = round(
+            (time.perf_counter() - started) * 1000, 1
+        )
+
+        started = time.perf_counter()
+        source_vm.wait_for_ready(timeout=60.0)
+        record["snapshot_source_ready_wait_ms"] = round(
+            (time.perf_counter() - started) * 1000, 1
+        )
+        record["snapshot_source_total_ready_ms"] = round(
+            record["snapshot_source_host_create_ms"]
+            + record["snapshot_source_vmm_start_ms"]
+            + record["snapshot_source_ready_wait_ms"],
+            1,
+        )
+        record["source_control_kind"] = getattr(source_vm._control_channel, "kind", None)
+
+        started = time.perf_counter()
+        source_vm.snapshot(snapshot_id=snapshot_id, snapshot_type=snapshot_type)
+        record["snapshot_create_ms"] = round((time.perf_counter() - started) * 1000, 1)
+
+        _safe_teardown(source_vm)
+        source_vm = None
+
+        started = time.perf_counter()
+        restored_vm = SmolVM.from_snapshot(
+            snapshot_id,
+            backend=backend,
+            resume_vm=True,
+            ssh_key_path=ssh_key_path,
+            comm_channel=transport,
+        )
+        record["snapshot_restore_ms"] = round((time.perf_counter() - started) * 1000, 1)
+
+        started = time.perf_counter()
+        restored_vm.wait_for_ready(timeout=60.0)
+        record["snapshot_restore_ready_wait_ms"] = round(
+            (time.perf_counter() - started) * 1000, 1
+        )
+        record["snapshot_restore_to_ready_ms"] = round(
+            record["snapshot_restore_ms"] + record["snapshot_restore_ready_wait_ms"],
+            1,
+        )
+        record["restore_control_kind"] = getattr(restored_vm._control_channel, "kind", None)
+
+        started = time.perf_counter()
+        first = restored_vm.run("true", shell="raw", timeout=10.0)
+        record["snapshot_first_command_ms"] = round((time.perf_counter() - started) * 1000, 1)
+        record["snapshot_first_command_exit_code"] = first.exit_code
+        record["snapshot_restore_to_first_command_ms"] = round(
+            record["snapshot_restore_to_ready_ms"] + record["snapshot_first_command_ms"],
+            1,
+        )
+
+        warm_exec_ms: list[float] = []
+        for _ in range(warm_exec_runs):
+            started = time.perf_counter()
+            result = restored_vm.run("true", shell="raw", timeout=10.0)
+            warm_exec_ms.append(round((time.perf_counter() - started) * 1000, 1))
+            if result.exit_code != 0:
+                record.setdefault("snapshot_warm_exec_errors", []).append(result.exit_code)
+        record["snapshot_warm_exec_ms"] = warm_exec_ms
+        record["snapshot_warm_exec_median_ms"] = _median(warm_exec_ms)
+
+        with suppress(Exception):
+            uptime = restored_vm.run("cat /proc/uptime", shell="raw", timeout=10.0)
+            record["snapshot_guest_uptime_after_ready_s"] = round(
+                float(uptime.stdout.split()[0]), 3
+            )
+    finally:
+        _safe_teardown(source_vm)
+        _safe_teardown(restored_vm)
+        _safe_delete_snapshot(snapshot_id)
+    return record
+
+
+def _summarize_snapshot(records: list[dict[str, Any]]) -> dict[str, Any]:
+    return _summarize_fields(
+        records,
+        [
+            "snapshot_source_host_create_ms",
+            "snapshot_source_vmm_start_ms",
+            "snapshot_source_ready_wait_ms",
+            "snapshot_source_total_ready_ms",
+            "snapshot_create_ms",
+            "snapshot_restore_ms",
+            "snapshot_restore_ready_wait_ms",
+            "snapshot_restore_to_ready_ms",
+            "snapshot_first_command_ms",
+            "snapshot_restore_to_first_command_ms",
+            "snapshot_warm_exec_median_ms",
+            "snapshot_guest_uptime_after_ready_s",
+        ],
+    )
+
+
+def _run_variant_group(
+    *,
+    iterations: int,
+    warm_exec_runs: int,
+    rootfs_source: RootfsSource,
+    variants: tuple[Variant, ...],
+    runner: Any,
+    summary: Any,
+    logger_prefix: str,
+    runner_extra: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    results: dict[str, Any] = {}
+    extra = runner_extra or {}
+    for backend, transport in variants:
+        key = _variant_key((backend, transport))
+        logger.info("[%s %s] warm-up", logger_prefix, key)
+        warmup_record: dict[str, Any] | None = None
+        with suppress(Exception):
+            warmup_record = runner(
+                backend,
+                transport,
+                -1,
+                rootfs_source=rootfs_source,
+                warm_exec_runs=warm_exec_runs,
+                warmup=True,
+                **extra,
+            )
+
+        records: list[dict[str, Any]] = []
+        for iteration in range(iterations):
+            logger.info("[%s %s] measured %d/%d", logger_prefix, key, iteration + 1, iterations)
+            try:
+                record = runner(
+                    backend,
+                    transport,
+                    iteration,
+                    rootfs_source=rootfs_source,
+                    warm_exec_runs=warm_exec_runs,
+                    **extra,
+                )
+            except Exception as exc:  # noqa: BLE001
+                logger.warning("[%s %s] iteration failed: %s", logger_prefix, key, exc)
+                record = {"iter": iteration, "error": repr(exc)}
+            records.append(record)
+
+        results[key] = {
+            "backend": backend,
+            "transport": transport,
+            "warmup": warmup_record,
+            "raw": records,
+            "summary": summary(records),
+        }
+    return results
+
+
 def run_benchmark(
     *,
     iterations: int,
     warm_exec_runs: int,
     rootfs_source: RootfsSource,
+    variants: tuple[Variant, ...] = ALL_VARIANTS,
+    include_snapshot: bool = False,
+    snapshot_type: SnapshotChoice = "auto",
 ) -> dict[str, Any]:
     report: dict[str, Any] = {
         "date": datetime.now(timezone.utc).isoformat(),
@@ -272,52 +526,32 @@ def run_benchmark(
         "rootfs_source": rootfs_source,
         "iterations": iterations,
         "warm_exec_runs": warm_exec_runs,
+        "selected_variants": [_variant_key(variant) for variant in variants],
+        "include_snapshot": include_snapshot,
+        "snapshot_type": snapshot_type,
         "variants": {},
     }
 
-    variants: tuple[tuple[Backend, Transport], ...] = (
-        ("qemu", "ssh"),
-        ("qemu", "vsock"),
-        ("firecracker", "ssh"),
-        ("firecracker", "vsock"),
+    report["variants"] = _run_variant_group(
+        iterations=iterations,
+        warm_exec_runs=warm_exec_runs,
+        rootfs_source=rootfs_source,
+        variants=variants,
+        runner=_run_one,
+        summary=_summarize,
+        logger_prefix="fresh",
     )
-    for backend, transport in variants:
-        key = f"{backend}-{transport}"
-        logger.info("[%s] warm-up", key)
-        warmup_record: dict[str, Any] | None = None
-        with suppress(Exception):
-            warmup_record = _run_one(
-                backend,
-                transport,
-                -1,
-                rootfs_source=rootfs_source,
-                warm_exec_runs=warm_exec_runs,
-                warmup=True,
-            )
-
-        records: list[dict[str, Any]] = []
-        for iteration in range(iterations):
-            logger.info("[%s] measured %d/%d", key, iteration + 1, iterations)
-            try:
-                record = _run_one(
-                    backend,
-                    transport,
-                    iteration,
-                    rootfs_source=rootfs_source,
-                    warm_exec_runs=warm_exec_runs,
-                )
-            except Exception as exc:  # noqa: BLE001
-                logger.warning("[%s] iteration failed: %s", key, exc)
-                record = {"iter": iteration, "error": repr(exc)}
-            records.append(record)
-
-        report["variants"][key] = {
-            "backend": backend,
-            "transport": transport,
-            "warmup": warmup_record,
-            "raw": records,
-            "summary": _summarize(records),
-        }
+    if include_snapshot:
+        report["snapshot_variants"] = _run_variant_group(
+            iterations=iterations,
+            warm_exec_runs=warm_exec_runs,
+            rootfs_source=rootfs_source,
+            variants=variants,
+            runner=_run_snapshot_one,
+            summary=_summarize_snapshot,
+            logger_prefix="snapshot",
+            runner_extra={"snapshot_choice": snapshot_type},
+        )
     return report
 
 
@@ -331,6 +565,25 @@ def main() -> None:
         default="published",
         help="Use published rootfs bytes, or patch /init from this checkout before booting.",
     )
+    parser.add_argument(
+        "--variants",
+        default="all",
+        help=(
+            "Comma-separated variants to run: qemu-ssh,qemu-vsock,"
+            "firecracker-ssh,firecracker-vsock, or all."
+        ),
+    )
+    parser.add_argument(
+        "--include-snapshot",
+        action="store_true",
+        help="Also measure snapshot restore-to-ready and restore-to-first-command.",
+    )
+    parser.add_argument(
+        "--snapshot-type",
+        choices=("auto", "full", "diff", "disk"),
+        default="auto",
+        help="Snapshot type for --include-snapshot. auto uses diff snapshots.",
+    )
     parser.add_argument("--output", type=Path, default=Path("/tmp/smolvm-ubuntu-transport.json"))
     parser.add_argument("--json", action="store_true", help="Print the full JSON report.")
     parser.add_argument("-v", "--verbose", action="store_true")
@@ -340,6 +593,10 @@ def main() -> None:
         parser.error("--iterations must be >= 1")
     if args.warm_exec_runs < 1:
         parser.error("--warm-exec-runs must be >= 1")
+    try:
+        selected_variants = _parse_variants(args.variants)
+    except ValueError as exc:
+        parser.error(str(exc))
 
     logging.basicConfig(
         level=logging.INFO if args.verbose else logging.WARNING,
@@ -349,6 +606,9 @@ def main() -> None:
         iterations=args.iterations,
         warm_exec_runs=args.warm_exec_runs,
         rootfs_source=args.rootfs_source,
+        variants=selected_variants,
+        include_snapshot=args.include_snapshot,
+        snapshot_type=args.snapshot_type,
     )
     payload = json.dumps(report, indent=2)
     args.output.write_text(payload + "\n")

--- a/scripts/benchmarks/ubuntu_transport.py
+++ b/scripts/benchmarks/ubuntu_transport.py
@@ -306,7 +306,10 @@ def _parse_variants(raw: str) -> tuple[Variant, ...]:
     if invalid or not selected:
         allowed = ", ".join(["all", *by_key])
         requested = ", ".join(invalid) if invalid else raw
-        raise ValueError(f"Unknown variant {requested!r}; choose one of: {allowed}")
+        raise ValueError(
+            f"Unknown variant {requested!r}; choose one of: {allowed}. "
+            "Run: uv run python scripts/benchmarks/ubuntu_transport.py --variants qemu-vsock"
+        )
     return tuple(selected)
 
 

--- a/src/smolvm/facade.py
+++ b/src/smolvm/facade.py
@@ -1446,6 +1446,7 @@ class SmolVM:
         force: bool = False,
         ssh_user: str = "root",
         ssh_key_path: str | None = None,
+        comm_channel: CommChannelKind | None = None,
     ) -> SmolVM:
         """Restore a snapshot and attach a facade to the restored VM."""
         requested_backend = None
@@ -1496,6 +1497,7 @@ class SmolVM:
             backend=restored_backend,
             ssh_user=ssh_user,
             ssh_key_path=ssh_key_path,
+            comm_channel=comm_channel,
         )
 
     # ------------------------------------------------------------------

--- a/src/smolvm/images/published.py
+++ b/src/smolvm/images/published.py
@@ -378,14 +378,39 @@ def to_image_source(entry: PublishedImage, version: str = __version__) -> ImageS
     )
 
 
+_SPARSE_DECOMPRESS_CHUNK_SIZE = 1024 * 1024
+_DECOMPRESSED_ROOTFS_CACHE_VERSION = "sparse-v1"
+
+
+def _decompressed_rootfs_sidecar_value(rootfs_sha256: str) -> str:
+    return f"{_DECOMPRESSED_ROOTFS_CACHE_VERSION}:{rootfs_sha256}"
+
+
 def _decompress_zstd(src: Path, dst: Path) -> None:
-    """Stream-decompress a zstd file. Writes to a sibling ``.tmp`` then renames."""
+    """Stream-decompress a zstd file. Writes to a sibling ``.tmp`` then renames.
+
+    Published raw ext4 images contain large zeroed regions. Keep those regions
+    sparse in the local cache so Firecracker isolated-disk materialization does
+    not copy gigabytes of zeros before every boot on filesystems without
+    reflink support.
+    """
     import zstandard
 
     tmp = dst.parent / (dst.name + ".tmp")
     try:
         with src.open("rb") as src_f, tmp.open("wb") as dst_f:
-            zstandard.ZstdDecompressor().copy_stream(src_f, dst_f)
+            reader = zstandard.ZstdDecompressor().stream_reader(src_f)
+            size = 0
+            while True:
+                chunk = reader.read(_SPARSE_DECOMPRESS_CHUNK_SIZE)
+                if not chunk:
+                    break
+                size += len(chunk)
+                if chunk.strip(b"\0"):
+                    dst_f.write(chunk)
+                else:
+                    dst_f.seek(len(chunk), os.SEEK_CUR)
+            dst_f.truncate(size)
         tmp.replace(dst)
     finally:
         tmp.unlink(missing_ok=True)
@@ -443,7 +468,7 @@ def ensure_published_image(
     # while diagnosing the openclaw uid bake regression.
     decompressed_path = local.rootfs_path.with_suffix("")
     sidecar_path = decompressed_path.with_name(decompressed_path.name + ".from-sha256")
-    expected_sha = entry.rootfs_sha256
+    expected_sha = _decompressed_rootfs_sidecar_value(entry.rootfs_sha256)
     sidecar_sha = sidecar_path.read_text().strip() if sidecar_path.is_file() else None
     if not decompressed_path.is_file() or sidecar_sha != expected_sha:
         _decompress_zstd(local.rootfs_path, decompressed_path)

--- a/src/smolvm/runtime/firecracker.py
+++ b/src/smolvm/runtime/firecracker.py
@@ -270,6 +270,8 @@ class FirecrackerRuntimeAdapter(RuntimeAdapter):
         control_socket_path = self._context.socket_dir / f"fc-{snapshot.vm_id}.sock"
         if control_socket_path.exists():
             self._context.unlink_socket(control_socket_path)
+        if vsock_uds_path is not None and vsock_uds_path.exists():
+            self._context.unlink_socket(vsock_uds_path)
 
         process: Any | None = None
         client: FirecrackerClient | None = None

--- a/src/smolvm/vm.py
+++ b/src/smolvm/vm.py
@@ -1510,23 +1510,29 @@ class SmolVMManager:
         raise NetworkError("No vsock CIDs available in pool")
 
     @staticmethod
-    def _live_qemu_vsock_cids() -> set[int]:
+    def _live_qemu_vsock_cids(proc_dir: Path = Path("/proc")) -> set[int]:
         """Return QEMU vhost-vsock CIDs visible in local process arguments."""
         if platform.system() != "Linux":
             return set()
+
         try:
-            result = subprocess.run(
-                ["ps", "-eo", "args="],
-                capture_output=True,
-                text=True,
-                check=False,
-                timeout=2,
+            entries = list(proc_dir.iterdir())
+        except OSError:
+            return set()
+
+        live_cids: set[int] = set()
+        for entry in entries:
+            if not entry.name.isdigit():
+                continue
+            try:
+                cmdline = (entry / "cmdline").read_bytes()
+            except OSError:
+                continue
+            text = cmdline.replace(b"\0", b" ").decode(errors="replace")
+            live_cids.update(
+                int(match.group(1)) for match in _QEMU_VSOCK_CID_RE.finditer(text)
             )
-        except (OSError, subprocess.SubprocessError, ValueError):
-            return set()
-        if result.returncode != 0 or not isinstance(result.stdout, str):
-            return set()
-        return {int(match.group(1)) for match in _QEMU_VSOCK_CID_RE.finditer(result.stdout)}
+        return live_cids
 
     @staticmethod
     def _uses_host_tap_networking(config: VMConfig, backend: str) -> bool:

--- a/src/smolvm/vm.py
+++ b/src/smolvm/vm.py
@@ -70,6 +70,7 @@ from smolvm.storage import (
     create_state_manager,
     ip_to_pool_index,
 )
+from smolvm.storage._base import VSOCK_CID_END, VSOCK_CID_START
 from smolvm.types import (
     GuestOS,
     NetworkConfig,
@@ -93,6 +94,7 @@ DEFAULT_SOCKET_DIR = Path("/tmp")
 # Backend-specific defaults
 QEMU_GUEST_IP = "10.0.2.15"
 _MIB = 1024 * 1024
+_QEMU_VSOCK_CID_RE = re.compile(r"vhost-vsock-(?:pci|device),guest-cid=(\d+)")
 
 
 def _linux_os_release_ids(os_release_path: Path = Path("/etc/os-release")) -> set[str]:
@@ -1447,8 +1449,9 @@ class SmolVMManager:
         if resolution.kind != "vsock" and not should_reserve_device:
             return vm_info
 
-        cid = self.state.reserve_vsock_cid(
+        cid = self._reserve_vsock_cid_for_backend(
             config.vm_id,
+            backend,
             requested_vsock.guest_cid if requested_vsock is not None else None,
         )
         uds_path = requested_vsock.uds_path if requested_vsock is not None else None
@@ -1467,6 +1470,63 @@ class SmolVMManager:
         else:
             logger.info("VM %s reserved explicit vsock CID %d", config.vm_id, cid)
         return self.state.update_vm(config.vm_id, config=updated)
+
+    def _reserve_vsock_cid_for_backend(
+        self,
+        vm_id: str,
+        backend: str,
+        requested_cid: int | None,
+    ) -> int:
+        """Reserve a CID, avoiding live QEMU CIDs missing from local state."""
+        if backend != BACKEND_QEMU:
+            return self.state.reserve_vsock_cid(vm_id, requested_cid)
+
+        live_cids = self._live_qemu_vsock_cids()
+        if not live_cids:
+            return self.state.reserve_vsock_cid(vm_id, requested_cid)
+
+        if requested_cid is not None:
+            cid = self.state.reserve_vsock_cid(vm_id, requested_cid)
+            if cid in live_cids:
+                self.state.release_vsock_cid(vm_id)
+                raise NetworkError(
+                    f"Vsock CID {cid} is already in use by another running QEMU VM; "
+                    f"stop that VM, or run 'smolvm delete {vm_id}' and create it again "
+                    "without that explicit CID."
+                )
+            return cid
+
+        existing_cid = self.state.get_vsock_cid(vm_id)
+        if existing_cid is not None:
+            return existing_cid
+
+        for candidate_cid in range(VSOCK_CID_START, VSOCK_CID_END + 1):
+            if candidate_cid in live_cids:
+                continue
+            try:
+                return self.state.reserve_vsock_cid(vm_id, candidate_cid)
+            except NetworkError:
+                continue
+        raise NetworkError("No vsock CIDs available in pool")
+
+    @staticmethod
+    def _live_qemu_vsock_cids() -> set[int]:
+        """Return QEMU vhost-vsock CIDs visible in local process arguments."""
+        if platform.system() != "Linux":
+            return set()
+        try:
+            result = subprocess.run(
+                ["ps", "-eo", "args="],
+                capture_output=True,
+                text=True,
+                check=False,
+                timeout=2,
+            )
+        except (OSError, subprocess.SubprocessError, ValueError):
+            return set()
+        if result.returncode != 0 or not isinstance(result.stdout, str):
+            return set()
+        return {int(match.group(1)) for match in _QEMU_VSOCK_CID_RE.finditer(result.stdout)}
 
     @staticmethod
     def _uses_host_tap_networking(config: VMConfig, backend: str) -> bool:
@@ -2192,9 +2252,10 @@ class SmolVMManager:
                 )
             if effective_snapshot.backend == BACKEND_QEMU and persisted_vm_config.vsock is not None:
                 try:
-                    self.state.reserve_vsock_cid(
+                    self._reserve_vsock_cid_for_backend(
                         restore_vm_id,
-                        guest_cid=persisted_vm_config.vsock.guest_cid,
+                        effective_snapshot.backend,
+                        persisted_vm_config.vsock.guest_cid,
                     )
                 except NetworkError as exc:
                     raise NetworkError(

--- a/src/smolvm/vm.py
+++ b/src/smolvm/vm.py
@@ -716,7 +716,8 @@ class SmolVMManager:
         """Copy a file using reflink (CoW) when the filesystem supports it.
 
         On btrfs and XFS with reflinks, this is near-instant regardless of
-        file size. On other filesystems it falls back to a regular copy.
+        file size. On other filesystems it falls back to a sparse-preserving
+        Python copy.
         """
         result = subprocess.run(
             ["cp", "--reflink=auto", "--sparse=always", str(source_path), str(target_path)],
@@ -727,7 +728,24 @@ class SmolVMManager:
         if result.returncode != 0:
             # Fallback: --reflink=auto may not be supported on all platforms
             # (e.g. macOS cp doesn't have this flag).
-            shutil.copy2(source_path, target_path)
+            SmolVMManager._copy_sparse_preserving(source_path, target_path)
+
+    @staticmethod
+    def _copy_sparse_preserving(
+        source_path: Path,
+        target_path: Path,
+        *,
+        chunk_size: int = 1024 * 1024,
+    ) -> None:
+        """Copy a file while keeping all-zero regions as sparse holes."""
+        with source_path.open("rb") as src, target_path.open("wb") as dst:
+            while chunk := src.read(chunk_size):
+                if chunk.count(0) == len(chunk):
+                    dst.seek(len(chunk), os.SEEK_CUR)
+                else:
+                    dst.write(chunk)
+            dst.truncate(source_path.stat().st_size)
+        shutil.copystat(source_path, target_path)
 
     @staticmethod
     def _ceil_mib(size_bytes: int) -> int:
@@ -1491,8 +1509,8 @@ class SmolVMManager:
                 self.state.release_vsock_cid(vm_id)
                 raise NetworkError(
                     f"Vsock CID {cid} is already in use by another running QEMU VM; "
-                    f"stop that VM, or run 'smolvm delete {vm_id}' and create it again "
-                    "without that explicit CID."
+                    f"run 'smolvm delete {vm_id}' to remove this sandbox, then create it "
+                    "again without that explicit CID."
                 )
             return cid
 
@@ -2266,8 +2284,7 @@ class SmolVMManager:
                 except NetworkError as exc:
                     raise NetworkError(
                         f"Vsock CID {persisted_vm_config.vsock.guest_cid} is already in use; "
-                        f"stop the sandbox using that CID, or run "
-                        f"'smolvm delete {restore_vm_id}'."
+                        f"run 'smolvm delete {restore_vm_id}' to remove this restore attempt."
                     ) from exc
             self.state.update_vm(restore_vm_id, network=effective_snapshot.network_config)
             if effective_snapshot.backend == BACKEND_FIRECRACKER:
@@ -3342,8 +3359,6 @@ class SmolVMManager:
 
     async def _async_copy_with_reflink(self, source_path: Path, target_path: Path) -> None:
         """Async version of :meth:`_copy_with_reflink`."""
-        import shutil
-
         from smolvm.utils import async_run_command
 
         target_path.parent.mkdir(parents=True, exist_ok=True)
@@ -3353,7 +3368,7 @@ class SmolVMManager:
                 use_sudo=False,
             )
         except SmolVMError:
-            await asyncio.to_thread(shutil.copy2, source_path, target_path)
+            await asyncio.to_thread(self._copy_sparse_preserving, source_path, target_path)
 
     async def _async_unlink_socket(self, socket_path: Path) -> None:
         """Async version of :meth:`_unlink_socket`."""

--- a/src/smolvm/vm.py
+++ b/src/smolvm/vm.py
@@ -717,7 +717,7 @@ class SmolVMManager:
         file size. On other filesystems it falls back to a regular copy.
         """
         result = subprocess.run(
-            ["cp", "--reflink=auto", str(source_path), str(target_path)],
+            ["cp", "--reflink=auto", "--sparse=always", str(source_path), str(target_path)],
             capture_output=True,
             text=True,
             check=False,
@@ -3282,7 +3282,7 @@ class SmolVMManager:
         target_path.parent.mkdir(parents=True, exist_ok=True)
         try:
             await async_run_command(
-                ["cp", "--reflink=auto", str(source_path), str(target_path)],
+                ["cp", "--reflink=auto", "--sparse=always", str(source_path), str(target_path)],
                 use_sudo=False,
             )
         except SmolVMError:

--- a/tests/test_facade.py
+++ b/tests/test_facade.py
@@ -571,9 +571,10 @@ class TestVMInit:
         mock_sdk_cls.return_value = restore_manager
         mock_sdk_cls.from_id.return_value = attach_manager
 
-        vm = SmolVM.from_snapshot("snap-001")
+        vm = SmolVM.from_snapshot("snap-001", comm_channel="vsock")
 
         assert vm.vm_id == "vm001"
+        assert vm._comm_channel_request == "vsock"
         restore_manager.restore_snapshot.assert_called_once_with(
             "snap-001",
             resume_vm=False,

--- a/tests/test_published_images.py
+++ b/tests/test_published_images.py
@@ -595,8 +595,10 @@ class TestZstdDecompression:
         (image_dir / "vmlinux.bin").write_bytes(kernel_bytes)
         (image_dir / "rootfs.ext4.zst").write_bytes(rootfs_zst)
         (image_dir / "rootfs.ext4").write_bytes(rootfs_plain)
-        # Sidecar from a PREVIOUS rootfs SHA (not the one in `entry`).
-        (image_dir / "rootfs.ext4.from-sha256").write_text("0" * 64)
+        # Versioned sidecar from a PREVIOUS rootfs SHA (not the one in `entry`).
+        (image_dir / "rootfs.ext4.from-sha256").write_text(
+            _decompressed_rootfs_sidecar_value("0" * 64)
+        )
 
         with patch("smolvm.images.published._decompress_zstd") as mock_decompress:
             ensure_published_image(

--- a/tests/test_published_images.py
+++ b/tests/test_published_images.py
@@ -35,6 +35,7 @@ from smolvm.images.published import (
     Preset,
     PublishedImage,
     _decompress_zstd,
+    _decompressed_rootfs_sidecar_value,
     _preset_rows,
     cache_name,
     ensure_base_kernel,
@@ -557,7 +558,9 @@ class TestZstdDecompression:
         (image_dir / "vmlinux.bin").write_bytes(kernel_bytes)
         (image_dir / "rootfs.ext4.zst").write_bytes(rootfs_zst)
         (image_dir / "rootfs.ext4").write_bytes(rootfs_plain)
-        (image_dir / "rootfs.ext4.from-sha256").write_text(entry.rootfs_sha256)
+        (image_dir / "rootfs.ext4.from-sha256").write_text(
+            _decompressed_rootfs_sidecar_value(entry.rootfs_sha256)
+        )
 
         with patch("smolvm.images.published._decompress_zstd") as mock_decompress:
             local = ensure_published_image(
@@ -607,7 +610,43 @@ class TestZstdDecompression:
             mock_decompress.assert_called_once()
             mock_get.assert_not_called()
 
-        assert (image_dir / "rootfs.ext4.from-sha256").read_text().strip() == entry.rootfs_sha256
+        assert (image_dir / "rootfs.ext4.from-sha256").read_text().strip() == (
+            _decompressed_rootfs_sidecar_value(entry.rootfs_sha256)
+        )
+
+    @patch("smolvm.images.manager.requests.get")
+    def test_decompression_reruns_when_sidecar_format_is_old(
+        self,
+        mock_get: MagicMock,
+        compressed_entry: tuple[PublishedImage, bytes, bytes, bytes],
+        tmp_path: Path,
+    ) -> None:
+        """Old bare-SHA sidecars must re-decompress into sparse cache files."""
+        entry, kernel_bytes, rootfs_zst, rootfs_plain = compressed_entry
+        manifest = {(entry.preset, entry.arch, entry.vmm, entry.os): entry}
+
+        image_dir = tmp_path / cache_name(entry.preset, entry.arch, entry.vmm, "0.0.13")
+        image_dir.mkdir(parents=True)
+        (image_dir / "vmlinux.bin").write_bytes(kernel_bytes)
+        (image_dir / "rootfs.ext4.zst").write_bytes(rootfs_zst)
+        (image_dir / "rootfs.ext4").write_bytes(rootfs_plain)
+        (image_dir / "rootfs.ext4.from-sha256").write_text(entry.rootfs_sha256)
+
+        with patch("smolvm.images.published._decompress_zstd") as mock_decompress:
+            ensure_published_image(
+                entry.preset,
+                entry.arch,
+                entry.vmm,
+                cache_dir=tmp_path,
+                manifest=manifest,
+                version="0.0.13",
+            )
+            mock_decompress.assert_called_once()
+            mock_get.assert_not_called()
+
+        assert (image_dir / "rootfs.ext4.from-sha256").read_text().strip() == (
+            _decompressed_rootfs_sidecar_value(entry.rootfs_sha256)
+        )
 
     @patch("smolvm.images.manager.requests.get")
     def test_uncompressed_rootfs_url_skips_decompression_path(
@@ -848,6 +887,20 @@ class TestBundledManifest:
 
 class TestDecompressZstd:
     """Direct tests for the streaming decompressor."""
+
+    def test_decompress_zstd_preserves_sparse_zero_ranges(self, tmp_path: Path) -> None:
+        """Published raw ext4 caches should keep large zero regions sparse."""
+        import zstandard
+
+        plain = b"start" + (b"\0" * (4 * 1024 * 1024)) + b"end"
+        src = tmp_path / "rootfs.ext4.zst"
+        src.write_bytes(zstandard.ZstdCompressor(level=3).compress(plain))
+        dst = tmp_path / "rootfs.ext4"
+
+        _decompress_zstd(src, dst)
+
+        assert dst.read_bytes() == plain
+        assert dst.stat().st_blocks * 512 < dst.stat().st_size
 
     def test_corrupted_input_cleans_up_tmp_file(self, tmp_path: Path) -> None:
         """A failed decompress must not leave a half-written ``.tmp`` behind."""

--- a/tests/test_snapshot.py
+++ b/tests/test_snapshot.py
@@ -315,6 +315,7 @@ def test_restore_firecracker_full_snapshot_returns_vsock_uds_path(
     snapshot_dir = smol_vm.snapshot_dir / "snap-vsock"
     snapshot_dir.mkdir(parents=True)
     uds_path = tmp_path / "vsock-vm001.sock"
+    uds_path.write_text("stale socket")
     snapshot = SnapshotInfo(
         snapshot_id="snap-vsock",
         vm_id="vm001",
@@ -345,6 +346,7 @@ def test_restore_firecracker_full_snapshot_returns_vsock_uds_path(
         restored = smol_vm.restore_snapshot("snap-vsock", resume_vm=True)
 
     assert restored.vsock_uds_path == uds_path
+    assert not uds_path.exists()
     mock_client.load_snapshot.assert_called_once()
 
 

--- a/tests/test_ubuntu_transport_benchmark.py
+++ b/tests/test_ubuntu_transport_benchmark.py
@@ -180,5 +180,9 @@ def test_parse_variants_rejects_unknown_variant() -> None:
     except ValueError as exc:
         assert "qemu-bad" in str(exc)
         assert "qemu-vsock" in str(exc)
+        assert (
+            "uv run python scripts/benchmarks/ubuntu_transport.py --variants qemu-vsock"
+            in str(exc)
+        )
     else:
         raise AssertionError("expected invalid variant to fail")

--- a/tests/test_ubuntu_transport_benchmark.py
+++ b/tests/test_ubuntu_transport_benchmark.py
@@ -1,0 +1,184 @@
+# Copyright 2026 Celesto AI
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import annotations
+
+from pathlib import Path
+from types import SimpleNamespace
+from typing import Any
+
+from scripts.benchmarks import ubuntu_transport
+
+
+class _FakeConfig(SimpleNamespace):
+    rootfs_path: Path
+
+
+class _FakeSmolVM:
+    restored_calls: list[dict[str, Any]] = []
+    snapshots: list[dict[str, Any]] = []
+
+    def __init__(
+        self,
+        *,
+        config: Any | None = None,
+        ssh_key_path: str | None = None,
+        comm_channel: str | None = None,
+        **_: Any,
+    ) -> None:
+        self._vm_id = getattr(config, "vm_id", "bench-fake")
+        self._ssh_key_path = ssh_key_path
+        self._comm_channel = comm_channel
+        self._control_channel = SimpleNamespace(kind=comm_channel)
+        self._info = SimpleNamespace(
+            network=SimpleNamespace(ssh_host_port=2201),
+            config=SimpleNamespace(vsock=SimpleNamespace(guest_cid=1024)),
+        )
+
+    @classmethod
+    def from_snapshot(cls, snapshot_id: str, **kwargs: Any) -> _FakeSmolVM:
+        cls.restored_calls.append({"snapshot_id": snapshot_id, **kwargs})
+        return cls(
+            config=_FakeConfig(vm_id="restored", rootfs_path=Path("/tmp/restored.ext4")),
+            ssh_key_path=kwargs.get("ssh_key_path"),
+            comm_channel=kwargs.get("comm_channel"),
+        )
+
+    def start(self) -> None:
+        pass
+
+    def wait_for_ready(self, *, timeout: float) -> None:
+        assert timeout == 60.0
+
+    def run(self, command: str, *, shell: str, timeout: float) -> SimpleNamespace:
+        assert shell == "raw"
+        assert timeout == 10.0
+        if command == "cat /proc/uptime":
+            return SimpleNamespace(exit_code=0, stdout="0.42 0.01\n")
+        assert command == "true"
+        return SimpleNamespace(exit_code=0, stdout="", stderr="")
+
+    def snapshot(self, *, snapshot_id: str, snapshot_type: Any) -> SimpleNamespace:
+        self.snapshots.append(
+            {"snapshot_id": snapshot_id, "snapshot_type": snapshot_type.value}
+        )
+        return SimpleNamespace(snapshot_id=snapshot_id)
+
+    def stop(self, *, timeout: float = 15.0) -> None:
+        pass
+
+    def delete(self) -> None:
+        pass
+
+
+def test_snapshot_benchmark_restores_with_selected_transport(monkeypatch) -> None:
+    _FakeSmolVM.restored_calls = []
+    _FakeSmolVM.snapshots = []
+    deleted_snapshots: list[str] = []
+    config = _FakeConfig(vm_id="bench-fake", rootfs_path=Path("/tmp/rootfs.ext4"))
+
+    monkeypatch.setattr(ubuntu_transport, "SmolVM", _FakeSmolVM)
+    monkeypatch.setattr(
+        ubuntu_transport,
+        "_config_for_variant",
+        lambda *_args, **_kwargs: (config, "/tmp/id_ed25519", Path("/tmp/rootfs.ext4"), None),
+    )
+    monkeypatch.setattr(ubuntu_transport, "_safe_teardown", lambda _vm: None)
+    monkeypatch.setattr(
+        ubuntu_transport,
+        "_safe_delete_snapshot",
+        lambda snapshot_id: deleted_snapshots.append(snapshot_id),
+    )
+
+    record = ubuntu_transport._run_snapshot_one(
+        "qemu",
+        "vsock",
+        0,
+        rootfs_source="published",
+        warm_exec_runs=2,
+        snapshot_choice="auto",
+    )
+
+    assert record["snapshot_type"] == "diff"
+    assert record["source_control_kind"] == "vsock"
+    assert record["restore_control_kind"] == "vsock"
+    assert record["snapshot_restore_to_first_command_ms"] >= record["snapshot_restore_ms"]
+    assert len(record["snapshot_warm_exec_ms"]) == 2
+    assert deleted_snapshots == [record["snapshot_id"]]
+    assert _FakeSmolVM.snapshots == [
+        {"snapshot_id": record["snapshot_id"], "snapshot_type": "diff"}
+    ]
+    assert _FakeSmolVM.restored_calls == [
+        {
+            "snapshot_id": record["snapshot_id"],
+            "backend": "qemu",
+            "resume_vm": True,
+            "ssh_key_path": "/tmp/id_ed25519",
+            "comm_channel": "vsock",
+        }
+    ]
+
+
+def test_run_benchmark_keeps_snapshot_lane_opt_in(monkeypatch) -> None:
+    calls: list[dict[str, Any]] = []
+
+    def _fake_group(**kwargs: Any) -> dict[str, Any]:
+        calls.append(kwargs)
+        return {kwargs["logger_prefix"]: {"summary": {}}}
+
+    monkeypatch.setattr(ubuntu_transport, "_images_release_tag", lambda: "images-test")
+    monkeypatch.setattr(ubuntu_transport, "_run_variant_group", _fake_group)
+
+    without_snapshot = ubuntu_transport.run_benchmark(
+        iterations=1,
+        warm_exec_runs=1,
+        rootfs_source="published",
+        variants=(("qemu", "vsock"),),
+    )
+    assert "snapshot_variants" not in without_snapshot
+    assert without_snapshot["selected_variants"] == ["qemu-vsock"]
+    assert [call["logger_prefix"] for call in calls] == ["fresh"]
+    assert calls[0]["variants"] == (("qemu", "vsock"),)
+
+    calls.clear()
+    with_snapshot = ubuntu_transport.run_benchmark(
+        iterations=1,
+        warm_exec_runs=1,
+        rootfs_source="published",
+        variants=(("qemu", "vsock"),),
+        include_snapshot=True,
+        snapshot_type="disk",
+    )
+    assert "snapshot_variants" in with_snapshot
+    assert [call["logger_prefix"] for call in calls] == ["fresh", "snapshot"]
+    assert calls[1]["variants"] == (("qemu", "vsock"),)
+    assert calls[1]["runner_extra"] == {"snapshot_choice": "disk"}
+
+
+def test_parse_variants_accepts_all_and_deduplicates_selected_variants() -> None:
+    assert ubuntu_transport._parse_variants("all") == ubuntu_transport.ALL_VARIANTS
+    assert ubuntu_transport._parse_variants("qemu-vsock, qemu-vsock,firecracker-vsock") == (
+        ("qemu", "vsock"),
+        ("firecracker", "vsock"),
+    )
+
+
+def test_parse_variants_rejects_unknown_variant() -> None:
+    try:
+        ubuntu_transport._parse_variants("qemu-bad")
+    except ValueError as exc:
+        assert "qemu-bad" in str(exc)
+        assert "qemu-vsock" in str(exc)
+    else:
+        raise AssertionError("expected invalid variant to fail")

--- a/tests/test_vm.py
+++ b/tests/test_vm.py
@@ -504,6 +504,22 @@ class TestSmolVMCreate:
 class TestSmolVMDiskLifecycle:
     """Tests for per-VM disk materialization and cleanup."""
 
+    @staticmethod
+    def _write_sparse_file(path: Path) -> None:
+        with path.open("wb") as file:
+            file.write(b"start")
+            file.seek(4 * 1024 * 1024)
+            file.write(b"end")
+
+    @staticmethod
+    def _assert_sparse_copy(source: Path, target: Path) -> None:
+        assert target.stat().st_size == source.stat().st_size
+        with target.open("rb") as file:
+            assert file.read(5) == b"start"
+            file.seek(4 * 1024 * 1024)
+            assert file.read(3) == b"end"
+        assert target.stat().st_blocks * 512 < target.stat().st_size
+
     def test_copy_with_reflink_preserves_sparse_holes(self, tmp_path: Path) -> None:
         """Raw isolated-disk copies should not inflate sparse rootfs holes."""
         source = tmp_path / "source.ext4"
@@ -520,6 +536,39 @@ class TestSmolVMDiskLifecycle:
             text=True,
             check=False,
         )
+
+    def test_copy_with_reflink_fallback_preserves_sparse_holes(self, tmp_path: Path) -> None:
+        """The non-GNU cp fallback should also avoid writing sparse zero ranges."""
+        source = tmp_path / "source.ext4"
+        target = tmp_path / "target.ext4"
+        self._write_sparse_file(source)
+
+        with (
+            patch("smolvm.vm.subprocess.run", return_value=SimpleNamespace(returncode=1)),
+            patch("smolvm.vm.shutil.copy2", side_effect=AssertionError("must stay sparse")),
+        ):
+            SmolVMManager._copy_with_reflink(source, target)
+
+        self._assert_sparse_copy(source, target)
+
+    @pytest.mark.asyncio
+    async def test_async_copy_with_reflink_fallback_preserves_sparse_holes(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        """Async disk materialization should use the same sparse fallback."""
+        source = tmp_path / "source.ext4"
+        target = tmp_path / "target.ext4"
+        self._write_sparse_file(source)
+        manager = SmolVMManager(data_dir=tmp_path / "data", socket_dir=tmp_path / "sockets")
+
+        with (
+            patch("smolvm.utils.async_run_command", side_effect=SmolVMError("cp failed")),
+            patch("smolvm.vm.shutil.copy2", side_effect=AssertionError("must stay sparse")),
+        ):
+            await manager._async_copy_with_reflink(source, target)
+
+        self._assert_sparse_copy(source, target)
 
     @patch("smolvm.vm.NetworkManager")
     def test_create_materializes_isolated_disk(

--- a/tests/test_vm.py
+++ b/tests/test_vm.py
@@ -504,6 +504,23 @@ class TestSmolVMCreate:
 class TestSmolVMDiskLifecycle:
     """Tests for per-VM disk materialization and cleanup."""
 
+    def test_copy_with_reflink_preserves_sparse_holes(self, tmp_path: Path) -> None:
+        """Raw isolated-disk copies should not inflate sparse rootfs holes."""
+        source = tmp_path / "source.ext4"
+        target = tmp_path / "target.ext4"
+        source.write_bytes(b"rootfs")
+
+        with patch("smolvm.vm.subprocess.run") as mock_run:
+            mock_run.return_value = SimpleNamespace(returncode=0)
+            SmolVMManager._copy_with_reflink(source, target)
+
+        mock_run.assert_called_once_with(
+            ["cp", "--reflink=auto", "--sparse=always", str(source), str(target)],
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+
     @patch("smolvm.vm.NetworkManager")
     def test_create_materializes_isolated_disk(
         self,

--- a/tests/test_vm_qemu.py
+++ b/tests/test_vm_qemu.py
@@ -19,7 +19,7 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
-from smolvm.exceptions import SmolVMError
+from smolvm.exceptions import NetworkError, SmolVMError, VMNotFoundError
 from smolvm.types import NetworkConfig, PortForwardConfig, VMConfig, VMInfo, VMState, VsockConfig
 from smolvm.vm import SmolVMManager
 
@@ -270,6 +270,65 @@ def test_create_qemu_preserves_requested_vsock_cid(tmp_path: Path) -> None:
         uds_path="/tmp/vm-qemu-vsock.sock",
     )
     assert sdk.state.get_vsock_cid("vm-qemu-vsock") == 42
+
+
+def test_create_qemu_auto_vsock_skips_live_qemu_cids(tmp_path: Path) -> None:
+    """Automatic QEMU vsock allocation should avoid CIDs already bound by QEMU."""
+    kernel = tmp_path / "vmlinux"
+    rootfs = tmp_path / "rootfs.ext4"
+    kernel.touch()
+    rootfs.touch()
+
+    config = VMConfig(
+        vm_id="vm-qemu-auto-vsock",
+        kernel_path=kernel,
+        rootfs_path=rootfs,
+        backend="qemu",
+        comm_channel="vsock",
+    )
+    sdk = SmolVMManager(data_dir=tmp_path / "data", socket_dir=tmp_path / "sockets", backend="qemu")
+
+    with (
+        patch("smolvm.comm.select.host_supports_vsock", return_value=True),
+        patch.object(SmolVMManager, "_live_qemu_vsock_cids", return_value={3, 4, 5}),
+        patch.object(SmolVMManager, "_create_qemu_overlay_disk") as mock_overlay,
+    ):
+        mock_overlay.side_effect = lambda source, target, **_kwargs: target.write_text("overlay")
+        vm_info = sdk.create(config)
+
+    assert vm_info.config.vsock == VsockConfig(guest_cid=6)
+    assert sdk.state.get_vsock_cid("vm-qemu-auto-vsock") == 6
+
+
+def test_create_qemu_explicit_vsock_cid_rejects_live_qemu_conflict(tmp_path: Path) -> None:
+    """Explicit QEMU CID conflicts should fail before QEMU exits at start time."""
+    kernel = tmp_path / "vmlinux"
+    rootfs = tmp_path / "rootfs.ext4"
+    kernel.touch()
+    rootfs.touch()
+
+    config = VMConfig(
+        vm_id="vm-qemu-vsock-conflict",
+        kernel_path=kernel,
+        rootfs_path=rootfs,
+        backend="qemu",
+        comm_channel="vsock",
+        vsock=VsockConfig(guest_cid=42),
+    )
+    sdk = SmolVMManager(data_dir=tmp_path / "data", socket_dir=tmp_path / "sockets", backend="qemu")
+
+    with (
+        patch("smolvm.comm.select.host_supports_vsock", return_value=True),
+        patch.object(SmolVMManager, "_live_qemu_vsock_cids", return_value={42}),
+        patch.object(SmolVMManager, "_create_qemu_overlay_disk") as mock_overlay,
+        pytest.raises(NetworkError, match="Vsock CID 42 is already in use"),
+    ):
+        mock_overlay.side_effect = lambda source, target, **_kwargs: target.write_text("overlay")
+        sdk.create(config)
+
+    assert sdk.state.get_vsock_cid("vm-qemu-vsock-conflict") is None
+    with pytest.raises(VMNotFoundError):
+        sdk.state.get_vm("vm-qemu-vsock-conflict")
 
 
 def test_create_qemu_reserves_vsock_even_when_control_channel_is_ssh(tmp_path: Path) -> None:

--- a/tests/test_vm_qemu.py
+++ b/tests/test_vm_qemu.py
@@ -342,11 +342,12 @@ def test_create_qemu_explicit_vsock_cid_rejects_live_qemu_conflict(tmp_path: Pat
         patch("smolvm.comm.select.host_supports_vsock", return_value=True),
         patch.object(SmolVMManager, "_live_qemu_vsock_cids", return_value={42}),
         patch.object(SmolVMManager, "_create_qemu_overlay_disk") as mock_overlay,
-        pytest.raises(NetworkError, match="Vsock CID 42 is already in use"),
+        pytest.raises(NetworkError, match="Vsock CID 42 is already in use") as exc_info,
     ):
         mock_overlay.side_effect = lambda source, target, **_kwargs: target.write_text("overlay")
         sdk.create(config)
 
+    assert "smolvm delete vm-qemu-vsock-conflict" in str(exc_info.value)
     assert sdk.state.get_vsock_cid("vm-qemu-vsock-conflict") is None
     with pytest.raises(VMNotFoundError):
         sdk.state.get_vm("vm-qemu-vsock-conflict")

--- a/tests/test_vm_qemu.py
+++ b/tests/test_vm_qemu.py
@@ -49,6 +49,27 @@ def _qemu_vm_info(tmp_path: Path) -> VMInfo:
     )
 
 
+def test_live_qemu_vsock_cids_reads_proc_cmdline_without_subprocess(tmp_path: Path) -> None:
+    """The live-CID guard should not spawn ``ps`` during VM create."""
+    proc = tmp_path / "proc"
+    proc.mkdir()
+    (proc / "1").mkdir()
+    (proc / "1" / "cmdline").write_bytes(
+        b"qemu-system-x86_64\0-device\0vhost-vsock-pci,guest-cid=7,id=vsock0\0"
+    )
+    (proc / "2").mkdir()
+    (proc / "2" / "cmdline").write_bytes(
+        b"qemu-system-aarch64\0-device\0vhost-vsock-device,guest-cid=8,id=vsock0\0"
+    )
+    (proc / "not-a-pid").mkdir()
+
+    with (
+        patch("smolvm.vm.platform.system", return_value="Linux"),
+        patch("smolvm.vm.subprocess.run", side_effect=AssertionError("must not spawn ps")),
+    ):
+        assert SmolVMManager._live_qemu_vsock_cids(proc) == {7, 8}
+
+
 def test_start_qemu_missing_binary_uses_linux_install_hint(tmp_path: Path) -> None:
     """Linux users should get a Linux package-manager hint, not Homebrew."""
     sdk = SmolVMManager(data_dir=tmp_path / "data", socket_dir=tmp_path / "sockets", backend="qemu")


### PR DESCRIPTION
## Summary
- preserve sparse zero ranges when decompressing published zstd rootfs assets
- make raw isolated-disk copies use cp --sparse=always alongside reflink auto
- version the decompressed-rootfs sidecar so existing fully allocated caches refresh once
- update the startup optimization plan and speed ledger with published images-2026.06.14.0 benchmarks

## Benchmark
Command:

```bash
uv run python scripts/benchmarks/ubuntu_transport.py \
  --iterations 3 \
  --warm-exec-runs 5 \
  --rootfs-source published \
  --output /tmp/smolvm-benchmarks/ubuntu-transport-published-sparse-2026-06-14.json \
  -v
```

Published Ubuntu medians after sparse cache refresh:

| Backend | Transport | Host create | Total ready | Total first command | Warm exec |
|---|---:|---:|---:|---:|---:|
| QEMU | SSH | 73.7 ms | 1751.6 ms | 1761.0 ms | 43.0 ms |
| QEMU | vsock | 80.6 ms | 1059.7 ms | 1061.4 ms | 0.8 ms |
| Firecracker | SSH | 310.0 ms | 1797.9 ms | 1850.7 ms | 43.0 ms |
| Firecracker | vsock | 200.5 ms | 1057.4 ms | 1058.5 ms | 1.0 ms |

Firecracker vsock improved from 1979.1 ms to 1057.4 ms total ready versus the first published images-2026.06.14.0 run because host_create_ms dropped from 1123.6 ms to 200.5 ms.

## Validation
- uv run pytest tests/test_published_images.py tests/test_vm.py::TestSmolVMDiskLifecycle -q
- uv run ruff check src/smolvm/images/published.py src/smolvm/vm.py tests/test_published_images.py tests/test_vm.py
- git diff --check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an opt-in snapshot lane to the Ubuntu transport benchmarking workflow, with selectable transport variants and separate snapshot-restore timing outputs.
  * Snapshot restoration now supports specifying a preferred communication channel when reconnecting.
* **Bug Fixes**
  * Improved sparse handling for published rootfs decompression and copy operations to reduce disk bloat and improve Firecracker startup.
  * Enhanced vsock reliability by cleaning stale host sockets and improving QEMU vsock-CID conflict detection.
* **Documentation**
  * Updated benchmark results and startup-time optimization guidance with corrected sparse-cache and snapshot measurement details.
* **Tests**
  * Expanded coverage for sparse preservation, published-image cache compatibility, and snapshot benchmark behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->