### PR TITLE
[codex] Add opt-in QEMU microvm machine

### DIFF
--- a/docs/benchmarks/startup-speedups.md
+++ b/docs/benchmarks/startup-speedups.md
@@ -26,6 +26,7 @@ Primary target:
 | 2026-06-14 | #373 sparse published rootfs cache and raw disk copy | Firecracker | vsock | 1979.1 ms | 1057.4 ms | -921.7 ms | 46.6% faster | Published `images-2026.06.14.0`; host create dropped from 1123.6 ms to 200.5 ms. |
 | 2026-06-14 | #374 Ubuntu transport telemetry and Ed25519 SSH host key | QEMU | SSH | 1455.6 ms | 1233.9 ms | -221.7 ms | 15.2% faster | Current-init local run; replaces `ssh-keygen -A` with one Ed25519 host key. |
 | 2026-06-14 | #374 Ubuntu transport telemetry and Ed25519 SSH host key | Firecracker | SSH | 1827.7 ms | 1576.5 ms | -251.2 ms | 13.7% faster | Current-init local run; SSH host-key phase median is now 10.0 ms. |
+| 2026-06-17 | Current PR opt-in QEMU microvm experiment | QEMU | vsock | 1091.8 ms | 408.4 ms | -683.4 ms | 62.6% faster | Opt-in only via `SMOLVM_QEMU_MACHINE=microvm`; default remains q35. |
 
 ## Current Published Ubuntu Medians
 
@@ -64,6 +65,25 @@ methodology.
 | QEMU | vsock | ... | ... | ... | ... |
 | Firecracker | vsock | ... | ... | ... | ... |
 ```
+
+## 2026-06-17 - Current PR: Opt-In QEMU Microvm Experiment
+
+- Commit: current PR branch.
+- Image tag: `images-2026.06.14.0`.
+- Commands:
+  - `uv run python scripts/benchmarks/ubuntu_transport.py --variants qemu-vsock --iterations 5 --warm-exec-runs 5 --rootfs-source published --output /tmp/smolvm-qemu-q35-vsock.json`
+  - `SMOLVM_QEMU_MACHINE=microvm uv run python scripts/benchmarks/ubuntu_transport.py --variants qemu-vsock --iterations 5 --warm-exec-runs 5 --rootfs-source published --output /tmp/smolvm-qemu-microvm-vsock.json`
+- Host: AMD Ryzen 7 7800X3D, Linux x86_64, kernel `7.0.0-15-generic`,
+  KVM and `/dev/vhost-vsock` available.
+- Method: one warm-up VM per variant, then five measured published-image
+  iterations per variant.
+- Behavior changed: QEMU can opt into the `microvm` machine for Linux x86_64
+  direct-kernel guests with `SMOLVM_QEMU_MACHINE=microvm`; this addresses
+  compatibility issue #329 while leaving the default q35 path unchanged.
+
+| Backend | Transport | Before total ready | After total ready | Delta | Improvement | First command | Warm exec |
+|---|---|---:|---:|---:|---:|---:|---:|
+| QEMU | vsock | 1091.8 ms | 408.4 ms | -683.4 ms | 62.6% faster | 1.3 ms | 0.9 ms |
 
 ## 2026-06-14 - PR #374: Ubuntu Transport Telemetry And Ed25519 Host Key
 

--- a/src/smolvm/runtime/qemu_args.py
+++ b/src/smolvm/runtime/qemu_args.py
@@ -21,13 +21,15 @@ and returns a ``list[str]`` argv. All side effects (spawning the process,
 opening log files, tracking PIDs) stay in ``_start_qemu``.
 
 For the Linux all-defaults spec (``_LINUX_SPEC``) this function produces
-output byte-identical to the pre-refactor ``_start_qemu``. The
+output byte-identical to the pre-refactor ``_start_qemu`` unless the
+experimental ``SMOLVM_QEMU_MACHINE=microvm`` switch is set. The
 ``GuestPlatformSpec`` fields exist to let later commits add Windows-specific
 fragments without disturbing the Linux path.
 """
 
 from __future__ import annotations
 
+import os
 import platform
 from pathlib import Path
 
@@ -45,6 +47,9 @@ QEMU_SLIRP_DNS = "10.0.2.3"
 # cdrom_bus="ide" occupy ide.0..ide.5 in order; any beyond port 5 fall back
 # to virtio-blk-pci so the QEMU command line stays valid.
 _Q35_AHCI_PORTS = 6
+
+_QEMU_MACHINE_ENV = "SMOLVM_QEMU_MACHINE"
+_QEMU_MICROVM_MACHINE = "microvm,accel=kvm,acpi=on,pcie=off,pic=off,pit=off,rtc=on"
 
 
 # Candidate UEFI firmware locations for aarch64 QEMU firmware-boot.
@@ -68,6 +73,25 @@ def _find_aarch64_uefi_firmware() -> Path | None:
         if path.is_file():
             return path
     return None
+
+
+def _use_experimental_qemu_microvm(
+    vm_info: VMInfo,
+    *,
+    qemu_name: str,
+    system: str,
+    platform_spec: GuestPlatformSpec,
+) -> bool:
+    """Return whether to use the opt-in x86_64 QEMU microvm machine."""
+    requested_machine = os.environ.get(_QEMU_MACHINE_ENV, "").strip().lower()
+    if requested_machine != "microvm":
+        return False
+    return (
+        system == "Linux"
+        and qemu_name == "qemu-system-x86_64"
+        and vm_info.config.boot_mode == "direct_kernel"
+        and platform_spec.guest_os in {GuestOS.ALPINE, GuestOS.UBUNTU}
+    )
 
 
 def build_qemu_argv(
@@ -158,6 +182,12 @@ def build_qemu_argv(
 
     qemu_name = qemu_bin.name
     system = host_system if host_system is not None else platform.system()
+    use_qemu_microvm = _use_experimental_qemu_microvm(
+        vm_info,
+        qemu_name=qemu_name,
+        system=system,
+        platform_spec=platform_spec,
+    )
 
     disk_format = vm_info.config.qemu_rootfs_format
     root_drive_id = f"{root_node_name}-drive"
@@ -184,6 +214,8 @@ def build_qemu_argv(
         "-m",
         str(vm_info.config.memory),
     ]
+    if use_qemu_microvm:
+        cmd.extend(["-nodefaults", "-serial", "stdio"])
     # Boot mode: direct-kernel passes -kernel/-append (optionally -initrd);
     # firmware mode lets QEMU boot the rootfs disk via default firmware
     # (OVMF on aarch64, SeaBIOS on x86_64) — the guest kernel lives inside
@@ -207,6 +239,8 @@ def build_qemu_argv(
             "-no-reboot",
         ]
     )
+    if use_qemu_microvm:
+        cmd.extend(["-monitor", "none"])
     # Pin the emulated hardware RTC to host wall-clock UTC. clock=host is
     # already QEMU's default, but we set it explicitly because the guest's
     # clock-sync loop depends on it: under HVF (macOS) there is no kvm-clock,
@@ -292,6 +326,20 @@ def build_qemu_argv(
         # cloud-init seed), the rootdisk-block device must be the LAST
         # virtio-blk-device added. Workspace fsdevs and the NIC must
         # come before it too.
+        for drive_id in extra_drive_ids:
+            cmd.extend(["-device", f"virtio-blk-device,drive={drive_id}"])
+        for fsdev_id, tag in workspace_fsdev_ids:
+            cmd.extend(["-device", f"virtio-9p-device,fsdev={fsdev_id},mount_tag={tag}"])
+        cmd.extend(
+            [
+                "-device",
+                f"virtio-net-device,netdev=net0,mac={guest_mac}",
+                "-device",
+                f"virtio-blk-device,drive={root_drive_id}",
+            ]
+        )
+    elif use_qemu_microvm:
+        cmd.extend(["-machine", _QEMU_MICROVM_MACHINE, "-cpu", "host"])
         for drive_id in extra_drive_ids:
             cmd.extend(["-device", f"virtio-blk-device,drive={drive_id}"])
         for fsdev_id, tag in workspace_fsdev_ids:
@@ -419,9 +467,13 @@ def build_qemu_argv(
     # host RustHttpVsockChannel connects to it. Native vhost-vsock needs the host's
     # /dev/vhost-vsock, which only exists on Linux — macOS/HVF has no
     # equivalent, so we emit nothing there and the host stays on SSH. The
-    # device variant differs by machine type (PCI for q35, MMIO for virt).
+    # device variant differs by machine type (PCI for q35, MMIO for virt/microvm).
     if vm_info.config.vsock is not None and system == "Linux":
-        vsock_device = "vhost-vsock-device" if "aarch64" in qemu_name else "vhost-vsock-pci"
+        vsock_device = (
+            "vhost-vsock-device"
+            if "aarch64" in qemu_name or use_qemu_microvm
+            else "vhost-vsock-pci"
+        )
         cmd.extend(["-device", f"{vsock_device},guest-cid={vm_info.config.vsock.guest_cid}"])
 
     return cmd

--- a/tests/test_qemu_args.py
+++ b/tests/test_qemu_args.py
@@ -28,7 +28,20 @@ from smolvm.runtime.guest_platforms import (
     _build_windows_spec,
 )
 from smolvm.runtime.qemu_args import build_qemu_argv
-from smolvm.types import GuestOS, NetworkConfig, VMConfig, VMInfo, VMState, VsockConfig
+from smolvm.types import (
+    GuestOS,
+    NetworkConfig,
+    VMConfig,
+    VMInfo,
+    VMState,
+    VsockConfig,
+    WorkspaceMount,
+)
+
+
+@pytest.fixture(autouse=True)
+def _clear_experimental_qemu_machine_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("SMOLVM_QEMU_MACHINE", raising=False)
 
 
 def _qemu_vm_info(tmp_path: Path, *, vm_id: str = "vm-test") -> VMInfo:
@@ -137,6 +150,87 @@ def test_vsock_device_emitted_on_linux_x86(tmp_path: Path) -> None:
     )
     assert "-device" in cmd
     assert "vhost-vsock-pci,guest-cid=42" in cmd
+
+
+def test_experimental_qemu_microvm_emits_mmio_devices(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("SMOLVM_QEMU_MACHINE", "microvm")
+    vm_info = _with_vsock(_qemu_vm_info(tmp_path))
+    extra_drive = tmp_path / "extra.raw"
+    extra_drive.touch()
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    config = vm_info.config.model_copy(
+        update={
+            "extra_drives": [extra_drive],
+            "workspace_mounts": [WorkspaceMount(host_path=workspace, mount_tag="ws0")],
+        }
+    )
+    vm_info = vm_info.model_copy(update={"config": config})
+
+    cmd = build_qemu_argv(
+        vm_info,
+        qemu_bin=Path("/usr/bin/qemu-system-x86_64"),
+        boot_args=vm_info.config.boot_args,
+        platform_spec=_LINUX_SPEC,
+        host_system="Linux",
+    )
+
+    assert cmd[cmd.index("-machine") + 1] == (
+        "microvm,accel=kvm,acpi=on,pcie=off,pic=off,pit=off,rtc=on"
+    )
+    assert cmd[cmd.index("-serial") + 1] == "stdio"
+    assert cmd[cmd.index("-monitor") + 1] == "none"
+    assert "-nodefaults" in cmd
+    device_args = [cmd[i + 1] for i, token in enumerate(cmd) if token == "-device"]
+    assert "virtio-blk-device,drive=extra0-drive" in device_args
+    assert "virtio-9p-device,fsdev=fsdev-ws0,mount_tag=ws0" in device_args
+    assert "virtio-net-device,netdev=net0,mac=52:54:00:12:34:56" in device_args
+    assert "virtio-blk-device,drive=rootdisk0-drive" in device_args
+    assert "vhost-vsock-device,guest-cid=42" in device_args
+    assert not any(arg.startswith("virtio-blk-pci,") for arg in device_args)
+    assert not any(arg.startswith("virtio-net-pci,") for arg in device_args)
+    assert "vhost-vsock-pci,guest-cid=42" not in device_args
+
+
+def test_experimental_qemu_microvm_ignored_on_darwin(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("SMOLVM_QEMU_MACHINE", "microvm")
+    cmd = build_qemu_argv(
+        _with_vsock(_qemu_vm_info(tmp_path)),
+        qemu_bin=Path("/opt/homebrew/bin/qemu-system-x86_64"),
+        boot_args="console=ttyS0 root=/dev/vda rw init=/init",
+        platform_spec=_LINUX_SPEC,
+        host_system="Darwin",
+    )
+
+    assert cmd[cmd.index("-machine") + 1] == "q35,accel=hvf"
+    assert "-nodefaults" not in cmd
+    assert not any("vhost-vsock" in arg for arg in cmd)
+
+
+def test_experimental_qemu_microvm_ignored_for_windows(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("SMOLVM_QEMU_MACHINE", "microvm")
+    spec = _fake_windows_spec()
+    cmd = build_qemu_argv(
+        _windows_vm_info(tmp_path),
+        qemu_bin=Path("/usr/bin/qemu-system-x86_64"),
+        boot_args="",
+        platform_spec=spec,
+        firmware_vars_path=Path("/state/OVMF_VARS.fd"),
+        swtpm_socket=Path("/state/swtpm-sock"),
+        host_system="Linux",
+    )
+
+    assert cmd[cmd.index("-machine") + 1].startswith("q35,accel=kvm")
+    assert "-nodefaults" not in cmd
 
 
 def test_vsock_device_uses_mmio_variant_on_aarch64(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary

- Add an opt-in `SMOLVM_QEMU_MACHINE=microvm` path for Linux x86_64 QEMU direct-kernel guests.
- Emit MMIO virtio devices for the microvm path while keeping the q35 default unchanged.
- Record the published Ubuntu qemu-vsock benchmark delta in the startup ledger.

Fixes #329.

## Validation

- `uv run pytest tests/test_qemu_args.py tests/test_vm_qemu.py tests/test_facade_vsock.py tests/test_rust_http_vsock_channel.py -q`
- `uv run ruff check .`
- `uv run ruff format --check src/smolvm/runtime/qemu_args.py tests/test_qemu_args.py`
- `git diff --check`

## Benchmark

- q35 baseline: `1091.8 ms` p50 total-ready, `1.0 ms` warm exec p50.
- opt-in microvm: `408.4 ms` p50 total-ready, `0.9 ms` warm exec p50.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added opt-in QEMU microvm mode for faster VM startup on Linux/x86_64. Enable via `SMOLVM_QEMU_MACHINE=microvm` environment variable. Benchmarks demonstrate significant latency improvements in startup scenarios.

* **Tests**
  * Added comprehensive tests for microvm functionality across platforms.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->