### PR TITLE
[codex] Bundle Ubuntu startup telemetry and create readiness fixes

### DIFF
--- a/docs/benchmarks/startup-speedups.md
+++ b/docs/benchmarks/startup-speedups.md
@@ -63,6 +63,30 @@ methodology.
 | Firecracker | vsock | ... | ... | ... | ... |
 ```
 
+## 2026-06-14 - PR TBD: Ubuntu Transport Boot Telemetry
+
+- Commit: current branch.
+- Image tag: `images-2026.06.14.0`.
+- Commands:
+  - `uv run python scripts/benchmarks/ubuntu_transport.py --iterations 1 --warm-exec-runs 1 --rootfs-source published --variants qemu-vsock --output /tmp/smolvm-ubuntu-boot-telemetry-probe.json -v`
+  - `uv run python scripts/benchmarks/ubuntu_transport.py --iterations 1 --warm-exec-runs 1 --rootfs-source published --variants qemu-ssh --output /tmp/smolvm-ubuntu-boot-telemetry-qemu-ssh.json -v`
+- Host: Linux x86_64, kernel `7.0.0-15-generic`, KVM available.
+- Method: one warm-up plus one measured smoke iteration per selected variant.
+- Behavior changed: benchmark methodology only; Ubuntu transport raw records now
+  include parsed guest boot telemetry from `SMOLVM_TS` runtime-log markers, and
+  each variant summary includes phase stats under `boot_telemetry_stats`.
+
+Smoke results:
+
+| Backend | Transport | Total ready | Notable guest phase |
+|---|---|---:|---|
+| QEMU | vsock | 1057.4 ms | Guest-agent marker present; VM tears down before later SSH markers. |
+| QEMU | SSH | 1452.3 ms | `ssh_hostkey_check_ms=290.0 ms`. |
+
+This section is not a speedup claim and is intentionally excluded from the
+summary timeline. It records the benchmark payload change that lets later PRs
+explain readiness variance by guest init phase.
+
 ## 2026-06-14 - PR #367: Startup Phase Telemetry And Early Guest-Agent Path
 
 - Commit: `85a7e0a`

--- a/docs/benchmarks/startup-speedups.md
+++ b/docs/benchmarks/startup-speedups.md
@@ -24,6 +24,8 @@ Primary target:
 | 2026-06-14 | #371 Firecracker explicit-vsock lazy network setup | Firecracker | vsock | 1195.3 ms | 1098.3 ms | -97.0 ms | 8.1% faster | Current-init local run, 3 measured iterations; published artifact was still `images-2026.06.12.0`. |
 | 2026-06-14 | #373 sparse published rootfs cache and raw disk copy | Firecracker | SSH | 2500.2 ms | 1797.9 ms | -702.3 ms | 28.1% faster | Published `images-2026.06.14.0`; avoids copying fully allocated zero regions during Firecracker disk materialization. |
 | 2026-06-14 | #373 sparse published rootfs cache and raw disk copy | Firecracker | vsock | 1979.1 ms | 1057.4 ms | -921.7 ms | 46.6% faster | Published `images-2026.06.14.0`; host create dropped from 1123.6 ms to 200.5 ms. |
+| 2026-06-14 | #374 Ubuntu transport telemetry and Ed25519 SSH host key | QEMU | SSH | 1455.6 ms | 1233.9 ms | -221.7 ms | 15.2% faster | Current-init local run; replaces `ssh-keygen -A` with one Ed25519 host key. |
+| 2026-06-14 | #374 Ubuntu transport telemetry and Ed25519 SSH host key | Firecracker | SSH | 1827.7 ms | 1576.5 ms | -251.2 ms | 13.7% faster | Current-init local run; SSH host-key phase median is now 10.0 ms. |
 
 ## Current Published Ubuntu Medians
 
@@ -63,29 +65,45 @@ methodology.
 | Firecracker | vsock | ... | ... | ... | ... |
 ```
 
-## 2026-06-14 - PR TBD: Ubuntu Transport Boot Telemetry
+## 2026-06-14 - PR #374: Ubuntu Transport Telemetry And Ed25519 Host Key
 
-- Commit: current branch.
+- Commit: current PR branch.
 - Image tag: `images-2026.06.14.0`.
 - Commands:
   - `uv run python scripts/benchmarks/ubuntu_transport.py --iterations 1 --warm-exec-runs 1 --rootfs-source published --variants qemu-vsock --output /tmp/smolvm-ubuntu-boot-telemetry-probe.json -v`
   - `uv run python scripts/benchmarks/ubuntu_transport.py --iterations 1 --warm-exec-runs 1 --rootfs-source published --variants qemu-ssh --output /tmp/smolvm-ubuntu-boot-telemetry-qemu-ssh.json -v`
+  - `uv run python scripts/benchmarks/ubuntu_transport.py --iterations 3 --warm-exec-runs 1 --rootfs-source current-init --variants all --output /tmp/smolvm-ubuntu-bundle-current-init.json -v`
 - Host: Linux x86_64, kernel `7.0.0-15-generic`, KVM available.
-- Method: one warm-up plus one measured smoke iteration per selected variant.
-- Behavior changed: benchmark methodology only; Ubuntu transport raw records now
-  include parsed guest boot telemetry from `SMOLVM_TS` runtime-log markers, and
-  each variant summary includes phase stats under `boot_telemetry_stats`.
+- Method: one warm-up VM per variant, then three measured current-init
+  iterations per variant for the bundled result.
+- Behavior changed: Ubuntu transport raw records now include parsed guest boot
+  telemetry from `SMOLVM_TS` runtime-log markers, each variant summary includes
+  phase stats under `boot_telemetry_stats`, summary stats include p90/p95, the
+  CLI prints a compact Markdown table, and `/init` generates only an Ed25519 SSH
+  host key instead of running `ssh-keygen -A`.
 
-Smoke results:
+Telemetry smoke results:
 
 | Backend | Transport | Total ready | Notable guest phase |
 |---|---|---:|---|
 | QEMU | vsock | 1057.4 ms | Guest-agent marker present; VM tears down before later SSH markers. |
 | QEMU | SSH | 1452.3 ms | `ssh_hostkey_check_ms=290.0 ms`. |
 
-This section is not a speedup claim and is intentionally excluded from the
-summary timeline. It records the benchmark payload change that lets later PRs
-explain readiness variance by guest init phase.
+Full current-init medians after Ed25519 host-key generation:
+
+| Backend | Transport | Host create | VMM start | Ready wait | Total ready | Total p95 | First command | Total first command | Warm exec | SSH host-key phase |
+|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|
+| QEMU | SSH | 67.7 ms | 52.7 ms | 1113.9 ms | 1233.9 ms | 1235.2 ms | 9.9 ms | 1243.8 ms | 43.2 ms | 10.0 ms |
+| QEMU | vsock | 74.5 ms | 53.2 ms | 924.7 ms | 1052.1 ms | 1071.5 ms | 1.2 ms | 1053.6 ms | 1.6 ms | 0.0 ms |
+| Firecracker | SSH | 305.4 ms | 120.6 ms | 1146.0 ms | 1576.5 ms | 1582.8 ms | 51.8 ms | 1628.3 ms | 42.4 ms | 10.0 ms |
+| Firecracker | vsock | 207.4 ms | 122.4 ms | 736.8 ms | 1066.2 ms | 1282.5 ms | 1.1 ms | 1067.3 ms | 0.9 ms | 210.0 ms |
+
+Notes:
+
+- The Firecracker-vsock SSH host-key phase is visible in the runtime log after
+  the guest agent is ready, but it is not on the vsock readiness critical path.
+- The published image still contains the old init until the next image release;
+  use the current-init numbers above as the implementation signal for this PR.
 
 ## 2026-06-14 - PR #367: Startup Phase Telemetry And Early Guest-Agent Path
 

--- a/docs/benchmarks/startup-speedups.md
+++ b/docs/benchmarks/startup-speedups.md
@@ -80,7 +80,9 @@ methodology.
   telemetry from `SMOLVM_TS` runtime-log markers, each variant summary includes
   phase stats under `boot_telemetry_stats`, summary stats include p90/p95, the
   CLI prints a compact Markdown table, and `/init` generates only an Ed25519 SSH
-  host key instead of running `ssh-keygen -A`.
+  host key instead of running `ssh-keygen -A`. The plain `smolvm create` command
+  now waits for the resolved control channel by default, so QEMU Ubuntu can use
+  the same vsock readiness path measured by this benchmark.
 
 Telemetry smoke results:
 

--- a/docs/deep-dive/microvm-from-first-principles.md
+++ b/docs/deep-dive/microvm-from-first-principles.md
@@ -137,7 +137,7 @@ They do six things, in order:
 1. mount /proc, /sys, /dev, /dev/pts, /run, /tmp
 2. parse ip=<guest>::<gw>:<netmask>:... from /proc/cmdline
 3. bring up lo + eth0, add address, add default route
-4. ssh-keygen -A   (generate host keys if missing)
+4. ssh-keygen -t ed25519   (generate a host key if missing)
 5. parse smolvm.authorized_key_b64=<base64> from /proc/cmdline
    → decode, write to /root/.ssh/authorized_keys mode 0600
 6. exec /usr/sbin/sshd -e

--- a/docs/deep-dive/startup-time-optimization-plan.md
+++ b/docs/deep-dive/startup-time-optimization-plan.md
@@ -73,6 +73,8 @@ Current status:
 - `scripts/benchmarks/ubuntu_transport.py` now attaches parsed `SMOLVM_TS`
   guest boot markers to each raw fresh-boot record and summarizes those phases
   under `boot_telemetry_stats`.
+- Ubuntu transport summaries now include p90/p95 tail latency and the CLI prints
+  a compact Markdown table for quick comparison after writing the JSON report.
 - Snapshot runs also keep separate source and restored-VM telemetry, so restore
   timing stays distinct from source fresh-boot timing.
 
@@ -106,6 +108,10 @@ Current status:
 - Published zstd rootfs decompression preserves sparse zero regions, and raw
   isolated-disk copies preserve those holes. This removes the accidental
   4 GiB copy from the Firecracker critical path on non-reflink filesystems.
+- The Ubuntu init path now generates one Ed25519 SSH host key when no host key
+  exists instead of running `ssh-keygen -A`. In the current-init benchmark this
+  moved QEMU SSH total ready from `1455.6 ms` to `1233.9 ms` and Firecracker SSH
+  total ready from `1827.7 ms` to `1576.5 ms`.
 
 Acceptance:
 

--- a/docs/deep-dive/startup-time-optimization-plan.md
+++ b/docs/deep-dive/startup-time-optimization-plan.md
@@ -68,6 +68,14 @@ Acceptance:
 - The speed ledger is updated in the same PR when behavior or methodology
   changes.
 
+Current status:
+
+- `scripts/benchmarks/ubuntu_transport.py` now attaches parsed `SMOLVM_TS`
+  guest boot markers to each raw fresh-boot record and summarizes those phases
+  under `boot_telemetry_stats`.
+- Snapshot runs also keep separate source and restored-VM telemetry, so restore
+  timing stays distinct from source fresh-boot timing.
+
 ### Phase 2: Explicit-vsock Fast Path
 
 For explicit vsock sandboxes, the guest-agent should become available before

--- a/docs/deep-dive/startup-time-optimization-plan.md
+++ b/docs/deep-dive/startup-time-optimization-plan.md
@@ -112,6 +112,10 @@ Current status:
   exists instead of running `ssh-keygen -A`. In the current-init benchmark this
   moved QEMU SSH total ready from `1455.6 ms` to `1233.9 ms` and Firecracker SSH
   total ready from `1827.7 ms` to `1576.5 ms`.
+- `smolvm create` now waits for the resolved control channel by default, so a
+  plain QEMU Ubuntu create can return when the vsock guest-agent is ready instead
+  of always waiting for SSH. Users can still force the old SSH-ready behavior
+  with `smolvm create --comm-channel ssh`.
 
 Acceptance:
 

--- a/scripts/benchmarks/README.md
+++ b/scripts/benchmarks/README.md
@@ -71,6 +71,12 @@ diff snapshots when the runtime can store them safely; QEMU may fall back to a
 full snapshot when the active disk has no backing file.
 Use `--variants qemu-vsock` or a comma-separated list such as
 `--variants qemu-vsock,firecracker-vsock` when you want a focused run.
+Each raw Ubuntu transport record includes `boot_telemetry` when the guest image
+emits `SMOLVM_TS` markers. The per-variant `summary` also includes
+`boot_telemetry_stats`, so readiness changes can be traced to guest phases such
+as guest-agent startup, network setup, SSH host-key checks, and sshd startup.
+Snapshot runs report the same data as `snapshot_source_boot_telemetry` and
+`snapshot_restore_boot_telemetry`.
 
 ## What each benchmark means
 

--- a/scripts/benchmarks/README.md
+++ b/scripts/benchmarks/README.md
@@ -77,6 +77,9 @@ emits `SMOLVM_TS` markers. The per-variant `summary` also includes
 as guest-agent startup, network setup, SSH host-key checks, and sshd startup.
 Snapshot runs report the same data as `snapshot_source_boot_telemetry` and
 `snapshot_restore_boot_telemetry`.
+The command also prints a compact Markdown table after writing JSON. Use it for
+quick inspection, and use the JSON when you need exact medians, p90/p95 tail
+latency, or per-iteration raw data.
 
 ## What each benchmark means
 

--- a/scripts/benchmarks/ubuntu_transport.py
+++ b/scripts/benchmarks/ubuntu_transport.py
@@ -42,11 +42,14 @@ from typing import Any, Literal
 
 _REPO_ROOT = Path(__file__).resolve().parent.parent.parent
 sys.path.insert(0, str(_REPO_ROOT / "src"))
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+from boot_telemetry import collect_boot_telemetry, summarize_boot_telemetry  # noqa: E402
 
 from smolvm.facade import SmolVM, _build_auto_config  # noqa: E402
 from smolvm.images.published import _images_release_tag  # noqa: E402
 from smolvm.types import SnapshotType  # noqa: E402
-from smolvm.vm import SmolVMManager  # noqa: E402
+from smolvm.vm import SmolVMManager, resolve_data_dir  # noqa: E402
 
 logger = logging.getLogger("smolvm.bench.ubuntu_transport")
 
@@ -99,6 +102,14 @@ def _safe_teardown(vm: SmolVM | None) -> None:
 def _safe_delete_snapshot(snapshot_id: str) -> None:
     with suppress(Exception), SmolVMManager() as sdk:
         sdk.delete_snapshot(snapshot_id)
+
+
+def _vm_log_path(vm: SmolVM | None) -> Path | None:
+    """Return the runtime log path for a benchmark VM."""
+    vm_id = getattr(vm, "_vm_id", None)
+    if not vm_id:
+        return None
+    return resolve_data_dir() / f"{vm_id}.log"
 
 
 def _current_init_path() -> Path:
@@ -181,6 +192,7 @@ def _run_one(
     vm_name = f"bench-{backend[:2]}-{transport[:2]}-{uuid.uuid4().hex[:8]}"
     record: dict[str, Any] = {"iter": iteration, "vm_id": vm_name, "warmup": warmup}
     vm: SmolVM | None = None
+    log_path: Path | None = None
     try:
         started = time.perf_counter()
         config, ssh_key_path, published_rootfs, patched_rootfs = _config_for_variant(
@@ -189,6 +201,7 @@ def _run_one(
             rootfs_source=rootfs_source,
         )
         vm = SmolVM(config=config, ssh_key_path=ssh_key_path, comm_channel=transport)
+        log_path = _vm_log_path(vm)
         record["host_create_ms"] = round((time.perf_counter() - started) * 1000, 1)
         record["create_ms"] = record["host_create_ms"]
         record["published_rootfs_path"] = str(published_rootfs)
@@ -239,7 +252,10 @@ def _run_one(
             1,
         )
     finally:
+        if log_path is None:
+            log_path = _vm_log_path(vm)
         _safe_teardown(vm)
+        record["boot_telemetry"] = collect_boot_telemetry(log_path)
     return record
 
 
@@ -257,7 +273,7 @@ def _summarize_fields(records: list[dict[str, Any]], fields: list[str]) -> dict[
 
 
 def _summarize(records: list[dict[str, Any]]) -> dict[str, Any]:
-    return _summarize_fields(
+    summary = _summarize_fields(
         records,
         [
             "host_create_ms",
@@ -274,6 +290,10 @@ def _summarize(records: list[dict[str, Any]]) -> dict[str, Any]:
             "total_ready_ms",
         ],
     )
+    boot_telemetry_stats = summarize_boot_telemetry(records, _stats)
+    if boot_telemetry_stats:
+        summary["boot_telemetry_stats"] = boot_telemetry_stats
+    return summary
 
 
 def _snapshot_type_for_choice(choice: SnapshotChoice) -> SnapshotType:
@@ -335,6 +355,8 @@ def _run_snapshot_one(
     }
     source_vm: SmolVM | None = None
     restored_vm: SmolVM | None = None
+    source_log_path: Path | None = None
+    restored_log_path: Path | None = None
     try:
         started = time.perf_counter()
         config, ssh_key_path, published_rootfs, patched_rootfs = _config_for_variant(
@@ -343,6 +365,7 @@ def _run_snapshot_one(
             rootfs_source=rootfs_source,
         )
         source_vm = SmolVM(config=config, ssh_key_path=ssh_key_path, comm_channel=transport)
+        source_log_path = _vm_log_path(source_vm)
         record["snapshot_source_host_create_ms"] = round(
             (time.perf_counter() - started) * 1000, 1
         )
@@ -390,6 +413,7 @@ def _run_snapshot_one(
             ssh_key_path=ssh_key_path,
             comm_channel=transport,
         )
+        restored_log_path = _vm_log_path(restored_vm)
         record["snapshot_restore_ms"] = round((time.perf_counter() - started) * 1000, 1)
 
         started = time.perf_counter()
@@ -428,14 +452,20 @@ def _run_snapshot_one(
                 float(uptime.stdout.split()[0]), 3
             )
     finally:
+        if source_log_path is None:
+            source_log_path = _vm_log_path(source_vm)
+        if restored_log_path is None:
+            restored_log_path = _vm_log_path(restored_vm)
         _safe_teardown(source_vm)
         _safe_teardown(restored_vm)
         _safe_delete_snapshot(snapshot_id)
+        record["snapshot_source_boot_telemetry"] = collect_boot_telemetry(source_log_path)
+        record["snapshot_restore_boot_telemetry"] = collect_boot_telemetry(restored_log_path)
     return record
 
 
 def _summarize_snapshot(records: list[dict[str, Any]]) -> dict[str, Any]:
-    return _summarize_fields(
+    summary = _summarize_fields(
         records,
         [
             "snapshot_source_host_create_ms",
@@ -451,6 +481,29 @@ def _summarize_snapshot(records: list[dict[str, Any]]) -> dict[str, Any]:
             "snapshot_warm_exec_median_ms",
             "snapshot_guest_uptime_after_ready_s",
         ],
+    )
+    source_telemetry_stats = _summarize_boot_telemetry_key(
+        records,
+        "snapshot_source_boot_telemetry",
+    )
+    if source_telemetry_stats:
+        summary["snapshot_source_boot_telemetry_stats"] = source_telemetry_stats
+    restore_telemetry_stats = _summarize_boot_telemetry_key(
+        records,
+        "snapshot_restore_boot_telemetry",
+    )
+    if restore_telemetry_stats:
+        summary["snapshot_restore_boot_telemetry_stats"] = restore_telemetry_stats
+    return summary
+
+
+def _summarize_boot_telemetry_key(
+    records: list[dict[str, Any]],
+    key: str,
+) -> dict[str, Any]:
+    return summarize_boot_telemetry(
+        [{"boot_telemetry": record.get(key)} for record in records],
+        _stats,
     )
 
 

--- a/scripts/benchmarks/ubuntu_transport.py
+++ b/scripts/benchmarks/ubuntu_transport.py
@@ -78,11 +78,34 @@ def _mean(values: list[float]) -> float | None:
     return round(sum(values) / len(values), 1)
 
 
+def _percentile(values: list[float], percentile: float) -> float | None:
+    if not values:
+        return None
+    ordered = sorted(values)
+    if len(ordered) == 1:
+        return round(ordered[0], 1)
+    position = (len(ordered) - 1) * percentile
+    lower = int(position)
+    upper = min(lower + 1, len(ordered) - 1)
+    weight = position - lower
+    return round(ordered[lower] * (1.0 - weight) + ordered[upper] * weight, 1)
+
+
 def _stats(values: list[float]) -> dict[str, Any]:
     if not values:
-        return {"median": None, "mean": None, "min": None, "max": None, "count": 0}
+        return {
+            "median": None,
+            "p90": None,
+            "p95": None,
+            "mean": None,
+            "min": None,
+            "max": None,
+            "count": 0,
+        }
     return {
         "median": _median(values),
+        "p90": _percentile(values, 0.90),
+        "p95": _percentile(values, 0.95),
         "mean": _mean(values),
         "min": round(min(values), 1),
         "max": round(max(values), 1),
@@ -331,6 +354,68 @@ def _parse_variants(raw: str) -> tuple[Variant, ...]:
             "Run: uv run python scripts/benchmarks/ubuntu_transport.py --variants qemu-vsock"
         )
     return tuple(selected)
+
+
+def _format_ms(value: Any) -> str:
+    if isinstance(value, int | float) and not isinstance(value, bool):
+        return f"{value:.1f} ms"
+    return "-"
+
+
+def _summary_metric(summary: dict[str, Any], metric: str, stat: str = "median") -> Any:
+    value = summary.get(metric)
+    if not isinstance(value, dict):
+        return None
+    return value.get(stat)
+
+
+def _phase_summary(summary: dict[str, Any]) -> str:
+    phase_stats = summary.get("boot_telemetry_stats", {}).get("guest_init_phases_ms", {})
+    if not isinstance(phase_stats, dict):
+        return "-"
+
+    ranked: list[tuple[str, float]] = []
+    for phase_name, stats in phase_stats.items():
+        if not isinstance(stats, dict):
+            continue
+        value = stats.get("median")
+        if isinstance(value, int | float) and not isinstance(value, bool):
+            ranked.append((phase_name, float(value)))
+    if not ranked:
+        return "-"
+
+    ranked.sort(key=lambda item: item[1], reverse=True)
+    return ", ".join(f"{name}={value:.1f} ms" for name, value in ranked[:3])
+
+
+def _format_variant_summary_table(report: dict[str, Any]) -> str:
+    rows = [
+        "| Backend | Transport | Total ready p50 | Total ready p95 | "
+        "First command p50 | Warm exec p50 | Top guest phases |",
+        "|---|---|---:|---:|---:|---:|---|",
+    ]
+    variants = report.get("variants", {})
+    if not isinstance(variants, dict):
+        return "\n".join(rows)
+
+    for key in sorted(variants):
+        variant = variants[key]
+        if not isinstance(variant, dict):
+            continue
+        summary = variant.get("summary", {})
+        if not isinstance(summary, dict):
+            continue
+        rows.append(
+            "| "
+            f"{variant.get('backend', '-')} | "
+            f"{variant.get('transport', '-')} | "
+            f"{_format_ms(_summary_metric(summary, 'total_fresh_ready_ms'))} | "
+            f"{_format_ms(_summary_metric(summary, 'total_fresh_ready_ms', 'p95'))} | "
+            f"{_format_ms(_summary_metric(summary, 'first_command_ms'))} | "
+            f"{_format_ms(_summary_metric(summary, 'warm_exec_median_ms'))} | "
+            f"{_phase_summary(summary)} |"
+        )
+    return "\n".join(rows)
 
 
 def _run_snapshot_one(
@@ -672,6 +757,7 @@ def main() -> None:
         print(payload)
     else:
         print(f"Wrote {args.output}")
+        print(_format_variant_summary_table(report))
 
 
 if __name__ == "__main__":

--- a/scripts/ci/Dockerfile.base-alpine-rootfs
+++ b/scripts/ci/Dockerfile.base-alpine-rootfs
@@ -54,7 +54,7 @@ RUN curl -LsSf https://astral.sh/uv/install.sh | sh \
 
 # ── SSH hardening ───────────────────────────────────────────────
 # Host keys generated at first boot via /init (preset-init.sh runs
-# ``ssh-keygen -A`` if no host keys are present).
+# ``ssh-keygen -t ed25519`` if no host keys are present).
 RUN rm -f /etc/ssh/ssh_host_* \
     && mkdir -p /run/sshd /root/.ssh \
     && chmod 700 /root/.ssh \

--- a/scripts/ci/preset-init.sh
+++ b/scripts/ci/preset-init.sh
@@ -10,7 +10,7 @@
 #   1. mounts the essential virtual filesystems
 #   2. starts the vsock guest-agent control plane
 #   3. brings up loopback + eth0 (DHCP-style static IP from kernel cmdline)
-#   4. generates SSH host keys on first boot
+#   4. generates a lightweight SSH host key on first boot
 #   5. injects the launching user's pubkey from the kernel cmdline param
 #      smolvm.authorized_key_b64=<base64> (matches openclaw's mechanism)
 #   6. starts sshd
@@ -149,7 +149,7 @@ log_ts "net-ready"
 # ── SSH host keys ────────────────────────────────────────────
 log_ts "ssh-hostkey-check-start"
 if ! ls /etc/ssh/ssh_host_*_key >/dev/null 2>&1; then
-    ssh-keygen -A 2>/dev/null
+    ssh-keygen -t ed25519 -f /etc/ssh/ssh_host_ed25519_key -N "" -q 2>/dev/null
 fi
 log_ts "ssh-hostkey-check-done"
 

--- a/src/smolvm/cli/main.py
+++ b/src/smolvm/cli/main.py
@@ -24,11 +24,11 @@ import platform
 import re
 import subprocess
 import sys
-from collections.abc import Sequence
+from collections.abc import Callable, Sequence
 from contextlib import suppress
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import TYPE_CHECKING, TypedDict
+from typing import TYPE_CHECKING, Any, TypedDict
 
 from rich.panel import Panel
 from rich.progress import (
@@ -806,6 +806,7 @@ def build_parser() -> argparse.ArgumentParser:
         default=None,
         help="Virtualization backend (default: auto-detected).",
     )
+    _add_comm_channel_arg(create_parser)
     create_parser.add_argument(
         "--json",
         action="store_true",
@@ -1842,18 +1843,18 @@ def _build_and_boot_with_progress(
     console: object,
     build_fn: object,
     boot_timeout: int,
+    comm_channel: str | None = None,
+    wait_for_control_channel: bool = False,
     mounts: list[str] | None = None,
     writable_mounts: bool = False,
 ) -> object:
     """Build a VM config and boot it, showing a Rich progress bar.
 
     Displays per-file download progress when the OS image is not cached,
-    then switches to a spinner while the VM boots and SSH becomes available.
+    then switches to a spinner while the VM boots and the requested readiness
+    check completes.
     Returns a started :class:`~smolvm.facade.SmolVM` instance.
     """
-    from collections.abc import Callable
-    from typing import Any
-
     from rich.console import Console
 
     from smolvm.facade import SmolVM
@@ -1882,8 +1883,8 @@ def _build_and_boot_with_progress(
         config, ssh_key_path = _build_fn(on_download)
 
         # One task that re-labels as the boot pipeline progresses
-        # (boot → ssh-ready → workspace mount when --mount is set).
-        # Phases come from start()/wait_for_ssh() via on_progress, so the
+        # (boot → ready → workspace mount when --mount is set).
+        # Phases come from start() and the selected readiness wait, so the
         # spinner reflects what's actually slow rather than parking on
         # "Starting VM..." for the full duration.
         boot_task = progress.add_task("Booting sandbox...", total=None)
@@ -1891,20 +1892,41 @@ def _build_and_boot_with_progress(
         def on_phase(phase: str) -> None:
             progress.update(boot_task, description=phase)
 
-        vm = SmolVM(
-            config,
-            ssh_key_path=ssh_key_path,
-            mounts=mounts,
-            writable_mounts=writable_mounts,
-        )
+        vm_kwargs: dict[str, Any] = {
+            "ssh_key_path": ssh_key_path,
+            "mounts": mounts,
+            "writable_mounts": writable_mounts,
+        }
+        if comm_channel is not None:
+            vm_kwargs["comm_channel"] = comm_channel
+        vm = SmolVM(config, **vm_kwargs)
         vm.start(boot_timeout=boot_timeout, on_progress=on_phase)
-        # Idempotent: a no-op when start() already waited (mounts/env_vars
-        # path), and the on_progress flips the label only when a real wait
-        # actually happens.
-        vm.wait_for_ssh(timeout=boot_timeout, on_progress=on_phase)
+        if wait_for_control_channel:
+            _wait_after_create(
+                vm,
+                comm_channel=comm_channel,
+                boot_timeout=boot_timeout,
+                on_progress=on_phase,
+            )
+        else:
+            vm.wait_for_ssh(timeout=boot_timeout, on_progress=on_phase)
         progress.remove_task(boot_task)
 
     return vm
+
+
+def _wait_after_create(
+    vm: Any,
+    *,
+    comm_channel: str | None,
+    boot_timeout: float,
+    on_progress: Callable[[str], None] | None = None,
+) -> None:
+    """Wait for the channel promised by ``smolvm create``."""
+    if comm_channel == "ssh":
+        vm.wait_for_ssh(timeout=boot_timeout, on_progress=on_progress)
+        return
+    vm.wait_for_ready(timeout=boot_timeout, on_progress=on_progress)
 
 
 def _run_create(args: argparse.Namespace) -> int:
@@ -1994,6 +2016,8 @@ def _run_create(args: argparse.Namespace) -> int:
                         vm_name=args.name,
                     ),
                     boot_timeout=args.boot_timeout,
+                    comm_channel=args.comm_channel,
+                    wait_for_control_channel=True,
                     mounts=args.mounts,
                     writable_mounts=args.writable_mounts,
                 )
@@ -2006,14 +2030,20 @@ def _run_create(args: argparse.Namespace) -> int:
                     ssh_key_path=None,
                     vm_name=args.name,
                 )
-                vm = SmolVM(
-                    config,
-                    ssh_key_path=ssh_key_path,
-                    mounts=args.mounts,
-                    writable_mounts=args.writable_mounts,
-                )
+                vm_kwargs: dict[str, Any] = {
+                    "ssh_key_path": ssh_key_path,
+                    "mounts": args.mounts,
+                    "writable_mounts": args.writable_mounts,
+                }
+                if args.comm_channel is not None:
+                    vm_kwargs["comm_channel"] = args.comm_channel
+                vm = SmolVM(config, **vm_kwargs)
                 vm.start(boot_timeout=args.boot_timeout)
-                vm.wait_for_ssh(timeout=args.boot_timeout)
+                _wait_after_create(
+                    vm,
+                    comm_channel=args.comm_channel,
+                    boot_timeout=args.boot_timeout,
+                )
         elif use_s3_image:
             # S3 image path
             if not args.json:
@@ -2029,6 +2059,8 @@ def _run_create(args: argparse.Namespace) -> int:
                         on_download=on_download,
                     ),
                     boot_timeout=args.boot_timeout,
+                    comm_channel=args.comm_channel,
+                    wait_for_control_channel=True,
                     mounts=args.mounts,
                     writable_mounts=args.writable_mounts,
                 )
@@ -2040,14 +2072,20 @@ def _run_create(args: argparse.Namespace) -> int:
                     memory=args.memory_mib,
                     ssh_key_path=None,
                 )
-                vm = SmolVM(
-                    config,
-                    ssh_key_path=ssh_key_path,
-                    mounts=args.mounts,
-                    writable_mounts=args.writable_mounts,
-                )
+                vm_kwargs = {
+                    "ssh_key_path": ssh_key_path,
+                    "mounts": args.mounts,
+                    "writable_mounts": args.writable_mounts,
+                }
+                if args.comm_channel is not None:
+                    vm_kwargs["comm_channel"] = args.comm_channel
+                vm = SmolVM(config, **vm_kwargs)
                 vm.start(boot_timeout=args.boot_timeout)
-                vm.wait_for_ssh(timeout=args.boot_timeout)
+                _wait_after_create(
+                    vm,
+                    comm_channel=args.comm_channel,
+                    boot_timeout=args.boot_timeout,
+                )
         else:
             # Standard auto-config path
             if not args.json:
@@ -2064,6 +2102,8 @@ def _run_create(args: argparse.Namespace) -> int:
                         on_download=on_download,
                     ),
                     boot_timeout=args.boot_timeout,
+                    comm_channel=args.comm_channel,
+                    wait_for_control_channel=True,
                     mounts=args.mounts,
                     writable_mounts=args.writable_mounts,
                 )
@@ -2076,14 +2116,20 @@ def _run_create(args: argparse.Namespace) -> int:
                     disk_size_mib=args.disk_size_mib,
                     ssh_key_path=None,
                 )
-                vm = SmolVM(
-                    config,
-                    ssh_key_path=ssh_key_path,
-                    mounts=args.mounts,
-                    writable_mounts=args.writable_mounts,
-                )
+                vm_kwargs = {
+                    "ssh_key_path": ssh_key_path,
+                    "mounts": args.mounts,
+                    "writable_mounts": args.writable_mounts,
+                }
+                if args.comm_channel is not None:
+                    vm_kwargs["comm_channel"] = args.comm_channel
+                vm = SmolVM(config, **vm_kwargs)
                 vm.start(boot_timeout=args.boot_timeout)
-                vm.wait_for_ssh(timeout=args.boot_timeout)
+                _wait_after_create(
+                    vm,
+                    comm_channel=args.comm_channel,
+                    boot_timeout=args.boot_timeout,
+                )
 
         os_label = "s3-image" if use_s3_image else resolved_guest_os.value
         data: CreatePayload = {
@@ -3264,8 +3310,9 @@ def _run_ssh(args: argparse.Namespace) -> int:
                 "before attaching."
             )
         else:
-            # VM is already running — connect directly without probing.
-            completed = subprocess.run(vm._ssh_direct_command(), check=False)
+            with console.status("Waiting for SSH...", spinner="dots"):
+                vm.wait_for_ssh(timeout=args.boot_timeout)
+            completed = subprocess.run(vm._ssh_attach_command(), check=False)
             if completed.returncode != 0:
                 _hint_if_vm_crashed(vm)
             return completed.returncode

--- a/src/smolvm/images/builder.py
+++ b/src/smolvm/images/builder.py
@@ -1507,8 +1507,8 @@ fi
 # ── SSH ──────────────────────────────────────────────────────
 log_ts "ssh-hostkey-check-start"
 if ! ls /etc/ssh/ssh_host_*_key >/dev/null 2>&1; then
-    echo "SmolVM init: SSH host keys missing; generating..."
-    ssh-keygen -A 2>/dev/null
+    echo "SmolVM init: SSH host keys missing; generating Ed25519 key..."
+    ssh-keygen -t ed25519 -f /etc/ssh/ssh_host_ed25519_key -N "" -q 2>/dev/null
 fi
 log_ts "ssh-hostkey-check-done"
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -651,7 +651,8 @@ class TestCliCreate:
             writable_mounts=False,
         )
         vm.start.assert_called_once_with(boot_timeout=30.0, on_progress=ANY)
-        vm.wait_for_ssh.assert_called_once_with(timeout=30.0, on_progress=ANY)
+        vm.wait_for_ready.assert_called_once_with(timeout=30.0, on_progress=ANY)
+        vm.wait_for_ssh.assert_not_called()
         vm.close.assert_called_once()
         out = capsys.readouterr().out
         assert "Created VM 'vm-a1b2c3d4'." in out
@@ -721,7 +722,8 @@ class TestCliCreate:
             writable_mounts=False,
         )
         vm.start.assert_called_once_with(boot_timeout=45.0, on_progress=ANY)
-        vm.wait_for_ssh.assert_called_once_with(timeout=45.0, on_progress=ANY)
+        vm.wait_for_ready.assert_called_once_with(timeout=45.0, on_progress=ANY)
+        vm.wait_for_ssh.assert_not_called()
         vm.stop.assert_not_called()
         vm.delete.assert_not_called()
         vm.close.assert_called_once()
@@ -735,6 +737,43 @@ class TestCliCreate:
         assert "Backend" not in out
         assert "172.16.0.2" not in out
         assert "2200" not in out
+
+    @patch("smolvm.facade._build_auto_config")
+    @patch("smolvm.facade.SmolVM")
+    @patch("smolvm.runtime.backends.platform.system", return_value="Darwin")
+    def test_create_explicit_ssh_waits_for_ssh(
+        self,
+        _: MagicMock,
+        mock_vm_cls: MagicMock,
+        mock_build_auto_config: MagicMock,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """`smolvm create --comm-channel ssh` preserves the SSH-ready contract."""
+        monkeypatch.delenv("SMOLVM_BACKEND", raising=False)
+        config = MagicMock(vm_id="project-spacex")
+        mock_build_auto_config.return_value = (config, "/tmp/id_ed25519")
+
+        vm = MagicMock()
+        vm.vm_id = "project-spacex"
+        vm.info.config.backend = "qemu"
+        vm.info.network = MagicMock(spec=NetworkConfig)
+        vm.info.network.guest_ip = "172.16.0.2"
+        vm.info.network.ssh_host_port = 2200
+        mock_vm_cls.return_value = vm
+
+        ret = main(["create", "--name", "project-spacex", "--comm-channel", "ssh"])
+
+        assert ret == 0
+        mock_vm_cls.assert_called_once_with(
+            config,
+            ssh_key_path="/tmp/id_ed25519",
+            comm_channel="ssh",
+            mounts=None,
+            writable_mounts=False,
+        )
+        vm.start.assert_called_once_with(boot_timeout=30.0, on_progress=ANY)
+        vm.wait_for_ssh.assert_called_once_with(timeout=30.0, on_progress=ANY)
+        vm.wait_for_ready.assert_not_called()
 
     @patch("smolvm.facade._build_auto_config")
     @patch("smolvm.facade.SmolVM")
@@ -778,7 +817,8 @@ class TestCliCreate:
             writable_mounts=False,
         )
         vm.start.assert_called_once_with(boot_timeout=30.0, on_progress=ANY)
-        vm.wait_for_ssh.assert_called_once_with(timeout=30.0, on_progress=ANY)
+        vm.wait_for_ready.assert_called_once_with(timeout=30.0, on_progress=ANY)
+        vm.wait_for_ssh.assert_not_called()
         vm.close.assert_called_once()
 
     @patch("smolvm.facade._build_auto_config")
@@ -916,7 +956,8 @@ class TestCliCreate:
             ssh_key_path=None,
         )
         vm.start.assert_called_once_with(boot_timeout=30.0)
-        vm.wait_for_ssh.assert_called_once_with(timeout=30.0)
+        vm.wait_for_ready.assert_called_once_with(timeout=30.0, on_progress=None)
+        vm.wait_for_ssh.assert_not_called()
         vm.close.assert_called_once()
 
     @patch("smolvm.facade._build_auto_config")
@@ -1619,7 +1660,7 @@ class TestCliSSH:
         """`smolvm ssh` should attach to a running VM without restarting it."""
         vm = MagicMock()
         vm.status = VMState.RUNNING
-        vm._ssh_direct_command.return_value = [
+        vm._ssh_attach_command.return_value = [
             "ssh",
             "-o",
             "StrictHostKeyChecking=no",
@@ -1654,9 +1695,9 @@ class TestCliSSH:
             ssh_key_path="/custom/key",
         )
         vm.start.assert_not_called()
-        vm.wait_for_ssh.assert_not_called()
-        vm._ssh_direct_command.assert_called_once_with()
-        mock_run.assert_called_once_with(vm._ssh_direct_command.return_value, check=False)
+        vm.wait_for_ssh.assert_called_once_with(timeout=15.0)
+        vm._ssh_attach_command.assert_called_once_with()
+        mock_run.assert_called_once_with(vm._ssh_attach_command.return_value, check=False)
         vm.close.assert_called_once()
 
     @pytest.mark.parametrize("status", [VMState.CREATED, VMState.STOPPED])

--- a/tests/test_guest_agent_image.py
+++ b/tests/test_guest_agent_image.py
@@ -42,7 +42,7 @@ def _assert_guest_agent_starts_before_network_and_ssh(script: str) -> None:
         else script.index("hostname smolvm")
     )
     assert agent_start < network_ready
-    assert agent_start < script.index("ssh-keygen -A")
+    assert agent_start < script.index("ssh-keygen -t ed25519")
     assert agent_start < script.index("/usr/sbin/sshd")
 
 
@@ -108,6 +108,8 @@ def test_ci_preset_init_launches_guest_agent_before_sshd() -> None:
     script = (_REPO_ROOT / "scripts" / "ci" / "preset-init.sh").read_text()
     assert "/usr/local/bin/smolvm-guest-agent --listen vsock://1024" in script
     assert "python3 /usr/local/bin/smolvm-guest-agent" not in script
+    assert "ssh-keygen -A" not in script
+    assert "ssh-keygen -t ed25519" in script
     _assert_guest_agent_starts_before_network_and_ssh(script)
     _assert_startup_timestamp_markers(script)
 
@@ -178,6 +180,8 @@ def test_base_init_script_launches_guest_agent_before_sshd() -> None:
     script = ImageBuilder()._default_init_script()
     assert "/usr/local/bin/smolvm-guest-agent --listen vsock://1024" in script
     assert "python3 /usr/local/bin/smolvm-guest-agent" not in script
+    assert "ssh-keygen -A" not in script
+    assert "ssh-keygen -t ed25519" in script
     # The agent must start before sshd so the channel is up independent of it.
     _assert_guest_agent_starts_before_network_and_ssh(script)
     _assert_startup_timestamp_markers(script)

--- a/tests/test_ubuntu_transport_benchmark.py
+++ b/tests/test_ubuntu_transport_benchmark.py
@@ -82,11 +82,25 @@ class _FakeSmolVM:
         pass
 
 
-def test_snapshot_benchmark_restores_with_selected_transport(monkeypatch) -> None:
-    _FakeSmolVM.restored_calls = []
-    _FakeSmolVM.snapshots = []
-    deleted_snapshots: list[str] = []
+def _sample_log() -> str:
+    return """
+SMOLVM_TS stage=init-start epoch_s=1781280000 uptime_s=0.10
+SMOLVM_TS stage=guest-agent-start epoch_s=1781280000 uptime_s=0.20
+SMOLVM_TS stage=guest-agent-started epoch_s=1781280000 uptime_s=0.24
+SMOLVM_TS stage=net-config-start epoch_s=1781280000 uptime_s=0.30
+SMOLVM_TS stage=net-ready epoch_s=1781280000 uptime_s=0.40
+SMOLVM_TS stage=ssh-hostkey-check-start epoch_s=1781280000 uptime_s=0.42
+SMOLVM_TS stage=ssh-hostkey-check-done epoch_s=1781280000 uptime_s=0.62
+SMOLVM_TS stage=sshd-start epoch_s=1781280000 uptime_s=0.64
+SMOLVM_TS stage=sshd-invoked epoch_s=1781280000 uptime_s=0.72
+SMOLVM_TS stage=init-complete epoch_s=1781280000 uptime_s=0.74
+"""
+
+
+def test_fresh_benchmark_attaches_boot_telemetry(monkeypatch, tmp_path: Path) -> None:
     config = _FakeConfig(vm_id="bench-fake", rootfs_path=Path("/tmp/rootfs.ext4"))
+    log_path = tmp_path / "bench-fake.log"
+    log_path.write_text(_sample_log())
 
     monkeypatch.setattr(ubuntu_transport, "SmolVM", _FakeSmolVM)
     monkeypatch.setattr(
@@ -95,6 +109,49 @@ def test_snapshot_benchmark_restores_with_selected_transport(monkeypatch) -> Non
         lambda *_args, **_kwargs: (config, "/tmp/id_ed25519", Path("/tmp/rootfs.ext4"), None),
     )
     monkeypatch.setattr(ubuntu_transport, "_safe_teardown", lambda _vm: None)
+    monkeypatch.setattr(ubuntu_transport, "_vm_log_path", lambda _vm: log_path)
+
+    record = ubuntu_transport._run_one(
+        "qemu",
+        "ssh",
+        0,
+        rootfs_source="published",
+        warm_exec_runs=1,
+    )
+    summary = ubuntu_transport._summarize([record])
+
+    assert record["boot_telemetry"]["guest_init_phases_ms"]["ssh_hostkey_check_ms"] == 200.0
+    assert (
+        summary["boot_telemetry_stats"]["guest_init_phases_ms"]["ssh_hostkey_check_ms"][
+            "median"
+        ]
+        == 200.0
+    )
+
+
+def test_snapshot_benchmark_restores_with_selected_transport(monkeypatch, tmp_path: Path) -> None:
+    _FakeSmolVM.restored_calls = []
+    _FakeSmolVM.snapshots = []
+    deleted_snapshots: list[str] = []
+    config = _FakeConfig(vm_id="bench-fake", rootfs_path=Path("/tmp/rootfs.ext4"))
+    source_log = tmp_path / "bench-fake.log"
+    restored_log = tmp_path / "restored.log"
+    source_log.write_text(_sample_log())
+    restored_log.write_text(_sample_log())
+    logs = {"bench-fake": source_log, "restored": restored_log}
+
+    monkeypatch.setattr(ubuntu_transport, "SmolVM", _FakeSmolVM)
+    monkeypatch.setattr(
+        ubuntu_transport,
+        "_config_for_variant",
+        lambda *_args, **_kwargs: (config, "/tmp/id_ed25519", Path("/tmp/rootfs.ext4"), None),
+    )
+    monkeypatch.setattr(ubuntu_transport, "_safe_teardown", lambda _vm: None)
+    monkeypatch.setattr(
+        ubuntu_transport,
+        "_vm_log_path",
+        lambda vm: logs[vm._vm_id],
+    )
     monkeypatch.setattr(
         ubuntu_transport,
         "_safe_delete_snapshot",
@@ -113,6 +170,31 @@ def test_snapshot_benchmark_restores_with_selected_transport(monkeypatch) -> Non
     assert record["snapshot_type"] == "diff"
     assert record["source_control_kind"] == "vsock"
     assert record["restore_control_kind"] == "vsock"
+    assert (
+        record["snapshot_source_boot_telemetry"]["guest_init_phases_ms"][
+            "ssh_hostkey_check_ms"
+        ]
+        == 200.0
+    )
+    assert (
+        record["snapshot_restore_boot_telemetry"]["guest_init_phases_ms"][
+            "ssh_hostkey_check_ms"
+        ]
+        == 200.0
+    )
+    summary = ubuntu_transport._summarize_snapshot([record])
+    assert (
+        summary["snapshot_source_boot_telemetry_stats"]["guest_init_phases_ms"][
+            "ssh_hostkey_check_ms"
+        ]["median"]
+        == 200.0
+    )
+    assert (
+        summary["snapshot_restore_boot_telemetry_stats"]["guest_init_phases_ms"][
+            "ssh_hostkey_check_ms"
+        ]["median"]
+        == 200.0
+    )
     assert record["snapshot_restore_to_first_command_ms"] >= record["snapshot_restore_ms"]
     assert len(record["snapshot_warm_exec_ms"]) == 2
     assert deleted_snapshots == [record["snapshot_id"]]

--- a/tests/test_ubuntu_transport_benchmark.py
+++ b/tests/test_ubuntu_transport_benchmark.py
@@ -256,6 +256,41 @@ def test_parse_variants_accepts_all_and_deduplicates_selected_variants() -> None
     )
 
 
+def test_stats_include_tail_percentiles() -> None:
+    stats = ubuntu_transport._stats([100.0, 200.0, 300.0])
+
+    assert stats["median"] == 200.0
+    assert stats["p90"] == 280.0
+    assert stats["p95"] == 290.0
+
+
+def test_format_variant_summary_table_includes_ready_and_guest_phases() -> None:
+    report = {
+        "variants": {
+            "qemu-ssh": {
+                "backend": "qemu",
+                "transport": "ssh",
+                "summary": {
+                    "total_fresh_ready_ms": {"median": 1450.0, "p95": 1700.0},
+                    "first_command_ms": {"median": 9.5},
+                    "warm_exec_median_ms": {"median": 42.0},
+                    "boot_telemetry_stats": {
+                        "guest_init_phases_ms": {
+                            "ssh_hostkey_check_ms": {"median": 290.0},
+                            "network_config_ms": {"median": 10.0},
+                        }
+                    },
+                },
+            }
+        }
+    }
+
+    table = ubuntu_transport._format_variant_summary_table(report)
+
+    assert "| qemu | ssh | 1450.0 ms | 1700.0 ms | 9.5 ms | 42.0 ms |" in table
+    assert "ssh_hostkey_check_ms=290.0 ms" in table
+
+
 def test_parse_variants_rejects_unknown_variant() -> None:
     try:
         ubuntu_transport._parse_variants("qemu-bad")


### PR DESCRIPTION
## Summary

- add parsed `SMOLVM_TS` boot telemetry to `scripts/benchmarks/ubuntu_transport.py` raw records
- summarize guest init phase timings under `boot_telemetry_stats` for fresh runs and separate source/restore telemetry for snapshot runs
- add p90/p95 stats and print a compact Markdown summary table after benchmark runs
- replace first-boot `ssh-keygen -A` with one Ed25519 host key in both published-image init paths
- make plain `smolvm create` wait for the resolved control channel by default instead of always waiting for SSH
- add `smolvm create --comm-channel {ssh,vsock}` so users can force the transport when needed
- keep preset starts SSH-backed because they still need SSH for setup and credential transfer
- update startup docs and benchmark ledger with current-init results and the CLI readiness fix

## Why

The Ubuntu transport benchmark already showed host create, VMM launch, readiness wait, first command, and warm exec timing. It did not explain why readiness changed inside the guest. This PR adds the guest `/init` marker breakdown and uses it to remove the measured SSH host-key delay.

It also fixes a CLI mismatch: the host control path can now use vsock, but `smolvm create --backend qemu` still called `wait_for_ssh()`. Plain create now uses `wait_for_ready()`, so QEMU Ubuntu can return when the Rust guest-agent is ready. Explicit `--comm-channel ssh` keeps the old SSH-ready behavior.

## Benchmark result

Current-init benchmark command:

```bash
uv run python scripts/benchmarks/ubuntu_transport.py --iterations 3 --warm-exec-runs 1 --rootfs-source current-init --variants all --output /tmp/smolvm-ubuntu-bundle-current-init.json -v
```

Medians:

| Backend | Transport | Total ready | Total p95 | First command | Warm exec | SSH host-key phase |
|---|---|---:|---:|---:|---:|---:|
| QEMU | SSH | 1233.9 ms | 1235.2 ms | 9.9 ms | 43.2 ms | 10.0 ms |
| QEMU | vsock | 1052.1 ms | 1071.5 ms | 1.2 ms | 1.6 ms | 0.0 ms |
| Firecracker | SSH | 1576.5 ms | 1582.8 ms | 51.8 ms | 42.4 ms | 10.0 ms |
| Firecracker | vsock | 1066.2 ms | 1282.5 ms | 1.1 ms | 0.9 ms | 210.0 ms |

The Firecracker-vsock SSH host-key phase appears in the runtime log after the guest agent is already ready, so it is not on the vsock readiness critical path.

## Validation

- `uv run pytest tests/test_ubuntu_transport_benchmark.py tests/test_benchmark_boot_telemetry.py tests/test_guest_agent_image.py -q`
- `uv run ruff check scripts/benchmarks/ubuntu_transport.py tests/test_ubuntu_transport_benchmark.py tests/test_guest_agent_image.py`
- `uv run pytest tests/test_cli.py -q`
- `uv run ruff check tests/test_cli.py`
- `git diff --check`
- `uv run pytest -q`
- `uv run smolvm create --help`
- live smoke: `uv run smolvm create --backend qemu --name sbx-create-vsock-smoke --boot-timeout 20 --json`
- cleanup smoke VM: `uv run smolvm delete sbx-create-vsock-smoke --json`
- live smoke: `uv run python scripts/benchmarks/ubuntu_transport.py --iterations 1 --warm-exec-runs 1 --rootfs-source published --variants qemu-vsock --output /tmp/smolvm-ubuntu-boot-telemetry-probe.json -v`
- live smoke: `uv run python scripts/benchmarks/ubuntu_transport.py --iterations 1 --warm-exec-runs 1 --rootfs-source published --variants qemu-ssh --output /tmp/smolvm-ubuntu-boot-telemetry-qemu-ssh.json -v`
- full current-init benchmark listed above


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added `--comm-channel` option to `smolvm create` for controlling VM readiness behavior.
  * Enhanced benchmark reporting with boot telemetry collection, percentile statistics (p90/p95), and formatted Markdown tables.

* **Bug Fixes**
  * SSH host key generation now generates Ed25519 host keys specifically instead of multiple key types.

* **Documentation**
  * Updated benchmarks documentation with latest performance results and progress status.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->