### PR TITLE
Fix local image builds from installed package

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -135,6 +135,7 @@ jobs:
             "smolvm==${VERSION}"
 
           .smoke-venv/bin/python3 - <<PY
+          import os
           import platform
           import subprocess
           from pathlib import Path
@@ -142,6 +143,7 @@ jobs:
 
           from smolvm.host._accel import HAS_NETLINK
           from smolvm.host.setup import detect_setup_platform, resolve_setup_script
+          from smolvm.images import builder as image_builder
 
           assert pkg_version("smolvm") == "${VERSION}"
           assert pkg_version("smolvm-core") == "${CORE_VERSION}"
@@ -164,5 +166,18 @@ jobs:
           ):
               helper_path = assets_dir / "internal" / helper
               assert helper_path.is_file(), f"missing packaged helper: {helper_path}"
+
+          os.environ.pop("SMOLVM_GUEST_AGENT_BINARY", None)
+          assert not image_builder._has_guest_agent_source_checkout()
+          release_downloads = []
+          expected_agent = Path("/tmp/fake-smolvm-guest-agent")
+
+          def fake_download_guest_agent_binary():
+              release_downloads.append("download")
+              return expected_agent
+
+          image_builder._download_guest_agent_binary = fake_download_guest_agent_binary
+          assert image_builder._guest_agent_binary() == expected_agent
+          assert release_downloads == ["download"]
           print("artifact install: OK")
           PY

--- a/src/smolvm/images/builder.py
+++ b/src/smolvm/images/builder.py
@@ -18,6 +18,7 @@ Automatically builds VM images with SSH using Docker.
 """
 
 import hashlib
+import io
 import json
 import logging
 import os
@@ -31,7 +32,7 @@ import tempfile
 import typing
 import urllib.error
 import urllib.request
-from contextlib import contextmanager
+from contextlib import contextmanager, suppress
 from pathlib import Path
 
 from smolvm.exceptions import ImageError, SmolVMError
@@ -64,6 +65,10 @@ _REPO_ROOT = Path(__file__).resolve().parents[3]
 _GUEST_AGENT_CRATE_DIR = _REPO_ROOT / "guest-agent"
 _GUEST_AGENT_BUILD_FILE = "smolvm-guest-agent"
 _GUEST_AGENT_GUEST_PATH = "/usr/local/bin/smolvm-guest-agent"
+_GUEST_AGENT_RELEASE_SHA256: dict[str, str] = {
+    "amd64": "08f10561688891b43f64a2e0d83dd365fadf515bb0889603c974e506b2eceed5",
+    "arm64": "8976db4f9a337ad3b7e9b44b4f96913577598373d772fb79d50adca11e3364a7",
+}
 
 
 def _guest_agent_target_triple(arch: str | None = None) -> str:
@@ -78,6 +83,21 @@ def _guest_agent_target_triple(arch: str | None = None) -> str:
 
 def _guest_agent_binary_path() -> Path:
     return _REPO_ROOT / "target" / _guest_agent_target_triple() / "release" / "smolvm-guest-agent"
+
+
+def _has_guest_agent_source_checkout() -> bool:
+    """Whether the installed package is running from a Rust workspace checkout."""
+    return (_REPO_ROOT / "Cargo.toml").is_file() and (
+        _GUEST_AGENT_CRATE_DIR / "Cargo.toml"
+    ).is_file()
+
+
+def _sha256_file(path: Path) -> str:
+    hasher = hashlib.sha256()
+    with path.open("rb") as handle:
+        for chunk in iter(lambda: handle.read(1024 * 1024), b""):
+            hasher.update(chunk)
+    return hasher.hexdigest()
 
 
 def _cargo_binary() -> str:
@@ -112,6 +132,20 @@ def _guest_agent_source_digest() -> str:
     """Return a digest of source files that affect the guest-agent binary."""
     hasher = hashlib.sha256()
     hasher.update(_guest_agent_target_triple().encode())
+    configured = _configured_guest_agent_binary()
+    if configured is not None:
+        hasher.update(b"configured-binary")
+        hasher.update(str(configured).encode())
+        hasher.update(_sha256_file(configured).encode())
+        return hasher.hexdigest()
+
+    if not _has_guest_agent_source_checkout():
+        url, _asset_name, expected_sha256 = _guest_agent_release_asset()
+        hasher.update(b"release-binary")
+        hasher.update(url.encode())
+        hasher.update(expected_sha256.encode())
+        return hasher.hexdigest()
+
     for path in (
         _REPO_ROOT / "Cargo.toml",
         _REPO_ROOT / "Cargo.lock",
@@ -126,8 +160,100 @@ def _guest_agent_source_digest() -> str:
     return hasher.hexdigest()
 
 
+def _configured_guest_agent_binary() -> Path | None:
+    raw = os.environ.get("SMOLVM_GUEST_AGENT_BINARY")
+    if not raw:
+        return None
+    path = Path(raw).expanduser()
+    if not path.is_file():
+        raise ImageError(
+            f"SMOLVM_GUEST_AGENT_BINARY points to a missing file: {path}; "
+            "run `unset SMOLVM_GUEST_AGENT_BINARY` and retry to use the published "
+            "SmolVM guest agent binary."
+        )
+    return path
+
+
+def _guest_agent_release_asset() -> tuple[str, str, str]:
+    """Return URL, asset name, and SHA-256 for the published guest-agent binary."""
+    from smolvm.images.published import _images_release_tag
+
+    arch = to_published_arch(platform.machine())
+    asset_name = f"smolvm-guest-agent-linux-{arch}"
+    expected_sha256 = _GUEST_AGENT_RELEASE_SHA256[arch]
+    url = (
+        "https://github.com/CelestoAI/SmolVM/releases/download/"
+        f"{_images_release_tag()}/{asset_name}"
+    )
+    return url, asset_name, expected_sha256
+
+
+def _guest_agent_binary_cache_dir() -> Path:
+    return Path.home() / ".smolvm" / "images" / "_guest-agent"
+
+
+def _download_guest_agent_binary() -> Path:
+    """Download and cache the pinned Rust guest-agent binary for installed wheels."""
+    from smolvm.images.published import _images_release_tag
+
+    url, asset_name, expected_sha256 = _guest_agent_release_asset()
+    cache_dir = (
+        _guest_agent_binary_cache_dir()
+        / _images_release_tag()
+        / to_published_arch(platform.machine())
+    )
+    binary_path = cache_dir / asset_name
+    quoted_binary_path = shlex.quote(str(binary_path))
+    if binary_path.is_file() and _sha256_file(binary_path) == expected_sha256:
+        binary_path.chmod(0o755)
+        return binary_path
+
+    cache_dir.mkdir(parents=True, exist_ok=True)
+    tmp_path: Path | None = None
+    try:
+        with tempfile.NamedTemporaryFile(
+            prefix=f".{asset_name}.",
+            dir=cache_dir,
+            delete=False,
+        ) as tmp:
+            tmp_path = Path(tmp.name)
+            with urllib.request.urlopen(  # noqa: S310 - pinned GitHub release URL
+                url,
+                timeout=60,
+            ) as response:
+                shutil.copyfileobj(typing.cast(io.BufferedReader, response), tmp)
+        actual_sha256 = _sha256_file(tmp_path)
+        if actual_sha256 != expected_sha256:
+            raise ImageError(
+                f"Downloaded Rust guest agent binary from {url} failed SHA-256 "
+                f"verification (expected {expected_sha256}, got {actual_sha256}); "
+                f"run `rm -f {quoted_binary_path}` and retry so SmolVM downloads it again."
+            )
+        tmp_path.chmod(0o755)
+        os.replace(tmp_path, binary_path)
+        return binary_path
+    except ImageError:
+        raise
+    except (OSError, urllib.error.URLError) as exc:
+        raise ImageError(
+            f"Could not download the Rust guest agent binary from {url}; run "
+            f"`mkdir -p {shlex.quote(str(cache_dir))} && curl -fL {shlex.quote(url)} "
+            f"-o {quoted_binary_path} && chmod 755 {quoted_binary_path}` and retry."
+        ) from exc
+    finally:
+        if tmp_path is not None and tmp_path.exists():
+            with suppress(OSError):
+                tmp_path.unlink()
+
+
 def _guest_agent_binary() -> Path:
     """Build and return the Rust guest-agent binary used by rootfs builders."""
+    configured = _configured_guest_agent_binary()
+    if configured is not None:
+        return configured
+    if not _has_guest_agent_source_checkout():
+        return _download_guest_agent_binary()
+
     target = _guest_agent_target_triple()
     binary_path = _guest_agent_binary_path()
     try:

--- a/tests/test_guest_agent_image.py
+++ b/tests/test_guest_agent_image.py
@@ -14,12 +14,15 @@
 
 """Tests that the guest agent is baked into and launched by built images."""
 
+import hashlib
+import io
 import subprocess
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
 import pytest
 
+from smolvm.exceptions import ImageError
 from smolvm.images import builder as builder_mod
 from smolvm.images.builder import ImageBuilder
 from smolvm.images.published import IMAGES_RELEASE_TAG
@@ -172,6 +175,136 @@ def test_guest_agent_source_digest_tracks_rust_crate() -> None:
     digest = builder_mod._guest_agent_source_digest()
     assert len(digest) == 64
     assert (builder_mod._GUEST_AGENT_CRATE_DIR / "src" / "main.rs").is_file()
+
+
+def test_guest_agent_source_digest_tracks_release_binary_without_source(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.delenv("SMOLVM_GUEST_AGENT_BINARY", raising=False)
+    monkeypatch.setattr(builder_mod, "_has_guest_agent_source_checkout", lambda: False)
+    monkeypatch.setattr(
+        builder_mod,
+        "_guest_agent_release_asset",
+        lambda: ("https://example.invalid/agent-a", "smolvm-guest-agent-linux-amd64", "a" * 64),
+    )
+    first = builder_mod._guest_agent_source_digest()
+    monkeypatch.setattr(
+        builder_mod,
+        "_guest_agent_release_asset",
+        lambda: ("https://example.invalid/agent-b", "smolvm-guest-agent-linux-amd64", "b" * 64),
+    )
+    second = builder_mod._guest_agent_source_digest()
+
+    assert len(first) == 64
+    assert len(second) == 64
+    assert first != second
+
+
+def test_guest_agent_source_digest_tracks_env_binary(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    binary = tmp_path / "custom-agent"
+    binary.write_bytes(b"first")
+    monkeypatch.setenv("SMOLVM_GUEST_AGENT_BINARY", str(binary))
+
+    first = builder_mod._guest_agent_source_digest()
+    binary.write_bytes(b"second")
+    second = builder_mod._guest_agent_source_digest()
+
+    assert len(first) == 64
+    assert len(second) == 64
+    assert first != second
+
+
+def test_guest_agent_binary_honors_env_override(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    binary = tmp_path / "custom-agent"
+    binary.write_bytes(b"custom")
+    monkeypatch.setenv("SMOLVM_GUEST_AGENT_BINARY", str(binary))
+    monkeypatch.setattr(
+        builder_mod,
+        "_download_guest_agent_binary",
+        lambda: pytest.fail("env override should not download"),
+    )
+
+    assert builder_mod._guest_agent_binary() == binary
+
+
+def test_guest_agent_binary_downloads_release_without_source_checkout(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    payload = b"release-agent"
+    expected_sha = hashlib.sha256(payload).hexdigest()
+    opened_urls: list[str] = []
+
+    class Response(io.BytesIO):
+        def __enter__(self) -> "Response":
+            return self
+
+        def __exit__(self, *_exc: object) -> None:
+            self.close()
+
+    def fake_urlopen(url: str, **_kwargs: object) -> Response:
+        opened_urls.append(url)
+        return Response(payload)
+
+    monkeypatch.delenv("SMOLVM_GUEST_AGENT_BINARY", raising=False)
+    monkeypatch.setattr(builder_mod, "_has_guest_agent_source_checkout", lambda: False)
+    monkeypatch.setattr(builder_mod, "_guest_agent_binary_cache_dir", lambda: tmp_path)
+    monkeypatch.setattr(builder_mod.platform, "machine", lambda: "x86_64")
+    monkeypatch.setattr(
+        builder_mod,
+        "_guest_agent_release_asset",
+        lambda: ("https://example.invalid/agent", "smolvm-guest-agent-linux-amd64", expected_sha),
+    )
+    monkeypatch.setattr(builder_mod.urllib.request, "urlopen", fake_urlopen)
+    monkeypatch.setattr(
+        builder_mod.subprocess,
+        "run",
+        lambda *_args, **_kwargs: pytest.fail("installed package should not run cargo"),
+    )
+
+    binary = builder_mod._guest_agent_binary()
+
+    assert binary.name == "smolvm-guest-agent-linux-amd64"
+    assert binary.read_bytes() == payload
+    assert binary.stat().st_mode & 0o111
+    assert opened_urls == ["https://example.invalid/agent"]
+    assert builder_mod._guest_agent_binary() == binary
+    assert opened_urls == ["https://example.invalid/agent"]
+
+
+def test_guest_agent_binary_rejects_bad_release_sha(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    class Response(io.BytesIO):
+        def __enter__(self) -> "Response":
+            return self
+
+        def __exit__(self, *_exc: object) -> None:
+            self.close()
+
+    monkeypatch.delenv("SMOLVM_GUEST_AGENT_BINARY", raising=False)
+    monkeypatch.setattr(builder_mod, "_guest_agent_binary_cache_dir", lambda: tmp_path)
+    monkeypatch.setattr(builder_mod.platform, "machine", lambda: "x86_64")
+    monkeypatch.setattr(
+        builder_mod,
+        "_guest_agent_release_asset",
+        lambda: ("https://example.invalid/agent", "smolvm-guest-agent-linux-amd64", "0" * 64),
+    )
+    monkeypatch.setattr(
+        builder_mod.urllib.request,
+        "urlopen",
+        lambda _url, **_kwargs: Response(b"not-the-pinned-binary"),
+    )
+
+    with pytest.raises(ImageError, match="SHA-256 verification"):
+        builder_mod._download_guest_agent_binary()
 
 
 def test_base_init_script_launches_guest_agent_before_sshd() -> None:


### PR DESCRIPTION
## Summary
- use the pinned GitHub release guest-agent binary when SmolVM is running from an installed wheel without the Rust workspace
- keep source-checkout behavior unchanged: local repo builds still compile the Rust guest agent with cargo
- add unit coverage and package-smoke coverage for the installed-wheel fallback path

## Why this failed
Firecracker defaults to the Alpine local image-builder path, which needs to inject the Rust guest agent. In an installed uv tool environment there is no Cargo.toml, so the old code tried to run cargo from site-packages and failed. QEMU defaults to the published Ubuntu preset, so it avoided the local builder and did not hit this path.

## Validation
- uv run pytest tests/test_build.py tests/test_guest_agent_image.py -q
- uv run ruff check src/smolvm/images/builder.py tests/test_guest_agent_image.py
- git diff --check
- local wheel-install smoke for installed-package fallback
- live pinned release binary download/hash smoke for images-2026.06.14.0

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added guest-agent installation support via a user-supplied prebuilt binary or an automatic, pinned release download with SHA-256 verification, caching, and safe install behavior.
* **Tests**
  * Expanded coverage to validate guest-agent identity/digest tracking, env override behavior, download+cache flow, and rejection of incorrect SHA-256 artifacts.
* **Chores**
  * Enhanced CI smoke-test assertions to verify guest-agent binary behavior, including download attempt counting and error handling paths.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->