### PR TITLE
[codex] Refactor CLI to Click command tree

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -105,7 +105,7 @@ into right now:
 This sandbox was set up to share the folder '...' with you, but that
 folder no longer exists on your machine. The sandbox cannot start
 until you put the folder back, or delete the sandbox with
-'smolvm delete sbx-einstein'.
+'smolvm sandbox delete sbx-einstein'.
 ```
 
 **Good** — one sentence, true in every state, names the recovery:
@@ -113,5 +113,5 @@ until you put the folder back, or delete the sandbox with
 ```
 Shared folder is missing on your machine:
 '/Users/aniket/conductor/workspaces/SmolVM/lome'. Restore it, or run
-'smolvm delete sbx-einstein' to remove the sandbox.
+'smolvm sandbox delete sbx-einstein' to remove the sandbox.
 ```

--- a/README.md
+++ b/README.md
@@ -293,7 +293,7 @@ This is useful when an agent needs a config file, script, or small input file.
 
 ```bash
 # Copy a file from your machine into the sandbox.
-smolvm file upload my-sandbox ./prompt.txt /tmp/prompt.txt
+smolvm sandbox file upload my-sandbox ./prompt.txt /tmp/prompt.txt
 
 # Open a shell in the sandbox to confirm the file is there.
 smolvm sandbox ssh my-sandbox

--- a/README.md
+++ b/README.md
@@ -256,7 +256,7 @@ See [docs/concepts/network-egress-controls.md](docs/concepts/network-egress-cont
 You can give a sandbox access to a folder on your machine. This is useful when an agent needs to work with an existing project without copying files back and forth.
 
 ```bash
-smolvm sandbox create --mount ~/Projects/my-app
+smolvm sandbox create --name my-sandbox --mount ~/Projects/my-app
 smolvm sandbox ssh my-sandbox
 ls /workspace   # your host files appear here
 ```

--- a/README.md
+++ b/README.md
@@ -126,20 +126,20 @@ vm.stop()
 Create a sandbox, check that it's running, then stop it:
 
 ```bash
-smolvm create --name my-sandbox
+smolvm sandbox create --name my-sandbox
 # my-sandbox  running  172.16.0.2
 
-smolvm list
+smolvm sandbox list
 # NAME         STATUS   IP
 # my-sandbox   running  172.16.0.2
 
-smolvm stop my-sandbox
+smolvm sandbox stop my-sandbox
 ```
 
 Open a shell inside a running sandbox:
 
 ```bash
-smolvm ssh my-sandbox
+smolvm sandbox ssh my-sandbox
 ```
 
 ## Windows sandbox
@@ -256,8 +256,8 @@ See [docs/concepts/network-egress-controls.md](docs/concepts/network-egress-cont
 You can give a sandbox access to a folder on your machine. This is useful when an agent needs to work with an existing project without copying files back and forth.
 
 ```bash
-smolvm create --mount ~/Projects/my-app
-smolvm ssh my-sandbox
+smolvm sandbox create --mount ~/Projects/my-app
+smolvm sandbox ssh my-sandbox
 ls /workspace   # your host files appear here
 ```
 
@@ -266,13 +266,13 @@ By default the host folder is read-only — the sandbox can read every file, but
 Mount at a custom path, or mount multiple directories:
 
 ```bash
-smolvm create --mount ~/Projects/my-app:/code --mount ~/data:/mnt/data
+smolvm sandbox create --mount ~/Projects/my-app:/code --mount ~/data:/mnt/data
 ```
 
 When you do want the sandbox to edit your host files, add `--writable-mounts`:
 
 ```bash
-smolvm create --mount ~/Projects/my-app --writable-mounts
+smolvm sandbox create --mount ~/Projects/my-app --writable-mounts
 ```
 
 Every directory passed with `--mount` becomes writable; writes from the guest are visible on the host immediately. The flag applies to all mounts on that command, so don't pair a folder you want the sandbox to modify with one you want kept untouched.
@@ -296,7 +296,7 @@ This is useful when an agent needs a config file, script, or small input file.
 smolvm file upload my-sandbox ./prompt.txt /tmp/prompt.txt
 
 # Open a shell in the sandbox to confirm the file is there.
-smolvm ssh my-sandbox
+smolvm sandbox ssh my-sandbox
 # Then, inside the sandbox shell:
 cat /tmp/prompt.txt
 ```

--- a/docs/benchmarks/startup-speedups.md
+++ b/docs/benchmarks/startup-speedups.md
@@ -114,7 +114,7 @@ Published QEMU preset sweep, vsock-ready p50:
   telemetry from `SMOLVM_TS` runtime-log markers, each variant summary includes
   phase stats under `boot_telemetry_stats`, summary stats include p90/p95, the
   CLI prints a compact Markdown table, and `/init` generates only an Ed25519 SSH
-  host key instead of running `ssh-keygen -A`. The plain `smolvm create` command
+  host key instead of running `ssh-keygen -A`. The plain `smolvm sandbox create` command
   now waits for the resolved control channel by default, so QEMU Ubuntu can use
   the same vsock readiness path measured by this benchmark.
 

--- a/docs/deep-dive/microvm-from-first-principles.md
+++ b/docs/deep-dive/microvm-from-first-principles.md
@@ -74,7 +74,7 @@ Earlier versions of SmolVM pulled kernels from elsewhere:
 - Ubuntu cloud images' `vmlinuz-6.x` from `cloud-images.ubuntu.com`
 
 That had three problems:
-1. **External CDN dependencies** — Ubuntu's CDN had a slow first-byte that hung `smolvm create` for a user.
+1. **External CDN dependencies** — Ubuntu's CDN had a slow first-byte that hung `smolvm sandbox create` for a user.
 2. **Old kernel** — 5.10 missed years of microVM optimizations and CVE patches.
 3. **Generic kernel surface** — Ubuntu ships drivers for Bluetooth, USB, sound, etc. None of that exists in a microVM. Dead code = bigger attack surface.
 
@@ -544,7 +544,7 @@ Back on the host, `cli/main.py` polls TCP port 2200 with a 30-second timeout. As
 │ Started 'codex-davinci' │
 │ with codex preinstalled │
 ╰─────────────────────────╯
-Next: smolvm ssh codex-davinci
+Next: smolvm sandbox ssh codex-davinci
 ```
 
 End-to-end, on a warm cache, this takes 5–10 seconds. On a cold cache (first download), add ~30s for the rootfs zstd download.
@@ -591,9 +591,9 @@ Lesson: when you generalize a code path that used to be single-purpose, audit th
 
 A few open threads, in the order I'd tackle them.
 
-### `smolvm create` uses our base rootfs (#273)
+### `smolvm sandbox create` uses our base rootfs (#273)
 
-`smolvm create` now uses the published Ubuntu base rootfs from the SmolVM image release instead of downloading Ubuntu's official cloud image from `cloud-images.ubuntu.com`. That removes the last external CDN from the boot path and keeps the default image pinned by SHA.
+`smolvm sandbox create` now uses the published Ubuntu base rootfs from the SmolVM image release instead of downloading Ubuntu's official cloud image from `cloud-images.ubuntu.com`. That removes the last external CDN from the boot path and keeps the default image pinned by SHA.
 
 The remaining work is operational: keep the base ext4 published alongside preset images, keep `/init` in the base Dockerfile, and bump the image release tag when those bytes change.
 

--- a/docs/deep-dive/optimization-plan.md
+++ b/docs/deep-dive/optimization-plan.md
@@ -87,8 +87,8 @@ S3 bucket
 
 **CLI:**
 ```bash
-smolvm create --image s3://bucket/images/alpine-ssh/
-smolvm create --image s3://bucket/images/alpine-ssh/ --name my-vm --memory 1024
+smolvm sandbox create --image s3://bucket/images/alpine-ssh/
+smolvm sandbox create --image s3://bucket/images/alpine-ssh/ --name my-vm --memory 1024
 ```
 `--image` and `--os` are mutually exclusive.
 
@@ -125,7 +125,7 @@ Falls back to boto3's standard credential chain (`AWS_*` env vars, `~/.aws/crede
 - Offline cache fallback — fully cached images work when S3 is unreachable
 - Path traversal protection — manifest filenames validated via Pydantic (rejects `../`, absolute paths, collisions)
 
-**Verified end-to-end:** Ubuntu cloud image uploaded to Cloudflare R2, pulled via `smolvm create --image s3://...`, VM booted, SSH connected, commands executed.
+**Verified end-to-end:** Ubuntu cloud image uploaded to Cloudflare R2, pulled via `smolvm sandbox create --image s3://...`, VM booted, SSH connected, commands executed.
 
 **Phase 2b (FUSE mount) was evaluated and dropped** — see Recommended Order section for rationale.
 

--- a/docs/deep-dive/startup-time-optimization-plan.md
+++ b/docs/deep-dive/startup-time-optimization-plan.md
@@ -112,10 +112,10 @@ Current status:
   exists instead of running `ssh-keygen -A`. In the current-init benchmark this
   moved QEMU SSH total ready from `1455.6 ms` to `1233.9 ms` and Firecracker SSH
   total ready from `1827.7 ms` to `1576.5 ms`.
-- `smolvm create` now waits for the resolved control channel by default, so a
+- `smolvm sandbox create` now waits for the resolved control channel by default, so a
   plain QEMU Ubuntu create can return when the vsock guest-agent is ready instead
   of always waiting for SSH. Users can still force the old SSH-ready behavior
-  with `smolvm create --comm-channel ssh`.
+  with `smolvm sandbox create --comm-channel ssh`.
 
 Acceptance:
 

--- a/kernel/microvm/config.fragment
+++ b/kernel/microvm/config.fragment
@@ -63,7 +63,7 @@ CONFIG_VSOCKETS=y               # why: AF_VSOCK socket family
 CONFIG_VIRTIO_VSOCKETS=y        # why: virtio transport for vsock
 
 # ── Workspace mounts (--mount / --writable-mounts) ───────────────────
-# `smolvm create --mount <host-dir>` shares a host directory into the
+# `smolvm sandbox create --mount <host-dir>` shares a host directory into the
 # guest using virtio-9p (a paravirt filesystem that speaks the 9P2000.L
 # protocol over a virtio transport). For read-only host shares the guest
 # stacks overlayfs on top so writes inside the VM stay in a tmpfs upper

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,6 +28,7 @@ classifiers = [
     "Topic :: System :: Emulators",
 ]
 dependencies = [
+    "click>=8.0",
     "smolvm-core~=0.0.14",
     "paramiko>=3.0",
     "pycdlib>=1.14.0",
@@ -70,7 +71,6 @@ all = [
 
 [project.scripts]
 smolvm = "smolvm.cli.main:main"
-smolvm-delete = "smolvm.cli.cleanup:main"
 
 [tool.hatch.build.targets.wheel]
 packages = ["src/smolvm"]

--- a/scripts/benchmarks/README.md
+++ b/scripts/benchmarks/README.md
@@ -19,7 +19,7 @@ Firecracker on macOS errors out at startup.
 
 1. SmolVM installed and `smolvm setup` completed for your platform.
 2. The default image is already pulled (`smolvm doctor` will tell you, or run
-   `smolvm create --name probe` once and `smolvm delete probe`).
+   `smolvm sandbox create --name probe` once and `smolvm sandbox delete probe`).
 3. Linux only: `smolvm setup` configured the host networking and your user can
    talk to Firecracker.
 
@@ -174,5 +174,5 @@ becomes `{"status": "unsupported", "backend": "...", "reason": "..."}`.
 - **Cleanup**: every benchmark wraps work in `try/finally` and stops/deletes its VMs
   even on error. The teardown chain is `vm.delete()` → `SmolVMManager.delete()` →
   direct SIGKILL + DB row removal, so flaky QEMU shutdown paths on macOS don't
-  leak VMs. If a run is killed mid-flight, run `smolvm list` to spot leftovers.
+  leak VMs. If a run is killed mid-flight, run `smolvm sandbox list` to spot leftovers.
 - **CI**: not currently wired in. Run locally on each platform.

--- a/src/smolvm/_naming.py
+++ b/src/smolvm/_naming.py
@@ -14,7 +14,7 @@
 
 """Friendly auto-names for sandboxes (e.g. ``sbx-einstein``).
 
-When a user runs ``smolvm create`` without a name we pick a scientist's last
+When a user runs ``smolvm sandbox create`` without a name we pick a scientist's last
 name. If that name is already taken we append a city for disambiguation
 (``sbx-tesla-london``). A short hex suffix is used as a final fallback to
 guarantee uniqueness when the scientist+city space is exhausted.

--- a/src/smolvm/cli/_kvm_session.py
+++ b/src/smolvm/cli/_kvm_session.py
@@ -87,6 +87,12 @@ _SKIP_SANDBOX_ACTIONS: frozenset[str] = frozenset(
     }
 )
 
+_SKIP_SANDBOX_NESTED_ACTIONS: frozenset[tuple[str, str]] = frozenset(
+    {
+        ("snapshot", "list"),
+    }
+)
+
 _SKIP_BROWSER_ACTIONS: frozenset[str] = frozenset({"list", "stop", "open", "logs"})
 
 # Help/version flags can appear anywhere in argv (top-level *or* per-verb,
@@ -165,6 +171,12 @@ def _should_attempt_reexec(argv: Sequence[str] | None) -> bool:
     if args and args[0] in _SKIP_FIRST_ARGS:
         return False
     if len(args) >= 2 and args[0] == "sandbox" and args[1] in _SKIP_SANDBOX_ACTIONS:
+        return False
+    if (
+        len(args) >= 3
+        and args[0] == "sandbox"
+        and (args[1], args[2]) in _SKIP_SANDBOX_NESTED_ACTIONS
+    ):
         return False
     if len(args) >= 2 and args[0] == "browser" and args[1] in _SKIP_BROWSER_ACTIONS:
         return False

--- a/src/smolvm/cli/_kvm_session.py
+++ b/src/smolvm/cli/_kvm_session.py
@@ -72,7 +72,6 @@ _SKIP_FIRST_ARGS: frozenset[str] = frozenset(
         # Running-sandbox operations
         "env",
         "file",
-        "port",
     }
 )
 
@@ -85,6 +84,7 @@ _SKIP_SANDBOX_ACTIONS: frozenset[str] = frozenset(
         "pause",
         "resume",
         "delete",
+        "port",
     }
 )
 

--- a/src/smolvm/cli/_kvm_session.py
+++ b/src/smolvm/cli/_kvm_session.py
@@ -69,9 +69,6 @@ _SKIP_FIRST_ARGS: frozenset[str] = frozenset(
         "prune",
         "ui",
         "server",
-        # Running-sandbox operations
-        "env",
-        "file",
     }
 )
 
@@ -84,6 +81,8 @@ _SKIP_SANDBOX_ACTIONS: frozenset[str] = frozenset(
         "pause",
         "resume",
         "delete",
+        "env",
+        "file",
         "port",
     }
 )

--- a/src/smolvm/cli/_kvm_session.py
+++ b/src/smolvm/cli/_kvm_session.py
@@ -58,30 +58,41 @@ _REEXEC_DISABLE_ENV = "SMOLVM_NO_KVM_REEXEC"
 #      kvm at all.
 #
 # ``-h``/``--help``/``-V``/``--version`` are checked separately because they
-# can appear at *any* depth (e.g. ``smolvm create --help``), not just as
+# can appear at *any* depth (e.g. ``smolvm sandbox create --help``), not just as
 # the first argument.
 _SKIP_FIRST_ARGS: frozenset[str] = frozenset(
     {
         # Diagnostic / administrative
         "doctor",
         "setup",
-        # Read-only state inspection
-        "list",
-        "info",
+        "update",
+        "prune",
+        "ui",
+        "server",
+        # Running-sandbox operations
         "env",
-        # VM-process-targeted (talks to an already-running sandbox; no kvm open)
-        "ssh",
-        "stop",
-        "pause",
-        # State-file maintenance
-        "delete",
-        "cleanup",
+        "file",
+        "port",
     }
 )
 
+_SKIP_SANDBOX_ACTIONS: frozenset[str] = frozenset(
+    {
+        "list",
+        "info",
+        "ssh",
+        "stop",
+        "pause",
+        "resume",
+        "delete",
+    }
+)
+
+_SKIP_BROWSER_ACTIONS: frozenset[str] = frozenset({"list", "stop", "open", "logs"})
+
 # Help/version flags can appear anywhere in argv (top-level *or* per-verb,
-# e.g. ``smolvm create --help``). When any of these is present, argparse
-# is going to short-circuit before any kvm work happens, so we should too.
+# e.g. ``smolvm sandbox create --help``). When any of these is present, Click is
+# going to short-circuit before any kvm work happens, so we should too.
 _HELP_VERSION_FLAGS: frozenset[str] = frozenset({"-h", "--help", "-V", "--version"})
 
 _KVM_DEV = Path("/dev/kvm")
@@ -153,6 +164,10 @@ def _should_attempt_reexec(argv: Sequence[str] | None) -> bool:
 
     args = list(argv) if argv is not None else sys.argv[1:]
     if args and args[0] in _SKIP_FIRST_ARGS:
+        return False
+    if len(args) >= 2 and args[0] == "sandbox" and args[1] in _SKIP_SANDBOX_ACTIONS:
+        return False
+    if len(args) >= 2 and args[0] == "browser" and args[1] in _SKIP_BROWSER_ACTIONS:
         return False
     if any(arg in _HELP_VERSION_FLAGS for arg in args):
         return False

--- a/src/smolvm/cli/cleanup.py
+++ b/src/smolvm/cli/cleanup.py
@@ -25,7 +25,14 @@ from rich.panel import Panel
 from rich.table import Table
 from rich.text import Text
 
-from smolvm.cli.output import console_stdout, emit_json, render_empty, render_error, status_style
+from smolvm.cli.output import (
+    console_stdout,
+    emit_error,
+    emit_json,
+    render_empty,
+    render_error,
+    status_style,
+)
 from smolvm.vm import SmolVMManager
 
 # ---------------------------------------------------------------------------
@@ -239,7 +246,7 @@ def run_delete(
             return exit_code
     except Exception as exc:
         if json_output:
-            emit_json(command_name, 1, data=None, error=_error_payload(exc))
+            emit_error(command_name, exit_code=1, **_error_payload(exc))
         else:
             render_error(f"Error: {exc}")
         return 1
@@ -268,17 +275,13 @@ def _confirm_cleanup(
         return None
 
     if json_output:
-        emit_json(
+        emit_error(
             command_name,
-            1,
-            data=None,
-            error={
-                "message": (
-                    "Refusing to delete VMs without --force in --json mode. "
-                    "Pass --force to confirm."
-                ),
-                "code": "refused",
-            },
+            "refused",
+            "Refusing to delete VMs without --force in --json mode. "
+            "Run 'smolvm sandbox delete --all --force --json' to confirm.",
+            recovery="Run 'smolvm sandbox delete --all --force --json' to confirm.",
+            exit_code=1,
         )
         return 1
 
@@ -358,7 +361,7 @@ def run_cleanup(
             return exit_code
     except Exception as exc:
         if json_output:
-            emit_json(command_name, 1, data=None, error=_error_payload(exc))
+            emit_error(command_name, exit_code=1, **_error_payload(exc))
         else:
             render_error(f"Error: {exc}")
         return 1

--- a/src/smolvm/cli/cleanup.py
+++ b/src/smolvm/cli/cleanup.py
@@ -16,10 +16,8 @@
 
 from __future__ import annotations
 
-import argparse
 import os
 import sys
-from collections.abc import Sequence
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from dataclasses import asdict, dataclass
 
@@ -65,51 +63,6 @@ class DeleteResult:
 
 
 # ---------------------------------------------------------------------------
-# Argument helpers
-# ---------------------------------------------------------------------------
-
-
-def add_delete_args(parser: argparse.ArgumentParser) -> None:
-    """Add CLI arguments for ``smolvm delete``."""
-    parser.add_argument(
-        "vm_ids",
-        nargs="+",
-        metavar="vm-id",
-        help="One or more VM IDs to delete.",
-    )
-    parser.add_argument(
-        "--dry-run",
-        action="store_true",
-        help="Show what would be deleted without actually deleting.",
-    )
-    parser.add_argument(
-        "--json",
-        action="store_true",
-        help="Emit machine-readable JSON output.",
-    )
-
-
-def add_cleanup_args(parser: argparse.ArgumentParser) -> None:
-    """Add CLI arguments for ``smolvm cleanup``."""
-    parser.add_argument(
-        "--dry-run",
-        action="store_true",
-        help="Show what would be cleaned up without actually deleting.",
-    )
-    parser.add_argument(
-        "--force",
-        "-f",
-        action="store_true",
-        help="Skip the confirmation prompt and delete all VMs.",
-    )
-    parser.add_argument(
-        "--json",
-        action="store_true",
-        help="Emit machine-readable JSON output.",
-    )
-
-
-# ---------------------------------------------------------------------------
 # Shared rendering
 # ---------------------------------------------------------------------------
 
@@ -117,7 +70,7 @@ def add_cleanup_args(parser: argparse.ArgumentParser) -> None:
 def _error_payload(exc: Exception) -> dict[str, str]:
     return {
         "message": str(exc),
-        "type": "runtime_error",
+        "code": "runtime_error",
     }
 
 
@@ -234,17 +187,17 @@ def _delete_vms_concurrent(
     with ThreadPoolExecutor(max_workers=min(len(target_ids), 8)) as pool:
         futures = {pool.submit(_do_delete, vm_id): vm_id for vm_id in target_ids}
         for future in as_completed(futures):
-            vm_id, exc = future.result()
-            if exc is None:
+            vm_id, delete_error = future.result()
+            if delete_error is None:
                 deleted.append(vm_id)
             else:
-                failed.append(DeleteFailure(vm_id=vm_id, error=str(exc)))
+                failed.append(DeleteFailure(vm_id=vm_id, error=str(delete_error)))
 
     return deleted, failed
 
 
 # ---------------------------------------------------------------------------
-# smolvm delete <vm-id> [vm-id ...]
+# smolvm sandbox delete <vm-id> [vm-id ...]
 # ---------------------------------------------------------------------------
 
 
@@ -253,6 +206,7 @@ def run_delete(
     vm_ids: list[str],
     dry_run: bool = False,
     json_output: bool = False,
+    command_name: str = "sandbox.delete",
 ) -> int:
     """Delete specific VMs by ID."""
     warn_not_root = sys.platform == "linux" and os.geteuid() != 0
@@ -278,21 +232,21 @@ def run_delete(
             exit_code = 1 if failed else 0
 
             if json_output:
-                emit_json("delete", exit_code, data=asdict(result))
+                emit_json(command_name, exit_code, data=asdict(result))
             else:
                 _render_result(result, command="delete", warn_not_root=warn_not_root)
 
             return exit_code
     except Exception as exc:
         if json_output:
-            emit_json("delete", 1, data=None, error=_error_payload(exc))
+            emit_json(command_name, 1, data=None, error=_error_payload(exc))
         else:
             render_error(f"Error: {exc}")
         return 1
 
 
 # ---------------------------------------------------------------------------
-# smolvm cleanup
+# smolvm sandbox delete --all
 # ---------------------------------------------------------------------------
 
 
@@ -301,6 +255,7 @@ def _confirm_cleanup(
     *,
     force: bool,
     json_output: bool,
+    command_name: str,
 ) -> int | None:
     """Confirm the destructive cleanup with the user.
 
@@ -314,7 +269,7 @@ def _confirm_cleanup(
 
     if json_output:
         emit_json(
-            "cleanup",
+            command_name,
             1,
             data=None,
             error={
@@ -322,7 +277,7 @@ def _confirm_cleanup(
                     "Refusing to delete VMs without --force in --json mode. "
                     "Pass --force to confirm."
                 ),
-                "type": "refused",
+                "code": "refused",
             },
         )
         return 1
@@ -356,6 +311,7 @@ def run_cleanup(
     dry_run: bool = False,
     json_output: bool = False,
     force: bool = False,
+    command_name: str = "sandbox.delete",
 ) -> int:
     """Delete all VMs."""
     warn_not_root = sys.platform == "linux" and os.geteuid() != 0
@@ -369,7 +325,12 @@ def run_cleanup(
             deleted: list[str] = []
             failed: list[DeleteFailure] = []
             if not dry_run and target_ids:
-                abort_code = _confirm_cleanup(target_ids, force=force, json_output=json_output)
+                abort_code = _confirm_cleanup(
+                    target_ids,
+                    force=force,
+                    json_output=json_output,
+                    command_name=command_name,
+                )
                 if abort_code is not None:
                     return abort_code
             if not dry_run:
@@ -390,35 +351,14 @@ def run_cleanup(
             exit_code = 1 if failed else 0
 
             if json_output:
-                emit_json("cleanup", exit_code, data=asdict(result))
+                emit_json(command_name, exit_code, data=asdict(result))
             else:
-                _render_result(result, command="cleanup", warn_not_root=warn_not_root)
+                _render_result(result, command="delete", warn_not_root=warn_not_root)
 
             return exit_code
     except Exception as exc:
         if json_output:
-            emit_json("cleanup", 1, data=None, error=_error_payload(exc))
+            emit_json(command_name, 1, data=None, error=_error_payload(exc))
         else:
             render_error(f"Error: {exc}")
         return 1
-
-
-# ---------------------------------------------------------------------------
-# Standalone entrypoint (smolvm-cleanup)
-# ---------------------------------------------------------------------------
-
-
-def build_parser() -> argparse.ArgumentParser:
-    parser = argparse.ArgumentParser(description="Delete all SmolVM VMs")
-    add_cleanup_args(parser)
-    return parser
-
-
-def main(argv: Sequence[str] | None = None) -> int:
-    """Cleanup CLI entrypoint."""
-    args = build_parser().parse_args(argv)
-    return run_cleanup(
-        dry_run=args.dry_run,
-        json_output=args.json,
-        force=args.force,
-    )

--- a/src/smolvm/cli/commands/__init__.py
+++ b/src/smolvm/cli/commands/__init__.py
@@ -1,0 +1,5 @@
+"""Click command registration for the SmolVM CLI."""
+
+from smolvm.cli.commands.app import build_cli
+
+__all__ = ["build_cli"]

--- a/src/smolvm/cli/commands/app.py
+++ b/src/smolvm/cli/commands/app.py
@@ -1,0 +1,898 @@
+"""Click command tree for the SmolVM CLI."""
+
+from __future__ import annotations
+
+import importlib.metadata
+from types import SimpleNamespace
+from typing import Any
+
+import click
+
+from smolvm.cli.commands.options import (
+    LinuxOnlyOption,
+    backend_option,
+    boot_timeout_option,
+    comm_channel_option,
+    json_option,
+    positive_float_type,
+    positive_int_type,
+    qemu_machine_option,
+    ssh_auth_options,
+)
+from smolvm.cli.version_check import maybe_print_update_notice
+from smolvm.host.doctor import run_doctor
+from smolvm.types import BrowserSessionState, GuestOS, SnapshotType, VMState
+
+CONTEXT_SETTINGS = {"help_option_names": ["-h", "--help"]}
+
+
+def _handlers() -> Any:
+    from smolvm.cli import main
+
+    return main
+
+
+def _before_command(*, json_output: bool = False, skip_update_notice: bool = False) -> None:
+    maybe_print_update_notice(json_output=json_output or skip_update_notice)
+
+
+def _ns(**values: Any) -> SimpleNamespace:
+    return SimpleNamespace(**values)
+
+
+def _mounts(values: tuple[str, ...]) -> list[str] | None:
+    return list(values) or None
+
+
+@click.group(context_settings=CONTEXT_SETTINGS, invoke_without_command=True)
+@click.version_option(
+    importlib.metadata.version("smolvm"),
+    "-V",
+    "--version",
+    prog_name="smolvm",
+    message="%(prog)s %(version)s",
+)
+@click.pass_context
+def cli(ctx: click.Context) -> int | None:
+    """Create, manage, and connect to disposable sandboxes for AI agents."""
+    if ctx.invoked_subcommand is None:
+        click.echo(ctx.get_help())
+        return 0
+    return None
+
+
+@cli.group(context_settings=CONTEXT_SETTINGS)
+def sandbox() -> None:
+    """Create, inspect, connect to, and delete sandboxes."""
+
+
+@sandbox.command("create")
+@click.option("-n", "--name", default=None, help="Name for the sandbox.")
+@click.option(
+    "--os",
+    "os_name",
+    type=click.Choice([guest_os.value for guest_os in GuestOS]),
+    default=None,
+    help="Operating system image; auto-detected when omitted.",
+)
+@click.option("--image", default=None, help="S3 URI or local qcow2 image path.")
+@click.option("--memory", "memory_mib", type=int, default=None, metavar="MIB")
+@click.option("--disk-size", "disk_size_mib", type=int, default=None, metavar="MIB")
+@backend_option(default=None)
+@qemu_machine_option
+@comm_channel_option
+@click.option("--mount", "mounts", multiple=True, metavar="HOST_PATH[:GUEST_PATH]")
+@click.option("--writable-mounts", is_flag=True, help="Allow writes to mounted host folders.")
+@boot_timeout_option
+@json_option
+def sandbox_create(
+    name: str | None,
+    os_name: str | None,
+    image: str | None,
+    memory_mib: int | None,
+    disk_size_mib: int | None,
+    backend: str | None,
+    qemu_machine: str,
+    comm_channel: str | None,
+    mounts: tuple[str, ...],
+    writable_mounts: bool,
+    boot_timeout: float,
+    json_output: bool,
+) -> Any:
+    _before_command(json_output=json_output)
+    return _handlers()._run_create(
+        _ns(
+            command_name="sandbox.create",
+            name=name,
+            os=os_name,
+            image=image,
+            memory_mib=memory_mib,
+            disk_size_mib=disk_size_mib,
+            backend=backend,
+            qemu_machine=qemu_machine,
+            comm_channel=comm_channel,
+            mounts=_mounts(mounts),
+            writable_mounts=writable_mounts,
+            boot_timeout=boot_timeout,
+            json=json_output,
+        )
+    )
+
+
+@sandbox.command("list")
+@click.option("--all", "include_all", is_flag=True, help="Show all sandboxes.")
+@click.option(
+    "--status",
+    "status_filter",
+    type=click.Choice([state.value for state in VMState]),
+    default=None,
+)
+@json_option
+def sandbox_list(include_all: bool, status_filter: str | None, json_output: bool) -> Any:
+    if include_all and status_filter is not None:
+        raise click.UsageError("Use either --all or --status, not both.")
+    _before_command(json_output=json_output)
+    return _handlers()._run_list(
+        include_all=include_all,
+        status_filter=status_filter,
+        json_output=json_output,
+        command_name="sandbox.list",
+    )
+
+
+@sandbox.command("info")
+@click.argument("vm_id", metavar="sandbox")
+@json_option
+def sandbox_info(vm_id: str, json_output: bool) -> Any:
+    _before_command(json_output=json_output)
+    return _handlers()._run_info(
+        vm_id=vm_id,
+        json_output=json_output,
+        command_name="sandbox.info",
+    )
+
+
+@sandbox.command("start")
+@click.argument("vm_id", metavar="sandbox")
+@boot_timeout_option
+@json_option
+def sandbox_start(vm_id: str, boot_timeout: float, json_output: bool) -> Any:
+    _before_command(json_output=json_output)
+    return _handlers()._run_vm_start(
+        _ns(command_name="sandbox.start", vm_id=vm_id, boot_timeout=boot_timeout, json=json_output)
+    )
+
+
+@sandbox.command("stop")
+@click.argument("vm_id", metavar="sandbox")
+@click.option(
+    "--timeout",
+    type=positive_float_type(),
+    default=3.0,
+    show_default=True,
+    help="Seconds to wait before forcing shutdown.",
+)
+@json_option
+def sandbox_stop(vm_id: str, timeout: float, json_output: bool) -> Any:
+    _before_command(json_output=json_output)
+    return _handlers()._run_stop(
+        _ns(command_name="sandbox.stop", vm_id=vm_id, timeout=timeout, json=json_output)
+    )
+
+
+@sandbox.command("pause")
+@click.argument("vm_id", metavar="sandbox")
+@json_option
+def sandbox_pause(vm_id: str, json_output: bool) -> Any:
+    _before_command(json_output=json_output)
+    return _handlers()._run_pause(
+        _ns(command_name="sandbox.pause", vm_id=vm_id, json=json_output)
+    )
+
+
+@sandbox.command("resume")
+@click.argument("vm_id", metavar="sandbox")
+@json_option
+def sandbox_resume(vm_id: str, json_output: bool) -> Any:
+    _before_command(json_output=json_output)
+    return _handlers()._run_resume(
+        _ns(command_name="sandbox.resume", vm_id=vm_id, json=json_output)
+    )
+
+
+@sandbox.command("ssh")
+@click.argument("vm_id", metavar="sandbox")
+@ssh_auth_options
+@boot_timeout_option
+def sandbox_ssh(vm_id: str, ssh_key: str | None, ssh_user: str, boot_timeout: float) -> Any:
+    _before_command()
+    return _handlers()._run_ssh(
+        _ns(
+            command_name="sandbox.ssh",
+            vm_id=vm_id,
+            ssh_key=ssh_key,
+            ssh_user=ssh_user,
+            boot_timeout=boot_timeout,
+        )
+    )
+
+
+@sandbox.command("delete")
+@click.argument("vm_ids", nargs=-1, metavar="sandbox...")
+@click.option("--all", "all_sandboxes", is_flag=True, help="Delete every sandbox.")
+@click.option("--force", is_flag=True, help="Skip the confirmation prompt for --all.")
+@click.option("--dry-run", is_flag=True, help="Show what would be deleted.")
+@json_option
+def sandbox_delete(
+    vm_ids: tuple[str, ...],
+    all_sandboxes: bool,
+    force: bool,
+    dry_run: bool,
+    json_output: bool,
+) -> Any:
+    if all_sandboxes and vm_ids:
+        raise click.UsageError("Use either sandbox names or --all, not both.")
+    if not all_sandboxes and not vm_ids:
+        raise click.UsageError("Pass one or more sandboxes, or use --all.")
+    if all_sandboxes and json_output and not force:
+        from smolvm.cli.output import emit_error
+
+        return emit_error(
+            "sandbox.delete",
+            "refused",
+            "Refusing to delete sandboxes without --force in --json mode.",
+            recovery="Run 'smolvm sandbox delete --all --force --json' to confirm.",
+        )
+
+    _before_command(json_output=json_output)
+    from smolvm.cli.cleanup import run_cleanup, run_delete
+
+    if all_sandboxes:
+        return run_cleanup(
+            dry_run=dry_run,
+            json_output=json_output,
+            force=force,
+            command_name="sandbox.delete",
+        )
+    return run_delete(
+        vm_ids=list(vm_ids),
+        dry_run=dry_run,
+        json_output=json_output,
+        command_name="sandbox.delete",
+    )
+
+
+@cli.command("setup", help="Install or validate local runtime dependencies.")
+@click.option("--check-only", is_flag=True, help="Check what is needed without installing.")
+@click.option("--with-docker", is_flag=True, help="Also install or check Docker.")
+@click.option("--skip-deps", is_flag=True, help="Skip installing system packages.")
+@click.option("--assets-dir", is_flag=True, help="Print the packaged setup-assets directory.")
+@click.option("--no-configure-runtime", cls=LinuxOnlyOption, is_flag=True)
+@click.option("--runtime-user", cls=LinuxOnlyOption, default=None)
+@click.option("--remove-runtime-config", cls=LinuxOnlyOption, is_flag=True)
+@click.option("--for-bake", cls=LinuxOnlyOption, is_flag=True)
+@click.option("--skip-kvm-check", cls=LinuxOnlyOption, is_flag=True)
+@click.option("--skip-runtime-check", cls=LinuxOnlyOption, is_flag=True)
+@click.option("--firecracker-version", cls=LinuxOnlyOption, default=None, metavar="VER")
+def setup(
+    check_only: bool,
+    with_docker: bool,
+    skip_deps: bool,
+    assets_dir: bool,
+    no_configure_runtime: bool,
+    runtime_user: str | None,
+    remove_runtime_config: bool,
+    for_bake: bool,
+    skip_kvm_check: bool,
+    skip_runtime_check: bool,
+    firecracker_version: str | None,
+) -> Any:
+    _before_command(skip_update_notice=assets_dir)
+    return _handlers()._run_setup(
+        check_only=check_only,
+        with_docker=with_docker,
+        configure_runtime=not no_configure_runtime,
+        no_configure_runtime=no_configure_runtime,
+        skip_deps=skip_deps,
+        runtime_user=runtime_user,
+        remove_runtime_config=remove_runtime_config,
+        for_bake=for_bake,
+        skip_kvm_check=skip_kvm_check,
+        skip_runtime_check=skip_runtime_check,
+        firecracker_version=firecracker_version,
+        assets_dir=assets_dir,
+    )
+
+
+@cli.command("doctor", help="Check whether this machine can run sandboxes.")
+@backend_option(default=None)
+@click.option("--strict", is_flag=True, help="Fail if any check reports a warning.")
+@json_option
+def doctor(backend: str | None, strict: bool, json_output: bool) -> Any:
+    _before_command(json_output=json_output)
+    return run_doctor(backend=backend, json_output=json_output, strict=strict)
+
+
+@cli.command("update", help="Upgrade SmolVM to the latest stable release.")
+@click.option("--check", "check_only", is_flag=True, help="Check without installing.")
+@json_option
+def update(check_only: bool, json_output: bool) -> Any:
+    _before_command(json_output=json_output)
+    from smolvm.cli.update import run_update
+
+    return run_update(check=check_only, json_output=json_output)
+
+
+@cli.command("prune", help="Remove stale image-cache entries.")
+@click.option("--dry-run", is_flag=True, help="Show what would be removed.")
+@click.option("--cache-dir", default=None, hidden=True)
+@json_option
+def prune(dry_run: bool, cache_dir: str | None, json_output: bool) -> Any:
+    _before_command(json_output=json_output)
+    from smolvm.cli.prune import run_prune
+
+    return run_prune(dry_run=dry_run, json_output=json_output, cache_dir=cache_dir)
+
+
+@cli.command("ui", help="Start the local dashboard.")
+@click.option("--host", default="127.0.0.1", show_default=True)
+@click.option("--port", default=8080, show_default=True, type=int)
+@click.option("--allow-beta", is_flag=True)
+def ui(host: str, port: int, allow_beta: bool) -> Any:
+    _before_command()
+    return _handlers()._run_ui(host=host, port=port, allow_beta=allow_beta)
+
+
+@cli.group(context_settings=CONTEXT_SETTINGS)
+def server() -> None:
+    """Run the local SmolVM HTTP API."""
+
+
+@server.command("start")
+@click.option("--host", default="127.0.0.1", show_default=True)
+@click.option("--port", default=8000, show_default=True, type=int)
+def server_start(host: str, port: int) -> Any:
+    _before_command()
+    return _handlers()._run_server_start(host=host, port=port)
+
+
+@cli.group(context_settings=CONTEXT_SETTINGS)
+def snapshot() -> None:
+    """Save and restore sandbox state."""
+
+
+@snapshot.command("create")
+@click.argument("vm_id", metavar="sandbox")
+@click.option("--snapshot-id", default=None)
+@click.option(
+    "--snapshot-type",
+    type=click.Choice([snapshot_type.value for snapshot_type in SnapshotType]),
+    default=SnapshotType.FULL.value,
+    show_default=True,
+)
+@click.option("--resume-source", is_flag=True)
+@json_option
+def snapshot_create(
+    vm_id: str,
+    snapshot_id: str | None,
+    snapshot_type: str,
+    resume_source: bool,
+    json_output: bool,
+) -> Any:
+    _before_command(json_output=json_output)
+    return _handlers()._run_snapshot(
+        _ns(
+            snapshot_action="create",
+            vm_id=vm_id,
+            snapshot_id=snapshot_id,
+            snapshot_type=snapshot_type,
+            resume_source=resume_source,
+            json=json_output,
+        )
+    )
+
+
+@snapshot.command("restore")
+@click.argument("snapshot_id", metavar="snapshot")
+@click.option("--resume", is_flag=True)
+@click.option("--force", is_flag=True)
+@json_option
+def snapshot_restore(snapshot_id: str, resume: bool, force: bool, json_output: bool) -> Any:
+    _before_command(json_output=json_output)
+    return _handlers()._run_snapshot(
+        _ns(
+            snapshot_action="restore",
+            snapshot_id=snapshot_id,
+            resume=resume,
+            force=force,
+            json=json_output,
+        )
+    )
+
+
+@snapshot.command("delete")
+@click.argument("snapshot_id", metavar="snapshot")
+@json_option
+def snapshot_delete(snapshot_id: str, json_output: bool) -> Any:
+    _before_command(json_output=json_output)
+    return _handlers()._run_snapshot(
+        _ns(snapshot_action="delete", snapshot_id=snapshot_id, json=json_output)
+    )
+
+
+@snapshot.command("list")
+@click.option("--vm-id", default=None)
+@json_option
+def snapshot_list(vm_id: str | None, json_output: bool) -> Any:
+    _before_command(json_output=json_output)
+    return _handlers()._run_snapshot(
+        _ns(snapshot_action="list", vm_id=vm_id, json=json_output)
+    )
+
+
+@cli.group(context_settings=CONTEXT_SETTINGS)
+def file() -> None:
+    """Copy files into or out of a sandbox."""
+
+
+@file.command("upload")
+@click.argument("vm_id", metavar="sandbox")
+@click.argument("local_path", metavar="local-path")
+@click.argument("guest_path", metavar="guest-path")
+@click.option("--no-create-dirs", is_flag=True)
+@ssh_auth_options
+@comm_channel_option
+@json_option
+def file_upload(
+    vm_id: str,
+    local_path: str,
+    guest_path: str,
+    no_create_dirs: bool,
+    ssh_key: str | None,
+    ssh_user: str,
+    comm_channel: str | None,
+    json_output: bool,
+) -> Any:
+    _before_command(json_output=json_output)
+    return _handlers()._run_file(
+        _ns(
+            file_action="upload",
+            vm_id=vm_id,
+            local_path=local_path,
+            guest_path=guest_path,
+            no_create_dirs=no_create_dirs,
+            ssh_key=ssh_key,
+            ssh_user=ssh_user,
+            comm_channel=comm_channel,
+            json=json_output,
+        )
+    )
+
+
+@file.command("download")
+@click.argument("vm_id", metavar="sandbox")
+@click.argument("guest_path", metavar="guest-path")
+@click.argument("local_path", metavar="local-path")
+@click.option("--no-create-dirs", is_flag=True)
+@ssh_auth_options
+@comm_channel_option
+@json_option
+def file_download(
+    vm_id: str,
+    guest_path: str,
+    local_path: str,
+    no_create_dirs: bool,
+    ssh_key: str | None,
+    ssh_user: str,
+    comm_channel: str | None,
+    json_output: bool,
+) -> Any:
+    _before_command(json_output=json_output)
+    return _handlers()._run_file(
+        _ns(
+            file_action="download",
+            vm_id=vm_id,
+            guest_path=guest_path,
+            local_path=local_path,
+            no_create_dirs=no_create_dirs,
+            ssh_key=ssh_key,
+            ssh_user=ssh_user,
+            comm_channel=comm_channel,
+            json=json_output,
+        )
+    )
+
+
+@cli.group(context_settings=CONTEXT_SETTINGS)
+def env() -> None:
+    """Manage sandbox environment variables."""
+
+
+@env.command("set")
+@click.argument("vm_id", metavar="sandbox")
+@click.argument("pairs", nargs=-1, required=True, metavar="KEY=VALUE...")
+@ssh_auth_options
+@comm_channel_option
+@json_option
+def env_set(
+    vm_id: str,
+    pairs: tuple[str, ...],
+    ssh_key: str | None,
+    ssh_user: str,
+    comm_channel: str | None,
+    json_output: bool,
+) -> Any:
+    _before_command(json_output=json_output)
+    return _handlers()._run_env(
+        _ns(
+            env_action="set",
+            vm_id=vm_id,
+            pairs=list(pairs),
+            ssh_key=ssh_key,
+            ssh_user=ssh_user,
+            comm_channel=comm_channel,
+            json=json_output,
+        )
+    )
+
+
+@env.command("unset")
+@click.argument("vm_id", metavar="sandbox")
+@click.argument("keys", nargs=-1, required=True, metavar="KEY...")
+@ssh_auth_options
+@comm_channel_option
+@json_option
+def env_unset(
+    vm_id: str,
+    keys: tuple[str, ...],
+    ssh_key: str | None,
+    ssh_user: str,
+    comm_channel: str | None,
+    json_output: bool,
+) -> Any:
+    _before_command(json_output=json_output)
+    return _handlers()._run_env(
+        _ns(
+            env_action="unset",
+            vm_id=vm_id,
+            keys=list(keys),
+            ssh_key=ssh_key,
+            ssh_user=ssh_user,
+            comm_channel=comm_channel,
+            json=json_output,
+        )
+    )
+
+
+@env.command("list")
+@click.argument("vm_id", metavar="sandbox")
+@click.option("--show-values", is_flag=True)
+@ssh_auth_options
+@comm_channel_option
+@json_option
+def env_list(
+    vm_id: str,
+    show_values: bool,
+    ssh_key: str | None,
+    ssh_user: str,
+    comm_channel: str | None,
+    json_output: bool,
+) -> Any:
+    _before_command(json_output=json_output)
+    return _handlers()._run_env(
+        _ns(
+            env_action="list",
+            vm_id=vm_id,
+            show_values=show_values,
+            ssh_key=ssh_key,
+            ssh_user=ssh_user,
+            comm_channel=comm_channel,
+            json=json_output,
+        )
+    )
+
+
+@cli.group(context_settings=CONTEXT_SETTINGS)
+def port() -> None:
+    """Manage port forwarding for a sandbox."""
+
+
+@port.command("expose")
+@click.argument("vm_id", metavar="sandbox")
+@click.argument("mapping", metavar="[host-port:]sandbox-port")
+@ssh_auth_options
+@comm_channel_option
+@json_option
+def port_expose(
+    vm_id: str,
+    mapping: str,
+    ssh_key: str | None,
+    ssh_user: str,
+    comm_channel: str | None,
+    json_output: bool,
+) -> Any:
+    _before_command(json_output=json_output)
+    return _handlers()._run_port_expose(
+        _ns(
+            vm_id=vm_id,
+            mapping=mapping,
+            ssh_key=ssh_key,
+            ssh_user=ssh_user,
+            comm_channel=comm_channel,
+            json=json_output,
+        )
+    )
+
+
+@port.command("close")
+@click.argument("vm_id", metavar="sandbox")
+@click.argument("mapping", metavar="host-port:sandbox-port")
+@ssh_auth_options
+@comm_channel_option
+@json_option
+def port_close(
+    vm_id: str,
+    mapping: str,
+    ssh_key: str | None,
+    ssh_user: str,
+    comm_channel: str | None,
+    json_output: bool,
+) -> Any:
+    _before_command(json_output=json_output)
+    return _handlers()._run_port_close(
+        _ns(
+            vm_id=vm_id,
+            mapping=mapping,
+            ssh_key=ssh_key,
+            ssh_user=ssh_user,
+            comm_channel=comm_channel,
+            json=json_output,
+        )
+    )
+
+
+@port.command("list")
+@click.argument("vm_id", metavar="sandbox")
+@ssh_auth_options
+@comm_channel_option
+@json_option
+def port_list(
+    vm_id: str,
+    ssh_key: str | None,
+    ssh_user: str,
+    comm_channel: str | None,
+    json_output: bool,
+) -> Any:
+    _before_command(json_output=json_output)
+    return _handlers()._run_port_list(
+        _ns(
+            vm_id=vm_id,
+            ssh_key=ssh_key,
+            ssh_user=ssh_user,
+            comm_channel=comm_channel,
+            json=json_output,
+        )
+    )
+
+
+@cli.group(context_settings=CONTEXT_SETTINGS)
+def windows() -> None:
+    """Build Windows guest images."""
+
+
+@windows.command("build-image")
+@click.option("--iso", "windows_iso", required=True, metavar="PATH")
+@click.option("--virtio-win-iso", "virtio_win_iso", required=True, metavar="PATH")
+@click.option("--output", "output_qcow2", required=True, metavar="PATH")
+@click.option("--username", default="smolvm", show_default=True)
+@click.option("--password", default="smolvm", show_default=True)
+@click.option("--hostname", default="smolvm-win", show_default=True)
+@click.option("--edition", default="Windows 11 Pro", show_default=True)
+@click.option("--disk-size", "disk_size_mib", type=positive_int_type(), default=64 * 1024)
+@click.option("--build-timeout", "build_timeout_s", type=positive_float_type(), default=45 * 60)
+@json_option
+def windows_build_image(
+    windows_iso: str,
+    virtio_win_iso: str,
+    output_qcow2: str,
+    username: str,
+    password: str,
+    hostname: str,
+    edition: str,
+    disk_size_mib: int,
+    build_timeout_s: float,
+    json_output: bool,
+) -> Any:
+    _before_command(json_output=json_output)
+    return _handlers()._run_windows_build_image(
+        _ns(
+            windows_iso=windows_iso,
+            virtio_win_iso=virtio_win_iso,
+            output_qcow2=output_qcow2,
+            username=username,
+            password=password,
+            hostname=hostname,
+            edition=edition,
+            disk_size_mib=disk_size_mib,
+            build_timeout_s=build_timeout_s,
+            json=json_output,
+        )
+    )
+
+
+@cli.group(context_settings=CONTEXT_SETTINGS)
+def browser() -> None:
+    """Manage browser sandboxes."""
+
+
+@browser.command("start")
+@click.option("--session-id", default=None)
+@backend_option(default="auto")
+@click.option("--live", is_flag=True)
+@click.option("--profile-mode", type=click.Choice(["ephemeral", "persistent"]), default="ephemeral")
+@click.option("--profile-id", default=None)
+@click.option("--timeout-minutes", type=int, default=30, show_default=True)
+@click.option("--viewport-width", type=int, default=1280, show_default=True)
+@click.option("--viewport-height", type=int, default=720, show_default=True)
+@click.option("--memory", "memory_mib", type=int, default=2048, show_default=True)
+@click.option("--disk-size", "disk_size_mib", type=int, default=4096, show_default=True)
+@click.option("--record-video", is_flag=True)
+@click.option("--no-downloads", is_flag=True)
+@boot_timeout_option
+@json_option
+def browser_start(
+    session_id: str | None,
+    backend: str,
+    live: bool,
+    profile_mode: str,
+    profile_id: str | None,
+    timeout_minutes: int,
+    viewport_width: int,
+    viewport_height: int,
+    memory_mib: int,
+    disk_size_mib: int,
+    record_video: bool,
+    no_downloads: bool,
+    boot_timeout: float,
+    json_output: bool,
+) -> Any:
+    _before_command(json_output=json_output)
+    return _handlers()._run_browser(
+        _ns(
+            browser_action="start",
+            session_id=session_id,
+            backend=backend,
+            live=live,
+            profile_mode=profile_mode,
+            profile_id=profile_id,
+            timeout_minutes=timeout_minutes,
+            viewport_width=viewport_width,
+            viewport_height=viewport_height,
+            memory_mib=memory_mib,
+            disk_size_mib=disk_size_mib,
+            record_video=record_video,
+            no_downloads=no_downloads,
+            boot_timeout=boot_timeout,
+            json=json_output,
+        )
+    )
+
+
+@browser.command("stop")
+@click.argument("session_id", required=False, metavar="sandbox")
+@click.option("--all", "all_sessions", is_flag=True)
+def browser_stop(session_id: str | None, all_sessions: bool) -> Any:
+    if all_sessions == (session_id is not None):
+        raise click.UsageError("Pass a browser sandbox ID or --all.")
+    _before_command()
+    return _handlers()._run_browser(
+        _ns(browser_action="stop", session_id=session_id, all=all_sessions)
+    )
+
+
+@browser.command("list")
+@click.option(
+    "--status",
+    type=click.Choice([state.value for state in BrowserSessionState]),
+    default=None,
+)
+@json_option
+def browser_list(status: str | None, json_output: bool) -> Any:
+    _before_command(json_output=json_output)
+    return _handlers()._run_browser(
+        _ns(browser_action="list", status=status, json=json_output)
+    )
+
+
+@browser.command("open")
+@click.argument("session_id", metavar="sandbox")
+def browser_open(session_id: str) -> Any:
+    _before_command()
+    return _handlers()._run_browser(_ns(browser_action="open", session_id=session_id))
+
+
+@browser.command("logs")
+@click.argument("session_id", metavar="sandbox")
+@click.option("--tail", type=int, default=100, show_default=True)
+def browser_logs(session_id: str, tail: int) -> Any:
+    _before_command()
+    return _handlers()._run_browser(_ns(browser_action="logs", session_id=session_id, tail=tail))
+
+
+def _register_preset_commands() -> None:
+    from smolvm.presets import list_presets
+
+    for preset in list_presets():
+        public_name = "claude" if preset.name == "claude-code" else preset.name
+        if public_name not in {"codex", "claude", "openclaw", "hermes", "pi"}:
+            continue
+
+        @click.group(public_name, context_settings=CONTEXT_SETTINGS, help=preset.summary)
+        def preset_group() -> None:
+            pass
+
+        def _make_start_callback(preset_name: str, command_name: str) -> Any:
+            @click.command("start")
+            @click.option("-n", "--name", default=None)
+            @click.option("--memory", "memory_mib", type=int, default=None)
+            @click.option("--disk-size", "disk_size_mib", type=int, default=None)
+            @backend_option(default=None)
+            @qemu_machine_option
+            @click.option(
+                "--os",
+                "os_name",
+                type=click.Choice([guest_os.value for guest_os in GuestOS]),
+                default=None,
+            )
+            @click.option("--mount", "mounts", multiple=True, metavar="HOST_PATH[:GUEST_PATH]")
+            @click.option("--writable-mounts", is_flag=True)
+            @click.option("--install-timeout", type=positive_float_type(), default=600.0)
+            @click.option("--attach/--no-attach", default=None)
+            @boot_timeout_option
+            @json_option
+            def start(
+                name: str | None,
+                memory_mib: int | None,
+                disk_size_mib: int | None,
+                backend: str | None,
+                qemu_machine: str,
+                os_name: str | None,
+                mounts: tuple[str, ...],
+                writable_mounts: bool,
+                install_timeout: float,
+                attach: bool | None,
+                boot_timeout: float,
+                json_output: bool,
+            ) -> Any:
+                _before_command(json_output=json_output)
+                return _handlers()._run_start(
+                    _ns(
+                        command_name=f"{command_name}.start",
+                        preset_name=preset_name,
+                        name=name,
+                        memory_mib=memory_mib,
+                        disk_size_mib=disk_size_mib,
+                        backend=backend,
+                        qemu_machine=qemu_machine,
+                        os=os_name,
+                        mounts=_mounts(mounts),
+                        writable_mounts=writable_mounts,
+                        install_timeout=install_timeout,
+                        attach=attach,
+                        boot_timeout=boot_timeout,
+                        json=json_output,
+                    )
+                )
+
+            return start
+
+        preset_group.add_command(_make_start_callback(preset.name, public_name))
+        cli.add_command(preset_group)
+
+
+_register_preset_commands()
+
+
+def build_cli() -> click.Group:
+    """Return the root Click command."""
+    return cli

--- a/src/smolvm/cli/commands/app.py
+++ b/src/smolvm/cli/commands/app.py
@@ -442,7 +442,7 @@ def snapshot_list(vm_id: str | None, json_output: bool) -> Any:
     )
 
 
-@cli.group(context_settings=CONTEXT_SETTINGS)
+@sandbox.group(context_settings=CONTEXT_SETTINGS)
 def file() -> None:
     """Copy files into or out of a sandbox."""
 
@@ -476,6 +476,7 @@ def file_upload(
             ssh_key=ssh_key,
             ssh_user=ssh_user,
             comm_channel=comm_channel,
+            command_name="sandbox.file.upload",
             json=json_output,
         )
     )
@@ -510,12 +511,13 @@ def file_download(
             ssh_key=ssh_key,
             ssh_user=ssh_user,
             comm_channel=comm_channel,
+            command_name="sandbox.file.download",
             json=json_output,
         )
     )
 
 
-@cli.group(context_settings=CONTEXT_SETTINGS)
+@sandbox.group(context_settings=CONTEXT_SETTINGS)
 def env() -> None:
     """Manage sandbox environment variables."""
 
@@ -543,6 +545,7 @@ def env_set(
             ssh_key=ssh_key,
             ssh_user=ssh_user,
             comm_channel=comm_channel,
+            command_name="sandbox.env.set",
             json=json_output,
         )
     )
@@ -571,6 +574,7 @@ def env_unset(
             ssh_key=ssh_key,
             ssh_user=ssh_user,
             comm_channel=comm_channel,
+            command_name="sandbox.env.unset",
             json=json_output,
         )
     )
@@ -599,6 +603,7 @@ def env_list(
             ssh_key=ssh_key,
             ssh_user=ssh_user,
             comm_channel=comm_channel,
+            command_name="sandbox.env.list",
             json=json_output,
         )
     )

--- a/src/smolvm/cli/commands/app.py
+++ b/src/smolvm/cli/commands/app.py
@@ -130,7 +130,10 @@ def sandbox_create(
 @json_option
 def sandbox_list(include_all: bool, status_filter: str | None, json_output: bool) -> Any:
     if include_all and status_filter is not None:
-        raise click.UsageError("Use either --all or --status, not both.")
+        raise click.UsageError(
+            "Use one filter. Run 'smolvm sandbox list --all' or "
+            "'smolvm sandbox list --status running'."
+        )
     _before_command(json_output=json_output)
     return _handlers()._run_list(
         include_all=include_all,
@@ -229,16 +232,23 @@ def sandbox_delete(
     json_output: bool,
 ) -> Any:
     if all_sandboxes and vm_ids:
-        raise click.UsageError("Use either sandbox names or --all, not both.")
+        raise click.UsageError(
+            "Choose one target. Run 'smolvm sandbox delete my-sandbox' or "
+            "'smolvm sandbox delete --all --force'."
+        )
     if not all_sandboxes and not vm_ids:
-        raise click.UsageError("Pass one or more sandboxes, or use --all.")
+        raise click.UsageError(
+            "Pass a target. Run 'smolvm sandbox delete my-sandbox' or "
+            "'smolvm sandbox delete --all --force'."
+        )
     if all_sandboxes and json_output and not force:
         from smolvm.cli.output import emit_error
 
         return emit_error(
             "sandbox.delete",
             "refused",
-            "Refusing to delete sandboxes without --force in --json mode.",
+            "Refusing to delete sandboxes without --force in --json mode. "
+            "Run 'smolvm sandbox delete --all --force --json' to confirm.",
             recovery="Run 'smolvm sandbox delete --all --force --json' to confirm.",
         )
 
@@ -801,7 +811,10 @@ def browser_start(
 @click.option("--all", "all_sessions", is_flag=True)
 def browser_stop(session_id: str | None, all_sessions: bool) -> Any:
     if all_sessions == (session_id is not None):
-        raise click.UsageError("Pass a browser sandbox ID or --all.")
+        raise click.UsageError(
+            "Choose one target. Run 'smolvm browser stop browser-id' or "
+            "'smolvm browser stop --all'."
+        )
     _before_command()
     return _handlers()._run_browser(
         _ns(browser_action="stop", session_id=session_id, all=all_sessions)

--- a/src/smolvm/cli/commands/app.py
+++ b/src/smolvm/cli/commands/app.py
@@ -185,9 +185,7 @@ def sandbox_stop(vm_id: str, timeout: float, json_output: bool) -> Any:
 @json_option
 def sandbox_pause(vm_id: str, json_output: bool) -> Any:
     _before_command(json_output=json_output)
-    return _handlers()._run_pause(
-        _ns(command_name="sandbox.pause", vm_id=vm_id, json=json_output)
-    )
+    return _handlers()._run_pause(_ns(command_name="sandbox.pause", vm_id=vm_id, json=json_output))
 
 
 @sandbox.command("resume")
@@ -819,9 +817,7 @@ def browser_stop(session_id: str | None, all_sessions: bool) -> Any:
 @json_option
 def browser_list(status: str | None, json_output: bool) -> Any:
     _before_command(json_output=json_output)
-    return _handlers()._run_browser(
-        _ns(browser_action="list", status=status, json=json_output)
-    )
+    return _handlers()._run_browser(_ns(browser_action="list", status=status, json=json_output))
 
 
 @browser.command("open")

--- a/src/smolvm/cli/commands/app.py
+++ b/src/smolvm/cli/commands/app.py
@@ -356,7 +356,7 @@ def server_start(host: str, port: int) -> Any:
     return _handlers()._run_server_start(host=host, port=port)
 
 
-@cli.group(context_settings=CONTEXT_SETTINGS)
+@sandbox.group(context_settings=CONTEXT_SETTINGS)
 def snapshot() -> None:
     """Save and restore sandbox state."""
 
@@ -387,6 +387,7 @@ def snapshot_create(
             snapshot_id=snapshot_id,
             snapshot_type=snapshot_type,
             resume_source=resume_source,
+            command_name="sandbox.snapshot.create",
             json=json_output,
         )
     )
@@ -405,6 +406,7 @@ def snapshot_restore(snapshot_id: str, resume: bool, force: bool, json_output: b
             snapshot_id=snapshot_id,
             resume=resume,
             force=force,
+            command_name="sandbox.snapshot.restore",
             json=json_output,
         )
     )
@@ -416,7 +418,12 @@ def snapshot_restore(snapshot_id: str, resume: bool, force: bool, json_output: b
 def snapshot_delete(snapshot_id: str, json_output: bool) -> Any:
     _before_command(json_output=json_output)
     return _handlers()._run_snapshot(
-        _ns(snapshot_action="delete", snapshot_id=snapshot_id, json=json_output)
+        _ns(
+            snapshot_action="delete",
+            snapshot_id=snapshot_id,
+            command_name="sandbox.snapshot.delete",
+            json=json_output,
+        )
     )
 
 
@@ -426,7 +433,12 @@ def snapshot_delete(snapshot_id: str, json_output: bool) -> Any:
 def snapshot_list(vm_id: str | None, json_output: bool) -> Any:
     _before_command(json_output=json_output)
     return _handlers()._run_snapshot(
-        _ns(snapshot_action="list", vm_id=vm_id, json=json_output)
+        _ns(
+            snapshot_action="list",
+            vm_id=vm_id,
+            command_name="sandbox.snapshot.list",
+            json=json_output,
+        )
     )
 
 
@@ -592,7 +604,7 @@ def env_list(
     )
 
 
-@cli.group(context_settings=CONTEXT_SETTINGS)
+@sandbox.group(context_settings=CONTEXT_SETTINGS)
 def port() -> None:
     """Manage port forwarding for a sandbox."""
 
@@ -619,6 +631,7 @@ def port_expose(
             ssh_key=ssh_key,
             ssh_user=ssh_user,
             comm_channel=comm_channel,
+            command_name="sandbox.port.expose",
             json=json_output,
         )
     )
@@ -646,6 +659,7 @@ def port_close(
             ssh_key=ssh_key,
             ssh_user=ssh_user,
             comm_channel=comm_channel,
+            command_name="sandbox.port.close",
             json=json_output,
         )
     )
@@ -670,6 +684,7 @@ def port_list(
             ssh_key=ssh_key,
             ssh_user=ssh_user,
             comm_channel=comm_channel,
+            command_name="sandbox.port.list",
             json=json_output,
         )
     )

--- a/src/smolvm/cli/commands/options.py
+++ b/src/smolvm/cli/commands/options.py
@@ -1,0 +1,109 @@
+"""Small Click helpers shared by SmolVM commands."""
+
+from __future__ import annotations
+
+import platform
+from collections.abc import Callable, Mapping
+from functools import wraps
+from typing import Any, TypeVar
+
+import click
+
+F = TypeVar("F", bound=Callable[..., Any])
+
+BACKENDS = ["auto", "firecracker", "qemu", "libkrun"]
+QEMU_MACHINES = ["auto", "q35", "microvm"]
+COMM_CHANNELS = ["ssh", "vsock"]
+
+
+class LinuxOnlyOption(click.Option):
+    """Hide and reject Linux-only options on non-Linux hosts."""
+
+    def get_help_record(self, ctx: click.Context) -> tuple[str, str] | None:
+        if platform.system() != "Linux":
+            return None
+        return super().get_help_record(ctx)
+
+    def handle_parse_result(
+        self,
+        ctx: click.Context,
+        opts: Mapping[str, Any],
+        args: list[str],
+    ) -> tuple[Any, list[str]]:
+        if self.name in opts and platform.system() != "Linux":
+            option = next(iter(self.opts), f"--{self.name}")
+            raise click.UsageError(
+                f"{option} is only supported on Linux. Run 'smolvm setup' without this flag."
+            )
+        return super().handle_parse_result(ctx, opts, args)
+
+
+def _positive_number(
+    ctx: click.Context,
+    param: click.Parameter,
+    value: float | int | None,
+) -> float | int | None:
+    if value is not None and value <= 0:
+        raise click.BadParameter("value must be > 0", ctx=ctx, param=param)
+    return value
+
+
+def json_option(fn: F) -> F:
+    return click.option("--json", "json_output", is_flag=True, help="Output a JSON envelope.")(fn)
+
+
+def backend_option(*, default: str | None = None) -> Callable[[F], F]:
+    return click.option(
+        "--backend",
+        type=click.Choice(BACKENDS),
+        default=default,
+        help="Virtualization backend.",
+    )
+
+
+def qemu_machine_option(fn: F) -> F:
+    return click.option(
+        "--qemu-machine",
+        type=click.Choice(QEMU_MACHINES),
+        default="auto",
+        show_default=True,
+        help="QEMU machine model.",
+    )(fn)
+
+
+def comm_channel_option(fn: F) -> F:
+    return click.option(
+        "--comm-channel",
+        type=click.Choice(COMM_CHANNELS),
+        default=None,
+        help="Host-to-guest control channel.",
+    )(fn)
+
+
+def boot_timeout_option(fn: F) -> F:
+    return click.option(
+        "--boot-timeout",
+        type=float,
+        callback=_positive_number,
+        default=30.0,
+        show_default=True,
+        help="Seconds to wait for the sandbox to be ready.",
+    )(fn)
+
+
+def ssh_auth_options(fn: F) -> F:
+    @click.option("--ssh-key", default=None, help="Path to SSH private key.")
+    @click.option("--ssh-user", default="root", show_default=True, help="SSH user.")
+    @wraps(fn)
+    def wrapper(*args: Any, **kwargs: Any) -> Any:
+        return fn(*args, **kwargs)
+
+    return wrapper  # type: ignore[return-value]
+
+
+def positive_int_type() -> click.IntRange:
+    return click.IntRange(min=1)
+
+
+def positive_float_type() -> click.FloatRange:
+    return click.FloatRange(min=0, min_open=True)

--- a/src/smolvm/cli/main.py
+++ b/src/smolvm/cli/main.py
@@ -1875,7 +1875,10 @@ def _run_snapshot(args: SimpleNamespace) -> int:
     )
 
     if args.snapshot_action is None:
-        render_error("Usage: smolvm sandbox snapshot {create,restore,delete,list} ...")
+        render_error(
+            "Usage: smolvm sandbox snapshot {create,restore,delete,list} ... "
+            "Run 'smolvm sandbox snapshot --help' for usage."
+        )
         return 2
 
     if args.snapshot_action == "create":
@@ -2028,7 +2031,10 @@ def _run_env(args: SimpleNamespace) -> int:
     from smolvm.facade import SmolVM
 
     if args.env_action is None:
-        render_error("Usage: smolvm sandbox env {set,unset,list} <vm_id> ...")
+        render_error(
+            "Usage: smolvm sandbox env {set,unset,list} <vm_id> ... "
+            "Run 'smolvm sandbox env --help' for usage."
+        )
         return 2
 
     vm: SmolVM | None = None
@@ -2163,7 +2169,10 @@ def _run_file(args: SimpleNamespace) -> int:
     from smolvm.facade import SmolVM
 
     if args.file_action is None:
-        render_error("Usage: smolvm sandbox file {upload,download} ...")
+        render_error(
+            "Usage: smolvm sandbox file {upload,download} ... "
+            "Run 'smolvm sandbox file --help' for usage."
+        )
         return 2
 
     json_output = args.json
@@ -2211,7 +2220,10 @@ def _run_file(args: SimpleNamespace) -> int:
                 _render_file_download(download_data)
             return 0
 
-        render_error("Usage: smolvm sandbox file {upload,download} ...")
+        render_error(
+            "Usage: smolvm sandbox file {upload,download} ... "
+            "Run 'smolvm sandbox file --help' for usage."
+        )
         return 2
     except Exception as exc:
         return _emit_cli_error(command_name, 1, exc, json_output=json_output)
@@ -2536,7 +2548,10 @@ def _run_port(args: SimpleNamespace) -> int:
     if action == "list":
         return _run_port_list(args)
 
-    render_error("Usage: smolvm sandbox port {expose,close,list} ...")
+    render_error(
+        "Usage: smolvm sandbox port {expose,close,list} ... "
+        "Run 'smolvm sandbox port --help' for usage."
+    )
     return 2
 
 

--- a/src/smolvm/cli/main.py
+++ b/src/smolvm/cli/main.py
@@ -212,7 +212,7 @@ class SnapshotListFiltersPayload(TypedDict):
 
 
 class SnapshotListPayload(TypedDict):
-    """JSON payload for ``smolvm snapshot list``."""
+    """JSON payload for ``smolvm sandbox snapshot list``."""
 
     filters: SnapshotListFiltersPayload
     snapshots: list[SnapshotRow]
@@ -225,7 +225,7 @@ class SnapshotPayload(TypedDict):
 
 
 class SnapshotRestoreVmPayload(TypedDict):
-    """Machine-readable VM details for ``smolvm snapshot restore``."""
+    """Machine-readable VM details for ``smolvm sandbox snapshot restore``."""
 
     name: str
     status: str
@@ -234,7 +234,7 @@ class SnapshotRestoreVmPayload(TypedDict):
 
 
 class SnapshotRestorePayload(TypedDict):
-    """JSON payload for ``smolvm snapshot restore``."""
+    """JSON payload for ``smolvm sandbox snapshot restore``."""
 
     snapshot: SnapshotRow
     vm: SnapshotRestoreVmPayload
@@ -1865,15 +1865,19 @@ def _run_vm_start(args: SimpleNamespace) -> int:
 
 
 def _run_snapshot(args: SimpleNamespace) -> int:
-    """Handle ``smolvm snapshot`` commands."""
+    """Handle ``smolvm sandbox snapshot`` commands."""
     from smolvm.facade import SmolVM
     from smolvm.vm import SmolVMManager
 
     json_output = getattr(args, "json", False)
-    command_name = f"snapshot.{args.snapshot_action}" if args.snapshot_action else "snapshot"
+    command_name = getattr(args, "command_name", None) or (
+        f"sandbox.snapshot.{args.snapshot_action}"
+        if args.snapshot_action
+        else "sandbox.snapshot"
+    )
 
     if args.snapshot_action is None:
-        render_error("Usage: smolvm snapshot {create,restore,delete,list} ...")
+        render_error("Usage: smolvm sandbox snapshot {create,restore,delete,list} ...")
         return 2
 
     if args.snapshot_action == "create":
@@ -2335,23 +2339,25 @@ def _save_port_forwards(vm_id: str, forwards: list[dict]) -> None:
 
 
 def _run_port_expose(args: SimpleNamespace) -> int:
-    """Handle ``smolvm port expose``."""
+    """Handle ``smolvm sandbox port expose``."""
     from smolvm.facade import SmolVM
 
     json_output: bool = args.json
+    command_name = getattr(args, "command_name", "sandbox.port.expose")
     vm: SmolVM | None = None
 
     try:
         host_port_req, guest_port = _parse_port_mapping(args.mapping)
     except ValueError:
         return _emit_cli_error(
-            "port.expose",
+            command_name,
             1,
             ValueError(
                 f"Invalid mapping {args.mapping!r}. "
-                f"Run 'smolvm port expose {args.vm_id} 8080:3000'"
+                f"Run 'smolvm sandbox port expose {args.vm_id} 8080:3000'"
                 f" to forward host port 8080 to sandbox port 3000, "
-                f"or 'smolvm port expose {args.vm_id} 3000' to auto-select a host port."
+                f"or 'smolvm sandbox port expose {args.vm_id} 3000' "
+                "to auto-select a host port."
             ),
             json_output=json_output,
         )
@@ -2384,7 +2390,7 @@ def _run_port_expose(args: SimpleNamespace) -> int:
 
         if json_output:
             emit_json(
-                "port.expose",
+                command_name,
                 0,
                 data={
                     "sandbox": args.vm_id,
@@ -2400,10 +2406,11 @@ def _run_port_expose(args: SimpleNamespace) -> int:
             )
             console.print(f"Connect to [bold]localhost:{host_port}[/bold]")
             console.print(
-                f"Stop with: [bold]smolvm port close {args.vm_id} {host_port}:{guest_port}[/bold]"
+                f"Stop with: [bold]smolvm sandbox port close "
+                f"{args.vm_id} {host_port}:{guest_port}[/bold]"
             )
     except Exception as exc:
-        return _emit_cli_error("port.expose", 1, exc, json_output=json_output)
+        return _emit_cli_error(command_name, 1, exc, json_output=json_output)
     finally:
         if vm is not None:
             vm.close()
@@ -2412,10 +2419,11 @@ def _run_port_expose(args: SimpleNamespace) -> int:
 
 
 def _run_port_close(args: SimpleNamespace) -> int:
-    """Handle ``smolvm port close``."""
+    """Handle ``smolvm sandbox port close``."""
     from smolvm.facade import SmolVM
 
     json_output: bool = args.json
+    command_name = getattr(args, "command_name", "sandbox.port.close")
     vm: SmolVM | None = None
 
     try:
@@ -2423,10 +2431,10 @@ def _run_port_close(args: SimpleNamespace) -> int:
         if host_port is None:
             raise ValueError(
                 f"Use 'host-port:sandbox-port' format. "
-                f"Run 'smolvm port list {args.vm_id}' to see active forwards."
+                f"Run 'smolvm sandbox port list {args.vm_id}' to see active forwards."
             )
     except ValueError as exc:
-        return _emit_cli_error("port.close", 1, exc, json_output=json_output)
+        return _emit_cli_error(command_name, 1, exc, json_output=json_output)
 
     try:
         # Kill stored SSH tunnel process if present.
@@ -2472,7 +2480,7 @@ def _run_port_close(args: SimpleNamespace) -> int:
 
         if json_output:
             emit_json(
-                "port.close",
+                command_name,
                 0,
                 data={"sandbox": args.vm_id, "host_port": host_port, "guest_port": guest_port},
             )
@@ -2482,7 +2490,7 @@ def _run_port_close(args: SimpleNamespace) -> int:
             )
 
     except Exception as exc:
-        return _emit_cli_error("port.close", 1, exc, json_output=json_output)
+        return _emit_cli_error(command_name, 1, exc, json_output=json_output)
     finally:
         if vm is not None:
             vm.close()
@@ -2491,12 +2499,13 @@ def _run_port_close(args: SimpleNamespace) -> int:
 
 
 def _run_port_list(args: SimpleNamespace) -> int:
-    """Handle ``smolvm port list``."""
+    """Handle ``smolvm sandbox port list``."""
     json_output: bool = args.json
+    command_name = getattr(args, "command_name", "sandbox.port.list")
     forwards = _load_port_forwards(args.vm_id)
 
     if json_output:
-        emit_json("port.list", 0, data={"sandbox": args.vm_id, "forwards": forwards})
+        emit_json(command_name, 0, data={"sandbox": args.vm_id, "forwards": forwards})
     else:
         console = console_stdout()
         if not forwards:
@@ -2520,7 +2529,7 @@ def _run_port_list(args: SimpleNamespace) -> int:
 
 
 def _run_port(args: SimpleNamespace) -> int:
-    """Dispatch ``smolvm port <action>``."""
+    """Dispatch ``smolvm sandbox port <action>``."""
     action = getattr(args, "port_action", None)
     if action == "expose":
         return _run_port_expose(args)
@@ -2529,7 +2538,7 @@ def _run_port(args: SimpleNamespace) -> int:
     if action == "list":
         return _run_port_list(args)
 
-    render_error("Usage: smolvm port {expose,close,list} ...")
+    render_error("Usage: smolvm sandbox port {expose,close,list} ...")
     return 2
 
 
@@ -2945,12 +2954,16 @@ def _command_name_from_argv(args: Sequence[str]) -> str:
     tokens = [arg for arg in args if not arg.startswith("-")]
     if not tokens:
         return "smolvm"
+    if (
+        len(tokens) >= 3
+        and tokens[0] == "sandbox"
+        and tokens[1] in {"snapshot", "port"}
+    ):
+        return f"sandbox.{tokens[1]}.{tokens[2]}"
     if len(tokens) >= 2 and tokens[0] in {
         "sandbox",
-        "snapshot",
         "file",
         "env",
-        "port",
         "windows",
         "browser",
         "server",
@@ -2966,6 +2979,12 @@ def _command_name_from_argv(args: Sequence[str]) -> str:
 
 def _recovery_from_argv(args: Sequence[str]) -> str:
     tokens = [arg for arg in args if not arg.startswith("-")]
+    if (
+        len(tokens) >= 3
+        and tokens[0] == "sandbox"
+        and tokens[1] in {"snapshot", "port"}
+    ):
+        return f"Run 'smolvm {' '.join(tokens[:3])} --help' for usage."
     if tokens:
         return f"Run 'smolvm {' '.join(tokens[:2])} --help' for usage."
     return "Run 'smolvm --help' for usage."

--- a/src/smolvm/cli/main.py
+++ b/src/smolvm/cli/main.py
@@ -16,7 +16,6 @@
 
 from __future__ import annotations
 
-import argparse
 import importlib
 import importlib.metadata
 import os
@@ -28,8 +27,10 @@ from collections.abc import Callable, Sequence
 from contextlib import suppress
 from datetime import datetime, timezone
 from pathlib import Path
+from types import SimpleNamespace
 from typing import TYPE_CHECKING, Any, TypedDict
 
+import click
 from rich.panel import Panel
 from rich.progress import (
     BarColumn,
@@ -44,11 +45,15 @@ from rich.table import Table
 from rich.text import Text
 
 from smolvm.cli._kvm_session import maybe_reexec_for_kvm_group
-from smolvm.cli.cleanup import add_cleanup_args, add_delete_args, run_cleanup, run_delete
-from smolvm.cli.output import console_stdout, emit_json, render_empty, render_error, status_style
-from smolvm.cli.version_check import maybe_print_update_notice
-from smolvm.host.doctor import run_doctor
-from smolvm.types import BrowserSessionState, GuestOS, SnapshotType, VMState
+from smolvm.cli.output import (
+    console_stdout,
+    emit_error,
+    emit_json,
+    render_empty,
+    render_error,
+    status_style,
+)
+from smolvm.types import BrowserSessionState, GuestOS, VMState
 
 if TYPE_CHECKING:
     from smolvm.images.published import Arch, Vmm
@@ -82,14 +87,14 @@ class ListFiltersPayload(TypedDict):
 
 
 class ListPayload(TypedDict):
-    """JSON payload for ``smolvm list``."""
+    """JSON payload for ``smolvm sandbox list``."""
 
     filters: ListFiltersPayload
     vms: list[VmRow]
 
 
 class CreateVmPayload(TypedDict):
-    """Machine-readable VM details for ``smolvm create``."""
+    """Machine-readable VM details for ``smolvm sandbox create``."""
 
     name: str
     status: str
@@ -98,14 +103,14 @@ class CreateVmPayload(TypedDict):
 
 
 class CreateNextPayload(TypedDict):
-    """Suggested follow-up actions for ``smolvm create``."""
+    """Suggested follow-up actions for ``smolvm sandbox create``."""
 
     ssh_command: str
     info_command: str
 
 
 class InfoVmPayload(TypedDict):
-    """Machine-readable VM details for ``smolvm info``.
+    """Machine-readable VM details for ``smolvm sandbox info``.
 
     Memory and disk fields are in MiB (SmolVM's house unit, matching
     :attr:`VMConfig.memory`).
@@ -125,13 +130,13 @@ class InfoVmPayload(TypedDict):
 
 
 class InfoPayload(TypedDict):
-    """JSON payload for ``smolvm info``."""
+    """JSON payload for ``smolvm sandbox info``."""
 
     vm: InfoVmPayload
 
 
 class CreatePayload(TypedDict):
-    """JSON payload for ``smolvm create``."""
+    """JSON payload for ``smolvm sandbox create``."""
 
     vm: CreateVmPayload
     next: CreateNextPayload
@@ -304,1141 +309,6 @@ def _current_version_is_prerelease() -> bool:
         return bool(_PRERELEASE_RE.search(ver))
 
 
-def _positive_float(value: str) -> float:
-    """argparse type enforcing a strictly positive floating-point number."""
-    parsed = float(value)
-    if parsed <= 0:
-        raise argparse.ArgumentTypeError("value must be > 0")
-    return parsed
-
-
-def _positive_int(value: str) -> int:
-    """argparse type enforcing a strictly positive integer."""
-    parsed = int(value)
-    if parsed <= 0:
-        raise argparse.ArgumentTypeError("value must be > 0")
-    return parsed
-
-
-class _LinuxOnlyOption(argparse.Action):
-    """Reject setup flags that are only valid on Linux when used on macOS."""
-
-    def __call__(
-        self,
-        parser: argparse.ArgumentParser,
-        namespace: argparse.Namespace,
-        values: str | Sequence[str] | None,
-        option_string: str | None = None,
-    ) -> None:
-        if platform.system() != "Linux":
-            parser.error(
-                f"argument {option_string}: only supported on Linux "
-                "(configures Firecracker/KVM runtime). "
-                f"Detected OS: {platform.system()}. "
-                "Run `smolvm setup` without this flag."
-            )
-
-        if self.nargs == 0:
-            setattr(namespace, self.dest, self.const if self.const is not None else True)
-            return
-
-        setattr(namespace, self.dest, values)
-
-
-def _add_ssh_auth_args(command_parser: argparse.ArgumentParser) -> None:
-    """Add common SSH identity arguments to a command parser."""
-    command_parser.add_argument(
-        "--ssh-key",
-        default=None,
-        help="Path to SSH private key (default: ~/.smolvm/keys/id_ed25519).",
-    )
-    command_parser.add_argument(
-        "--ssh-user",
-        default="root",
-        help="SSH user (default: root).",
-    )
-
-
-def _add_comm_channel_arg(command_parser: argparse.ArgumentParser) -> None:
-    """Add the host↔guest control-channel selector to a command parser."""
-    command_parser.add_argument(
-        "--comm-channel",
-        choices=["ssh", "vsock"],
-        default=None,
-        help=(
-            "Host-to-guest control channel for this command (default: auto — "
-            "vsock when the guest agent answers on a QEMU/Linux host, else SSH)."
-        ),
-    )
-
-
-def _add_qemu_machine_arg(command_parser: argparse.ArgumentParser) -> None:
-    """Add the QEMU machine selector to a command parser."""
-    command_parser.add_argument(
-        "--qemu-machine",
-        choices=["auto", "q35", "microvm"],
-        default="auto",
-        help="QEMU machine model (default: auto; use q35 for compatibility).",
-    )
-
-
-def _add_boot_timeout_arg(command_parser: argparse.ArgumentParser) -> None:
-    """Add a shared boot/SSH readiness timeout flag."""
-    command_parser.add_argument(
-        "--boot-timeout",
-        type=_positive_float,
-        default=30.0,
-        help="Seconds to wait for the sandbox to be ready (default: 30).",
-    )
-
-
-def _add_preset_parsers(
-    subparsers: argparse._SubParsersAction[argparse.ArgumentParser],
-) -> None:
-    """Wire ``smolvm <preset> <action>`` into the CLI.
-
-    Each agent harness is a top-level subcommand (``smolvm codex``,
-    ``smolvm claude-code``) with its own action subcommands. This follows
-    the project's NOUN-VERB CLI convention so future harness actions
-    (``logs``, ``status``, etc.) compose naturally.
-    """
-    from smolvm.presets import list_presets
-
-    for preset in list_presets():
-        preset_parser = subparsers.add_parser(
-            preset.name,
-            aliases=list(preset.aliases),
-            help=preset.summary,
-            description=preset.summary,
-        )
-        action_sub = preset_parser.add_subparsers(
-            dest="preset_action",
-            metavar="ACTION",
-            required=True,
-        )
-
-        start_p = action_sub.add_parser(
-            "start",
-            help=f"Start a sandbox preconfigured for {preset.name}.",
-            description=(
-                f"Boot a fresh sandbox and preinstall {preset.name}. "
-                "Copies relevant host config (e.g. ~/.codex, ~/.claude) "
-                "and forwards API keys from the host environment."
-            ),
-        )
-        start_p.set_defaults(preset_name=preset.name)
-
-        start_p.add_argument(
-            "-n",
-            "--name",
-            help="Name for the sandbox (default: auto-generated).",
-        )
-        start_p.add_argument(
-            "--memory",
-            dest="memory_mib",
-            type=int,
-            default=None,
-            metavar="MIB",
-            help=f"Sandbox memory in MiB (default: {preset.default_mem_mib}).",
-        )
-        start_p.add_argument(
-            "--disk-size",
-            dest="disk_size_mib",
-            type=int,
-            default=None,
-            metavar="MIB",
-            help=f"Sandbox disk size in MiB (default: {preset.default_disk_mib}).",
-        )
-        start_p.add_argument(
-            "--backend",
-            choices=["auto", "firecracker", "qemu", "libkrun"],
-            default=None,
-            help="Virtualization backend (default: qemu, required by ubuntu).",
-        )
-        _add_qemu_machine_arg(start_p)
-        start_p.add_argument(
-            "--os",
-            choices=[guest_os.value for guest_os in GuestOS],
-            default=None,
-            help="Operating system image (default: ubuntu).",
-        )
-        start_p.add_argument(
-            "--mount",
-            action="append",
-            default=None,
-            dest="mounts",
-            metavar="HOST_PATH[:GUEST_PATH]",
-            help=(
-                "Host directory to mount inside the sandbox. "
-                "Defaults to /workspace if no guest path is given. "
-                "Can be repeated."
-            ),
-        )
-        start_p.add_argument(
-            "--writable-mounts",
-            action="store_true",
-            dest="writable_mounts",
-            help=(
-                "Allow the sandbox to write back to mounted host directories. "
-                "Default is read-only with a writable in-VM overlay; writes "
-                "from the guest do not reach the host."
-            ),
-        )
-        start_p.add_argument(
-            "--install-timeout",
-            type=_positive_float,
-            default=600.0,
-            help="Seconds to wait for the harness install (default: 600).",
-        )
-        if preset.launch_command is not None:
-            attach_group = start_p.add_mutually_exclusive_group()
-            attach_group.add_argument(
-                "--attach",
-                dest="attach",
-                action="store_true",
-                default=None,
-                help=(
-                    f"After install, ssh in and run `{preset.launch_command}` without prompting."
-                ),
-            )
-            attach_group.add_argument(
-                "--no-attach",
-                dest="attach",
-                action="store_false",
-                help="Skip the post-install attach prompt.",
-            )
-        start_p.add_argument(
-            "--json",
-            action="store_true",
-            help="Emit machine-readable JSON output.",
-        )
-        _add_boot_timeout_arg(start_p)
-
-
-def _is_preset_command(args: argparse.Namespace) -> bool:
-    """Return True when ``args`` came from ``smolvm <preset> ...``.
-
-    Accepts canonical preset names and aliases (e.g. ``claude`` for
-    ``claude-code``); argparse stores whichever spelling the user typed
-    in ``args.command``.
-    """
-    from smolvm.presets import preset_command_names
-
-    return args.command in preset_command_names()
-
-
-def build_parser() -> argparse.ArgumentParser:
-    parser = argparse.ArgumentParser(
-        prog="smolvm",
-        description="Create, manage, and connect to disposable sandboxes for AI agents.",
-        epilog=(
-            "Most non-interactive commands support --json to emit machine-readable "
-            "output for LLMs, agents, and automation."
-        ),
-    )
-    parser.add_argument(
-        "-V",
-        "--version",
-        action="version",
-        version=f"%(prog)s {importlib.metadata.version('smolvm')}",
-    )
-    subparsers = parser.add_subparsers(dest="command")
-
-    delete = subparsers.add_parser(
-        "delete",
-        help="Delete one or more sandboxes by ID.",
-    )
-    add_delete_args(delete)
-
-    cleanup = subparsers.add_parser(
-        "cleanup",
-        help="Delete all sandboxes.",
-    )
-    add_cleanup_args(cleanup)
-
-    update = subparsers.add_parser(
-        "update",
-        help="Upgrade SmolVM to the latest stable release.",
-    )
-    update.add_argument(
-        "--check",
-        action="store_true",
-        help="Report whether an update is available without installing it.",
-    )
-    update.add_argument(
-        "--json",
-        action="store_true",
-        help="Emit machine-readable JSON output.",
-    )
-
-    prune = subparsers.add_parser(
-        "prune",
-        help="Remove stale image caches from older SmolVM versions.",
-    )
-    prune.add_argument(
-        "--dry-run",
-        action="store_true",
-        help="Show what would be removed without deleting anything.",
-    )
-    prune.add_argument(
-        "--json",
-        action="store_true",
-        help="Emit machine-readable JSON output.",
-    )
-    prune.add_argument(
-        "--cache-dir",
-        default=None,
-        help=argparse.SUPPRESS,
-    )
-
-    doctor = subparsers.add_parser(
-        "doctor",
-        help="Run host diagnostics for the selected backend.",
-    )
-    doctor.add_argument(
-        "--backend",
-        choices=["auto", "firecracker", "qemu", "libkrun"],
-        default=None,
-        help="Virtualization backend to check (default: auto-detected).",
-    )
-    doctor.add_argument(
-        "--json",
-        action="store_true",
-        help="Emit machine-readable JSON output.",
-    )
-    doctor.add_argument(
-        "--strict",
-        action="store_true",
-        help="Exit with an error if any check reports a warning.",
-    )
-
-    def _linux_only_help(text: str) -> str:
-        """Return *text* on Linux; suppress the flag from ``--help`` elsewhere."""
-        return text if platform.system() == "Linux" else argparse.SUPPRESS
-
-    setup = subparsers.add_parser(
-        "setup",
-        help="Install or validate one-time host prerequisites.",
-    )
-    setup.add_argument(
-        "--check-only",
-        action="store_true",
-        help="Check what's needed without installing anything.",
-    )
-    setup.add_argument(
-        "--with-docker",
-        action="store_true",
-        help="Also install or check Docker.",
-    )
-    setup.add_argument(
-        "--no-configure-runtime",
-        action=_LinuxOnlyOption,
-        nargs=0,
-        const=True,
-        default=False,
-        help=_linux_only_help("Skip runtime permission setup (Linux only)."),
-    )
-    setup.add_argument(
-        "--skip-deps",
-        action="store_true",
-        default=False,
-        help="Skip installing system packages.",
-    )
-    setup.add_argument(
-        "--runtime-user",
-        action=_LinuxOnlyOption,
-        default=None,
-        help=_linux_only_help("User to grant runtime permissions to (Linux only)."),
-    )
-    setup.add_argument(
-        "--remove-runtime-config",
-        action=_LinuxOnlyOption,
-        nargs=0,
-        const=True,
-        default=False,
-        help=_linux_only_help("Remove previously configured runtime permissions (Linux only)."),
-    )
-    setup.add_argument(
-        "--for-bake",
-        action=_LinuxOnlyOption,
-        nargs=0,
-        const=True,
-        default=False,
-        help=_linux_only_help(
-            "Bake-friendly install: skip KVM and runtime self-tests so this can run "
-            "on a builder without /dev/kvm. Run 'smolvm doctor' on the runtime host."
-        ),
-    )
-    setup.add_argument(
-        "--skip-kvm-check",
-        action=_LinuxOnlyOption,
-        nargs=0,
-        const=True,
-        default=False,
-        help=_linux_only_help("Do not require /dev/kvm at install time (Linux only)."),
-    )
-    setup.add_argument(
-        "--skip-runtime-check",
-        action=_LinuxOnlyOption,
-        nargs=0,
-        const=True,
-        default=False,
-        help=_linux_only_help("Skip the post-install sudoers self-test (Linux only)."),
-    )
-    setup.add_argument(
-        "--firecracker-version",
-        action=_LinuxOnlyOption,
-        default=None,
-        metavar="VER",
-        help=_linux_only_help(
-            "Pin Firecracker release tag (e.g. v1.14.1). "
-            "Falls back to the built-in default (Linux only)."
-        ),
-    )
-    setup.add_argument(
-        "--assets-dir",
-        action="store_true",
-        help="Print the packaged setup-assets directory and exit.",
-    )
-
-    def _add_ui_args(command_parser: argparse.ArgumentParser) -> None:
-        command_parser.add_argument(
-            "--host",
-            default="127.0.0.1",
-            help="Bind host (default: 127.0.0.1).",
-        )
-        command_parser.add_argument(
-            "--port",
-            type=int,
-            default=8080,
-            help="Bind port (default: 8080).",
-        )
-        command_parser.add_argument(
-            "--allow-beta",
-            action="store_true",
-            help="Allow dashboard UI downloads from prerelease/beta tags.",
-        )
-
-    ui = subparsers.add_parser(
-        "ui",
-        help="Start the SmolVM dashboard UI server.",
-    )
-    _add_ui_args(ui)
-
-    server_parser = subparsers.add_parser(
-        "server",
-        help="Run the SmolVM HTTP API server (for the TypeScript/other SDKs).",
-        description=(
-            "Expose SmolVM over a local HTTP API so non-Python clients "
-            "can drive sandboxes. VMs still boot on this machine."
-        ),
-    )
-    server_actions = server_parser.add_subparsers(
-        dest="server_action",
-        metavar="ACTION",
-        required=True,
-    )
-    server_start = server_actions.add_parser(
-        "start",
-        help="Start the HTTP API server.",
-    )
-    server_start.add_argument(
-        "--host",
-        default="127.0.0.1",
-        help="Address to bind (default: 127.0.0.1, localhost only).",
-    )
-    server_start.add_argument(
-        "--port",
-        type=int,
-        default=8000,
-        help="Port to listen on (default: 8000).",
-    )
-
-    list_parser = subparsers.add_parser(
-        "list",
-        help="List sandboxes and their status.",
-    )
-    list_filters = list_parser.add_mutually_exclusive_group()
-    list_filters.add_argument(
-        "--all",
-        action="store_true",
-        help="Show all sandboxes, not just running ones.",
-    )
-    list_filters.add_argument(
-        "--status",
-        choices=[state.value for state in VMState],
-        default=None,
-        help="Only show sandboxes with this status.",
-    )
-    list_parser.add_argument(
-        "--json",
-        action="store_true",
-        help="Emit machine-readable JSON output.",
-    )
-
-    info_parser = subparsers.add_parser(
-        "info",
-        help="Show full details for a sandbox.",
-    )
-    info_parser.add_argument("vm_id", metavar="sandbox", help="Name or ID of the sandbox.")
-    info_parser.add_argument(
-        "--json",
-        action="store_true",
-        help="Emit machine-readable JSON output.",
-    )
-
-    create_parser = subparsers.add_parser(
-        "create",
-        help="Create a sandbox and leave it running.",
-    )
-    create_parser.add_argument(
-        "-n",
-        "--name",
-        help="Name for the sandbox (default: auto-generated).",
-    )
-    # --os and --image are not in an argparse mutex group: Windows guests
-    # need BOTH (--os windows + --image /path/to/win11.qcow2). The facade
-    # rejects illegal combos (e.g. --os alpine + S3 image) at runtime with
-    # a clearer message than argparse can produce.
-    create_parser.add_argument(
-        "--os",
-        choices=[guest_os.value for guest_os in GuestOS],
-        default=None,
-        help=(
-            "Operating system image (default: auto-detected based on backend). "
-            "--os windows requires --image with a local Windows qcow2 path."
-        ),
-    )
-    create_parser.add_argument(
-        "--image",
-        default=None,
-        help=(
-            "Image URI: S3 URI (e.g. s3://bucket/path/to/image/) or a local "
-            "filesystem path / file:// URI to a pre-built qcow2 (used with "
-            "--os windows). Configure S3-compatible stores via "
-            "SMOLVM_S3_ENDPOINT_URL, SMOLVM_S3_ACCESS_KEY_ID, "
-            "SMOLVM_S3_SECRET_ACCESS_KEY env vars."
-        ),
-    )
-    create_parser.add_argument(
-        "--memory",
-        dest="memory_mib",
-        type=int,
-        default=None,
-        metavar="MIB",
-        help="Sandbox memory in MiB (default: 512).",
-    )
-    create_parser.add_argument(
-        "--disk-size",
-        dest="disk_size_mib",
-        type=int,
-        default=None,
-        metavar="MIB",
-        help=(
-            "Sandbox disk size in MiB. Defaults: 512 for alpine, "
-            "4096 for debian/ubuntu. Minimum: 64 for alpine; 2048 for "
-            "debian/ubuntu on qemu (values below 2048 are rejected)."
-        ),
-    )
-    create_parser.add_argument(
-        "--backend",
-        choices=["auto", "firecracker", "qemu", "libkrun"],
-        default=None,
-        help="Virtualization backend (default: auto-detected).",
-    )
-    _add_qemu_machine_arg(create_parser)
-    _add_comm_channel_arg(create_parser)
-    create_parser.add_argument(
-        "--json",
-        action="store_true",
-        help="Emit machine-readable JSON output.",
-    )
-    create_parser.add_argument(
-        "--mount",
-        action="append",
-        default=None,
-        dest="mounts",
-        metavar="HOST_PATH[:GUEST_PATH]",
-        help=(
-            "Host directory to mount inside the sandbox. "
-            "Defaults to /workspace if no guest path is given. "
-            "The host directory stays read-only by default; writes go "
-            "to an overlay and do not affect the host. "
-            "Pass --writable-mounts to allow guest writes to reach the host. "
-            "Can be repeated for multiple mounts."
-        ),
-    )
-    create_parser.add_argument(
-        "--writable-mounts",
-        action="store_true",
-        dest="writable_mounts",
-        help=(
-            "Allow the sandbox to write back to mounted host directories. "
-            "Default is read-only with a writable in-VM overlay; writes "
-            "from the guest do not reach the host."
-        ),
-    )
-    _add_boot_timeout_arg(create_parser)
-
-    _add_preset_parsers(subparsers)
-
-    stop_parser = subparsers.add_parser(
-        "stop",
-        help="Stop a running sandbox.",
-    )
-    stop_parser.add_argument("vm_id", metavar="sandbox", help="Name or ID of the sandbox.")
-    stop_parser.add_argument(
-        "--timeout",
-        type=_positive_float,
-        default=3.0,
-        help="Seconds to wait before forcing shutdown (default: 3).",
-    )
-    stop_parser.add_argument(
-        "--json",
-        action="store_true",
-        help="Emit machine-readable JSON output.",
-    )
-
-    pause_parser = subparsers.add_parser(
-        "pause",
-        help="Pause a running sandbox.",
-    )
-    pause_parser.add_argument("vm_id", metavar="sandbox", help="Name or ID of the sandbox.")
-    pause_parser.add_argument(
-        "--json",
-        action="store_true",
-        help="Emit machine-readable JSON output.",
-    )
-
-    resume_parser = subparsers.add_parser(
-        "resume",
-        help="Resume a paused sandbox.",
-    )
-    resume_parser.add_argument("vm_id", metavar="sandbox", help="Name or ID of the sandbox.")
-    resume_parser.add_argument(
-        "--json",
-        action="store_true",
-        help="Emit machine-readable JSON output.",
-    )
-
-    start_parser = subparsers.add_parser(
-        "start",
-        help="Start a stopped sandbox.",
-    )
-    start_parser.add_argument("vm_id", metavar="sandbox", help="Name or ID of the sandbox.")
-    _add_boot_timeout_arg(start_parser)
-    start_parser.add_argument(
-        "--json",
-        action="store_true",
-        help="Emit machine-readable JSON output.",
-    )
-
-    snapshot_parser = subparsers.add_parser(
-        "snapshot",
-        help="Save and restore sandbox state.",
-    )
-    snapshot_sub = snapshot_parser.add_subparsers(dest="snapshot_action")
-
-    snapshot_create = snapshot_sub.add_parser(
-        "create",
-        help="Create a full snapshot for a sandbox.",
-    )
-    snapshot_create.add_argument("vm_id", metavar="sandbox", help="Name or ID of the sandbox.")
-    snapshot_create.add_argument(
-        "--snapshot-id",
-        default=None,
-        help="Custom snapshot name (default: auto-generated).",
-    )
-    snapshot_create.add_argument(
-        "--snapshot-type",
-        choices=[t.value for t in SnapshotType],
-        default=SnapshotType.FULL.value,
-        help=(
-            "How much disk to store. 'full' (default) is a self-contained copy "
-            "that always restores on its own. 'diff' stores only what changed "
-            "since the base image to save space, but needs that base image to "
-            "stay present."
-        ),
-    )
-    snapshot_create.add_argument(
-        "--resume-source",
-        action="store_true",
-        help="Keep the sandbox running after the snapshot is taken.",
-    )
-    snapshot_create.add_argument(
-        "--json",
-        action="store_true",
-        help="Emit machine-readable JSON output.",
-    )
-
-    snapshot_restore = snapshot_sub.add_parser(
-        "restore",
-        help="Restore a snapshot back into its original sandbox.",
-    )
-    snapshot_restore.add_argument(
-        "snapshot_id", metavar="snapshot", help="Name or ID of the snapshot."
-    )
-    snapshot_restore.add_argument(
-        "--resume",
-        action="store_true",
-        help="Resume the restored VM immediately.",
-    )
-    snapshot_restore.add_argument(
-        "--force",
-        action="store_true",
-        help="Allow restoring a snapshot that was already restored once.",
-    )
-    snapshot_restore.add_argument(
-        "--json",
-        action="store_true",
-        help="Emit machine-readable JSON output.",
-    )
-
-    snapshot_delete = snapshot_sub.add_parser(
-        "delete",
-        help="Delete a snapshot and its files.",
-    )
-    snapshot_delete.add_argument(
-        "snapshot_id", metavar="snapshot", help="Name or ID of the snapshot."
-    )
-    snapshot_delete.add_argument(
-        "--json",
-        action="store_true",
-        help="Emit machine-readable JSON output.",
-    )
-
-    snapshot_list = snapshot_sub.add_parser(
-        "list",
-        help="List snapshots.",
-    )
-    snapshot_list.add_argument(
-        "--vm-id",
-        default=None,
-        help="Only show snapshots from this sandbox.",
-    )
-    snapshot_list.add_argument(
-        "--json",
-        action="store_true",
-        help="Emit machine-readable JSON output.",
-    )
-
-    ssh_parser = subparsers.add_parser(
-        "ssh",
-        help="Open a shell in a sandbox (starts it if stopped).",
-    )
-    ssh_parser.add_argument("vm_id", metavar="sandbox", help="Name or ID of the sandbox.")
-    _add_ssh_auth_args(ssh_parser)
-    _add_boot_timeout_arg(ssh_parser)
-
-    file_parser = subparsers.add_parser(
-        "file",
-        help="Copy files into or out of a sandbox.",
-    )
-    file_sub = file_parser.add_subparsers(dest="file_action")
-
-    file_upload = file_sub.add_parser(
-        "upload",
-        help="Upload one local file into a running sandbox.",
-    )
-    file_upload.add_argument("vm_id", metavar="sandbox", help="Name or ID of the sandbox.")
-    file_upload.add_argument("local_path", metavar="local-path", help="File on this machine.")
-    file_upload.add_argument(
-        "guest_path",
-        metavar="guest-path",
-        help="Destination path in the sandbox.",
-    )
-    file_upload.add_argument(
-        "--no-create-dirs",
-        action="store_true",
-        help="Do not create the destination directory in the sandbox.",
-    )
-    file_upload.add_argument(
-        "--json",
-        action="store_true",
-        help="Emit machine-readable JSON output.",
-    )
-    _add_ssh_auth_args(file_upload)
-    _add_comm_channel_arg(file_upload)
-
-    file_download = file_sub.add_parser(
-        "download",
-        help="Download one file from a running sandbox.",
-    )
-    file_download.add_argument("vm_id", metavar="sandbox", help="Name or ID of the sandbox.")
-    file_download.add_argument(
-        "guest_path",
-        metavar="guest-path",
-        help="File path in the sandbox.",
-    )
-    file_download.add_argument(
-        "local_path",
-        metavar="local-path",
-        help="Destination path on this machine.",
-    )
-    file_download.add_argument(
-        "--no-create-dirs",
-        action="store_true",
-        help="Do not create the destination directory on this machine.",
-    )
-    file_download.add_argument(
-        "--json",
-        action="store_true",
-        help="Emit machine-readable JSON output.",
-    )
-    _add_ssh_auth_args(file_download)
-    _add_comm_channel_arg(file_download)
-
-    # ── windows: image-building helpers ────────────────────────────
-    windows_parser = subparsers.add_parser(
-        "windows",
-        help="Windows-guest helpers (image building, etc.).",
-    )
-    windows_sub = windows_parser.add_subparsers(dest="windows_action")
-
-    windows_build = windows_sub.add_parser(
-        "build-image",
-        help=(
-            "Build a reusable Windows qcow2 from a Windows ISO via "
-            "unattended install (no clicks required)."
-        ),
-    )
-    windows_build.add_argument(
-        "--iso",
-        dest="windows_iso",
-        required=True,
-        metavar="PATH",
-        help="Path to the Windows ISO (e.g. ./Win11.iso).",
-    )
-    windows_build.add_argument(
-        "--virtio-win-iso",
-        dest="virtio_win_iso",
-        required=True,
-        metavar="PATH",
-        help=(
-            "Path to the virtio-win driver ISO. Download from "
-            "https://fedorapeople.org/groups/virt/virtio-win/direct-downloads/"
-            "stable-virtio/virtio-win.iso (one-time, ~750 MiB)."
-        ),
-    )
-    windows_build.add_argument(
-        "--output",
-        dest="output_qcow2",
-        required=True,
-        metavar="PATH",
-        help="Where to write the built qcow2 (e.g. ~/.smolvm/images/win11.qcow2).",
-    )
-    windows_build.add_argument(
-        "--username",
-        default="smolvm",
-        help="Local admin account name to create (default: smolvm).",
-    )
-    windows_build.add_argument(
-        "--password",
-        default="smolvm",
-        help=(
-            "Local admin account password (default: smolvm — OVERRIDE for "
-            "any image you'll re-use beyond throwaway POC work)."
-        ),
-    )
-    windows_build.add_argument(
-        "--hostname",
-        default="smolvm-win",
-        help="Windows computer name baked into the install (default: smolvm-win).",
-    )
-    windows_build.add_argument(
-        "--edition",
-        default="Windows 11 Pro",
-        help=(
-            "Edition to install, as it appears in install.wim "
-            "(default: 'Windows 11 Pro'; 'Windows 11 Home' also valid)."
-        ),
-    )
-    windows_build.add_argument(
-        "--disk-size",
-        dest="disk_size_mib",
-        type=_positive_int,
-        default=64 * 1024,
-        metavar="MIB",
-        help="Virtual size of the built qcow2 in MiB (default: 65536 = 64 GiB).",
-    )
-    windows_build.add_argument(
-        "--build-timeout",
-        dest="build_timeout_s",
-        type=_positive_float,
-        default=45 * 60,
-        metavar="SECONDS",
-        help="Upper bound on the install duration (default: 2700 = 45 min).",
-    )
-    windows_build.add_argument(
-        "--json",
-        action="store_true",
-        help="Emit machine-readable JSON output.",
-    )
-
-    browser_parser = subparsers.add_parser(
-        "browser",
-        help="Manage disposable browser sandboxes.",
-    )
-    browser_sub = browser_parser.add_subparsers(dest="browser_action")
-
-    browser_start = browser_sub.add_parser(
-        "start",
-        help="Create and start a browser sandbox.",
-    )
-    browser_start.add_argument(
-        "--session-id",
-        default=None,
-        help="Custom session ID (default: auto-generated).",
-    )
-    browser_start.add_argument(
-        "--backend",
-        choices=["auto", "firecracker", "qemu", "libkrun"],
-        default="auto",
-        help="Virtualization backend (default: auto-detected).",
-    )
-    browser_start.add_argument(
-        "--live",
-        action="store_true",
-        help="Expose viewer_url and display_url so you can watch and control the browser.",
-    )
-    browser_start.add_argument(
-        "--profile-mode",
-        choices=["ephemeral", "persistent"],
-        default="ephemeral",
-        help="Browser profile mode: ephemeral (fresh each time) or persistent (default: ephemeral).",  # noqa: E501
-    )
-    browser_start.add_argument(
-        "--profile-id",
-        default=None,
-        help="Reuse a saved browser profile by its ID.",
-    )
-    browser_start.add_argument(
-        "--timeout-minutes",
-        type=int,
-        default=30,
-        help="Auto-stop the sandbox after this many minutes (default: 30).",
-    )
-    browser_start.add_argument(
-        "--viewport-width",
-        type=int,
-        default=1280,
-        help="Browser viewport width (default: 1280).",
-    )
-    browser_start.add_argument(
-        "--viewport-height",
-        type=int,
-        default=720,
-        help="Browser viewport height (default: 720).",
-    )
-    browser_start.add_argument(
-        "--memory",
-        dest="memory_mib",
-        type=int,
-        default=2048,
-        metavar="MIB",
-        help="Sandbox memory in MiB (default: 2048).",
-    )
-    browser_start.add_argument(
-        "--disk-size",
-        dest="disk_size_mib",
-        type=int,
-        default=4096,
-        metavar="MIB",
-        help="Sandbox disk size in MiB (default: 4096).",
-    )
-    browser_start.add_argument(
-        "--record-video",
-        action="store_true",
-        help="Record a video of the browser sandbox.",
-    )
-    browser_start.add_argument(
-        "--no-downloads",
-        action="store_true",
-        help="Prevent the browser from saving downloaded files.",
-    )
-    browser_start.add_argument(
-        "--json",
-        action="store_true",
-        help="Emit machine-readable JSON output.",
-    )
-    _add_boot_timeout_arg(browser_start)
-
-    browser_stop = browser_sub.add_parser(
-        "stop",
-        help="Stop and delete a browser sandbox.",
-    )
-    browser_stop_target = browser_stop.add_mutually_exclusive_group(required=True)
-    browser_stop_target.add_argument(
-        "session_id",
-        nargs="?",
-        metavar="sandbox",
-        help="Sandbox ID (printed by 'browser start').",
-    )
-    browser_stop_target.add_argument(
-        "--all",
-        action="store_true",
-        help="Stop all browser sandboxes.",
-    )
-
-    browser_list = browser_sub.add_parser(
-        "list",
-        help="List browser sandboxes.",
-    )
-    browser_list.add_argument(
-        "--status",
-        choices=["created", "starting", "ready", "stopping", "error"],
-        default=None,
-        help="Only show sandboxes with this status.",
-    )
-    browser_list.add_argument(
-        "--json",
-        action="store_true",
-        help="Emit machine-readable JSON output.",
-    )
-
-    browser_open = browser_sub.add_parser(
-        "open",
-        help="Open a browser sandbox viewer in your default browser.",
-    )
-    browser_open.add_argument(
-        "session_id", metavar="sandbox", help="Sandbox ID (printed by 'browser start')."
-    )
-
-    browser_logs = browser_sub.add_parser(
-        "logs",
-        help="Print browser sandbox logs.",
-    )
-    browser_logs.add_argument(
-        "session_id", metavar="sandbox", help="Sandbox ID (printed by 'browser start')."
-    )
-    browser_logs.add_argument(
-        "--tail",
-        type=int,
-        default=100,
-        help="Number of recent log lines to show (default: 100).",
-    )
-
-    env_parser = subparsers.add_parser(
-        "env",
-        help="Manage environment variables on a running sandbox.",
-    )
-    env_sub = env_parser.add_subparsers(dest="env_action")
-
-    env_set = env_sub.add_parser(
-        "set",
-        help="Set environment variables (merges with existing).",
-    )
-    env_set.add_argument("vm_id", metavar="sandbox", help="Name or ID of the sandbox.")
-    env_set.add_argument(
-        "pairs",
-        nargs="+",
-        metavar="KEY=VALUE",
-        help="One or more KEY=VALUE pairs",
-    )
-    env_set.add_argument(
-        "--json",
-        action="store_true",
-        help="Emit machine-readable JSON output.",
-    )
-    _add_ssh_auth_args(env_set)
-    _add_comm_channel_arg(env_set)
-
-    env_unset = env_sub.add_parser(
-        "unset",
-        help="Remove environment variables.",
-    )
-    env_unset.add_argument("vm_id", metavar="sandbox", help="Name or ID of the sandbox.")
-    env_unset.add_argument(
-        "keys",
-        nargs="+",
-        metavar="KEY",
-        help="Variable names to remove",
-    )
-    env_unset.add_argument(
-        "--json",
-        action="store_true",
-        help="Emit machine-readable JSON output.",
-    )
-    _add_ssh_auth_args(env_unset)
-    _add_comm_channel_arg(env_unset)
-
-    env_list = env_sub.add_parser(
-        "list",
-        help="List current environment variables.",
-    )
-    env_list.add_argument("vm_id", metavar="sandbox", help="Name or ID of the sandbox.")
-    env_list.add_argument(
-        "--show-values",
-        action="store_true",
-        help="Show variable values (masked by default).",
-    )
-    env_list.add_argument(
-        "--json",
-        action="store_true",
-        help="Emit machine-readable JSON output.",
-    )
-    _add_ssh_auth_args(env_list)
-
-    port_parser = subparsers.add_parser(
-        "port",
-        help="Manage port forwarding for a running sandbox.",
-    )
-    port_sub = port_parser.add_subparsers(dest="port_action")
-
-    port_expose = port_sub.add_parser(
-        "expose",
-        help="Forward a guest port to localhost.",
-    )
-    port_expose.add_argument("vm_id", metavar="sandbox", help="Name or ID of the same sandbox.")
-    port_expose.add_argument(
-        "mapping",
-        metavar="[host-port:]sandbox-port",
-        help="Port mapping, e.g. 8080:3000 or just 3000 to auto-select host port.",
-    )
-    port_expose.add_argument(
-        "--json",
-        action="store_true",
-        help="Emit machine-readable JSON output.",
-    )
-    _add_ssh_auth_args(port_expose)
-    _add_comm_channel_arg(port_expose)
-
-    port_close = port_sub.add_parser(
-        "close",
-        help="Remove a forwarded port.",
-    )
-    port_close.add_argument("vm_id", metavar="sandbox", help="Name or ID of the sandbox.")
-    port_close.add_argument(
-        "mapping",
-        metavar="host-port:sandbox-port",
-        help="Mapping to remove, e.g. 8080:3000.",
-    )
-    port_close.add_argument(
-        "--json",
-        action="store_true",
-        help="Emit machine-readable JSON output.",
-    )
-    _add_ssh_auth_args(port_close)
-    _add_comm_channel_arg(port_close)
-
-    port_list = port_sub.add_parser(
-        "list",
-        help="List active port forwards for a sandbox.",
-    )
-    port_list.add_argument("vm_id", metavar="sandbox", help="Name or ID of the sandbox.")
-    port_list.add_argument(
-        "--json",
-        action="store_true",
-        help="Emit machine-readable JSON output.",
-    )
-    _add_ssh_auth_args(port_list)
-    _add_comm_channel_arg(port_list)
-
-    _add_comm_channel_arg(env_list)
-
-    return parser
-
-
 def _parse_env_pairs(pairs: list[str]) -> dict[str, str]:
     """Parse ``KEY=VALUE`` pairs, raising on malformed entries."""
     from smolvm.env import validate_env_key
@@ -1506,7 +376,7 @@ def _vm_warnings(vm: VMInfo) -> list[str]:
             warnings.append(
                 f"Shared folder is missing on your machine: "
                 f"'{mount.host_path}'. Restore it, or run "
-                f"'smolvm delete {vm.vm_id}' to remove the sandbox."
+                f"'smolvm sandbox delete {vm.vm_id}' to remove the sandbox."
             )
     return warnings
 
@@ -1558,41 +428,55 @@ def _render_list(rows: list[VmRow]) -> None:
                 console.print(f"  • {warning}")
 
 
-def _run_setup(parser: argparse.ArgumentParser, args: argparse.Namespace) -> int:
+def _run_setup(
+    *,
+    check_only: bool,
+    with_docker: bool,
+    configure_runtime: bool,
+    no_configure_runtime: bool,
+    skip_deps: bool,
+    runtime_user: str | None,
+    remove_runtime_config: bool,
+    for_bake: bool,
+    skip_kvm_check: bool,
+    skip_runtime_check: bool,
+    firecracker_version: str | None,
+    assets_dir: bool,
+) -> int:
     """Handle ``smolvm setup``."""
     from smolvm.host.setup import SetupOptions, packaged_asset_root, run_setup
 
-    if args.assets_dir:
+    if assets_dir:
         print(packaged_asset_root())
         return 0
 
     invalid_remove_runtime_flags: list[str] = []
-    if args.check_only:
+    if check_only:
         invalid_remove_runtime_flags.append("--check-only")
-    if args.with_docker:
+    if with_docker:
         invalid_remove_runtime_flags.append("--with-docker")
-    if args.no_configure_runtime:
+    if no_configure_runtime:
         invalid_remove_runtime_flags.append("--no-configure-runtime")
-    if args.skip_deps:
+    if skip_deps:
         invalid_remove_runtime_flags.append("--skip-deps")
 
-    if args.remove_runtime_config and invalid_remove_runtime_flags:
-        parser.error(
+    if remove_runtime_config and invalid_remove_runtime_flags:
+        raise click.UsageError(
             "argument --remove-runtime-config: not allowed with "
             + ", ".join(invalid_remove_runtime_flags)
         )
 
     options = SetupOptions(
-        check_only=args.check_only,
-        with_docker=args.with_docker,
-        configure_runtime=not args.no_configure_runtime,
-        skip_deps=args.skip_deps,
-        runtime_user=args.runtime_user,
-        remove_runtime_config=args.remove_runtime_config,
-        for_bake=args.for_bake,
-        skip_kvm_check=args.skip_kvm_check,
-        skip_runtime_check=args.skip_runtime_check,
-        firecracker_version=args.firecracker_version,
+        check_only=check_only,
+        with_docker=with_docker,
+        configure_runtime=configure_runtime,
+        skip_deps=skip_deps,
+        runtime_user=runtime_user,
+        remove_runtime_config=remove_runtime_config,
+        for_bake=for_bake,
+        skip_kvm_check=skip_kvm_check,
+        skip_runtime_check=skip_runtime_check,
+        firecracker_version=firecracker_version,
     )
 
     if options.for_bake:
@@ -1607,8 +491,14 @@ def _run_setup(parser: argparse.ArgumentParser, args: argparse.Namespace) -> int
         return _emit_cli_error("setup", 1, exc, json_output=False)
 
 
-def _run_list(*, include_all: bool, status_filter: str | None, json_output: bool) -> int:
-    """Handle ``smolvm list``."""
+def _run_list(
+    *,
+    include_all: bool,
+    status_filter: str | None,
+    json_output: bool,
+    command_name: str = "sandbox.list",
+) -> int:
+    """Handle ``smolvm sandbox list``."""
     from smolvm.vm import SmolVMManager
 
     with SmolVMManager() as sdk:
@@ -1631,7 +521,7 @@ def _run_list(*, include_all: bool, status_filter: str | None, json_output: bool
                 "vms": rows,
             }
             if json_output:
-                emit_json("list", 0, data=data)
+                emit_json(command_name, 0, data=data)
                 return 0
 
             if not vms:
@@ -1647,7 +537,7 @@ def _run_list(*, include_all: bool, status_filter: str | None, json_output: bool
             _render_list(rows)
             return 0
         except Exception as exc:
-            return _emit_cli_error("list", 1, exc, json_output=json_output)
+            return _emit_cli_error(command_name, 1, exc, json_output=json_output)
 
 
 _OS_HINT_KEYWORDS = ("ubuntu", "alpine")
@@ -1818,8 +708,8 @@ def _render_info_result(data: InfoPayload) -> None:
     console.print(details)
 
 
-def _run_info(*, vm_id: str, json_output: bool) -> int:
-    """Handle ``smolvm info``."""
+def _run_info(*, vm_id: str, json_output: bool, command_name: str = "sandbox.info") -> int:
+    """Handle ``smolvm sandbox info``."""
     from smolvm.vm import SmolVMManager
 
     with SmolVMManager() as sdk:
@@ -1830,12 +720,12 @@ def _run_info(*, vm_id: str, json_output: bool) -> int:
                 live_data = _query_live_vm_info(vm)
             data = _info_payload(vm, live_data=live_data)
             if json_output:
-                emit_json("info", 0, data=data)
+                emit_json(command_name, 0, data=data)
             else:
                 _render_info_result(data)
             return 0
         except Exception as exc:
-            return _emit_cli_error("info", 1, exc, json_output=json_output)
+            return _emit_cli_error(command_name, 1, exc, json_output=json_output)
 
 
 def _format_started_at(iso_ts: str) -> str:
@@ -1959,15 +849,15 @@ def _wait_after_create(
     boot_timeout: float,
     on_progress: Callable[[str], None] | None = None,
 ) -> None:
-    """Wait for the channel promised by ``smolvm create``."""
+    """Wait for the channel promised by ``smolvm sandbox create``."""
     if comm_channel == "ssh":
         vm.wait_for_ssh(timeout=boot_timeout, on_progress=on_progress)
         return
     vm.wait_for_ready(timeout=boot_timeout, on_progress=on_progress)
 
 
-def _run_create(args: argparse.Namespace) -> int:
-    """Handle ``smolvm create``."""
+def _run_create(args: SimpleNamespace) -> int:
+    """Handle ``smolvm sandbox create``."""
     from smolvm.facade import (
         SmolVM,
         _build_auto_config,
@@ -1979,6 +869,7 @@ def _run_create(args: argparse.Namespace) -> int:
     from smolvm.runtime.backends import resolve_backend
 
     vm: SmolVM | None = None
+    command_name = getattr(args, "command_name", "sandbox.create")
     try:
         # Workspace mounts ride a virtio-9p share, which only the QEMU backend
         # exposes today. Auto-pick QEMU when the user asked for --mount but did
@@ -2031,7 +922,7 @@ def _run_create(args: argparse.Namespace) -> int:
             )
 
         # CLI default: roomier disk for ubuntu so package installs
-        # and apt cache don't fill the rootfs on a basic `smolvm create`.
+        # and apt cache don't fill the rootfs on a basic `smolvm sandbox create`.
         if not use_s3_image and args.disk_size_mib is None and resolved_guest_os is GuestOS.UBUNTU:
             args.disk_size_mib = 4096
 
@@ -2187,18 +1078,18 @@ def _run_create(args: argparse.Namespace) -> int:
                 "started_at": datetime.now(timezone.utc).isoformat(),
             },
             "next": {
-                "ssh_command": f"smolvm ssh {vm.vm_id}",
-                "info_command": f"smolvm info {vm.vm_id}",
+                "ssh_command": f"smolvm sandbox ssh {vm.vm_id}",
+                "info_command": f"smolvm sandbox info {vm.vm_id}",
             },
         }
 
         if args.json:
-            emit_json("create", 0, data=data)
+            emit_json(command_name, 0, data=data)
         else:
             _render_create_result(data)
         return 0
     except Exception as exc:
-        return _emit_cli_error("create", 1, exc, json_output=args.json)
+        return _emit_cli_error(command_name, 1, exc, json_output=args.json)
     finally:
         if vm is not None:
             vm.close()
@@ -2324,7 +1215,7 @@ def _host_arch_for_published() -> Arch:
     raise RuntimeError(f"Unsupported host architecture for published images: {machine!r}.")
 
 
-def _run_start_with_published_image(args: argparse.Namespace, preset: object) -> int:
+def _run_start_with_published_image(args: SimpleNamespace, preset: object) -> int:
     """Launch a sandbox using a pre-built published image.
 
     Bypasses the default install-at-boot flow:
@@ -2346,15 +1237,16 @@ def _run_start_with_published_image(args: argparse.Namespace, preset: object) ->
     from smolvm.utils import ensure_ssh_key
 
     _preset: Preset = preset  # type: ignore[assignment]
+    command_name = getattr(args, "command_name", f"{_preset.name}.start")
 
     try:
         vmm = _vmm_for_host()
     except RuntimeError as exc:
-        return _emit_cli_error("start", 2, exc, json_output=args.json)
+        return _emit_cli_error(command_name, 2, exc, json_output=args.json)
 
     if (_preset.name, vmm) not in _PUBLISHED_IMAGE_BOOT_ARGS:
         return _emit_cli_error(
-            "start",
+            command_name,
             2,
             ValueError(
                 f"Preset {_preset.name!r} isn't available as a prebuilt image "
@@ -2444,10 +1336,10 @@ def _run_start_with_published_image(args: argparse.Namespace, preset: object) ->
                     "injected_env_keys": [],
                     "no_env_hint": _preset.no_env_hint,
                 },
-                "next": {"ssh_command": f"smolvm ssh {vm.vm_id}"},
+                "next": {"ssh_command": f"smolvm sandbox ssh {vm.vm_id}"},
             }
             if args.json:
-                emit_json("start", 0, data=data)
+                emit_json(command_name, 0, data=data)
             else:
                 _render_start_result(data)
 
@@ -2470,18 +1362,19 @@ def _run_start_with_published_image(args: argparse.Namespace, preset: object) ->
                         vm.delete()
                 vm.close()
     except ImageError as exc:
-        return _emit_cli_error("start", 1, exc, json_output=args.json)
+        return _emit_cli_error(command_name, 1, exc, json_output=args.json)
     except Exception as exc:
-        return _emit_cli_error("start", 1, exc, json_output=args.json)
+        return _emit_cli_error(command_name, 1, exc, json_output=args.json)
 
 
-def _run_start(args: argparse.Namespace) -> int:
+def _run_start(args: SimpleNamespace) -> int:
     """Handle ``smolvm <preset> start``."""
     from smolvm.facade import SmolVM, _build_auto_config
     from smolvm.images.published import is_preset_published
     from smolvm.presets import apply_preset, get_preset
 
     preset = get_preset(args.preset_name)
+    command_name = getattr(args, "command_name", f"{preset.name}.start")
 
     # The user-facing default is ubuntu when --os is omitted.
     requested_os = GuestOS(args.os) if args.os is not None else GuestOS.UBUNTU
@@ -2509,7 +1402,7 @@ def _run_start(args: argparse.Namespace) -> int:
         # Built-in presets target the ubuntu cloud image, which only boots on
         # qemu in this codebase. Fail loudly rather than silently downgrade.
         return _emit_cli_error(
-            "start",
+            command_name,
             2,
             ValueError(f"Preset {preset.name!r} requires --backend qemu (got {backend!r})."),
             json_output=args.json,
@@ -2595,12 +1488,12 @@ def _run_start(args: argparse.Namespace) -> int:
                 "no_env_hint": preset.no_env_hint,
             },
             "next": {
-                "ssh_command": f"smolvm ssh {vm.vm_id}",
+                "ssh_command": f"smolvm sandbox ssh {vm.vm_id}",
             },
         }
 
         if args.json:
-            emit_json("start", 0, data=data)
+            emit_json(command_name, 0, data=data)
         else:
             _render_start_result(data)
 
@@ -2609,7 +1502,7 @@ def _run_start(args: argparse.Namespace) -> int:
             return _maybe_attach_and_launch(vm, preset, attach=getattr(args, "attach", None))
         return 0
     except Exception as exc:
-        return _emit_cli_error("start", 1, exc, json_output=args.json)
+        return _emit_cli_error(command_name, 1, exc, json_output=args.json)
     finally:
         if vm is not None:
             if not success:
@@ -2858,11 +1751,12 @@ def _render_snapshot_restore(data: SnapshotRestorePayload) -> None:
     console.print(details)
 
 
-def _run_stop(args: argparse.Namespace) -> int:
-    """Handle ``smolvm stop``."""
+def _run_stop(args: SimpleNamespace) -> int:
+    """Handle ``smolvm sandbox stop``."""
     from smolvm.facade import SmolVM
 
     vm: SmolVM | None = None
+    command_name = getattr(args, "command_name", "sandbox.stop")
     try:
         vm = SmolVM.from_id(args.vm_id)
         vm.stop(timeout=args.timeout)
@@ -2870,7 +1764,7 @@ def _run_stop(args: argparse.Namespace) -> int:
         data = _vm_lifecycle_payload(vm.vm_id, VMState.STOPPED)
 
         if args.json:
-            emit_json("stop", 0, data=data)
+            emit_json(command_name, 0, data=data)
         else:
             _render_vm_lifecycle_result(
                 data,
@@ -2880,24 +1774,25 @@ def _run_stop(args: argparse.Namespace) -> int:
             )
         return 0
     except Exception as exc:
-        return _emit_cli_error("stop", 1, exc, json_output=args.json)
+        return _emit_cli_error(command_name, 1, exc, json_output=args.json)
     finally:
         if vm is not None:
             vm.close()
 
 
-def _run_pause(args: argparse.Namespace) -> int:
-    """Handle ``smolvm pause``."""
+def _run_pause(args: SimpleNamespace) -> int:
+    """Handle ``smolvm sandbox pause``."""
     from smolvm.facade import SmolVM
 
     vm: SmolVM | None = None
+    command_name = getattr(args, "command_name", "sandbox.pause")
     try:
         vm = SmolVM.from_id(args.vm_id)
         vm.pause()
 
         data = _vm_lifecycle_payload(vm.vm_id, VMState.PAUSED)
         if args.json:
-            emit_json("pause", 0, data=data)
+            emit_json(command_name, 0, data=data)
         else:
             _render_vm_lifecycle_result(
                 data,
@@ -2907,24 +1802,25 @@ def _run_pause(args: argparse.Namespace) -> int:
             )
         return 0
     except Exception as exc:
-        return _emit_cli_error("pause", 1, exc, json_output=args.json)
+        return _emit_cli_error(command_name, 1, exc, json_output=args.json)
     finally:
         if vm is not None:
             vm.close()
 
 
-def _run_resume(args: argparse.Namespace) -> int:
-    """Handle ``smolvm resume``."""
+def _run_resume(args: SimpleNamespace) -> int:
+    """Handle ``smolvm sandbox resume``."""
     from smolvm.facade import SmolVM
 
     vm: SmolVM | None = None
+    command_name = getattr(args, "command_name", "sandbox.resume")
     try:
         vm = SmolVM.from_id(args.vm_id)
         vm.resume()
 
         data = _vm_lifecycle_payload(vm.vm_id, VMState.RUNNING)
         if args.json:
-            emit_json("resume", 0, data=data)
+            emit_json(command_name, 0, data=data)
         else:
             _render_vm_lifecycle_result(
                 data,
@@ -2934,24 +1830,25 @@ def _run_resume(args: argparse.Namespace) -> int:
             )
         return 0
     except Exception as exc:
-        return _emit_cli_error("resume", 1, exc, json_output=args.json)
+        return _emit_cli_error(command_name, 1, exc, json_output=args.json)
     finally:
         if vm is not None:
             vm.close()
 
 
-def _run_vm_start(args: argparse.Namespace) -> int:
-    """Handle ``smolvm start``."""
+def _run_vm_start(args: SimpleNamespace) -> int:
+    """Handle ``smolvm sandbox start``."""
     from smolvm.facade import SmolVM
 
     vm: SmolVM | None = None
+    command_name = getattr(args, "command_name", "sandbox.start")
     try:
         vm = SmolVM.from_id(args.vm_id)
         vm.start(boot_timeout=args.boot_timeout)
 
         data = _vm_lifecycle_payload(vm.vm_id, VMState.RUNNING)
         if args.json:
-            emit_json("start", 0, data=data)
+            emit_json(command_name, 0, data=data)
         else:
             _render_vm_lifecycle_result(
                 data,
@@ -2961,13 +1858,13 @@ def _run_vm_start(args: argparse.Namespace) -> int:
             )
         return 0
     except Exception as exc:
-        return _emit_cli_error("start", 1, exc, json_output=args.json)
+        return _emit_cli_error(command_name, 1, exc, json_output=args.json)
     finally:
         if vm is not None:
             vm.close()
 
 
-def _run_snapshot(args: argparse.Namespace) -> int:
+def _run_snapshot(args: SimpleNamespace) -> int:
     """Handle ``smolvm snapshot`` commands."""
     from smolvm.facade import SmolVM
     from smolvm.vm import SmolVMManager
@@ -3124,7 +2021,7 @@ def _render_env_list(vm_id: str, data: dict[str, object]) -> None:
         console.print("Use --show-values to reveal values.")
 
 
-def _run_env(args: argparse.Namespace) -> int:
+def _run_env(args: SimpleNamespace) -> int:
     """Handle ``smolvm env set|unset|list``."""
     from smolvm.facade import SmolVM
 
@@ -3259,7 +2156,7 @@ def _render_file_download(data: FileDownloadPayload) -> None:
     )
 
 
-def _run_file(args: argparse.Namespace) -> int:
+def _run_file(args: SimpleNamespace) -> int:
     """Handle ``smolvm file`` commands."""
     from smolvm.facade import SmolVM
 
@@ -3340,11 +2237,12 @@ def _hint_if_vm_crashed(vm: object) -> None:
         render_error(_crashed_message(_vm.vm_id))
 
 
-def _run_ssh(args: argparse.Namespace) -> int:
-    """Handle ``smolvm ssh``."""
+def _run_ssh(args: SimpleNamespace) -> int:
+    """Handle ``smolvm sandbox ssh``."""
     from smolvm.facade import SmolVM
 
     vm: SmolVM | None = None
+    command_name = getattr(args, "command_name", "sandbox.ssh")
     try:
         vm = SmolVM.from_id(
             args.vm_id,
@@ -3381,13 +2279,13 @@ def _run_ssh(args: argparse.Namespace) -> int:
         return completed.returncode
     except FileNotFoundError:
         return _emit_cli_error(
-            "ssh",
+            command_name,
             1,
             FileNotFoundError("ssh binary not found. Install openssh-client."),
             json_output=False,
         )
     except Exception as exc:
-        return _emit_cli_error("ssh", 1, exc, json_output=False)
+        return _emit_cli_error(command_name, 1, exc, json_output=False)
     finally:
         if vm is not None:
             vm.close()
@@ -3436,7 +2334,7 @@ def _save_port_forwards(vm_id: str, forwards: list[dict]) -> None:
     _port_forwards_path(vm_id).write_text(json.dumps(forwards, indent=2))
 
 
-def _run_port_expose(args: argparse.Namespace) -> int:
+def _run_port_expose(args: SimpleNamespace) -> int:
     """Handle ``smolvm port expose``."""
     from smolvm.facade import SmolVM
 
@@ -3447,7 +2345,7 @@ def _run_port_expose(args: argparse.Namespace) -> int:
         host_port_req, guest_port = _parse_port_mapping(args.mapping)
     except ValueError:
         return _emit_cli_error(
-            "port expose",
+            "port.expose",
             1,
             ValueError(
                 f"Invalid mapping {args.mapping!r}. "
@@ -3486,7 +2384,7 @@ def _run_port_expose(args: argparse.Namespace) -> int:
 
         if json_output:
             emit_json(
-                "port expose",
+                "port.expose",
                 0,
                 data={
                     "sandbox": args.vm_id,
@@ -3505,7 +2403,7 @@ def _run_port_expose(args: argparse.Namespace) -> int:
                 f"Stop with: [bold]smolvm port close {args.vm_id} {host_port}:{guest_port}[/bold]"
             )
     except Exception as exc:
-        return _emit_cli_error("port expose", 1, exc, json_output=json_output)
+        return _emit_cli_error("port.expose", 1, exc, json_output=json_output)
     finally:
         if vm is not None:
             vm.close()
@@ -3513,7 +2411,7 @@ def _run_port_expose(args: argparse.Namespace) -> int:
     return 0
 
 
-def _run_port_close(args: argparse.Namespace) -> int:
+def _run_port_close(args: SimpleNamespace) -> int:
     """Handle ``smolvm port close``."""
     from smolvm.facade import SmolVM
 
@@ -3528,7 +2426,7 @@ def _run_port_close(args: argparse.Namespace) -> int:
                 f"Run 'smolvm port list {args.vm_id}' to see active forwards."
             )
     except ValueError as exc:
-        return _emit_cli_error("port close", 1, exc, json_output=json_output)
+        return _emit_cli_error("port.close", 1, exc, json_output=json_output)
 
     try:
         # Kill stored SSH tunnel process if present.
@@ -3574,7 +2472,7 @@ def _run_port_close(args: argparse.Namespace) -> int:
 
         if json_output:
             emit_json(
-                "port close",
+                "port.close",
                 0,
                 data={"sandbox": args.vm_id, "host_port": host_port, "guest_port": guest_port},
             )
@@ -3584,7 +2482,7 @@ def _run_port_close(args: argparse.Namespace) -> int:
             )
 
     except Exception as exc:
-        return _emit_cli_error("port close", 1, exc, json_output=json_output)
+        return _emit_cli_error("port.close", 1, exc, json_output=json_output)
     finally:
         if vm is not None:
             vm.close()
@@ -3592,13 +2490,13 @@ def _run_port_close(args: argparse.Namespace) -> int:
     return 0
 
 
-def _run_port_list(args: argparse.Namespace) -> int:
+def _run_port_list(args: SimpleNamespace) -> int:
     """Handle ``smolvm port list``."""
     json_output: bool = args.json
     forwards = _load_port_forwards(args.vm_id)
 
     if json_output:
-        emit_json("port list", 0, data={"sandbox": args.vm_id, "forwards": forwards})
+        emit_json("port.list", 0, data={"sandbox": args.vm_id, "forwards": forwards})
     else:
         console = console_stdout()
         if not forwards:
@@ -3621,7 +2519,7 @@ def _run_port_list(args: argparse.Namespace) -> int:
     return 0
 
 
-def _run_port(args: argparse.Namespace) -> int:
+def _run_port(args: SimpleNamespace) -> int:
     """Dispatch ``smolvm port <action>``."""
     action = getattr(args, "port_action", None)
     if action == "expose":
@@ -3630,9 +2528,8 @@ def _run_port(args: argparse.Namespace) -> int:
         return _run_port_close(args)
     if action == "list":
         return _run_port_list(args)
-    from smolvm.cli.main import build_parser
 
-    build_parser().parse_args(["port", "--help"])
+    render_error("Usage: smolvm port {expose,close,list} ...")
     return 2
 
 
@@ -3798,7 +2695,7 @@ def _render_browser_list(rows: list[BrowserRow]) -> None:
     console.print(f"Total: {len(rows)} sandbox(es).")
 
 
-def _run_windows(args: argparse.Namespace) -> int:
+def _run_windows(args: SimpleNamespace) -> int:
     """Handle ``smolvm windows`` commands."""
     action = getattr(args, "windows_action", None)
     if action == "build-image":
@@ -3811,7 +2708,7 @@ def _run_windows(args: argparse.Namespace) -> int:
     return 2
 
 
-def _run_windows_build_image(args: argparse.Namespace) -> int:
+def _run_windows_build_image(args: SimpleNamespace) -> int:
     """Handle ``smolvm windows build-image``."""
     from smolvm.windows import WindowsImageBuilder
 
@@ -3829,11 +2726,11 @@ def _run_windows_build_image(args: argparse.Namespace) -> int:
         )
         output = builder.build()
     except Exception as exc:  # noqa: BLE001
-        return _emit_cli_error("windows build-image", 1, exc, json_output=args.json)
+        return _emit_cli_error("windows.build-image", 1, exc, json_output=args.json)
 
     if args.json:
         emit_json(
-            "windows build-image",
+                "windows.build-image",
             0,
             data={
                 "output_qcow2": str(output),
@@ -3849,7 +2746,7 @@ def _run_windows_build_image(args: argparse.Namespace) -> int:
             Panel.fit(
                 f"Built Windows image: [bold]{output}[/bold]\n\n"
                 f"Boot it with:\n"
-                f"  [bold]smolvm create --os windows --image {output}[/bold]\n"
+                f"  [bold]smolvm sandbox create --os windows --image {output}[/bold]\n"
                 f"or in Python:\n"
                 f'  [bold]SmolVM(os="windows", image="{output}", '
                 f'ssh_user="{args.username}", ssh_password="<hidden>")[/bold]',
@@ -3860,7 +2757,7 @@ def _run_windows_build_image(args: argparse.Namespace) -> int:
     return 0
 
 
-def _run_browser(args: argparse.Namespace) -> int:
+def _run_browser(args: SimpleNamespace) -> int:
     """Handle ``smolvm browser`` commands."""
     from smolvm.browser import _BrowserSandbox
     from smolvm.storage import create_state_manager
@@ -4043,113 +2940,69 @@ def _run_browser(args: argparse.Namespace) -> int:
         return _emit_cli_error(command_name, 1, exc, json_output=json_output)
 
 
+def _command_name_from_argv(args: Sequence[str]) -> str:
+    """Best-effort command name for parse-time JSON errors."""
+    tokens = [arg for arg in args if not arg.startswith("-")]
+    if not tokens:
+        return "smolvm"
+    if len(tokens) >= 2 and tokens[0] in {
+        "sandbox",
+        "snapshot",
+        "file",
+        "env",
+        "port",
+        "windows",
+        "browser",
+        "server",
+        "codex",
+        "claude",
+        "openclaw",
+        "hermes",
+        "pi",
+    }:
+        return f"{tokens[0]}.{tokens[1]}"
+    return tokens[0]
+
+
+def _recovery_from_argv(args: Sequence[str]) -> str:
+    tokens = [arg for arg in args if not arg.startswith("-")]
+    if tokens:
+        return f"Run 'smolvm {' '.join(tokens[:2])} --help' for usage."
+    return "Run 'smolvm --help' for usage."
+
+
+def build_cli() -> click.Group:
+    """Return the Click root command."""
+    from smolvm.cli.commands import build_cli as _build_cli
+
+    return _build_cli()
+
+
 def main(argv: Sequence[str] | None = None) -> int:
     """CLI entrypoint for `smolvm`."""
-    # Best-effort: if the user has been added to the kvm group but the
-    # current shell session hasn't picked it up yet, re-exec under
-    # `sg kvm -c …` so /dev/kvm becomes accessible without a manual
-    # `newgrp kvm` or relog. Linux-only; no-op everywhere else.
     maybe_reexec_for_kvm_group(argv)
 
-    parser = build_parser()
-    args = parser.parse_args(argv)
-
-    # Best-effort PyPI update nag. Skipped in --json mode and for
-    # `setup --assets-dir` so we never pollute machine-readable output
-    # that scripts (Packer, Make, etc.) consume directly.
-    suppress_update_notice = bool(getattr(args, "json", False)) or (
-        args.command == "setup" and bool(getattr(args, "assets_dir", False))
-    )
-    maybe_print_update_notice(json_output=suppress_update_notice)
-
-    if args.command == "delete":
-        return run_delete(
-            vm_ids=args.vm_ids,
-            dry_run=args.dry_run,
-            json_output=args.json,
+    args = list(argv) if argv is not None else sys.argv[1:]
+    cli = build_cli()
+    try:
+        result = cli.main(
+            args=args,
+            prog_name="smolvm",
+            standalone_mode=False,
         )
-
-    if args.command == "cleanup":
-        return run_cleanup(
-            dry_run=args.dry_run,
-            json_output=args.json,
-            force=args.force,
-        )
-
-    if args.command == "update":
-        from smolvm.cli.update import run_update
-
-        return run_update(args)
-
-    if args.command == "prune":
-        from smolvm.cli.prune import run_prune
-
-        return run_prune(args)
-
-    if args.command == "setup":
-        return _run_setup(parser, args)
-
-    if args.command == "list":
-        return _run_list(
-            include_all=args.all,
-            status_filter=args.status,
-            json_output=args.json,
-        )
-
-    if args.command == "info":
-        return _run_info(vm_id=args.vm_id, json_output=args.json)
-
-    if args.command == "create":
-        return _run_create(args)
-
-    if _is_preset_command(args):
-        return _run_start(args)
-
-    if args.command == "stop":
-        return _run_stop(args)
-
-    if args.command == "pause":
-        return _run_pause(args)
-
-    if args.command == "resume":
-        return _run_resume(args)
-
-    if args.command == "start":
-        return _run_vm_start(args)
-
-    if args.command == "snapshot":
-        return _run_snapshot(args)
-
-    if args.command == "ssh":
-        return _run_ssh(args)
-
-    if args.command == "file":
-        return _run_file(args)
-
-    if args.command == "windows":
-        return _run_windows(args)
-
-    if args.command == "doctor":
-        return run_doctor(
-            backend=args.backend,
-            json_output=args.json,
-            strict=args.strict,
-        )
-
-    if args.command == "server":
-        return _run_server_start(host=args.host, port=args.port)
-
-    if args.command == "ui":
-        return _run_ui(host=args.host, port=args.port, allow_beta=args.allow_beta)
-
-    if args.command == "browser":
-        return _run_browser(args)
-
-    if args.command == "env":
-        return _run_env(args)
-
-    if args.command == "port":
-        return _run_port(args)
-
-    parser.print_help()
-    return 2
+        return 0 if result is None else int(result)
+    except click.ClickException as exc:
+        json_output = "--json" in args
+        if json_output:
+            emit_error(
+                _command_name_from_argv(args),
+                "usage_error",
+                exc.format_message(),
+                recovery=_recovery_from_argv(args),
+                exit_code=exc.exit_code,
+            )
+        else:
+            exc.show(file=sys.stderr)
+        return exc.exit_code
+    except click.Abort:
+        return 130

--- a/src/smolvm/cli/main.py
+++ b/src/smolvm/cli/main.py
@@ -241,7 +241,7 @@ class SnapshotRestorePayload(TypedDict):
 
 
 class FileUploadPayload(TypedDict):
-    """JSON payload for ``smolvm file upload``."""
+    """JSON payload for ``smolvm sandbox file upload``."""
 
     vm_id: str
     local_path: str
@@ -249,7 +249,7 @@ class FileUploadPayload(TypedDict):
 
 
 class FileDownloadPayload(TypedDict):
-    """JSON payload for ``smolvm file download``."""
+    """JSON payload for ``smolvm sandbox file download``."""
 
     vm_id: str
     guest_path: str
@@ -2026,16 +2026,16 @@ def _render_env_list(vm_id: str, data: dict[str, object]) -> None:
 
 
 def _run_env(args: SimpleNamespace) -> int:
-    """Handle ``smolvm env set|unset|list``."""
+    """Handle ``smolvm sandbox env set|unset|list``."""
     from smolvm.facade import SmolVM
 
     if args.env_action is None:
-        render_error("Usage: smolvm env {set,unset,list} <vm_id> ...")
+        render_error("Usage: smolvm sandbox env {set,unset,list} <vm_id> ...")
         return 2
 
     vm: SmolVM | None = None
     json_output = getattr(args, "json", False)
-    command_name = f"env.{args.env_action}"
+    command_name = getattr(args, "command_name", f"sandbox.env.{args.env_action}")
     try:
         parsed_env_vars: dict[str, str] | None = None
         if args.env_action == "set":
@@ -2161,15 +2161,15 @@ def _render_file_download(data: FileDownloadPayload) -> None:
 
 
 def _run_file(args: SimpleNamespace) -> int:
-    """Handle ``smolvm file`` commands."""
+    """Handle ``smolvm sandbox file`` commands."""
     from smolvm.facade import SmolVM
 
     if args.file_action is None:
-        render_error("Usage: smolvm file {upload,download} ...")
+        render_error("Usage: smolvm sandbox file {upload,download} ...")
         return 2
 
     json_output = args.json
-    command_name = f"file.{args.file_action}"
+    command_name = getattr(args, "command_name", f"sandbox.file.{args.file_action}")
     vm: SmolVM | None = None
     try:
         vm = SmolVM.from_id(
@@ -2213,7 +2213,7 @@ def _run_file(args: SimpleNamespace) -> int:
                 _render_file_download(download_data)
             return 0
 
-        render_error("Usage: smolvm file {upload,download} ...")
+        render_error("Usage: smolvm sandbox file {upload,download} ...")
         return 2
     except Exception as exc:
         return _emit_cli_error(command_name, 1, exc, json_output=json_output)
@@ -2957,13 +2957,11 @@ def _command_name_from_argv(args: Sequence[str]) -> str:
     if (
         len(tokens) >= 3
         and tokens[0] == "sandbox"
-        and tokens[1] in {"snapshot", "port"}
+        and tokens[1] in {"env", "file", "snapshot", "port"}
     ):
         return f"sandbox.{tokens[1]}.{tokens[2]}"
     if len(tokens) >= 2 and tokens[0] in {
         "sandbox",
-        "file",
-        "env",
         "windows",
         "browser",
         "server",
@@ -2982,7 +2980,7 @@ def _recovery_from_argv(args: Sequence[str]) -> str:
     if (
         len(tokens) >= 3
         and tokens[0] == "sandbox"
-        and tokens[1] in {"snapshot", "port"}
+        and tokens[1] in {"env", "file", "snapshot", "port"}
     ):
         return f"Run 'smolvm {' '.join(tokens[:3])} --help' for usage."
     if tokens:

--- a/src/smolvm/cli/main.py
+++ b/src/smolvm/cli/main.py
@@ -1871,9 +1871,7 @@ def _run_snapshot(args: SimpleNamespace) -> int:
 
     json_output = getattr(args, "json", False)
     command_name = getattr(args, "command_name", None) or (
-        f"sandbox.snapshot.{args.snapshot_action}"
-        if args.snapshot_action
-        else "sandbox.snapshot"
+        f"sandbox.snapshot.{args.snapshot_action}" if args.snapshot_action else "sandbox.snapshot"
     )
 
     if args.snapshot_action is None:
@@ -2739,7 +2737,7 @@ def _run_windows_build_image(args: SimpleNamespace) -> int:
 
     if args.json:
         emit_json(
-                "windows.build-image",
+            "windows.build-image",
             0,
             data={
                 "output_qcow2": str(output),

--- a/src/smolvm/cli/output.py
+++ b/src/smolvm/cli/output.py
@@ -42,17 +42,53 @@ def emit_json(
     error: dict[str, str] | None = None,
 ) -> None:
     """Emit the unified JSON envelope to stdout."""
+    normalized_error: dict[str, Any] | None = None
+    if error is not None:
+        normalized_error = {
+            "code": error.get("code") or error.get("type") or "runtime_error",
+            "message": error.get("message", ""),
+        }
+        if recovery := error.get("recovery"):
+            normalized_error["recovery"] = recovery
+        if details := error.get("details"):
+            normalized_error["details"] = details
+
     payload = {
-        "ok": exit_code == 0 and error is None,
+        "ok": exit_code == 0 and normalized_error is None,
         "command": command,
         "exit_code": exit_code,
         "data": data,
-        "error": error,
+        "error": normalized_error,
     }
     stdout = console_stdout().file
     stdout.write(json.dumps(payload, indent=2))
     stdout.write("\n")
     stdout.flush()
+
+
+def emit_success(command: str, data: Any = None, *, exit_code: int = 0) -> int:
+    """Emit a successful JSON envelope."""
+    emit_json(command, exit_code, data=data)
+    return exit_code
+
+
+def emit_error(
+    command: str,
+    code: str,
+    message: str,
+    *,
+    recovery: str | None = None,
+    details: Any = None,
+    exit_code: int = 1,
+) -> int:
+    """Emit a failed JSON envelope."""
+    error: dict[str, Any] = {"code": code, "message": message}
+    if recovery is not None:
+        error["recovery"] = recovery
+    if details is not None:
+        error["details"] = details
+    emit_json(command, exit_code, data=None, error=error)
+    return exit_code
 
 
 def render_error(message: str, hint: str | None = None) -> None:

--- a/src/smolvm/cli/output.py
+++ b/src/smolvm/cli/output.py
@@ -39,7 +39,7 @@ def emit_json(
     exit_code: int,
     *,
     data: Any = None,
-    error: dict[str, str] | None = None,
+    error: dict[str, Any] | None = None,
 ) -> None:
     """Emit the unified JSON envelope to stdout."""
     normalized_error: dict[str, Any] | None = None
@@ -50,8 +50,8 @@ def emit_json(
         }
         if recovery := error.get("recovery"):
             normalized_error["recovery"] = recovery
-        if details := error.get("details"):
-            normalized_error["details"] = details
+        if "details" in error:
+            normalized_error["details"] = error["details"]
 
     payload = {
         "ok": exit_code == 0 and normalized_error is None,

--- a/src/smolvm/cli/prune.py
+++ b/src/smolvm/cli/prune.py
@@ -16,7 +16,6 @@
 
 from __future__ import annotations
 
-import argparse
 import re
 import shutil
 from pathlib import Path
@@ -67,28 +66,33 @@ def find_stale_caches(
     return stale
 
 
-def run_prune(args: argparse.Namespace) -> int:
+def run_prune(
+    *,
+    dry_run: bool = False,
+    json_output: bool = False,
+    cache_dir: str | None = None,
+) -> int:
     """Execute ``smolvm prune``."""
-    cache_dir = Path(args.cache_dir) if getattr(args, "cache_dir", None) else None
-    stale = find_stale_caches(cache_dir=cache_dir)
+    cache_root = Path(cache_dir) if cache_dir else None
+    stale = find_stale_caches(cache_dir=cache_root)
 
     if not stale:
-        if args.json:
+        if json_output:
             emit_json("prune", 0, data={"removed": [], "freed_bytes": 0})
         else:
             console = console_stdout()
             console.print("Nothing to prune — cache is clean.")
         return 0
 
-    entries = []
+    entries: list[dict[str, str | int]] = []
     total_bytes = 0
     for path in stale:
         size = _total_size(path)
         total_bytes += size
         entries.append({"path": str(path), "size_bytes": size})
 
-    if args.dry_run:
-        if args.json:
+    if dry_run:
+        if json_output:
             emit_json(
                 "prune",
                 0,
@@ -105,13 +109,15 @@ def run_prune(args: argparse.Namespace) -> int:
                 f"({_format_bytes(total_bytes)}):[/bold]"
             )
             for e in entries:
-                console.print(f"  {e['path']}  ({_format_bytes(e['size_bytes'])})")
+                size_bytes = e["size_bytes"]
+                assert isinstance(size_bytes, int)
+                console.print(f"  {e['path']}  ({_format_bytes(size_bytes)})")
         return 0
 
     for path in stale:
         shutil.rmtree(path)
 
-    if args.json:
+    if json_output:
         emit_json(
             "prune",
             0,

--- a/src/smolvm/cli/update.py
+++ b/src/smolvm/cli/update.py
@@ -16,7 +16,6 @@
 
 from __future__ import annotations
 
-import argparse
 import re
 import shutil
 import subprocess
@@ -84,7 +83,7 @@ def _run_upgrade(*, json_output: bool) -> tuple[int, str]:
             output = result.stdout + result.stderr
             return result.returncode, output
         else:
-            result = subprocess.run(cmd)
+            result = subprocess.run(cmd, text=True)
             return result.returncode, ""
     except OSError as exc:
         if not json_output:
@@ -92,17 +91,18 @@ def _run_upgrade(*, json_output: bool) -> tuple[int, str]:
         return 1, str(exc)
 
 
-def run_update(args: argparse.Namespace) -> int:
+def run_update(*, check: bool = False, json_output: bool = False) -> int:
     """Execute ``smolvm update``."""
-    json_output: bool = getattr(args, "json", False)
-    check_only: bool = getattr(args, "check", False)
-
     current, latest = _check_for_stable_update()
 
-    if check_only:
+    if check:
         if latest is None:
             if current is None:
-                data = {"current": None, "latest": None, "update_available": False}
+                data: dict[str, object] = {
+                    "current": None,
+                    "latest": None,
+                    "update_available": False,
+                }
                 if json_output:
                     emit_json("update", 1, data=data)
                 else:

--- a/src/smolvm/facade.py
+++ b/src/smolvm/facade.py
@@ -610,7 +610,7 @@ def _build_auto_config(
             raise ValueError(
                 f"Ubuntu needs at least {required_disk_size_mib} MiB for sandbox "
                 f"'{resolved_vm_name}'; "
-                f"recreate it with: smolvm create --name {quoted_vm_name} --os ubuntu "
+                f"recreate it with: smolvm sandbox create --name {quoted_vm_name} --os ubuntu "
                 f"--backend {resolved_backend} --disk-size {required_disk_size_mib}."
             )
         should_grow_filesystem = (
@@ -697,7 +697,7 @@ def _build_auto_config(
 
 def _from_image_config_help(vm_id: str) -> str:
     """Return the recovery command shown by from_image validation errors."""
-    return f"smolvm create --name {vm_id} --help"
+    return f"smolvm sandbox create --name {vm_id} --help"
 
 
 def _from_image_port_help(vm_id: str) -> str:
@@ -1730,7 +1730,8 @@ class SmolVM:
         if self._info.status != VMState.RUNNING:
             raise SmolVMError(
                 f"Start sandbox '{self._vm_id}' before running commands by running "
-                f"'smolvm start {self._vm_id}' (current state: {self._info.status.value}).",
+                f"'smolvm sandbox start {self._vm_id}' "
+                f"(current state: {self._info.status.value}).",
                 {"vm_id": self._vm_id},
             )
         resolution = self._resolve_channel()
@@ -1746,7 +1747,8 @@ class SmolVM:
         if resolution.kind == "ssh" and self._info.network is None:
             raise SmolVMError(
                 f"Cannot run command in sandbox '{self._vm_id}' over SSH because it has "
-                f"no network; remove it with 'smolvm delete {self._vm_id}' and create it again.",
+                f"no network; remove it with 'smolvm sandbox delete {self._vm_id}' "
+                "and create it again.",
                 {"vm_id": self._vm_id},
             )
 
@@ -2039,13 +2041,14 @@ class SmolVM:
         if self._info.status != VMState.RUNNING:
             raise SmolVMError(
                 f"Start sandbox '{self._vm_id}' before waiting for it by running "
-                f"'smolvm start {self._vm_id}' (current state: {self._info.status.value}).",
+                f"'smolvm sandbox start {self._vm_id}' "
+                f"(current state: {self._info.status.value}).",
                 {"vm_id": self._vm_id},
             )
         if self._resolve_channel().kind == "ssh" and self._info.network is None:
             raise SmolVMError(
                 f"Cannot wait for sandbox '{self._vm_id}' over SSH because it has no network; "
-                f"remove it with 'smolvm delete {self._vm_id}' and create it again.",
+                f"remove it with 'smolvm sandbox delete {self._vm_id}' and create it again.",
                 {"vm_id": self._vm_id},
             )
 
@@ -2851,7 +2854,8 @@ modprobe 9pnet_virtio""".strip()
         if self._info.status != VMState.RUNNING:
             raise SmolVMError(
                 f"{prefix} in sandbox '{self._vm_id}' because it is "
-                f"{self._info.status.value}; start it with 'smolvm start {self._vm_id}'.",
+                f"{self._info.status.value}; start it with "
+                f"'smolvm sandbox start {self._vm_id}'.",
                 {"vm_id": self._vm_id},
             )
         resolution = self._resolve_channel()
@@ -2864,7 +2868,7 @@ modprobe 9pnet_virtio""".strip()
         if resolution.kind == "ssh" and self._info.network is None:
             raise SmolVMError(
                 f"{prefix} in sandbox '{self._vm_id}' over SSH because it has no network; "
-                f"remove it with 'smolvm delete {self._vm_id}' and create it again.",
+                f"remove it with 'smolvm sandbox delete {self._vm_id}' and create it again.",
                 {"vm_id": self._vm_id},
             )
 

--- a/src/smolvm/facade.py
+++ b/src/smolvm/facade.py
@@ -702,7 +702,7 @@ def _from_image_config_help(vm_id: str) -> str:
 
 def _from_image_port_help(vm_id: str) -> str:
     """Return the recovery command shown by port-forward validation errors."""
-    return f"smolvm port expose {vm_id} --help"
+    return f"smolvm sandbox port expose {vm_id} --help"
 
 
 def _normalize_from_image_arch(image: BootImage, arch: str | None, vm_id: str) -> str:
@@ -1684,8 +1684,8 @@ class SmolVM:
         if result.exit_code != 0:
             raise SmolVMError(
                 f"Cannot create disk snapshot for sandbox '{self._vm_id}' because syncing "
-                f"files inside it failed; retry with 'smolvm snapshot create {self._vm_id} "
-                "--snapshot-type disk'."
+                f"files inside it failed; retry with 'smolvm sandbox snapshot create "
+                f"{self._vm_id} --snapshot-type disk'."
             )
 
     def delete(self) -> None:

--- a/src/smolvm/host/doctor.py
+++ b/src/smolvm/host/doctor.py
@@ -468,7 +468,7 @@ def _check_kvm_runtime() -> DoctorCheck:
                 ),
                 fix=(
                     "Log out of this shell and reconnect to apply the new group, "
-                    "or run any other 'smolvm' command (such as 'smolvm list') — "
+                    "or run any other 'smolvm' command (such as 'smolvm sandbox list') — "
                     "it will auto-activate the group via 'sg kvm' for that run."
                 ),
             )

--- a/src/smolvm/runtime/libkrun.py
+++ b/src/smolvm/runtime/libkrun.py
@@ -112,7 +112,8 @@ class LibkrunRuntimeAdapter(RuntimeAdapter):
             rc = process.poll()
             if rc is not None:
                 raise SmolVMError(
-                    f"VM '{vm_id}' failed to start. Run 'smolvm delete {vm_id}' to remove it.",
+                    f"VM '{vm_id}' failed to start. "
+                    f"Run 'smolvm sandbox delete {vm_id}' to remove it.",
                     {"return_code": rc, "pid": process.pid},
                 )
             time.sleep(0.05)
@@ -122,7 +123,8 @@ class LibkrunRuntimeAdapter(RuntimeAdapter):
             with suppress(Exception):
                 self._context.kill_process(process.pid)
             raise SmolVMError(
-                f"VM '{vm_id}' failed to start. Run 'smolvm delete {vm_id}' to remove it.",
+                f"VM '{vm_id}' failed to start. "
+                f"Run 'smolvm sandbox delete {vm_id}' to remove it.",
                 {"return_code": rc, "pid": process.pid},
             )
 
@@ -136,7 +138,8 @@ class LibkrunRuntimeAdapter(RuntimeAdapter):
             rc = process.poll() if hasattr(process, "poll") else process.returncode
             if rc is not None:
                 raise SmolVMError(
-                    f"VM '{vm_id}' failed to start. Run 'smolvm delete {vm_id}' to remove it.",
+                    f"VM '{vm_id}' failed to start. "
+                    f"Run 'smolvm sandbox delete {vm_id}' to remove it.",
                     {"return_code": rc, "pid": process.pid},
                 )
             await asyncio.sleep(0.05)
@@ -146,6 +149,7 @@ class LibkrunRuntimeAdapter(RuntimeAdapter):
             with suppress(Exception):
                 self._context.kill_process(process.pid)
             raise SmolVMError(
-                f"VM '{vm_id}' failed to start. Run 'smolvm delete {vm_id}' to remove it.",
+                f"VM '{vm_id}' failed to start. "
+                f"Run 'smolvm sandbox delete {vm_id}' to remove it.",
                 {"return_code": rc, "pid": process.pid},
             )

--- a/src/smolvm/runtime/libkrun.py
+++ b/src/smolvm/runtime/libkrun.py
@@ -123,8 +123,7 @@ class LibkrunRuntimeAdapter(RuntimeAdapter):
             with suppress(Exception):
                 self._context.kill_process(process.pid)
             raise SmolVMError(
-                f"VM '{vm_id}' failed to start. "
-                f"Run 'smolvm sandbox delete {vm_id}' to remove it.",
+                f"VM '{vm_id}' failed to start. Run 'smolvm sandbox delete {vm_id}' to remove it.",
                 {"return_code": rc, "pid": process.pid},
             )
 
@@ -149,7 +148,6 @@ class LibkrunRuntimeAdapter(RuntimeAdapter):
             with suppress(Exception):
                 self._context.kill_process(process.pid)
             raise SmolVMError(
-                f"VM '{vm_id}' failed to start. "
-                f"Run 'smolvm sandbox delete {vm_id}' to remove it.",
+                f"VM '{vm_id}' failed to start. Run 'smolvm sandbox delete {vm_id}' to remove it.",
                 {"return_code": rc, "pid": process.pid},
             )

--- a/src/smolvm/runtime/qemu.py
+++ b/src/smolvm/runtime/qemu.py
@@ -411,7 +411,7 @@ class QemuRuntimeAdapter(RuntimeAdapter):
                 raise SmolVMError(
                     "This space-saving snapshot needs its original base image, "
                     f"which is missing: '{backing}'. Restore that file and run "
-                    f"'smolvm snapshot restore {snapshot.snapshot_id}' again, or take "
+                    f"'smolvm sandbox snapshot restore {snapshot.snapshot_id}' again, or take "
                     "a full snapshot next time with '--snapshot-type full'.",
                     {"snapshot_id": snapshot.snapshot_id, "backing_file": str(backing)},
                 )

--- a/src/smolvm/types.py
+++ b/src/smolvm/types.py
@@ -114,7 +114,7 @@ def _should_validate_paths(info: ValidationInfo) -> bool:
 
     Storage reads (``vm_config_from_json``) pass ``validate_paths=False`` in
     the validation context so a stale or missing host path on disk does not
-    blow up read-only commands like ``smolvm list``. Defaults to ``True`` so
+    blow up read-only commands like ``smolvm sandbox list``. Defaults to ``True`` so
     direct construction (creates, tests) keeps its safety net.
     """
     return bool((info.context or {}).get("validate_paths", True))

--- a/src/smolvm/vm.py
+++ b/src/smolvm/vm.py
@@ -245,13 +245,13 @@ def _crashed_message(vm_id: str) -> str:
     """User-facing message for a VM whose process is gone."""
     return (
         f"VM '{vm_id}' is not running — its process has exited; "
-        f"run 'smolvm delete {vm_id}' to clear it."
+        f"run 'smolvm sandbox delete {vm_id}' to clear it."
     )
 
 
 def _vsock_recovery_command(vm_id: str, backend: str) -> str:
     """Return a CLI recovery command for an explicit-vsock create failure."""
-    return f"smolvm create --name {vm_id} --backend {backend}"
+    return f"smolvm sandbox create --name {vm_id} --backend {backend}"
 
 
 def _vsock_not_supported_message(
@@ -758,7 +758,7 @@ class SmolVMManager:
     @staticmethod
     def _resize_recovery(vm_id: str) -> str:
         """Return a cleanup command for disk resize errors."""
-        return f"smolvm delete {vm_id}"
+        return f"smolvm sandbox delete {vm_id}"
 
     @staticmethod
     def _ensure_disk_can_be_resized(config: VMConfig) -> None:
@@ -1104,7 +1104,7 @@ class SmolVMManager:
         paths = ", ".join(str(p) for p in bad_paths)
         raise SmolVMError(
             f"Cannot start sandbox '{vm_info.vm_id}': shared folder is missing: "
-            f"{paths}. Restore it, or run 'smolvm delete {vm_info.vm_id}'.",
+            f"{paths}. Restore it, or run 'smolvm sandbox delete {vm_info.vm_id}'.",
             {
                 "vm_id": vm_info.vm_id,
                 "missing_mounts": [str(p) for p in bad_paths],
@@ -1131,7 +1131,7 @@ class SmolVMManager:
             raise SmolVMError(
                 f"Snapshots are not supported for raw QEMU disks in sandbox "
                 f"'{vm_info.vm_id}'; create it without grow_filesystem, or run "
-                f"'smolvm delete {vm_info.vm_id}'."
+                f"'smolvm sandbox delete {vm_info.vm_id}'."
             )
         if vm_info.config.extra_drives:
             raise SmolVMError("Snapshotting currently supports only VMs without extra drives")
@@ -1515,7 +1515,7 @@ class SmolVMManager:
                 self.state.release_vsock_cid(vm_id)
                 raise NetworkError(
                     f"Vsock CID {cid} is already in use by another running QEMU VM; "
-                    f"run 'smolvm delete {vm_id}' to remove this sandbox, then create it "
+                    f"run 'smolvm sandbox delete {vm_id}' to remove this sandbox, then create it "
                     "again without that explicit CID."
                 )
             return cid
@@ -1626,7 +1626,7 @@ class SmolVMManager:
         if ssh_port is not None and not self._local_ssh_port_is_available(ssh_port):
             raise SmolVMError(
                 f"Local SSH port {ssh_port} is already in use. Free that port, or run "
-                f"'smolvm delete {vm_info.vm_id}' to remove the sandbox.",
+                f"'smolvm sandbox delete {vm_info.vm_id}' to remove the sandbox.",
                 {"vm_id": vm_info.vm_id, "ssh_host_port": ssh_port},
             )
 
@@ -1635,7 +1635,8 @@ class SmolVMManager:
                 continue
             raise SmolVMError(
                 f"Local port {forward.host_address}:{forward.host_port} is already in use. "
-                f"Free that port, or run 'smolvm delete {vm_info.vm_id}' to remove the sandbox.",
+                f"Free that port, or run 'smolvm sandbox delete {vm_info.vm_id}' "
+                "to remove the sandbox.",
                 {
                     "vm_id": vm_info.vm_id,
                     "host_address": forward.host_address,
@@ -2028,9 +2029,9 @@ class SmolVMManager:
         # the status string itself is the explanation.
         recovery = ""
         if vm_info.status == VMState.ERROR:
-            recovery = f"; run 'smolvm delete {vm_info.vm_id}' to clear it"
+            recovery = f"; run 'smolvm sandbox delete {vm_info.vm_id}' to clear it"
         elif vm_info.status in (VMState.STOPPED, VMState.CREATED):
-            recovery = f"; run 'smolvm start {vm_info.vm_id}' to start it"
+            recovery = f"; run 'smolvm sandbox start {vm_info.vm_id}' to start it"
         raise SmolVMError(
             f"Cannot {action} VM in state '{vm_info.status.value}'{recovery}.",
             {"vm_id": vm_info.vm_id, "current_status": vm_info.status.value},
@@ -2290,7 +2291,8 @@ class SmolVMManager:
                 except NetworkError as exc:
                     raise NetworkError(
                         f"Vsock CID {persisted_vm_config.vsock.guest_cid} is already in use; "
-                        f"run 'smolvm delete {restore_vm_id}' to remove this restore attempt."
+                        f"run 'smolvm sandbox delete {restore_vm_id}' "
+                        "to remove this restore attempt."
                     ) from exc
             self.state.update_vm(restore_vm_id, network=effective_snapshot.network_config)
             if effective_snapshot.backend == BACKEND_FIRECRACKER:
@@ -2732,7 +2734,7 @@ class SmolVMManager:
             raise SmolVMError(
                 f"Cannot start sandbox '{vm_info.vm_id}' because libkrun is not ready; "
                 f"run 'smolvm doctor --backend libkrun', then run "
-                f"'smolvm start {vm_info.vm_id}'."
+                f"'smolvm sandbox start {vm_info.vm_id}'."
             )
 
         config_path = self._write_libkrun_config(vm_info, self._build_libkrun_config(vm_info))
@@ -3428,7 +3430,7 @@ class SmolVMManager:
             raise SmolVMError(
                 f"Cannot start sandbox '{vm_info.vm_id}' because libkrun is not ready; "
                 f"run 'smolvm doctor --backend libkrun', then run "
-                f"'smolvm start {vm_info.vm_id}'."
+                f"'smolvm sandbox start {vm_info.vm_id}'."
             )
 
         config_path = self._write_libkrun_config(vm_info, self._build_libkrun_config(vm_info))

--- a/tests/e2e/_util.py
+++ b/tests/e2e/_util.py
@@ -34,7 +34,7 @@ from smolvm.host.manager import HostManager
 from smolvm.runtime.backends import BACKEND_FIRECRACKER, BACKEND_QEMU
 
 E2EBackend = Literal["qemu", "firecracker"]
-E2ETransport = Literal["ssh", "vsock"]
+E2ETransport = Literal["sandbox", "ssh", "vsock"]
 
 
 @dataclass(frozen=True, slots=True)

--- a/tests/e2e/test_browser.py
+++ b/tests/e2e/test_browser.py
@@ -1,0 +1,65 @@
+# Copyright 2026 Celesto AI
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""End-to-end browser sandbox smoke test."""
+
+from __future__ import annotations
+
+import json
+from contextlib import suppress
+from urllib.request import urlopen
+
+import pytest
+from _util import BOOT_TIMEOUT, require_backend_available, selected_backend
+
+from smolvm import SmolVM
+from smolvm.runtime.backends import BACKEND_QEMU
+
+pytestmark = pytest.mark.e2e
+
+
+def test_browser_headless_exposes_live_cdp(
+    request: pytest.FixtureRequest,
+) -> None:
+    """Boot a real browser sandbox and confirm Chromium answers on CDP."""
+    selected = selected_backend(request.config)
+    if selected != "all" and selected != BACKEND_QEMU:
+        pytest.skip(f"Browser e2e runs on '{BACKEND_QEMU}' only; this run selected '{selected}'.")
+    require_backend_available(
+        BACKEND_QEMU,
+        request.config,
+        sandbox_name="browser-qemu",
+    )
+
+    sandbox = SmolVM.browser(
+        headless=True,
+        backend=BACKEND_QEMU,
+        boot_timeout=BOOT_TIMEOUT,
+        timeout_minutes=5,
+    )
+    try:
+        cdp_url = sandbox.cdp_url
+        assert cdp_url is not None
+        assert sandbox.viewer_url is None
+        assert sandbox.display_url is None
+
+        with urlopen(f"{cdp_url.rstrip('/')}/json/version", timeout=10) as response:
+            assert response.status == 200
+            version = json.load(response)
+
+        assert isinstance(version.get("Browser"), str)
+        assert version["webSocketDebuggerUrl"].startswith("ws://")
+    finally:
+        with suppress(Exception):
+            sandbox.stop()

--- a/tests/test_cleanup.py
+++ b/tests/test_cleanup.py
@@ -19,8 +19,7 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
-from smolvm.cli.cleanup import build_parser, run_cleanup, run_delete
-from smolvm.cli.cleanup import main as cleanup_main
+from smolvm.cli.cleanup import run_cleanup, run_delete
 from smolvm.cli.main import main as cli_main
 
 
@@ -31,7 +30,7 @@ def _make_vm(vm_id: str) -> MagicMock:
 
 
 class TestDelete:
-    """Tests for ``smolvm delete <vm-id>``."""
+    """Tests for ``smolvm sandbox delete <vm-id>``."""
 
     @pytest.fixture
     def mock_sdk_cls(self) -> MagicMock:
@@ -126,26 +125,27 @@ class TestDelete:
 
         assert ret == 0
         payload = json.loads(capsys.readouterr().out)
-        assert payload["command"] == "delete"
+        assert payload["command"] == "sandbox.delete"
         assert payload["ok"] is True
         assert payload["data"]["targets"] == ["vm-abc"]
         assert payload["data"]["deleted"] == ["vm-abc"]
 
-    @patch("smolvm.cli.main.run_delete", return_value=0)
+    @patch("smolvm.cli.cleanup.run_delete", return_value=0)
     def test_cli_delete_forwards_args(self, mock_run_delete: MagicMock) -> None:
-        """`smolvm delete vm-abc vm-def --json` forwards correctly."""
-        ret = cli_main(["delete", "vm-abc", "vm-def", "--json"])
+        """`smolvm sandbox delete vm-abc vm-def --json` forwards correctly."""
+        ret = cli_main(["sandbox", "delete", "vm-abc", "vm-def", "--json"])
 
         assert ret == 0
         mock_run_delete.assert_called_once_with(
             vm_ids=["vm-abc", "vm-def"],
             dry_run=False,
             json_output=True,
+            command_name="sandbox.delete",
         )
 
 
 class TestCleanup:
-    """Tests for ``smolvm cleanup``."""
+    """Tests for ``smolvm sandbox delete --all``."""
 
     @pytest.fixture
     def mock_sdk_cls(self) -> MagicMock:
@@ -220,7 +220,7 @@ class TestCleanup:
 
         assert ret == 1
         out = capsys.readouterr().out
-        assert "Cleanup Results" in out
+        assert "Delete Results" in out
         assert "deleted" in out
         assert "failed" in out
         assert "busy" in out
@@ -241,7 +241,7 @@ class TestCleanup:
 
         assert ret == 0
         payload = json.loads(capsys.readouterr().out)
-        assert payload["command"] == "cleanup"
+        assert payload["command"] == "sandbox.delete"
         assert payload["ok"] is True
         assert set(payload["data"]["targets"]) == {"vm-stale", "vm-other"}
         assert set(payload["data"]["deleted"]) == {"vm-stale", "vm-other"}
@@ -267,7 +267,7 @@ class TestCleanup:
         payload = json.loads(capsys.readouterr().out)
         assert isinstance(payload, dict)
         assert payload["ok"] is False
-        assert payload["command"] == "cleanup"
+        assert payload["command"] == "sandbox.delete"
         assert payload["exit_code"] == 1
         assert "force" in payload["error"]["message"].lower()
 
@@ -338,36 +338,31 @@ class TestCleanup:
         sdk.delete.assert_not_called()
         assert "Aborted" in capsys.readouterr().out
 
-    def test_cleanup_parser_includes_json(self) -> None:
-        """The standalone cleanup parser should expose `--json`."""
-        args = build_parser().parse_args(["--json"])
-        assert args.json is True
-
-    def test_cleanup_parser_includes_force(self) -> None:
-        """The standalone cleanup parser should expose `--force`."""
-        args = build_parser().parse_args(["--force"])
-        assert args.force is True
-
-    @patch("smolvm.cli.main.run_cleanup", return_value=0)
-    def test_cli_cleanup_forwards_json(self, mock_run_cleanup: MagicMock) -> None:
-        """`smolvm cleanup --json` forwards correctly."""
-        ret = cli_main(["cleanup", "--json"])
-
-        assert ret == 0
-        mock_run_cleanup.assert_called_once_with(
-            dry_run=False,
-            json_output=True,
-            force=False,
-        )
-
     @patch("smolvm.cli.cleanup.run_cleanup", return_value=0)
-    def test_standalone_cleanup_main_forwards_json(self, mock_run_cleanup: MagicMock) -> None:
-        """`smolvm-cleanup --json` forwards correctly."""
-        ret = cleanup_main(["--json"])
+    def test_cli_cleanup_forwards_json(self, mock_run_cleanup: MagicMock) -> None:
+        """`smolvm sandbox delete --all --force --json` forwards correctly."""
+        ret = cli_main(["sandbox", "delete", "--all", "--force", "--json"])
 
         assert ret == 0
         mock_run_cleanup.assert_called_once_with(
             dry_run=False,
             json_output=True,
-            force=False,
+            force=True,
+            command_name="sandbox.delete",
         )
+
+    @patch("smolvm.cli.cleanup.run_cleanup")
+    def test_cli_cleanup_json_requires_force(
+        self,
+        mock_run_cleanup: MagicMock,
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        """`smolvm sandbox delete --all --json` is rejected before runtime."""
+        ret = cli_main(["sandbox", "delete", "--all", "--json"])
+
+        assert ret == 1
+        payload = json.loads(capsys.readouterr().out)
+        assert payload["ok"] is False
+        assert payload["command"] == "sandbox.delete"
+        assert payload["error"]["code"] == "refused"
+        mock_run_cleanup.assert_not_called()

--- a/tests/test_cleanup.py
+++ b/tests/test_cleanup.py
@@ -270,6 +270,11 @@ class TestCleanup:
         assert payload["command"] == "sandbox.delete"
         assert payload["exit_code"] == 1
         assert "force" in payload["error"]["message"].lower()
+        assert "smolvm sandbox delete --all --force --json" in payload["error"]["message"]
+        assert (
+            payload["error"]["recovery"]
+            == "Run 'smolvm sandbox delete --all --force --json' to confirm."
+        )
 
     @patch("smolvm.cli.cleanup.os.geteuid", return_value=0)
     @patch("smolvm.cli.cleanup.sys.stdin")
@@ -365,4 +370,9 @@ class TestCleanup:
         assert payload["ok"] is False
         assert payload["command"] == "sandbox.delete"
         assert payload["error"]["code"] == "refused"
+        assert "smolvm sandbox delete --all --force --json" in payload["error"]["message"]
+        assert (
+            payload["error"]["recovery"]
+            == "Run 'smolvm sandbox delete --all --force --json' to confirm."
+        )
         mock_run_cleanup.assert_not_called()

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -25,7 +25,6 @@ import pytest
 from smolvm.cli.main import (
     DASHBOARD_ALLOW_BETA_ENV,
     _current_version_is_prerelease,
-    build_parser,
     main,
 )
 from smolvm.types import (
@@ -109,22 +108,25 @@ def _make_snapshot_info(
 
 
 def test_top_level_help_mentions_json_for_agents() -> None:
-    """Top-level help should describe the machine-readable JSON mode."""
-    help_text = build_parser().format_help()
+    """Command help should describe the machine-readable JSON mode."""
+    from click.testing import CliRunner
 
-    assert "--json" in help_text
-    assert "machine-readable output" in help_text
-    assert "LLMs, agents, and automation" in help_text
+    from smolvm.cli.main import build_cli
+
+    result = CliRunner().invoke(build_cli(), ["sandbox", "create", "--help"])
+
+    assert result.exit_code == 0
+    assert "--json" in result.output
+    assert "Output a JSON envelope" in result.output
 
 
 def test_create_help_describes_backend_specific_guest_default(
     capsys: pytest.CaptureFixture,
 ) -> None:
     """Create help should describe the OS option and its auto-detected default."""
-    with pytest.raises(SystemExit) as exc_info:
-        main(["create", "--help"])
+    ret = main(["sandbox", "create", "--help"])
 
-    assert exc_info.value.code == 0
+    assert ret == 0
     help_text = capsys.readouterr().out
     assert "Operating system image" in help_text
     assert "auto-detected" in help_text
@@ -606,7 +608,7 @@ class TestCliFile:
 
 
 class TestCliCreate:
-    """Tests for `smolvm create`."""
+    """Tests for `smolvm sandbox create`."""
 
     @patch("smolvm.facade._build_auto_config")
     @patch("smolvm.facade.SmolVM")
@@ -619,7 +621,7 @@ class TestCliCreate:
         monkeypatch: pytest.MonkeyPatch,
         capsys: pytest.CaptureFixture,
     ) -> None:
-        """`smolvm create` should auto-generate a VM name when omitted."""
+        """`smolvm sandbox create` should auto-generate a VM name when omitted."""
         monkeypatch.delenv("SMOLVM_BACKEND", raising=False)
         config = MagicMock(vm_id="vm-a1b2c3d4")
         mock_build_auto_config.return_value = (config, "/tmp/id_ed25519")
@@ -632,7 +634,7 @@ class TestCliCreate:
         vm.info.network.ssh_host_port = 2200
         mock_vm_cls.return_value = vm
 
-        ret = main(["create"])
+        ret = main(["sandbox", "create"])
 
         assert ret == 0
         mock_build_auto_config.assert_called_once_with(
@@ -660,8 +662,8 @@ class TestCliCreate:
         assert "OS" in out
         assert "ubuntu" in out
         assert "Started" in out
-        assert "smolvm ssh vm-a1b2c3d4" in out
-        assert "smolvm info vm-a1b2c3d4" in out
+        assert "smolvm sandbox ssh vm-a1b2c3d4" in out
+        assert "smolvm sandbox info vm-a1b2c3d4" in out
         assert "Backend" not in out
         assert "IP Address" not in out
         assert "SSH Port" not in out
@@ -677,7 +679,7 @@ class TestCliCreate:
         monkeypatch: pytest.MonkeyPatch,
         capsys: pytest.CaptureFixture,
     ) -> None:
-        """`smolvm create` should build, start, and report a named VM."""
+        """`smolvm sandbox create` should build, start, and report a named VM."""
         monkeypatch.delenv("SMOLVM_BACKEND", raising=False)
         config = MagicMock(vm_id="project-spacex")
         mock_build_auto_config.return_value = (config, "/tmp/id_ed25519")
@@ -692,6 +694,7 @@ class TestCliCreate:
 
         ret = main(
             [
+                "sandbox",
                 "create",
                 "--name",
                 "project-spacex",
@@ -736,8 +739,8 @@ class TestCliCreate:
         assert "OS" in out
         assert "ubuntu" in out
         assert "Started" in out
-        assert "smolvm ssh project-spacex" in out
-        assert "smolvm info project-spacex" in out
+        assert "smolvm sandbox ssh project-spacex" in out
+        assert "smolvm sandbox info project-spacex" in out
         assert "Backend" not in out
         assert "172.16.0.2" not in out
         assert "2200" not in out
@@ -752,7 +755,7 @@ class TestCliCreate:
         mock_build_auto_config: MagicMock,
         monkeypatch: pytest.MonkeyPatch,
     ) -> None:
-        """`smolvm create --comm-channel ssh` preserves the SSH-ready contract."""
+        """`smolvm sandbox create --comm-channel ssh` preserves the SSH-ready contract."""
         monkeypatch.delenv("SMOLVM_BACKEND", raising=False)
         config = MagicMock(vm_id="project-spacex")
         mock_build_auto_config.return_value = (config, "/tmp/id_ed25519")
@@ -765,7 +768,7 @@ class TestCliCreate:
         vm.info.network.ssh_host_port = 2200
         mock_vm_cls.return_value = vm
 
-        ret = main(["create", "--name", "project-spacex", "--comm-channel", "ssh"])
+        ret = main(["sandbox", "create", "--name", "project-spacex", "--comm-channel", "ssh"])
 
         assert ret == 0
         mock_vm_cls.assert_called_once_with(
@@ -789,7 +792,7 @@ class TestCliCreate:
         mock_build_auto_config: MagicMock,
         monkeypatch: pytest.MonkeyPatch,
     ) -> None:
-        """`smolvm create -n ...` should behave the same as `--name`."""
+        """`smolvm sandbox create -n ...` should behave the same as `--name`."""
         monkeypatch.delenv("SMOLVM_BACKEND", raising=False)
         config = MagicMock(vm_id="computer")
         mock_build_auto_config.return_value = (config, "/tmp/id_ed25519")
@@ -802,7 +805,7 @@ class TestCliCreate:
         vm.info.network.ssh_host_port = 2200
         mock_vm_cls.return_value = vm
 
-        ret = main(["create", "-n", "computer"])
+        ret = main(["sandbox", "create", "-n", "computer"])
 
         assert ret == 0
         mock_build_auto_config.assert_called_once_with(
@@ -837,7 +840,7 @@ class TestCliCreate:
         monkeypatch: pytest.MonkeyPatch,
         capsys: pytest.CaptureFixture,
     ) -> None:
-        """`smolvm create --json` should emit the shared envelope."""
+        """`smolvm sandbox create --json` should emit the shared envelope."""
         monkeypatch.delenv("SMOLVM_BACKEND", raising=False)
         config = MagicMock(vm_id="project-spacex")
         mock_build_auto_config.return_value = (config, "/tmp/id_ed25519")
@@ -850,18 +853,18 @@ class TestCliCreate:
         vm.info.network.ssh_host_port = 2200
         mock_vm_cls.return_value = vm
 
-        ret = main(["create", "--name", "project-spacex", "--json"])
+        ret = main(["sandbox", "create", "--name", "project-spacex", "--json"])
 
         assert ret == 0
         out = capsys.readouterr().out
         assert "Preparing ubuntu operating system image" not in out
         payload = json.loads(out)
-        assert payload["command"] == "create"
+        assert payload["command"] == "sandbox.create"
         assert payload["data"]["vm"]["name"] == "project-spacex"
         assert payload["data"]["vm"]["os"] == "ubuntu"
         assert payload["data"]["vm"]["started_at"]
-        assert payload["data"]["next"]["ssh_command"] == "smolvm ssh project-spacex"
-        assert payload["data"]["next"]["info_command"] == "smolvm info project-spacex"
+        assert payload["data"]["next"]["ssh_command"] == "smolvm sandbox ssh project-spacex"
+        assert payload["data"]["next"]["info_command"] == "smolvm sandbox info project-spacex"
 
     @patch("smolvm.facade.platform.machine", return_value="x86_64")
     @patch("smolvm.facade.build_seed_iso")
@@ -905,6 +908,7 @@ class TestCliCreate:
 
         ret = main(
             [
+                "sandbox",
                 "create",
                 "--name",
                 "project-spacex",
@@ -949,7 +953,7 @@ class TestCliCreate:
         vm.info.network.ssh_host_port = 2200
         mock_vm_cls.return_value = vm
 
-        ret = main(["create", "--os", "alpine", "--json"])
+        ret = main(["sandbox", "create", "--os", "alpine", "--json"])
 
         assert ret == 0
         mock_build_auto_config.assert_called_once_with(
@@ -978,7 +982,7 @@ class TestCliCreate:
         mock_build_auto_config.return_value = (MagicMock(vm_id="project-spacex"), "/tmp/id_ed25519")
         mock_vm_cls.side_effect = Exception("VM 'project-spacex' already exists")
 
-        ret = main(["create", "--name", "project-spacex"])
+        ret = main(["sandbox", "create", "--name", "project-spacex"])
 
         assert ret == 1
         assert "already exists" in capsys.readouterr().err
@@ -992,7 +996,7 @@ class TestCliCreate:
         """Invalid VM IDs should be reported to the user."""
         mock_build_auto_config.side_effect = Exception("1 validation error for VMConfig")
 
-        ret = main(["create", "--name", "Project SpaceX"])
+        ret = main(["sandbox", "create", "--name", "Project SpaceX"])
 
         assert ret == 1
         assert "validation error" in capsys.readouterr().err
@@ -1006,7 +1010,7 @@ class TestCliCreate:
         """Image build failures should surface actionable output."""
         mock_build_auto_config.side_effect = Exception("Docker is required to build images")
 
-        ret = main(["create", "--name", "project-spacex"])
+        ret = main(["sandbox", "create", "--name", "project-spacex"])
 
         assert ret == 1
         assert "Docker is required" in capsys.readouterr().err
@@ -1015,29 +1019,34 @@ class TestCliCreate:
         self,
         capsys: pytest.CaptureFixture[str],
     ) -> None:
-        """Argparse should reject unsupported guest OS values."""
-        with pytest.raises(SystemExit) as exc_info:
-            main(["create", "--os", "fedora"])
+        """Click should reject unsupported guest OS values."""
+        ret = main(["sandbox", "create", "--os", "fedora"])
 
-        assert exc_info.value.code == 2
-        assert "invalid choice" in capsys.readouterr().err
+        assert ret == 2
+        assert "Invalid value for '--os'" in capsys.readouterr().err
 
 
 class TestCliCreateImage:
-    """Tests for `smolvm create --image`."""
+    """Tests for `smolvm sandbox create --image`."""
 
-    def test_image_flag_parsed(self) -> None:
-        """--image flag should be recognized by the parser."""
-        parser = build_parser()
-        args = parser.parse_args(["create", "--image", "s3://bucket/images/test/"])
+    @patch("smolvm.cli.main._run_create", return_value=0)
+    def test_image_flag_parsed(self, mock_run_create: MagicMock) -> None:
+        """--image flag should be wired into the create handler."""
+        ret = main(["sandbox", "create", "--image", "s3://bucket/images/test/"])
+
+        assert ret == 0
+        args = mock_run_create.call_args.args[0]
         assert args.image == "s3://bucket/images/test/"
         assert args.os is None
 
-    def test_image_and_os_parsed_together(self) -> None:
+    @patch("smolvm.cli.main._run_create", return_value=0)
+    def test_image_and_os_parsed_together(self, mock_run_create: MagicMock) -> None:
         """--image and --os now both parse (Windows guests need both); the
         facade rejects illegal combos at runtime with a clearer message."""
-        parser = build_parser()
-        args = parser.parse_args(["create", "--image", "s3://bucket/img/", "--os", "alpine"])
+        ret = main(["sandbox", "create", "--image", "s3://bucket/img/", "--os", "alpine"])
+
+        assert ret == 0
+        args = mock_run_create.call_args.args[0]
         assert args.image == "s3://bucket/img/"
         assert args.os == "alpine"
 
@@ -1046,16 +1055,17 @@ class TestCliCreateImage:
         capsys: pytest.CaptureFixture[str],
     ) -> None:
         """S3 image + --os surfaces a one-sentence CLI error."""
-        ret = main(["create", "--image", "s3://bucket/img/", "--os", "alpine"])
+        ret = main(["sandbox", "create", "--image", "s3://bucket/img/", "--os", "alpine"])
         assert ret == 1
         err = capsys.readouterr().err
         assert "--image (S3) and --os are mutually exclusive" in err
 
-    def test_image_with_name_and_memory(self) -> None:
+    @patch("smolvm.cli.main._run_create", return_value=0)
+    def test_image_with_name_and_memory(self, mock_run_create: MagicMock) -> None:
         """--image should work alongside --name, --memory, and --disk-size."""
-        parser = build_parser()
-        args = parser.parse_args(
+        ret = main(
             [
+                "sandbox",
                 "create",
                 "--image",
                 "s3://bucket/img/",
@@ -1067,6 +1077,9 @@ class TestCliCreateImage:
                 "2048",
             ]
         )
+
+        assert ret == 0
+        args = mock_run_create.call_args.args[0]
         assert args.image == "s3://bucket/img/"
         assert args.name == "my-vm"
         assert args.memory_mib == 1024
@@ -1079,6 +1092,7 @@ class TestCliCreateImage:
         """--disk-size has no effect on prebuilt S3 images and must be rejected."""
         ret = main(
             [
+                "sandbox",
                 "create",
                 "--image",
                 "s3://bucket/img/",
@@ -1093,15 +1107,16 @@ class TestCliCreateImage:
 
 
 class TestCliCreateWindows:
-    """Tests for `smolvm create --os windows` routing."""
+    """Tests for `smolvm sandbox create --os windows` routing."""
 
     def test_windows_backend_explicit_firecracker_rejected(
         self,
         capsys: pytest.CaptureFixture[str],
     ) -> None:
-        """`smolvm create --os windows --backend firecracker` fails cleanly."""
+        """`smolvm sandbox create --os windows --backend firecracker` fails cleanly."""
         ret = main(
             [
+                "sandbox",
                 "create",
                 "--os",
                 "windows",
@@ -1123,6 +1138,7 @@ class TestCliCreateWindows:
         """libkrun + Windows also fails with the same shape of error."""
         ret = main(
             [
+                "sandbox",
                 "create",
                 "--os",
                 "windows",
@@ -1140,8 +1156,8 @@ class TestCliCreateWindows:
         self,
         capsys: pytest.CaptureFixture[str],
     ) -> None:
-        """`smolvm create --os windows` (no --image) fires the facade error."""
-        ret = main(["create", "--os", "windows"])
+        """`smolvm sandbox create --os windows` (no --image) fires the facade error."""
+        ret = main(["sandbox", "create", "--os", "windows"])
         assert ret == 1
         err = capsys.readouterr().err
         assert "Windows guests need a pre-installed disk image" in err
@@ -1171,6 +1187,7 @@ class TestCliCreateWindows:
 
         ret = main(
             [
+                "sandbox",
                 "create",
                 "--name",
                 "win-vm-1",
@@ -1194,14 +1211,16 @@ class TestCliCreateWindows:
             vm_name="win-vm-1",
         )
 
+    @patch("smolvm.cli.main._run_create", return_value=0)
     def test_windows_with_explicit_backend_qemu_is_accepted(
         self,
+        mock_run_create: MagicMock,
         tmp_path: Path,
     ) -> None:
-        """`--os windows --backend qemu` parses without error (no auto-pick conflict)."""
-        parser = build_parser()
-        args = parser.parse_args(
+        """`--os windows --backend qemu` parses without error."""
+        ret = main(
             [
+                "sandbox",
                 "create",
                 "--os",
                 "windows",
@@ -1211,6 +1230,9 @@ class TestCliCreateWindows:
                 "qemu",
             ]
         )
+
+        assert ret == 0
+        args = mock_run_create.call_args.args[0]
         assert args.os == "windows"
         assert args.backend == "qemu"
 
@@ -1220,17 +1242,14 @@ class TestCliWindowsBuildImage:
 
     def test_help_is_listed(self) -> None:
         """`smolvm windows --help` advertises the build-image verb."""
-        parser = build_parser()
-        # Argparse raises SystemExit(0) on --help.
-        with pytest.raises(SystemExit):
-            parser.parse_args(["windows", "--help"])
+        assert main(["windows", "--help"]) == 0
 
-    def test_build_image_flag_parsing(self, tmp_path: Path) -> None:
-        parser = build_parser()
+    @patch("smolvm.cli.main._run_windows_build_image", return_value=0)
+    def test_build_image_flag_parsing(self, mock_run_windows: MagicMock, tmp_path: Path) -> None:
         win = tmp_path / "Win11.iso"
         virtio = tmp_path / "virtio-win.iso"
         out = tmp_path / "win11.qcow2"
-        args = parser.parse_args(
+        ret = main(
             [
                 "windows",
                 "build-image",
@@ -1254,8 +1273,9 @@ class TestCliWindowsBuildImage:
                 "1200",
             ]
         )
-        assert args.command == "windows"
-        assert args.windows_action == "build-image"
+
+        assert ret == 0
+        args = mock_run_windows.call_args.args[0]
         assert args.windows_iso == str(win)
         assert args.virtio_win_iso == str(virtio)
         assert args.output_qcow2 == str(out)
@@ -1270,10 +1290,9 @@ class TestCliWindowsBuildImage:
         self,
         capsys: pytest.CaptureFixture[str],
     ) -> None:
-        """Missing required args → argparse exits with code 2."""
-        with pytest.raises(SystemExit) as exc_info:
-            main(["windows", "build-image", "--iso", "/tmp/win.iso"])
-        assert exc_info.value.code == 2
+        """Missing required args returns Click usage exit code 2."""
+        ret = main(["windows", "build-image", "--iso", "/tmp/win.iso"])
+        assert ret == 2
         err = capsys.readouterr().err
         assert "--virtio-win-iso" in err or "--output" in err
 
@@ -1358,12 +1377,12 @@ class TestCliWindowsBuildImage:
         mock_builder.build.assert_called_once()
         out_text = capsys.readouterr().out
         assert '"ok": true' in out_text
-        assert '"command": "windows build-image"' in out_text
+        assert '"command": "windows.build-image"' in out_text
         assert '"output_qcow2"' in out_text
 
 
 class TestCliStop:
-    """Tests for `smolvm stop`."""
+    """Tests for `smolvm sandbox stop`."""
 
     @patch("smolvm.facade.SmolVM")
     def test_stop_success(
@@ -1371,12 +1390,12 @@ class TestCliStop:
         mock_vm_cls: MagicMock,
         capsys: pytest.CaptureFixture,
     ) -> None:
-        """`smolvm stop` should stop an existing VM and report the result."""
+        """`smolvm sandbox stop` should stop an existing VM and report the result."""
         vm = MagicMock()
         vm.vm_id = "vm001"
         mock_vm_cls.from_id.return_value = vm
 
-        ret = main(["stop", "vm001", "--timeout", "7"])
+        ret = main(["sandbox", "stop", "vm001", "--timeout", "7"])
 
         assert ret == 0
         mock_vm_cls.from_id.assert_called_once_with("vm001")
@@ -1392,16 +1411,16 @@ class TestCliStop:
         mock_vm_cls: MagicMock,
         capsys: pytest.CaptureFixture,
     ) -> None:
-        """`smolvm stop --json` should emit the shared envelope."""
+        """`smolvm sandbox stop --json` should emit the shared envelope."""
         vm = MagicMock()
         vm.vm_id = "vm001"
         mock_vm_cls.from_id.return_value = vm
 
-        ret = main(["stop", "vm001", "--json"])
+        ret = main(["sandbox", "stop", "vm001", "--json"])
 
         assert ret == 0
         payload = json.loads(capsys.readouterr().out)
-        assert payload["command"] == "stop"
+        assert payload["command"] == "sandbox.stop"
         assert payload["ok"] is True
         assert payload["data"]["vm"]["name"] == "vm001"
         assert payload["data"]["vm"]["status"] == "stopped"
@@ -1415,14 +1434,14 @@ class TestCliStop:
         """Missing VMs should surface a clean error."""
         mock_vm_cls.from_id.side_effect = Exception("VM 'missing' not found")
 
-        ret = main(["stop", "missing"])
+        ret = main(["sandbox", "stop", "missing"])
 
         assert ret == 1
         assert "VM 'missing' not found" in capsys.readouterr().err
 
 
 class TestCliPauseResume:
-    """Tests for `smolvm pause` and `smolvm resume`."""
+    """Tests for `smolvm sandbox pause` and `smolvm sandbox resume`."""
 
     @patch("smolvm.facade.SmolVM")
     def test_pause_success(
@@ -1430,12 +1449,12 @@ class TestCliPauseResume:
         mock_vm_cls: MagicMock,
         capsys: pytest.CaptureFixture,
     ) -> None:
-        """`smolvm pause` should pause an existing VM and report the result."""
+        """`smolvm sandbox pause` should pause an existing VM and report the result."""
         vm = MagicMock()
         vm.vm_id = "vm001"
         mock_vm_cls.from_id.return_value = vm
 
-        ret = main(["pause", "vm001"])
+        ret = main(["sandbox", "pause", "vm001"])
 
         assert ret == 0
         mock_vm_cls.from_id.assert_called_once_with("vm001")
@@ -1451,23 +1470,23 @@ class TestCliPauseResume:
         mock_vm_cls: MagicMock,
         capsys: pytest.CaptureFixture,
     ) -> None:
-        """`smolvm resume --json` should emit the shared envelope."""
+        """`smolvm sandbox resume --json` should emit the shared envelope."""
         vm = MagicMock()
         vm.vm_id = "vm001"
         mock_vm_cls.from_id.return_value = vm
 
-        ret = main(["resume", "vm001", "--json"])
+        ret = main(["sandbox", "resume", "vm001", "--json"])
 
         assert ret == 0
         payload = json.loads(capsys.readouterr().out)
-        assert payload["command"] == "resume"
+        assert payload["command"] == "sandbox.resume"
         assert payload["ok"] is True
         assert payload["data"]["vm"]["name"] == "vm001"
         assert payload["data"]["vm"]["status"] == "running"
 
 
 class TestCliVmStart:
-    """Tests for `smolvm start`."""
+    """Tests for `smolvm sandbox start`."""
 
     @patch("smolvm.facade.SmolVM")
     def test_start_success(
@@ -1475,12 +1494,12 @@ class TestCliVmStart:
         mock_vm_cls: MagicMock,
         capsys: pytest.CaptureFixture,
     ) -> None:
-        """`smolvm start` should start a stopped VM and report the result."""
+        """`smolvm sandbox start` should start a stopped VM and report the result."""
         vm = MagicMock()
         vm.vm_id = "vm001"
         mock_vm_cls.from_id.return_value = vm
 
-        ret = main(["start", "vm001"])
+        ret = main(["sandbox", "start", "vm001"])
 
         assert ret == 0
         mock_vm_cls.from_id.assert_called_once_with("vm001")
@@ -1496,16 +1515,16 @@ class TestCliVmStart:
         mock_vm_cls: MagicMock,
         capsys: pytest.CaptureFixture,
     ) -> None:
-        """`smolvm start --json` should emit the shared envelope."""
+        """`smolvm sandbox start --json` should emit the shared envelope."""
         vm = MagicMock()
         vm.vm_id = "vm001"
         mock_vm_cls.from_id.return_value = vm
 
-        ret = main(["start", "vm001", "--json"])
+        ret = main(["sandbox", "start", "vm001", "--json"])
 
         assert ret == 0
         payload = json.loads(capsys.readouterr().out)
-        assert payload["command"] == "start"
+        assert payload["command"] == "sandbox.start"
         assert payload["ok"] is True
         assert payload["data"]["vm"]["name"] == "vm001"
         assert payload["data"]["vm"]["status"] == "running"
@@ -1515,12 +1534,12 @@ class TestCliVmStart:
         self,
         mock_vm_cls: MagicMock,
     ) -> None:
-        """`smolvm start --boot-timeout` should forward the value to the facade."""
+        """`smolvm sandbox start --boot-timeout` should forward the value to the facade."""
         vm = MagicMock()
         vm.vm_id = "vm001"
         mock_vm_cls.from_id.return_value = vm
 
-        ret = main(["start", "vm001", "--boot-timeout", "75"])
+        ret = main(["sandbox", "start", "vm001", "--boot-timeout", "75"])
 
         assert ret == 0
         vm.start.assert_called_once_with(boot_timeout=75.0)
@@ -1655,7 +1674,7 @@ class TestCliSnapshot:
 
 
 class TestCliSSH:
-    """Tests for `smolvm ssh`."""
+    """Tests for `smolvm sandbox ssh`."""
 
     @patch("smolvm.cli.main.subprocess.run")
     @patch("smolvm.facade.SmolVM")
@@ -1664,7 +1683,7 @@ class TestCliSSH:
         mock_vm_cls: MagicMock,
         mock_run: MagicMock,
     ) -> None:
-        """`smolvm ssh` should attach to a running VM without restarting it."""
+        """`smolvm sandbox ssh` should attach to a running VM without restarting it."""
         vm = MagicMock()
         vm.status = VMState.RUNNING
         vm._ssh_attach_command.return_value = [
@@ -1684,6 +1703,7 @@ class TestCliSSH:
 
         ret = main(
             [
+                "sandbox",
                 "ssh",
                 "vm001",
                 "--ssh-user",
@@ -1716,19 +1736,19 @@ class TestCliSSH:
         mock_run: MagicMock,
         status: VMState,
     ) -> None:
-        """`smolvm ssh` should auto-start attachable non-running VMs."""
+        """`smolvm sandbox ssh` should auto-start attachable non-running VMs."""
         vm = MagicMock()
         vm.status = status
-        vm._ssh_attach_command.return_value = ["ssh", "root@127.0.0.1"]
+        vm._ssh_attach_command.return_value = ["sandbox", "ssh", "root@127.0.0.1"]
         mock_vm_cls.from_id.return_value = vm
         mock_run.return_value = MagicMock(returncode=0)
 
-        ret = main(["ssh", "vm001"])
+        ret = main(["sandbox", "ssh", "vm001"])
 
         assert ret == 0
         vm.start.assert_called_once_with(boot_timeout=30.0)
         vm.wait_for_ssh.assert_called_once_with(timeout=30.0)
-        mock_run.assert_called_once_with(["ssh", "root@127.0.0.1"], check=False)
+        mock_run.assert_called_once_with(["sandbox", "ssh", "root@127.0.0.1"], check=False)
 
     @patch("smolvm.cli.main.subprocess.run")
     @patch("smolvm.facade.SmolVM")
@@ -1737,20 +1757,20 @@ class TestCliSSH:
         mock_vm_cls: MagicMock,
         mock_run: MagicMock,
     ) -> None:
-        """`smolvm ssh` should resume paused VMs before attaching."""
+        """`smolvm sandbox ssh` should resume paused VMs before attaching."""
         vm = MagicMock()
         vm.status = VMState.PAUSED
-        vm._ssh_attach_command.return_value = ["ssh", "root@127.0.0.1"]
+        vm._ssh_attach_command.return_value = ["sandbox", "ssh", "root@127.0.0.1"]
         mock_vm_cls.from_id.return_value = vm
         mock_run.return_value = MagicMock(returncode=0)
 
-        ret = main(["ssh", "vm001"])
+        ret = main(["sandbox", "ssh", "vm001"])
 
         assert ret == 0
         vm.resume.assert_called_once_with()
         vm.start.assert_not_called()
         vm.wait_for_ssh.assert_called_once_with(timeout=30.0)
-        mock_run.assert_called_once_with(["ssh", "root@127.0.0.1"], check=False)
+        mock_run.assert_called_once_with(["sandbox", "ssh", "root@127.0.0.1"], check=False)
 
     @patch("smolvm.cli.main.subprocess.run")
     @patch("smolvm.facade.SmolVM")
@@ -1765,7 +1785,7 @@ class TestCliSSH:
         vm.status = VMState.ERROR
         mock_vm_cls.from_id.return_value = vm
 
-        ret = main(["ssh", "vm001"])
+        ret = main(["sandbox", "ssh", "vm001"])
 
         assert ret == 1
         vm.start.assert_not_called()
@@ -1785,7 +1805,7 @@ class TestCliSSH:
         """Missing VMs should surface a clean error."""
         mock_vm_cls.from_id.side_effect = Exception("VM 'missing' not found")
 
-        ret = main(["ssh", "missing"])
+        ret = main(["sandbox", "ssh", "missing"])
 
         assert ret == 1
         mock_run.assert_not_called()
@@ -1802,10 +1822,10 @@ class TestCliSSH:
         """Missing host ssh binary should produce an actionable error."""
         vm = MagicMock()
         vm.status = VMState.RUNNING
-        vm._ssh_attach_command.return_value = ["ssh", "root@127.0.0.1"]
+        vm._ssh_attach_command.return_value = ["sandbox", "ssh", "root@127.0.0.1"]
         mock_vm_cls.from_id.return_value = vm
 
-        ret = main(["ssh", "vm001"])
+        ret = main(["sandbox", "ssh", "vm001"])
 
         assert ret == 1
         assert "openssh-client" in capsys.readouterr().err
@@ -1821,11 +1841,11 @@ class TestCliSSH:
         """Nonzero ssh child exit codes should be returned unchanged."""
         vm = MagicMock()
         vm.status = VMState.RUNNING
-        vm._ssh_attach_command.return_value = ["ssh", "root@127.0.0.1"]
+        vm._ssh_attach_command.return_value = ["sandbox", "ssh", "root@127.0.0.1"]
         mock_vm_cls.from_id.return_value = vm
         mock_run.return_value = MagicMock(returncode=255)
 
-        ret = main(["ssh", "vm001"])
+        ret = main(["sandbox", "ssh", "vm001"])
 
         assert ret == 255
 
@@ -1833,7 +1853,7 @@ class TestCliSSH:
 class TestCliDoctor:
     """Tests for `smolvm doctor`."""
 
-    @patch("smolvm.cli.main.run_doctor")
+    @patch("smolvm.cli.commands.app.run_doctor")
     def test_doctor_default(self, mock_run_doctor: MagicMock) -> None:
         """Default doctor invocation should call run_doctor with defaults."""
         mock_run_doctor.return_value = 0
@@ -1847,7 +1867,7 @@ class TestCliDoctor:
             strict=False,
         )
 
-    @patch("smolvm.cli.main.run_doctor")
+    @patch("smolvm.cli.commands.app.run_doctor")
     def test_doctor_with_flags(self, mock_run_doctor: MagicMock) -> None:
         """Doctor flags should be forwarded to run_doctor."""
         mock_run_doctor.return_value = 1
@@ -1880,21 +1900,20 @@ class TestCliSetup:
         assert ret == 0
         mock_run_setup.assert_called_once()
 
-    @patch("smolvm.cli.main.platform.system", return_value="Darwin")
+    @patch("smolvm.cli.commands.options.platform.system", return_value="Darwin")
     def test_setup_rejects_linux_only_flags_on_macos(
         self,
         mock_platform_system: MagicMock,
         capsys: pytest.CaptureFixture[str],
     ) -> None:
-        """Linux-only setup flags should fail at argparse time on macOS."""
-        with pytest.raises(SystemExit) as exc_info:
-            main(["setup", "--runtime-user", "foo"])
+        """Linux-only setup flags should fail at Click parse time on macOS."""
+        ret = main(["setup", "--runtime-user", "foo"])
 
-        assert exc_info.value.code == 2
+        assert ret == 2
         assert mock_platform_system.called
         err = capsys.readouterr().err
         assert "only supported on Linux" in err
-        assert "Firecracker/KVM" in err
+        assert "smolvm setup" in err
 
     @patch("smolvm.cli.main._run_setup")
     @patch("smolvm.cli.main.platform.system", return_value="Darwin")
@@ -1911,29 +1930,27 @@ class TestCliSetup:
         assert ret == 0
         mock_run_setup.assert_called_once()
 
-    @patch("smolvm.cli.main.platform.system", return_value="Windows")
+    @patch("smolvm.cli.commands.options.platform.system", return_value="Windows")
     def test_setup_rejects_linux_only_flags_on_unsupported_os(
         self,
         mock_platform_system: MagicMock,
         capsys: pytest.CaptureFixture[str],
     ) -> None:
         """Linux-only flags should be rejected on any non-Linux platform."""
-        with pytest.raises(SystemExit) as exc_info:
-            main(["setup", "--no-configure-runtime"])
+        ret = main(["setup", "--no-configure-runtime"])
 
-        assert exc_info.value.code == 2
+        assert ret == 2
         assert "only supported on Linux" in capsys.readouterr().err
 
-    @patch("smolvm.cli.main.platform.system", return_value="Darwin")
+    @patch("smolvm.cli.commands.options.platform.system", return_value="Darwin")
     def test_setup_help_hides_linux_only_flags_on_macos(
         self,
         mock_platform_system: MagicMock,
         capsys: pytest.CaptureFixture[str],
     ) -> None:
         """Linux-only flags should not appear in ``--help`` on macOS."""
-        with pytest.raises(SystemExit) as exc_info:
-            main(["setup", "--help"])
-        assert exc_info.value.code == 0
+        ret = main(["setup", "--help"])
+        assert ret == 0
 
         help_text = capsys.readouterr().out
 
@@ -1944,17 +1961,16 @@ class TestCliSetup:
         # Cross-platform flags should still appear
         assert "--skip-deps" in help_text
 
-    @patch("smolvm.cli.main.platform.system", return_value="Linux")
+    @patch("smolvm.cli.commands.options.platform.system", return_value="Linux")
     def test_setup_remove_runtime_config_conflicts_with_other_modes(
         self,
         mock_platform_system: MagicMock,
         capsys: pytest.CaptureFixture[str],
     ) -> None:
-        """Removal mode should reject provisioning flags via argparse."""
-        with pytest.raises(SystemExit) as exc_info:
-            main(["setup", "--remove-runtime-config", "--with-docker"])
+        """Removal mode should reject provisioning flags via Click usage errors."""
+        ret = main(["setup", "--remove-runtime-config", "--with-docker"])
 
-        assert exc_info.value.code == 2
+        assert ret == 2
         assert mock_platform_system.called
         assert "not allowed with --with-docker" in capsys.readouterr().err
 
@@ -2015,7 +2031,7 @@ class TestCliSetup:
             Path(out) / "system-setup-macos.sh"
         ).is_file()
 
-    @patch("smolvm.cli.main.maybe_print_update_notice")
+    @patch("smolvm.cli.commands.app.maybe_print_update_notice")
     @patch("smolvm.cli.main.platform.system", return_value="Linux")
     @patch("smolvm.host.setup.run_setup")
     def test_setup_assets_dir_suppresses_update_notice(
@@ -2031,7 +2047,7 @@ class TestCliSetup:
         mock_notice.assert_called_once()
         assert mock_notice.call_args.kwargs.get("json_output") is True
 
-    @patch("smolvm.cli.main.maybe_print_update_notice")
+    @patch("smolvm.cli.commands.app.maybe_print_update_notice")
     @patch("smolvm.cli.main.platform.system", return_value="Linux")
     @patch("smolvm.host.setup.run_setup")
     def test_setup_without_assets_dir_does_not_suppress_update_notice(
@@ -2421,7 +2437,7 @@ class TestCliUi:
 
 
 class TestCliList:
-    """Tests for `smolvm list`."""
+    """Tests for `smolvm sandbox list`."""
 
     @pytest.fixture
     def mock_sdk_cls(self) -> MagicMock:
@@ -2438,10 +2454,10 @@ class TestCliList:
         mock_sdk_cls: MagicMock,
         capsys: pytest.CaptureFixture,
     ) -> None:
-        """`smolvm list` with no running VMs should print a friendly message."""
+        """`smolvm sandbox list` with no running VMs should print a friendly message."""
         mock_sdk_cls.return_value.list_vms.return_value = []
 
-        ret = main(["list"])
+        ret = main(["sandbox", "list"])
 
         assert ret == 0
         assert "No running VMs found." in capsys.readouterr().out
@@ -2453,11 +2469,11 @@ class TestCliList:
         mock_sdk_cls: MagicMock,
         capsys: pytest.CaptureFixture,
     ) -> None:
-        """`smolvm list` should print a Rich table with name, status, and pid."""
+        """`smolvm sandbox list` should print a Rich table with name, status, and pid."""
         vms = [_make_vm_info("vm-abc123", VMState.RUNNING, "172.16.0.2", 2200, 12345)]
         mock_sdk_cls.return_value.list_vms.return_value = vms
 
-        ret = main(["list"])
+        ret = main(["sandbox", "list"])
 
         assert ret == 0
         out = capsys.readouterr().out
@@ -2476,14 +2492,14 @@ class TestCliList:
         mock_sdk_cls: MagicMock,
         capsys: pytest.CaptureFixture,
     ) -> None:
-        """`smolvm list --all` should include stopped VMs."""
+        """`smolvm sandbox list --all` should include stopped VMs."""
         vms = [
             _make_vm_info("vm-abc123", VMState.RUNNING, "172.16.0.2", 2200, 12345),
             _make_vm_info("vm-def456", VMState.STOPPED, "172.16.0.3", None, None),
         ]
         mock_sdk_cls.return_value.list_vms.return_value = vms
 
-        ret = main(["list", "--all"])
+        ret = main(["sandbox", "list", "--all"])
 
         assert ret == 0
         out = capsys.readouterr().out
@@ -2498,12 +2514,12 @@ class TestCliList:
         mock_sdk_cls: MagicMock,
         capsys: pytest.CaptureFixture,
     ) -> None:
-        """`smolvm list` should show '-' for a missing PID."""
+        """`smolvm sandbox list` should show '-' for a missing PID."""
         vms = [_make_vm_info("vm-abc123", VMState.RUNNING, "", None, None)]
         vms[0].network = None
         mock_sdk_cls.return_value.list_vms.return_value = vms
 
-        ret = main(["list"])
+        ret = main(["sandbox", "list"])
 
         assert ret == 0
         out = capsys.readouterr().out
@@ -2517,10 +2533,10 @@ class TestCliList:
         self,
         mock_sdk_cls: MagicMock,
     ) -> None:
-        """`smolvm list --status running` passes status to list_vms."""
+        """`smolvm sandbox list --status running` passes status to list_vms."""
         mock_sdk_cls.return_value.list_vms.return_value = []
 
-        ret = main(["list", "--status", "running"])
+        ret = main(["sandbox", "list", "--status", "running"])
 
         assert ret == 0
         mock_sdk_cls.return_value.list_vms.assert_called_once_with(status=VMState.RUNNING)
@@ -2530,16 +2546,16 @@ class TestCliList:
         mock_sdk_cls: MagicMock,
         capsys: pytest.CaptureFixture,
     ) -> None:
-        """`smolvm list --json` should emit structured data for running VMs."""
+        """`smolvm sandbox list --json` should emit structured data for running VMs."""
         mock_sdk_cls.return_value.list_vms.return_value = [
             _make_vm_info("vm-abc123", VMState.RUNNING, "172.16.0.2", 2200, 12345),
         ]
 
-        ret = main(["list", "--json"])
+        ret = main(["sandbox", "list", "--json"])
 
         assert ret == 0
         payload = json.loads(capsys.readouterr().out)
-        assert payload["command"] == "list"
+        assert payload["command"] == "sandbox.list"
         assert payload["ok"] is True
         assert payload["data"]["filters"] == {"all": False, "status": "running"}
         assert payload["data"]["vms"] == [
@@ -2559,10 +2575,10 @@ class TestCliList:
         mock_sdk_cls: MagicMock,
         capsys: pytest.CaptureFixture,
     ) -> None:
-        """`smolvm list --json` should emit an empty JSON array when nothing matches."""
+        """`smolvm sandbox list --json` should emit an empty JSON array when nothing matches."""
         mock_sdk_cls.return_value.list_vms.return_value = []
 
-        ret = main(["list", "--json"])
+        ret = main(["sandbox", "list", "--json"])
 
         assert ret == 0
         payload = json.loads(capsys.readouterr().out)
@@ -2575,13 +2591,13 @@ class TestCliList:
         mock_sdk_cls: MagicMock,
         capsys: pytest.CaptureFixture,
     ) -> None:
-        """`smolvm list --all --json` should emit all VM rows."""
+        """`smolvm sandbox list --all --json` should emit all VM rows."""
         mock_sdk_cls.return_value.list_vms.return_value = [
             _make_vm_info("vm-abc123", VMState.RUNNING, "172.16.0.2", 2200, 12345),
             _make_vm_info("vm-def456", VMState.STOPPED, "172.16.0.3", None, None),
         ]
 
-        ret = main(["list", "--all", "--json"])
+        ret = main(["sandbox", "list", "--all", "--json"])
 
         assert ret == 0
         payload = json.loads(capsys.readouterr().out)
@@ -2596,10 +2612,10 @@ class TestCliList:
         mock_sdk_cls: MagicMock,
         capsys: pytest.CaptureFixture,
     ) -> None:
-        """`smolvm list --status stopped` with no results shows filtered message."""
+        """`smolvm sandbox list --status stopped` with no results shows filtered message."""
         mock_sdk_cls.return_value.list_vms.return_value = []
 
-        ret = main(["list", "--status", "stopped"])
+        ret = main(["sandbox", "list", "--status", "stopped"])
 
         assert ret == 0
         assert "stopped" in capsys.readouterr().out
@@ -2609,10 +2625,10 @@ class TestCliList:
         mock_sdk_cls: MagicMock,
         capsys: pytest.CaptureFixture,
     ) -> None:
-        """`smolvm list` prints error and returns 1 on unexpected failure."""
+        """`smolvm sandbox list` prints error and returns 1 on unexpected failure."""
         mock_sdk_cls.return_value.list_vms.side_effect = RuntimeError("db unavailable")
 
-        ret = main(["list"])
+        ret = main(["sandbox", "list"])
 
         assert ret == 1
         assert "Error: db unavailable" in capsys.readouterr().err
@@ -2624,12 +2640,12 @@ class TestCliList:
         capsys: pytest.CaptureFixture,
         tmp_path: Path,
     ) -> None:
-        """`smolvm list` should keep listing VMs whose host mount is gone,
+        """`smolvm sandbox list` should keep listing VMs whose host mount is gone,
         and print a warning naming the missing path."""
         vm, missing = _make_vm_with_stale_mount(tmp_path)
         mock_sdk_cls.return_value.list_vms.return_value = [vm]
 
-        ret = main(["list"])
+        ret = main(["sandbox", "list"])
 
         # Rich may wrap long tmp paths across lines; flatten before asserting.
         out = capsys.readouterr().out.replace("\n", "")
@@ -2638,7 +2654,7 @@ class TestCliList:
         assert "Warnings:" in out
         assert str(missing) in out
         # The warning explains what to do, not just what's wrong.
-        assert "smolvm delete vm-abc123" in out
+        assert "smolvm sandbox delete vm-abc123" in out
 
     def test_list_warning_does_not_claim_running_sandbox_cannot_start(
         self,
@@ -2656,7 +2672,7 @@ class TestCliList:
         vm, _ = _make_vm_with_stale_mount(tmp_path, vm_id="sbx-running")
         mock_sdk_cls.return_value.list_vms.return_value = [vm]
 
-        ret = main(["list", "--json"])
+        ret = main(["sandbox", "list", "--json"])
 
         assert ret == 0
         payload = json.loads(capsys.readouterr().out)
@@ -2669,11 +2685,11 @@ class TestCliList:
         capsys: pytest.CaptureFixture,
         tmp_path: Path,
     ) -> None:
-        """`smolvm list --json` should expose stale mounts via `warnings`."""
+        """`smolvm sandbox list --json` should expose stale mounts via `warnings`."""
         vm, missing = _make_vm_with_stale_mount(tmp_path)
         mock_sdk_cls.return_value.list_vms.return_value = [vm]
 
-        ret = main(["list", "--json"])
+        ret = main(["sandbox", "list", "--json"])
 
         assert ret == 0
         payload = json.loads(capsys.readouterr().out)
@@ -2683,11 +2699,11 @@ class TestCliList:
         # what's wrong, the missing path, and how to recover.
         assert str(missing) in warnings[0]
         assert "missing" in warnings[0]
-        assert "smolvm delete vm-abc123" in warnings[0]
+        assert "smolvm sandbox delete vm-abc123" in warnings[0]
 
 
 class TestCliInfo:
-    """Tests for `smolvm info`."""
+    """Tests for `smolvm sandbox info`."""
 
     @pytest.fixture
     def mock_sdk_cls(self) -> MagicMock:
@@ -2734,7 +2750,7 @@ class TestCliInfo:
         tmp_path: Path,
         capsys: pytest.CaptureFixture,
     ) -> None:
-        """`smolvm info <name>` should show the full details table."""
+        """`smolvm sandbox info <name>` should show the full details table."""
         rootfs = tmp_path / "ubuntu-noble-minimal-qemu-x86_64" / "rootfs.qcow2"
         rootfs.parent.mkdir(parents=True)
         rootfs.write_bytes(b"\0" * (5 * 1024 * 1024))  # 5 MiB
@@ -2742,7 +2758,7 @@ class TestCliInfo:
             status=VMState.STOPPED, rootfs_path=rootfs
         )
 
-        ret = main(["info", "sbx-pauling"])
+        ret = main(["sandbox", "info", "sbx-pauling"])
 
         assert ret == 0
         out = capsys.readouterr().out
@@ -2775,7 +2791,7 @@ class TestCliInfo:
                 "memory_used": 312,
             }
 
-            ret = main(["info", "sbx-pauling"])
+            ret = main(["sandbox", "info", "sbx-pauling"])
 
         assert ret == 0
         out = capsys.readouterr().out
@@ -2795,7 +2811,7 @@ class TestCliInfo:
         with patch("smolvm.cli.main._query_live_vm_info") as mock_query:
             mock_query.return_value = {}
 
-            ret = main(["info", "sbx-pauling"])
+            ret = main(["sandbox", "info", "sbx-pauling"])
 
         assert ret == 0
         out = capsys.readouterr().out
@@ -2808,12 +2824,12 @@ class TestCliInfo:
         mock_sdk_cls: MagicMock,
         capsys: pytest.CaptureFixture,
     ) -> None:
-        """`smolvm info` should render '-' when the VM has no network."""
+        """`smolvm sandbox info` should render '-' when the VM has no network."""
         mock_sdk_cls.return_value.state.get_vm.return_value = self._make_info_vm(
             status=VMState.STOPPED, guest_ip=None, ssh_host_port=None, pid=None
         )
 
-        ret = main(["info", "sbx-pauling"])
+        ret = main(["sandbox", "info", "sbx-pauling"])
 
         assert ret == 0
         out = capsys.readouterr().out
@@ -2826,7 +2842,7 @@ class TestCliInfo:
         tmp_path: Path,
         capsys: pytest.CaptureFixture,
     ) -> None:
-        """`smolvm info --json` should emit a structured envelope."""
+        """`smolvm sandbox info --json` should emit a structured envelope."""
         rootfs = tmp_path / "alpine-virt" / "rootfs.ext4"
         rootfs.parent.mkdir(parents=True)
         rootfs.write_bytes(b"\0" * (3 * 1024 * 1024))  # 3 MiB
@@ -2834,11 +2850,11 @@ class TestCliInfo:
             status=VMState.STOPPED, rootfs_path=rootfs
         )
 
-        ret = main(["info", "sbx-pauling", "--json"])
+        ret = main(["sandbox", "info", "sbx-pauling", "--json"])
 
         assert ret == 0
         payload = json.loads(capsys.readouterr().out)
-        assert payload["command"] == "info"
+        assert payload["command"] == "sandbox.info"
         assert payload["ok"] is True
         assert payload["data"]["vm"] == {
             "name": "sbx-pauling",
@@ -2859,10 +2875,10 @@ class TestCliInfo:
         mock_sdk_cls: MagicMock,
         capsys: pytest.CaptureFixture,
     ) -> None:
-        """`smolvm info` returns 1 and an error message when the VM is missing."""
+        """`smolvm sandbox info` returns 1 and an error message when the VM is missing."""
         mock_sdk_cls.return_value.state.get_vm.side_effect = RuntimeError("VM 'ghost' not found")
 
-        ret = main(["info", "ghost"])
+        ret = main(["sandbox", "info", "ghost"])
 
         assert ret == 1
         assert "VM 'ghost' not found" in capsys.readouterr().err
@@ -2882,7 +2898,7 @@ class TestCliInfo:
             status=VMState.STOPPED, rootfs_path=rootfs
         )
         with patch("smolvm.facade._qcow2_virtual_size_mib", return_value=8192) as mock_qsize:
-            ret = main(["info", "sbx-pauling", "--json"])
+            ret = main(["sandbox", "info", "sbx-pauling", "--json"])
 
         assert ret == 0
         mock_qsize.assert_called_once_with(rootfs)
@@ -2905,26 +2921,26 @@ class TestCliStart:
 
     def test_top_level_help_lists_known_presets(self, capsys: pytest.CaptureFixture) -> None:
         """`smolvm --help` should list every registered preset as a top-level command."""
-        with pytest.raises(SystemExit):
-            main(["--help"])
+        ret = main(["--help"])
+        assert ret == 0
         out = capsys.readouterr().out
         assert "codex" in out
-        assert "claude-code" in out
+        assert "claude" in out
+        assert "claude-code" not in out
 
     def test_preset_help_lists_start_action(self, capsys: pytest.CaptureFixture) -> None:
         """`smolvm codex --help` should list the `start` action."""
-        with pytest.raises(SystemExit):
-            main(["codex", "--help"])
+        ret = main(["codex", "--help"])
+        assert ret == 0
         out = capsys.readouterr().out
         assert "start" in out
 
     def test_unknown_preset_errors(self, capsys: pytest.CaptureFixture) -> None:
-        """An unknown preset name should fail at argparse-level."""
-        with pytest.raises(SystemExit):
-            main(["nonexistent-agent", "start"])
+        """An unknown preset name should fail at Click parse time."""
+        ret = main(["nonexistent-agent", "start"])
+        assert ret == 2
         err = capsys.readouterr().err
-        # argparse produces "invalid choice" for unknown subcommand
-        assert "invalid choice" in err or "argument command" in err
+        assert "No such command" in err
 
     def test_launch_snippet_runs_when_env_file_missing(self, tmp_path: Path) -> None:
         """The remote command built by `_exec_launch_command` must exec the
@@ -2940,7 +2956,7 @@ class TestCliStart:
 
         class _StubSshVm:
             def _ssh_attach_command(self) -> list[str]:
-                return ["ssh", "-p", "2200", "root@127.0.0.1"]
+                return ["sandbox", "ssh", "-p", "2200", "root@127.0.0.1"]
 
         def fake_run(*args: object, **_kwargs: object) -> MagicMock:
             # Tolerate future kwargs (e.g. text=, env=) on the real
@@ -2982,7 +2998,7 @@ class TestCliStart:
 
         class _StubSshVm:
             def _ssh_attach_command(self) -> list[str]:
-                return ["ssh", "-p", "2200", "root@127.0.0.1"]
+                return ["sandbox", "ssh", "-p", "2200", "root@127.0.0.1"]
 
         def fake_run(*args: object, **_kwargs: object) -> MagicMock:
             captured.append(args[0])  # type: ignore[arg-type]
@@ -3016,34 +3032,23 @@ class TestCliStart:
         assert completed.returncode == 0
         assert str(local_bin / "claude") in completed.stdout
 
-    def test_claude_alias_resolves_to_claude_code(self) -> None:
-        """`smolvm claude start` should be accepted as an alias for
-        `smolvm claude-code start` — first-time users keep typing the
-        short name and the previous behaviour was an unfriendly
-        argparse 'invalid choice' error."""
-        parser = build_parser()
-        args = parser.parse_args(["claude", "start"])
-        # argparse stores whichever spelling the user typed in
-        # ``args.command``, but the canonical preset name (set via
-        # ``set_defaults``) is what the dispatch path looks up.
-        assert args.command == "claude"
-        assert args.preset_name == "claude-code"
-
-    def test_top_level_help_lists_claude_alias(self, capsys: pytest.CaptureFixture) -> None:
-        """The alias should appear in the top-level help so the
-        shorthand is discoverable, not a hidden trick."""
-        import re
-
-        with pytest.raises(SystemExit):
-            main(["--help"])
+    def test_top_level_help_lists_canonical_claude_only(
+        self,
+        capsys: pytest.CaptureFixture,
+    ) -> None:
+        """The public CLI should expose `claude`, not the old internal preset key."""
+        ret = main(["--help"])
+        assert ret == 0
         out = capsys.readouterr().out
-        # Must check 'claude' as a distinct token, not a substring of
-        # 'claude-code'. argparse renders the choices block as
-        # ``{a,b,claude-code,claude,...}`` so split on whitespace and the
-        # punctuation argparse uses there.
-        tokens = set(re.split(r"[\s{},]+", out))
-        assert "claude" in tokens
-        assert "claude-code" in tokens
+        assert "claude" in out
+        assert "claude-code" not in out
+
+    def test_old_claude_code_command_is_removed(self, capsys: pytest.CaptureFixture) -> None:
+        """The alpha redesign intentionally removes `claude-code` as a CLI command."""
+        ret = main(["claude-code", "start", "--help"])
+
+        assert ret == 2
+        assert "No such command" in capsys.readouterr().err
 
     @patch("smolvm.images.published.is_preset_published", return_value=False)
     @patch("smolvm.cli.main._apply_preset_with_progress")
@@ -3104,7 +3109,7 @@ class TestCliStart:
         assert "sbx-codex" in out
         assert "codex" in out
         assert "OPENAI_API_KEY" in out
-        assert "smolvm ssh sbx-codex" in out
+        assert "smolvm sandbox ssh sbx-codex" in out
 
     @patch("smolvm.images.published.is_preset_published", return_value=False)
     @patch("smolvm.presets.apply_preset")
@@ -3133,13 +3138,13 @@ class TestCliStart:
 
         assert ret == 0
         payload = json.loads(capsys.readouterr().out)
-        assert payload["command"] == "start"
+        assert payload["command"] == "codex.start"
         assert payload["ok"] is True
         assert payload["data"]["vm"]["name"] == "sbx-1"
         assert payload["data"]["vm"]["os"] == "ubuntu"
         assert payload["data"]["preset"]["name"] == "codex"
         assert payload["data"]["preset"]["injected_env_keys"] == ["OPENAI_API_KEY"]
-        assert payload["data"]["next"]["ssh_command"] == "smolvm ssh sbx-1"
+        assert payload["data"]["next"]["ssh_command"] == "smolvm sandbox ssh sbx-1"
 
     @patch("smolvm.images.published.is_preset_published", return_value=False)
     @patch("smolvm.cli.main._apply_preset_with_progress")
@@ -3170,7 +3175,7 @@ class TestCliStart:
 
         ret = main(
             [
-                "claude-code",
+                "claude",
                 "start",
                 "--name",
                 "sbx-claude",
@@ -3209,7 +3214,7 @@ class TestCliStart:
 
         mock_is_published.side_effect = _published_only_for_alpine
 
-        ret = main(["claude-code", "start", "--os", "alpine", "--json"])
+        ret = main(["claude", "start", "--os", "alpine", "--json"])
 
         assert ret == 0
         mock_published_path.assert_called_once()
@@ -3242,7 +3247,7 @@ class TestCliStart:
             "injected_env_keys": [],
         }
 
-        ret = main(["claude-code", "start", "--name", "sbx-claude"])
+        ret = main(["claude", "start", "--name", "sbx-claude"])
 
         assert ret == 0
         kwargs = mock_build_auto_config.call_args.kwargs
@@ -3252,12 +3257,11 @@ class TestCliStart:
         self,
         capsys: pytest.CaptureFixture[str],
     ) -> None:
-        """Argparse should reject unsupported --os values for preset start."""
-        with pytest.raises(SystemExit) as exc_info:
-            main(["codex", "start", "--os", "fedora"])
+        """Click should reject unsupported --os values for preset start."""
+        ret = main(["codex", "start", "--os", "fedora"])
 
-        assert exc_info.value.code == 2
-        assert "invalid choice" in capsys.readouterr().err
+        assert ret == 2
+        assert "Invalid value for '--os'" in capsys.readouterr().err
 
     @patch("smolvm.images.published.is_preset_published", return_value=False)
     @patch("smolvm.cli.main._apply_preset_with_progress")
@@ -3281,7 +3285,7 @@ class TestCliStart:
             "injected_env_keys": [],
         }
 
-        ret = main(["claude-code", "start", "--memory", "4096", "--disk-size", "16384"])
+        ret = main(["claude", "start", "--memory", "4096", "--disk-size", "16384"])
 
         assert ret == 0
         kwargs = mock_build_auto_config.call_args.kwargs
@@ -3416,7 +3420,7 @@ class TestCliStart:
         config = MagicMock(vm_id="sbx")
         mock_build_auto_config.return_value = (config, "/tmp/id_ed25519")
         vm = self._make_vm_mock("sbx")
-        vm._ssh_attach_command.return_value = ["ssh", "root@127.0.0.1"]
+        vm._ssh_attach_command.return_value = ["sandbox", "ssh", "root@127.0.0.1"]
         mock_vm_cls.return_value = vm
         mock_apply.return_value = {
             "preset": "codex",

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1547,7 +1547,7 @@ class TestCliVmStart:
 
 
 class TestCliSnapshot:
-    """Tests for `smolvm snapshot` subcommands."""
+    """Tests for `smolvm sandbox snapshot` subcommands."""
 
     @patch("smolvm.facade.SmolVM")
     def test_snapshot_create_success(
@@ -1555,12 +1555,12 @@ class TestCliSnapshot:
         mock_vm_cls: MagicMock,
         capsys: pytest.CaptureFixture,
     ) -> None:
-        """`smolvm snapshot create` should create a snapshot from an existing VM."""
+        """`smolvm sandbox snapshot create` should create a snapshot from an existing VM."""
         vm = MagicMock()
         vm.snapshot.return_value = _make_snapshot_info()
         mock_vm_cls.from_id.return_value = vm
 
-        ret = main(["snapshot", "create", "vm001", "--snapshot-id", "snap-001"])
+        ret = main(["sandbox", "snapshot", "create", "vm001", "--snapshot-id", "snap-001"])
 
         assert ret == 0
         mock_vm_cls.from_id.assert_called_once_with("vm001")
@@ -1577,16 +1577,16 @@ class TestCliSnapshot:
         mock_vm_cls: MagicMock,
         capsys: pytest.CaptureFixture,
     ) -> None:
-        """`smolvm snapshot create --json` should emit snapshot metadata."""
+        """`smolvm sandbox snapshot create --json` should emit snapshot metadata."""
         vm = MagicMock()
         vm.snapshot.return_value = _make_snapshot_info()
         mock_vm_cls.from_id.return_value = vm
 
-        ret = main(["snapshot", "create", "vm001", "--json"])
+        ret = main(["sandbox", "snapshot", "create", "vm001", "--json"])
 
         assert ret == 0
         payload = json.loads(capsys.readouterr().out)
-        assert payload["command"] == "snapshot.create"
+        assert payload["command"] == "sandbox.snapshot.create"
         assert payload["data"]["snapshot"]["snapshot_id"] == "snap-001"
         assert payload["data"]["snapshot"]["vm_id"] == "vm001"
         assert payload["data"]["snapshot"]["backend"] == "firecracker"
@@ -1600,7 +1600,7 @@ class TestCliSnapshot:
         mock_vm_cls: MagicMock,
         capsys: pytest.CaptureFixture,
     ) -> None:
-        """`smolvm snapshot restore --json` should report both snapshot and VM state."""
+        """`smolvm sandbox snapshot restore --json` should report both snapshot and VM state."""
         sdk = mock_sdk_cls.return_value
         sdk.__enter__.return_value = sdk
         sdk.__exit__.side_effect = lambda *args: sdk.close()
@@ -1612,7 +1612,7 @@ class TestCliSnapshot:
         vm.info = _make_vm_info("vm001", VMState.PAUSED, "172.16.0.2", 2200, 999)
         mock_vm_cls.from_snapshot.return_value = vm
 
-        ret = main(["snapshot", "restore", "snap-001", "--json"])
+        ret = main(["sandbox", "snapshot", "restore", "snap-001", "--json"])
 
         assert ret == 0
         mock_vm_cls.from_snapshot.assert_called_once_with(
@@ -1621,7 +1621,7 @@ class TestCliSnapshot:
             force=False,
         )
         payload = json.loads(capsys.readouterr().out)
-        assert payload["command"] == "snapshot.restore"
+        assert payload["command"] == "sandbox.snapshot.restore"
         assert payload["data"]["snapshot"]["restored"] is True
         assert payload["data"]["snapshot"]["backend"] == "firecracker"
         assert payload["data"]["vm"]["name"] == "vm001"
@@ -1633,13 +1633,13 @@ class TestCliSnapshot:
         mock_sdk_cls: MagicMock,
         capsys: pytest.CaptureFixture,
     ) -> None:
-        """`smolvm snapshot delete` should delete snapshot metadata and files."""
+        """`smolvm sandbox snapshot delete` should delete snapshot metadata and files."""
         sdk = mock_sdk_cls.return_value
         sdk.__enter__.return_value = sdk
         sdk.__exit__.side_effect = lambda *args: sdk.close()
         sdk.get_snapshot.return_value = _make_snapshot_info()
 
-        ret = main(["snapshot", "delete", "snap-001"])
+        ret = main(["sandbox", "snapshot", "delete", "snap-001"])
 
         assert ret == 0
         sdk.get_snapshot.assert_called_once_with("snap-001")
@@ -1652,7 +1652,7 @@ class TestCliSnapshot:
         mock_sdk_cls: MagicMock,
         capsys: pytest.CaptureFixture,
     ) -> None:
-        """`smolvm snapshot list --json` should emit snapshot rows."""
+        """`smolvm sandbox snapshot list --json` should emit snapshot rows."""
         sdk = mock_sdk_cls.return_value
         sdk.__enter__.return_value = sdk
         sdk.__exit__.side_effect = lambda *args: sdk.close()
@@ -1661,16 +1661,61 @@ class TestCliSnapshot:
             _make_snapshot_info("snap-002", restored=True, restored_vm_id="vm001"),
         ]
 
-        ret = main(["snapshot", "list", "--json"])
+        ret = main(["sandbox", "snapshot", "list", "--json"])
 
         assert ret == 0
         sdk.list_snapshots.assert_called_once_with(vm_id=None)
         payload = json.loads(capsys.readouterr().out)
-        assert payload["command"] == "snapshot.list"
+        assert payload["command"] == "sandbox.snapshot.list"
         assert payload["data"]["filters"] == {"vm_id": None}
         assert payload["data"]["snapshots"][0]["snapshot_id"] == "snap-001"
         assert payload["data"]["snapshots"][0]["backend"] == "firecracker"
         assert payload["data"]["snapshots"][1]["restored"] is True
+
+
+class TestCliPort:
+    """Tests for `smolvm sandbox port` subcommands."""
+
+    @patch("smolvm.cli.main._run_port_expose", return_value=0)
+    def test_port_expose_forwards_nested_command_name(
+        self,
+        mock_run_port_expose: MagicMock,
+    ) -> None:
+        ret = main(["sandbox", "port", "expose", "vm001", "8080:3000", "--json"])
+
+        assert ret == 0
+        args = mock_run_port_expose.call_args.args[0]
+        assert args.vm_id == "vm001"
+        assert args.mapping == "8080:3000"
+        assert args.command_name == "sandbox.port.expose"
+        assert args.json is True
+
+    @patch("smolvm.cli.main._run_port_close", return_value=0)
+    def test_port_close_forwards_nested_command_name(
+        self,
+        mock_run_port_close: MagicMock,
+    ) -> None:
+        ret = main(["sandbox", "port", "close", "vm001", "8080:3000", "--json"])
+
+        assert ret == 0
+        args = mock_run_port_close.call_args.args[0]
+        assert args.vm_id == "vm001"
+        assert args.mapping == "8080:3000"
+        assert args.command_name == "sandbox.port.close"
+        assert args.json is True
+
+    @patch("smolvm.cli.main._run_port_list", return_value=0)
+    def test_port_list_forwards_nested_command_name(
+        self,
+        mock_run_port_list: MagicMock,
+    ) -> None:
+        ret = main(["sandbox", "port", "list", "vm001", "--json"])
+
+        assert ret == 0
+        args = mock_run_port_list.call_args.args[0]
+        assert args.vm_id == "vm001"
+        assert args.command_name == "sandbox.port.list"
+        assert args.json is True
 
 
 class TestCliSSH:
@@ -2927,6 +2972,20 @@ class TestCliStart:
         assert "codex" in out
         assert "claude" in out
         assert "claude-code" not in out
+        assert "\n  snapshot" not in out
+        assert "\n  port" not in out
+
+    def test_sandbox_help_lists_nested_resource_groups(
+        self,
+        capsys: pytest.CaptureFixture,
+    ) -> None:
+        """`smolvm sandbox --help` should expose sandbox-owned resources."""
+        ret = main(["sandbox", "--help"])
+        assert ret == 0
+        out = capsys.readouterr().out
+        assert "snapshot" in out
+        assert "port" in out
+        assert "cleanup" not in out
 
     def test_preset_help_lists_start_action(self, capsys: pytest.CaptureFixture) -> None:
         """`smolvm codex --help` should list the `start` action."""

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -132,6 +132,59 @@ def test_create_help_describes_backend_specific_guest_default(
     assert "auto-detected" in help_text
 
 
+def test_json_error_preserves_empty_details(capsys: pytest.CaptureFixture) -> None:
+    """Explicit empty error details should survive JSON normalization."""
+    from smolvm.cli.output import emit_json
+
+    emit_json(
+        "sandbox.test",
+        1,
+        error={"code": "invalid_input", "message": "Bad input.", "details": []},
+    )
+
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["error"]["details"] == []
+
+
+@pytest.mark.parametrize(
+    ("argv", "expected"),
+    [
+        (
+            ["sandbox", "list", "--all", "--status", "running"],
+            ["smolvm sandbox list --all", "smolvm sandbox list --status running"],
+        ),
+        (
+            ["sandbox", "delete", "my-sandbox", "--all"],
+            ["smolvm sandbox delete my-sandbox", "smolvm sandbox delete --all --force"],
+        ),
+        (
+            ["sandbox", "delete"],
+            ["smolvm sandbox delete my-sandbox", "smolvm sandbox delete --all --force"],
+        ),
+        (
+            ["browser", "stop"],
+            ["smolvm browser stop browser-id", "smolvm browser stop --all"],
+        ),
+        (
+            ["browser", "stop", "browser-id", "--all"],
+            ["smolvm browser stop browser-id", "smolvm browser stop --all"],
+        ),
+    ],
+)
+def test_usage_errors_include_recovery_commands(
+    argv: list[str],
+    expected: list[str],
+    capsys: pytest.CaptureFixture,
+) -> None:
+    """Click usage errors should name concrete recovery commands."""
+    ret = main(argv)
+
+    assert ret == 2
+    err = capsys.readouterr().err
+    for text in expected:
+        assert text in err
+
+
 class TestCliEnv:
     """Tests for `smolvm sandbox env` subcommands."""
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -133,7 +133,7 @@ def test_create_help_describes_backend_specific_guest_default(
 
 
 class TestCliEnv:
-    """Tests for `smolvm env` subcommands."""
+    """Tests for `smolvm sandbox env` subcommands."""
 
     @pytest.fixture
     def mock_vm_cls(self) -> MagicMock:
@@ -151,11 +151,11 @@ class TestCliEnv:
         mock_vm_cls: MagicMock,
         capsys: pytest.CaptureFixture,
     ) -> None:
-        """Test `smolvm env set` success path."""
+        """Test `smolvm sandbox env set` success path."""
         vm = self._setup_vm(mock_vm_cls)
         vm.set_env_vars.return_value = ["FOO"]
 
-        ret = main(["env", "set", "vm001", "FOO=bar"])
+        ret = main(["sandbox", "env", "set", "vm001", "FOO=bar"])
 
         assert ret == 0
         mock_vm_cls.from_id.assert_called_once_with(
@@ -178,7 +178,7 @@ class TestCliEnv:
         vm = self._setup_vm(mock_vm_cls)
         vm.set_env_vars.return_value = ["FOO"]
 
-        ret = main(["env", "set", "vm001", "FOO=bar", "--comm-channel", channel])
+        ret = main(["sandbox", "env", "set", "vm001", "FOO=bar", "--comm-channel", channel])
 
         assert ret == 0
         mock_vm_cls.from_id.assert_called_once_with(
@@ -192,11 +192,11 @@ class TestCliEnv:
         self,
         mock_vm_cls: MagicMock,
     ) -> None:
-        """Test `smolvm env set` with multiple variables."""
+        """Test `smolvm sandbox env set` with multiple variables."""
         vm = self._setup_vm(mock_vm_cls)
         vm.set_env_vars.return_value = ["A", "B"]
 
-        ret = main(["env", "set", "vm001", "A=1", "B=2"])
+        ret = main(["sandbox", "env", "set", "vm001", "A=1", "B=2"])
 
         assert ret == 0
         vm.set_env_vars.assert_called_once_with({"A": "1", "B": "2"})
@@ -207,7 +207,7 @@ class TestCliEnv:
         capsys: pytest.CaptureFixture,
     ) -> None:
         """Test execution fails on malformed key=value pair."""
-        ret = main(["env", "set", "vm001", "BADPAIR"])
+        ret = main(["sandbox", "env", "set", "vm001", "BADPAIR"])
 
         assert ret == 1
         mock_vm_cls.from_id.assert_not_called()
@@ -218,11 +218,11 @@ class TestCliEnv:
         mock_vm_cls: MagicMock,
         capsys: pytest.CaptureFixture,
     ) -> None:
-        """Test `smolvm env unset` success path."""
+        """Test `smolvm sandbox env unset` success path."""
         vm = self._setup_vm(mock_vm_cls)
         vm.unset_env_vars.return_value = {"FOO": "bar"}
 
-        ret = main(["env", "unset", "vm001", "FOO"])
+        ret = main(["sandbox", "env", "unset", "vm001", "FOO"])
 
         assert ret == 0
         vm.unset_env_vars.assert_called_once_with(["FOO"])
@@ -233,11 +233,11 @@ class TestCliEnv:
         mock_vm_cls: MagicMock,
         capsys: pytest.CaptureFixture,
     ) -> None:
-        """Test `smolvm env list` success path (masked by default)."""
+        """Test `smolvm sandbox env list` success path (masked by default)."""
         vm = self._setup_vm(mock_vm_cls)
         vm.list_env_vars.return_value = {"FOO": "bar", "SECRET": "xyz"}
 
-        ret = main(["env", "list", "vm001"])
+        ret = main(["sandbox", "env", "list", "vm001"])
 
         assert ret == 0
         out = capsys.readouterr().out
@@ -251,11 +251,11 @@ class TestCliEnv:
         mock_vm_cls: MagicMock,
         capsys: pytest.CaptureFixture,
     ) -> None:
-        """Test `smolvm env list --show-values` reveals values."""
+        """Test `smolvm sandbox env list --show-values` reveals values."""
         vm = self._setup_vm(mock_vm_cls)
         vm.list_env_vars.return_value = {"FOO": "bar"}
 
-        ret = main(["env", "list", "vm001", "--show-values"])
+        ret = main(["sandbox", "env", "list", "vm001", "--show-values"])
 
         assert ret == 0
         out = capsys.readouterr().out
@@ -267,15 +267,15 @@ class TestCliEnv:
         mock_vm_cls: MagicMock,
         capsys: pytest.CaptureFixture,
     ) -> None:
-        """`smolvm env set --json` should emit the shared envelope."""
+        """`smolvm sandbox env set --json` should emit the shared envelope."""
         vm = self._setup_vm(mock_vm_cls)
         vm.set_env_vars.return_value = ["FOO"]
 
-        ret = main(["env", "set", "vm001", "FOO=bar", "--json"])
+        ret = main(["sandbox", "env", "set", "vm001", "FOO=bar", "--json"])
 
         assert ret == 0
         payload = json.loads(capsys.readouterr().out)
-        assert payload["command"] == "env.set"
+        assert payload["command"] == "sandbox.env.set"
         assert payload["ok"] is True
         assert payload["data"]["vm_id"] == "vm001"
         assert payload["data"]["requested_keys"] == ["FOO"]
@@ -287,15 +287,15 @@ class TestCliEnv:
         mock_vm_cls: MagicMock,
         capsys: pytest.CaptureFixture,
     ) -> None:
-        """`smolvm env unset --json` should emit removed and missing keys."""
+        """`smolvm sandbox env unset --json` should emit removed and missing keys."""
         vm = self._setup_vm(mock_vm_cls)
         vm.unset_env_vars.return_value = {"FOO": "bar"}
 
-        ret = main(["env", "unset", "vm001", "FOO", "MISSING", "--json"])
+        ret = main(["sandbox", "env", "unset", "vm001", "FOO", "MISSING", "--json"])
 
         assert ret == 0
         payload = json.loads(capsys.readouterr().out)
-        assert payload["command"] == "env.unset"
+        assert payload["command"] == "sandbox.env.unset"
         assert payload["data"]["removed_keys"] == ["FOO"]
         assert payload["data"]["missing_keys"] == ["MISSING"]
 
@@ -304,15 +304,15 @@ class TestCliEnv:
         mock_vm_cls: MagicMock,
         capsys: pytest.CaptureFixture,
     ) -> None:
-        """`smolvm env list --json` should mask values by default."""
+        """`smolvm sandbox env list --json` should mask values by default."""
         vm = self._setup_vm(mock_vm_cls)
         vm.list_env_vars.return_value = {"FOO": "bar"}
 
-        ret = main(["env", "list", "vm001", "--json"])
+        ret = main(["sandbox", "env", "list", "vm001", "--json"])
 
         assert ret == 0
         payload = json.loads(capsys.readouterr().out)
-        assert payload["command"] == "env.list"
+        assert payload["command"] == "sandbox.env.list"
         assert payload["data"]["masked"] is True
         assert payload["data"]["variables"] == {"FOO": "****"}
 
@@ -321,11 +321,11 @@ class TestCliEnv:
         mock_vm_cls: MagicMock,
         capsys: pytest.CaptureFixture,
     ) -> None:
-        """`smolvm env list --json --show-values` should reveal values."""
+        """`smolvm sandbox env list --json --show-values` should reveal values."""
         vm = self._setup_vm(mock_vm_cls)
         vm.list_env_vars.return_value = {"FOO": "bar"}
 
-        ret = main(["env", "list", "vm001", "--show-values", "--json"])
+        ret = main(["sandbox", "env", "list", "vm001", "--show-values", "--json"])
 
         assert ret == 0
         payload = json.loads(capsys.readouterr().out)
@@ -342,6 +342,7 @@ class TestCliEnv:
 
         main(
             [
+                "sandbox",
                 "env",
                 "list",
                 "vm001",
@@ -367,7 +368,7 @@ class TestCliEnv:
         """Test handling of VM lookup failure."""
         mock_vm_cls.from_id.side_effect = Exception("VM not found")
 
-        ret = main(["env", "list", "missing-vm"])
+        ret = main(["sandbox", "env", "list", "missing-vm"])
 
         assert ret == 1
         assert "Error: VM not found" in capsys.readouterr().err
@@ -381,7 +382,7 @@ class TestCliEnv:
         vm = self._setup_vm(mock_vm_cls)
         vm.list_env_vars.side_effect = Exception("VM has no network configuration")
 
-        ret = main(["env", "list", "vm001"])
+        ret = main(["sandbox", "env", "list", "vm001"])
 
         assert ret == 1
         assert "no network configuration" in capsys.readouterr().err
@@ -389,7 +390,7 @@ class TestCliEnv:
 
 
 class TestCliFile:
-    """Tests for `smolvm file` subcommands."""
+    """Tests for `smolvm sandbox file` subcommands."""
 
     @pytest.fixture
     def mock_vm_cls(self) -> MagicMock:
@@ -402,14 +403,14 @@ class TestCliFile:
         tmp_path: Path,
         capsys: pytest.CaptureFixture,
     ) -> None:
-        """`smolvm file upload` should copy a local file into a sandbox."""
+        """`smolvm sandbox file upload` should copy a local file into a sandbox."""
         source = tmp_path / "note.txt"
         source.write_text("hello")
         vm = MagicMock()
         vm.upload_file.return_value = "/tmp/note.txt"
         mock_vm_cls.from_id.return_value = vm
 
-        ret = main(["file", "upload", "vm001", str(source), "/tmp/"])
+        ret = main(["sandbox", "file", "upload", "vm001", str(source), "/tmp/"])
 
         assert ret == 0
         mock_vm_cls.from_id.assert_called_once_with(
@@ -440,7 +441,9 @@ class TestCliFile:
         vm.upload_file.return_value = "/tmp/note.txt"
         mock_vm_cls.from_id.return_value = vm
 
-        ret = main(["file", "upload", "vm001", str(source), "/tmp/", "--comm-channel", channel])
+        ret = main(
+            ["sandbox", "file", "upload", "vm001", str(source), "/tmp/", "--comm-channel", channel]
+        )
 
         assert ret == 0
         mock_vm_cls.from_id.assert_called_once_with(
@@ -456,18 +459,18 @@ class TestCliFile:
         tmp_path: Path,
         capsys: pytest.CaptureFixture,
     ) -> None:
-        """`smolvm file upload --json` should emit the upload destination."""
+        """`smolvm sandbox file upload --json` should emit the upload destination."""
         source = tmp_path / "note.txt"
         source.write_text("hello")
         vm = MagicMock()
         vm.upload_file.return_value = "/tmp/note.txt"
         mock_vm_cls.from_id.return_value = vm
 
-        ret = main(["file", "upload", "vm001", str(source), "/tmp/", "--json"])
+        ret = main(["sandbox", "file", "upload", "vm001", str(source), "/tmp/", "--json"])
 
         assert ret == 0
         payload = json.loads(capsys.readouterr().out)
-        assert payload["command"] == "file.upload"
+        assert payload["command"] == "sandbox.file.upload"
         assert payload["ok"] is True
         assert payload["data"]["vm_id"] == "vm001"
         assert payload["data"]["local_path"] == str(source)
@@ -485,7 +488,9 @@ class TestCliFile:
         vm.upload_file.return_value = "/tmp/note.txt"
         mock_vm_cls.from_id.return_value = vm
 
-        ret = main(["file", "upload", "vm001", str(source), "/tmp/note.txt", "--no-create-dirs"])
+        ret = main(
+            ["sandbox", "file", "upload", "vm001", str(source), "/tmp/note.txt", "--no-create-dirs"]
+        )
 
         assert ret == 0
         vm.upload_file.assert_called_once_with(
@@ -506,7 +511,7 @@ class TestCliFile:
         vm.upload_file.side_effect = RuntimeError("boom")
         mock_vm_cls.from_id.return_value = vm
 
-        ret = main(["file", "upload", "vm001", str(source), "/tmp/"])
+        ret = main(["sandbox", "file", "upload", "vm001", str(source), "/tmp/"])
 
         assert ret != 0
         vm.close.assert_called_once()
@@ -517,13 +522,13 @@ class TestCliFile:
         tmp_path: Path,
         capsys: pytest.CaptureFixture,
     ) -> None:
-        """`smolvm file download` should copy a guest file to the host."""
+        """`smolvm sandbox file download` should copy a guest file to the host."""
         destination = tmp_path / "note.txt"
         vm = MagicMock()
         vm.download_file.return_value = str(destination)
         mock_vm_cls.from_id.return_value = vm
 
-        ret = main(["file", "download", "vm001", "/tmp/note.txt", str(destination)])
+        ret = main(["sandbox", "file", "download", "vm001", "/tmp/note.txt", str(destination)])
 
         assert ret == 0
         mock_vm_cls.from_id.assert_called_once_with(
@@ -546,17 +551,19 @@ class TestCliFile:
         tmp_path: Path,
         capsys: pytest.CaptureFixture,
     ) -> None:
-        """`smolvm file download --json` should emit the resolved local path."""
+        """`smolvm sandbox file download --json` should emit the resolved local path."""
         destination = tmp_path / "note.txt"
         vm = MagicMock()
         vm.download_file.return_value = str(destination)
         mock_vm_cls.from_id.return_value = vm
 
-        ret = main(["file", "download", "vm001", "/tmp/note.txt", str(tmp_path) + "/", "--json"])
+        ret = main(
+            ["sandbox", "file", "download", "vm001", "/tmp/note.txt", str(tmp_path) + "/", "--json"]
+        )
 
         assert ret == 0
         payload = json.loads(capsys.readouterr().out)
-        assert payload["command"] == "file.download"
+        assert payload["command"] == "sandbox.file.download"
         assert payload["ok"] is True
         assert payload["data"]["vm_id"] == "vm001"
         assert payload["data"]["guest_path"] == "/tmp/note.txt"
@@ -575,6 +582,7 @@ class TestCliFile:
 
         ret = main(
             [
+                "sandbox",
                 "file",
                 "download",
                 "vm001",
@@ -601,7 +609,9 @@ class TestCliFile:
         vm.download_file.side_effect = RuntimeError("boom")
         mock_vm_cls.from_id.return_value = vm
 
-        ret = main(["file", "download", "vm001", "/tmp/note.txt", str(tmp_path / "out.txt")])
+        ret = main(
+            ["sandbox", "file", "download", "vm001", "/tmp/note.txt", str(tmp_path / "out.txt")]
+        )
 
         assert ret != 0
         vm.close.assert_called_once()
@@ -2972,6 +2982,8 @@ class TestCliStart:
         assert "codex" in out
         assert "claude" in out
         assert "claude-code" not in out
+        assert "\n  env" not in out
+        assert "\n  file" not in out
         assert "\n  snapshot" not in out
         assert "\n  port" not in out
 
@@ -2983,9 +2995,22 @@ class TestCliStart:
         ret = main(["sandbox", "--help"])
         assert ret == 0
         out = capsys.readouterr().out
+        assert "env" in out
+        assert "file" in out
         assert "snapshot" in out
         assert "port" in out
         assert "cleanup" not in out
+
+    @pytest.mark.parametrize("command", ["env", "file"])
+    def test_old_root_sandbox_resource_groups_are_absent(
+        self,
+        command: str,
+        capsys: pytest.CaptureFixture,
+    ) -> None:
+        """Sandbox-owned resource groups should not remain as root aliases."""
+        ret = main([command, "--help"])
+        assert ret == 2
+        assert "No such command" in capsys.readouterr().err
 
     def test_preset_help_lists_start_action(self, capsys: pytest.CaptureFixture) -> None:
         """`smolvm codex --help` should list the `start` action."""

--- a/tests/test_facade.py
+++ b/tests/test_facade.py
@@ -297,7 +297,7 @@ class TestVMInit:
         message = str(exc_info.value)
         assert "Ubuntu needs at least 4096 MiB for sandbox 'project spacex; rm -rf'" in message
         assert (
-            "smolvm create --name 'project spacex; rm -rf' --os ubuntu "
+            "smolvm sandbox create --name 'project spacex; rm -rf' --os ubuntu "
             "--backend qemu --disk-size 4096" in message
         )
 
@@ -838,7 +838,7 @@ class TestFromBootImage:
             backend="qemu",
         )
 
-        with pytest.raises(ValueError, match="smolvm create --name vm-mismatch --help"):
+        with pytest.raises(ValueError, match="smolvm sandbox create --name vm-mismatch --help"):
             SmolVM.from_image(image, vm_id="vm-mismatch", backend="firecracker")
 
     @patch("smolvm.facade.SmolVMManager")
@@ -2097,8 +2097,8 @@ class TestVMRun:
     ) -> None:
         """wait_for_ssh() without an explicit key should retry with ~/.smolvm/keys/id_ed25519.
 
-        Regression test for: smolvm ssh <name> failing with 'Authentication failed'
-        after smolvm create, because from_id() sets ssh_key_path=None but the VM
+        Regression test for: smolvm sandbox ssh <name> failing with 'Authentication failed'
+        after smolvm sandbox create, because from_id() sets ssh_key_path=None but the VM
         was provisioned with the default SmolVM key.
         """
         mock_network = MagicMock()

--- a/tests/test_facade.py
+++ b/tests/test_facade.py
@@ -674,7 +674,7 @@ class TestSnapshot:
 
         with pytest.raises(
             SmolVMError,
-            match=r"smolvm snapshot create vm001 --snapshot-type disk",
+            match=r"smolvm sandbox snapshot create vm001 --snapshot-type disk",
         ):
             vm._sync_guest_for_disk_snapshot()
 
@@ -926,7 +926,7 @@ class TestFromBootImage:
             backend="qemu",
         )
 
-        with pytest.raises(ValueError, match="smolvm port expose vm-tap-ports --help"):
+        with pytest.raises(ValueError, match="smolvm sandbox port expose vm-tap-ports --help"):
             SmolVM.from_image(
                 image,
                 vm_id="vm-tap-ports",
@@ -948,7 +948,7 @@ class TestFromBootImage:
             backend="qemu",
         )
 
-        with pytest.raises(ValueError, match="smolvm port expose vm-bad-port --help"):
+        with pytest.raises(ValueError, match="smolvm sandbox port expose vm-bad-port --help"):
             SmolVM.from_image(
                 image,
                 vm_id="vm-bad-port",

--- a/tests/test_kvm_session.py
+++ b/tests/test_kvm_session.py
@@ -90,12 +90,15 @@ class TestShouldAttemptReexec:
 
     @patch("smolvm.cli._kvm_session.platform.system", return_value="Linux")
     def test_verb_level_help_short_circuits(self, _mock_system: MagicMock) -> None:
-        # ``smolvm create --help`` argparse's into ["create", "--help"] —
+        # ``smolvm sandbox create --help`` argparse's into ["sandbox", "create", "--help"] —
         # this should not trigger a re-exec even though ``create`` is a
         # kvm-using verb, because no kvm work will actually run.
-        assert _kvm_session._should_attempt_reexec(["create", "--help"]) is False
+        assert _kvm_session._should_attempt_reexec(["sandbox", "create", "--help"]) is False
         assert _kvm_session._should_attempt_reexec(["snapshot", "create", "-h"]) is False
-        assert _kvm_session._should_attempt_reexec(["create", "--name", "x", "-V"]) is False
+        assert (
+            _kvm_session._should_attempt_reexec(["sandbox", "create", "--name", "x", "-V"])
+            is False
+        )
 
     @patch("smolvm.cli._kvm_session.platform.system", return_value="Linux")
     def test_read_only_verbs_skip(self, _mock_system: MagicMock) -> None:
@@ -110,7 +113,7 @@ class TestShouldAttemptReexec:
     @patch("smolvm.cli._kvm_session.platform.system", return_value="Linux")
     def test_no_dev_kvm_skips(self, _mock_system: MagicMock, mock_dev: MagicMock) -> None:
         mock_dev.exists.return_value = False
-        assert _kvm_session._should_attempt_reexec(["create"]) is False
+        assert _kvm_session._should_attempt_reexec(["sandbox", "create"]) is False
 
     @patch("smolvm.cli._kvm_session.os.access", return_value=True)
     @patch("smolvm.cli._kvm_session._KVM_DEV")
@@ -122,7 +125,7 @@ class TestShouldAttemptReexec:
         _mock_access: MagicMock,
     ) -> None:
         mock_dev.exists.return_value = True
-        assert _kvm_session._should_attempt_reexec(["create"]) is False
+        assert _kvm_session._should_attempt_reexec(["sandbox", "create"]) is False
 
     @patch("smolvm.cli._kvm_session.os.getuid", return_value=1000)
     @patch("smolvm.cli._kvm_session.os.access", return_value=False)
@@ -142,7 +145,7 @@ class TestShouldAttemptReexec:
             patch("grp.getgrnam", return_value=_mock_kvm_grp(members=["other"])),
             patch("pwd.getpwuid", return_value=_mock_pwd_user("alice")),
         ):
-            assert _kvm_session._should_attempt_reexec(["create"]) is False
+            assert _kvm_session._should_attempt_reexec(["sandbox", "create"]) is False
 
     @patch("smolvm.cli._kvm_session.os.getgroups", return_value=[999])
     @patch("smolvm.cli._kvm_session.os.getuid", return_value=1000)
@@ -168,7 +171,7 @@ class TestShouldAttemptReexec:
             ),
             patch("pwd.getpwuid", return_value=_mock_pwd_user("alice")),
         ):
-            assert _kvm_session._should_attempt_reexec(["create"]) is False
+            assert _kvm_session._should_attempt_reexec(["sandbox", "create"]) is False
 
     @patch("smolvm.cli._kvm_session.os.getgroups", return_value=[1000])
     @patch("smolvm.cli._kvm_session.os.getuid", return_value=1000)
@@ -191,7 +194,7 @@ class TestShouldAttemptReexec:
             ),
             patch("pwd.getpwuid", return_value=_mock_pwd_user("alice")),
         ):
-            assert _kvm_session._should_attempt_reexec(["create"]) is True
+            assert _kvm_session._should_attempt_reexec(["sandbox", "create"]) is True
 
 
 class TestMaybeReexec:

--- a/tests/test_kvm_session.py
+++ b/tests/test_kvm_session.py
@@ -90,11 +90,14 @@ class TestShouldAttemptReexec:
 
     @patch("smolvm.cli._kvm_session.platform.system", return_value="Linux")
     def test_verb_level_help_short_circuits(self, _mock_system: MagicMock) -> None:
-        # ``smolvm sandbox create --help`` argparse's into ["sandbox", "create", "--help"] —
+        # ``smolvm sandbox create --help`` reaches ["sandbox", "create", "--help"] —
         # this should not trigger a re-exec even though ``create`` is a
         # kvm-using verb, because no kvm work will actually run.
         assert _kvm_session._should_attempt_reexec(["sandbox", "create", "--help"]) is False
-        assert _kvm_session._should_attempt_reexec(["snapshot", "create", "-h"]) is False
+        assert (
+            _kvm_session._should_attempt_reexec(["sandbox", "snapshot", "create", "-h"])
+            is False
+        )
         assert (
             _kvm_session._should_attempt_reexec(["sandbox", "create", "--name", "x", "-V"])
             is False
@@ -104,9 +107,20 @@ class TestShouldAttemptReexec:
     def test_read_only_verbs_skip(self, _mock_system: MagicMock) -> None:
         # Read-only / VM-process-targeted verbs don't need /dev/kvm; a
         # re-exec for them would just print a confusing notice.
-        for verb in ("list", "info", "env", "ssh", "stop", "pause", "delete", "cleanup"):
-            assert _kvm_session._should_attempt_reexec([verb]) is False, (
-                f"expected {verb!r} to skip re-exec"
+        skipped = [
+            ["env"],
+            ["file"],
+            ["sandbox", "list"],
+            ["sandbox", "info"],
+            ["sandbox", "ssh"],
+            ["sandbox", "stop"],
+            ["sandbox", "pause"],
+            ["sandbox", "delete"],
+            ["sandbox", "port"],
+        ]
+        for argv in skipped:
+            assert _kvm_session._should_attempt_reexec(argv) is False, (
+                f"expected {argv!r} to skip re-exec"
             )
 
     @patch("smolvm.cli._kvm_session._KVM_DEV")

--- a/tests/test_kvm_session.py
+++ b/tests/test_kvm_session.py
@@ -108,14 +108,14 @@ class TestShouldAttemptReexec:
         # Read-only / VM-process-targeted verbs don't need /dev/kvm; a
         # re-exec for them would just print a confusing notice.
         skipped = [
-            ["env"],
-            ["file"],
             ["sandbox", "list"],
             ["sandbox", "info"],
             ["sandbox", "ssh"],
             ["sandbox", "stop"],
             ["sandbox", "pause"],
             ["sandbox", "delete"],
+            ["sandbox", "env"],
+            ["sandbox", "file"],
             ["sandbox", "port"],
         ]
         for argv in skipped:

--- a/tests/test_kvm_session.py
+++ b/tests/test_kvm_session.py
@@ -94,13 +94,9 @@ class TestShouldAttemptReexec:
         # this should not trigger a re-exec even though ``create`` is a
         # kvm-using verb, because no kvm work will actually run.
         assert _kvm_session._should_attempt_reexec(["sandbox", "create", "--help"]) is False
+        assert _kvm_session._should_attempt_reexec(["sandbox", "snapshot", "create", "-h"]) is False
         assert (
-            _kvm_session._should_attempt_reexec(["sandbox", "snapshot", "create", "-h"])
-            is False
-        )
-        assert (
-            _kvm_session._should_attempt_reexec(["sandbox", "create", "--name", "x", "-V"])
-            is False
+            _kvm_session._should_attempt_reexec(["sandbox", "create", "--name", "x", "-V"]) is False
         )
 
     @patch("smolvm.cli._kvm_session.platform.system", return_value="Linux")

--- a/tests/test_kvm_session.py
+++ b/tests/test_kvm_session.py
@@ -112,6 +112,7 @@ class TestShouldAttemptReexec:
             ["sandbox", "delete"],
             ["sandbox", "env"],
             ["sandbox", "file"],
+            ["sandbox", "snapshot", "list"],
             ["sandbox", "port"],
         ]
         for argv in skipped:

--- a/tests/test_ssh.py
+++ b/tests/test_ssh.py
@@ -396,7 +396,7 @@ class TestPwshEncodedCommand:
 class TestPutFileDirectoryDestination:
     """``put_file`` resolves a directory destination to a file inside it.
 
-    Regression for ``smolvm file upload <vm> ./f /root`` failing with the
+    Regression for ``smolvm sandbox file upload <vm> ./f /root`` failing with the
     opaque SFTP ``Failure`` because ``/root`` is a directory: SFTP ``put``
     cannot overwrite a directory with a regular file. ``put_file`` now stats
     the destination on the already-open SFTP channel and, when it is a

--- a/tests/test_update.py
+++ b/tests/test_update.py
@@ -16,7 +16,6 @@
 
 from __future__ import annotations
 
-import argparse
 import json
 from unittest.mock import MagicMock, patch
 
@@ -101,14 +100,11 @@ class TestIsUvToolInstall:
 
 
 class TestRunUpdate:
-    def _args(self, *, check: bool = False, json_output: bool = False) -> argparse.Namespace:
-        return argparse.Namespace(check=check, json=json_output)
-
     def test_check_only_no_update(self, capsys: pytest.CaptureFixture[str]) -> None:
         with (
             patch("smolvm.cli.update._check_for_stable_update", return_value=("1.0.0", None)),
         ):
-            rc = run_update(self._args(check=True))
+            rc = run_update(check=True)
         assert rc == 0
         out = capsys.readouterr().out
         assert "up to date" in out
@@ -117,7 +113,7 @@ class TestRunUpdate:
         with (
             patch("smolvm.cli.update._check_for_stable_update", return_value=(None, None)),
         ):
-            rc = run_update(self._args(check=True))
+            rc = run_update(check=True)
         assert rc == 1
         err = capsys.readouterr().err
         assert "Could not determine" in err
@@ -127,7 +123,7 @@ class TestRunUpdate:
         with (
             patch("smolvm.cli.update._check_for_stable_update", return_value=("0.9.0", "1.0.0")),
         ):
-            rc = run_update(self._args(check=True))
+            rc = run_update(check=True)
         assert rc == 0
         out = capsys.readouterr().out
         assert "1.0.0" in out
@@ -136,7 +132,7 @@ class TestRunUpdate:
         with (
             patch("smolvm.cli.update._check_for_stable_update", return_value=("1.0.0", None)),
         ):
-            rc = run_update(self._args(check=True, json_output=True))
+            rc = run_update(check=True, json_output=True)
         assert rc == 0
         payload = json.loads(capsys.readouterr().out)
         assert payload["data"]["update_available"] is False
@@ -146,7 +142,7 @@ class TestRunUpdate:
             patch("smolvm.cli.update._check_for_stable_update", return_value=("1.0.0", None)),
             patch("smolvm.cli.update._run_upgrade") as mock_pip,
         ):
-            rc = run_update(self._args())
+            rc = run_update()
         assert rc == 0
         mock_pip.assert_not_called()
 
@@ -156,7 +152,7 @@ class TestRunUpdate:
             patch("smolvm.cli.update._run_upgrade", return_value=(0, "")) as mock_pip,
             patch("smolvm.cli.update._get_current_version", return_value="1.0.0"),
         ):
-            rc = run_update(self._args())
+            rc = run_update()
         assert rc == 0
         mock_pip.assert_called_once_with(json_output=False)
 
@@ -166,7 +162,7 @@ class TestRunUpdate:
             patch("smolvm.cli.update._run_upgrade", return_value=(1, "error output")),
             patch("smolvm.cli.update._get_current_version", return_value="0.9.0"),
         ):
-            rc = run_update(self._args())
+            rc = run_update()
         assert rc == 1
 
     def test_upgrade_json_output(self, capsys: pytest.CaptureFixture[str]) -> None:
@@ -178,7 +174,7 @@ class TestRunUpdate:
             ),
             patch("smolvm.cli.update._get_current_version", return_value="1.0.0"),
         ):
-            rc = run_update(self._args(json_output=True))
+            rc = run_update(json_output=True)
         assert rc == 0
         payload = json.loads(capsys.readouterr().out)
         assert payload["data"]["upgraded"] is True

--- a/tests/test_version.py
+++ b/tests/test_version.py
@@ -1,8 +1,11 @@
 """Tests for SmolVM version consistency."""
 
+import importlib.metadata
+import inspect
 import re
 
-import pytest
+import smolvm
+from smolvm.cli.main import main
 
 
 class TestVersion:
@@ -10,45 +13,27 @@ class TestVersion:
 
     def test_package_version_is_semver(self) -> None:
         """Package version should be a valid semver string."""
-        import smolvm
-
         assert re.match(r"^\d+\.\d+\.\d+", smolvm.__version__), (
             f"Version {smolvm.__version__!r} is not a valid semver"
         )
 
     def test_init_version_matches_metadata(self) -> None:
         """smolvm.__version__ should match importlib.metadata."""
-        import importlib.metadata
-
-        import smolvm
-
         metadata_version = importlib.metadata.version("smolvm")
         assert smolvm.__version__ == metadata_version
 
-    def test_cli_version_flag(self) -> None:
+    def test_cli_version_flag(self, capsys) -> None:
         """smolvm --version should print the package version."""
-        from smolvm.cli.main import build_parser
+        assert main(["--version"]) == 0
+        assert smolvm.__version__ in capsys.readouterr().out
 
-        parser = build_parser()
-        with pytest.raises(SystemExit) as exc_info:
-            parser.parse_args(["--version"])
-        assert exc_info.value.code == 0
-
-    def test_cli_short_version_flag(self) -> None:
+    def test_cli_short_version_flag(self, capsys) -> None:
         """smolvm -V should also trigger version output."""
-        from smolvm.cli.main import build_parser
-
-        parser = build_parser()
-        with pytest.raises(SystemExit) as exc_info:
-            parser.parse_args(["-V"])
-        assert exc_info.value.code == 0
+        assert main(["-V"]) == 0
+        assert smolvm.__version__ in capsys.readouterr().out
 
     def test_version_not_hardcoded_in_init(self) -> None:
         """__version__ should come from package metadata, not a hardcoded string."""
-        import inspect
-
-        import smolvm
-
         source = inspect.getsource(smolvm)
         assert '__version__ = "' not in source, (
             "__version__ should be read from importlib.metadata, not hardcoded"

--- a/tests/test_vm.py
+++ b/tests/test_vm.py
@@ -466,11 +466,11 @@ class TestSmolVMCreate:
             str(exc_info.value)
             == "Cannot use vsock for sandbox 'vm-vsock-bad': this backend does not support "
             "vsock in this release; create it with SSH by running: "
-            "smolvm create --name vm-vsock-bad --backend libkrun."
+            "smolvm sandbox create --name vm-vsock-bad --backend libkrun."
         )
         assert exc_info.value.details == {
             "vm_id": "vm-vsock-bad",
-            "recovery_command": "smolvm create --name vm-vsock-bad --backend libkrun",
+            "recovery_command": "smolvm sandbox create --name vm-vsock-bad --backend libkrun",
         }
 
     @pytest.mark.asyncio
@@ -1564,7 +1564,7 @@ def _info(config: VMConfig, status: VMState, pid: int | None = None) -> VMInfo:
 
 
 class TestRefreshStatus:
-    """Tests for the cheap per-row liveness check used by ``smolvm list``."""
+    """Tests for the cheap per-row liveness check used by ``smolvm sandbox list``."""
 
     def test_running_with_live_pid_unchanged(
         self, smol_vm: SmolVMManager, sample_config: VMConfig

--- a/tests/test_vm_qemu.py
+++ b/tests/test_vm_qemu.py
@@ -347,7 +347,7 @@ def test_create_qemu_explicit_vsock_cid_rejects_live_qemu_conflict(tmp_path: Pat
         mock_overlay.side_effect = lambda source, target, **_kwargs: target.write_text("overlay")
         sdk.create(config)
 
-    assert "smolvm delete vm-qemu-vsock-conflict" in str(exc_info.value)
+    assert "smolvm sandbox delete vm-qemu-vsock-conflict" in str(exc_info.value)
     assert sdk.state.get_vsock_cid("vm-qemu-vsock-conflict") is None
     with pytest.raises(VMNotFoundError):
         sdk.state.get_vm("vm-qemu-vsock-conflict")

--- a/tests/test_workspace.py
+++ b/tests/test_workspace.py
@@ -79,7 +79,7 @@ class TestWorkspaceMountValidation:
     def test_missing_host_path_loads_under_validate_paths_false(self, tmp_path: Path) -> None:
         """Persisted configs reload even when the host path was deleted.
 
-        Read-only commands like ``smolvm list`` pass
+        Read-only commands like ``smolvm sandbox list`` pass
         ``context={"validate_paths": False}`` so a stale mount path on disk
         does not crash the whole command. The validator must respect that.
         """
@@ -164,7 +164,7 @@ class TestVMConfigWorkspaceMounts:
     def test_persisted_config_reloads_with_missing_mount_host(self, tmp_path: Path) -> None:
         """Storage reads must succeed when a workspace host folder is gone.
 
-        Reproduces the ``smolvm list`` crash where a deleted Conductor
+        Reproduces the ``smolvm sandbox list`` crash where a deleted Conductor
         worktree caused the whole command to fail. The fix is that
         ``WorkspaceMount`` honors the ``validate_paths=False`` context the
         storage layer already passes via ``vm_config_from_json``.
@@ -347,7 +347,7 @@ def test_start_friendly_error_when_workspace_host_path_missing(
     # user can act on it without reading the source.
     message = str(exc_info.value)
     assert "vm-stale-mount" in message
-    assert "smolvm delete vm-stale-mount" in message
+    assert "smolvm sandbox delete vm-stale-mount" in message
     mock_popen.assert_not_called()
 
 
@@ -607,27 +607,26 @@ def test_snapshot_rejected_with_workspace_mounts(tmp_path: Path) -> None:
 class TestCliMountFlag:
     """Tests for the --mount CLI flag on create."""
 
-    def test_single_mount_host_only(self) -> None:
-        from smolvm.cli.main import build_parser
+    def _create_args(self, argv: list[str]) -> object:
+        from smolvm.cli.main import main
 
-        parser = build_parser()
-        args = parser.parse_args(["create", "--mount", "/tmp/project"])
+        with patch("smolvm.cli.main._run_create", return_value=0) as mock_run_create:
+            ret = main(["sandbox", "create", *argv])
+
+        assert ret == 0
+        return mock_run_create.call_args.args[0]
+
+    def test_single_mount_host_only(self) -> None:
+        args = self._create_args(["--mount", "/tmp/project"])
         assert args.mounts == ["/tmp/project"]
 
     def test_single_mount_with_guest_path(self) -> None:
-        from smolvm.cli.main import build_parser
-
-        parser = build_parser()
-        args = parser.parse_args(["create", "--mount", "/tmp/project:/code"])
+        args = self._create_args(["--mount", "/tmp/project:/code"])
         assert args.mounts == ["/tmp/project:/code"]
 
     def test_multiple_mounts(self) -> None:
-        from smolvm.cli.main import build_parser
-
-        parser = build_parser()
-        args = parser.parse_args(
+        args = self._create_args(
             [
-                "create",
                 "--mount",
                 "/tmp/a",
                 "--mount",
@@ -637,26 +636,16 @@ class TestCliMountFlag:
         assert args.mounts == ["/tmp/a", "/tmp/b:/data"]
 
     def test_mount_defaults_to_none(self) -> None:
-        from smolvm.cli.main import build_parser
-
-        parser = build_parser()
-        args = parser.parse_args(["create"])
+        args = self._create_args([])
         assert args.mounts is None
 
     def test_writable_mounts_defaults_to_false(self) -> None:
-        from smolvm.cli.main import build_parser
-
-        parser = build_parser()
-        args = parser.parse_args(["create", "--mount", "/tmp/project"])
+        args = self._create_args(["--mount", "/tmp/project"])
         assert args.writable_mounts is False
 
     def test_writable_mounts_flag_sets_true(self) -> None:
-        from smolvm.cli.main import build_parser
-
-        parser = build_parser()
-        args = parser.parse_args(
+        args = self._create_args(
             [
-                "create",
                 "--mount",
                 "/tmp/project",
                 "--writable-mounts",
@@ -672,12 +661,12 @@ class TestCliMountFlag:
         mock_smolvm_cls: MagicMock,
         tmp_path: Path,
     ) -> None:
-        """`smolvm create --mount /path` (no --backend) must auto-select QEMU
+        """`smolvm sandbox create --mount /path` (no --backend) must auto-select QEMU
         at the CLI layer. Without this, _build_auto_config gets backend=None,
         resolves to the platform default (firecracker on Linux), and the
         downstream guard rejects the mount + firecracker combo with a
         confusing 'Re-run without --backend' message — the user already did."""
-        from smolvm.cli.main import _run_create, build_parser
+        from smolvm.cli.main import main
 
         kernel = tmp_path / "vmlinux"
         rootfs = tmp_path / "rootfs.ext4"
@@ -696,12 +685,9 @@ class TestCliMountFlag:
         mock_smolvm_cls.return_value.vm_id = "vm-mnt"
         mock_smolvm_cls.return_value.info.status = VMState.RUNNING
 
-        parser = build_parser()
-        args = parser.parse_args(["create", "--mount", str(tmp_path / "project"), "--json"])
+        ret = main(["sandbox", "create", "--mount", str(tmp_path / "project"), "--json"])
 
-        _run_create(args)
-
-        assert args.backend == "qemu"
+        assert ret == 0
         assert mock_build_auto_config.call_args.kwargs["backend"] == "qemu"
 
     @patch("smolvm.facade.SmolVM")
@@ -715,7 +701,7 @@ class TestCliMountFlag:
         """Explicit `--backend firecracker --mount /path` must NOT be silently
         upgraded; the downstream guard should still fire so the user sees the
         incompatibility they explicitly requested."""
-        from smolvm.cli.main import _run_create, build_parser
+        from smolvm.cli.main import main
 
         kernel = tmp_path / "vmlinux"
         rootfs = tmp_path / "rootfs.ext4"
@@ -734,9 +720,9 @@ class TestCliMountFlag:
         mock_smolvm_cls.return_value.vm_id = "vm-mnt"
         mock_smolvm_cls.return_value.info.status = VMState.RUNNING
 
-        parser = build_parser()
-        args = parser.parse_args(
+        ret = main(
             [
+                "sandbox",
                 "create",
                 "--mount",
                 str(tmp_path / "project"),
@@ -746,9 +732,8 @@ class TestCliMountFlag:
             ]
         )
 
-        _run_create(args)
-
-        assert args.backend == "firecracker"
+        assert ret == 0
+        assert mock_build_auto_config.call_args.kwargs["backend"] == "firecracker"
 
 
 # ── Mount spec parsing ──────────────────────────────────────────────


### PR DESCRIPTION
## Summary

Replaces the argparse-based SmolVM CLI surface with a Click command tree while keeping the `smolvm = "smolvm.cli.main:main"` console entrypoint. The sandbox lifecycle, env, file, snapshot, and port commands now live under `smolvm sandbox ...`; utility verbs stay top-level; and agent harnesses are exposed as top-level nouns with `claude` as the canonical Claude command. Cleanup remains part of `smolvm sandbox delete --all --force`, with no separate cleanup command.

## What changed

- Added `src/smolvm/cli/commands/` for Click command registration and shared option helpers.
- Removed old top-level lifecycle verbs from the public command tree and docs.
- Moved env commands to `smolvm sandbox env set|unset|list`.
- Moved file commands to `smolvm sandbox file upload|download`.
- Moved snapshot commands to `smolvm sandbox snapshot create|restore|delete|list`.
- Moved port commands to `smolvm sandbox port expose|close|list`.
- Kept cleanup folded into `smolvm sandbox delete --all --force`.
- Removed the standalone `smolvm-delete` packaging entrypoint.
- Added direct `click>=8.0` runtime dependency.
- Kept Rich as the human-output renderer and Click native help.
- Standardized JSON envelopes through the CLI output boundary, including parse/runtime error paths.
- Refactored cleanup, update, prune, and setup wiring away from parser-shaped `Namespace` inputs.
- Updated docs and tests to the new noun-verb command surface.

## Validation

Passed:

- `uv run ruff check .`
- `uv run pytest tests/test_cleanup.py tests/test_update.py tests/test_prune.py tests/test_version.py tests/test_cli.py tests/test_workspace.py tests/test_kvm_session.py -q` (272 passed)
- `uv run pytest tests/test_cli.py tests/test_cleanup.py tests/test_kvm_session.py tests/test_facade.py -q` (337 passed, 8 skipped)
- `uv run pytest tests/test_cli.py tests/test_kvm_session.py tests/test_ssh.py -q` (229 passed)
- `uv run mypy src/smolvm/cli/commands src/smolvm/cli/update.py src/smolvm/cli/cleanup.py src/smolvm/cli/prune.py`

Smoke checked:

- Root help hides `env`, `file`, `snapshot`, and `port`.
- `smolvm sandbox --help` lists `env`, `file`, `snapshot`, and `port`.
- Old root `smolvm env --help` and `smolvm file --help` return parse errors.
- `smolvm sandbox env set --json` parse failures emit JSON with `command: sandbox.env.set` and no stderr output.

Notes:

- Full `uv run pytest` currently has environment-sensitive failures unrelated to this CLI refactor: local `127.0.0.1:2200` is occupied by `qemu-syst`, sparse-file block accounting assertions fail on this APFS temp volume, and one macOS UDS path exceeds the socket path length.
- Full `uv run mypy .` remains blocked by existing missing optional modules/stubs in examples and integrations.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added browser sandbox support with headless mode and Chrome DevTools Protocol exposure.

* **Bug Fixes**
  * Updated CLI to consistently use the `smolvm sandbox …` namespace for sandbox lifecycle and related recovery commands.
  * Improved JSON output consistency and error fields (including clearer refusal/error codes).

* **Documentation**
  * Updated README and deep-dive/benchmark docs to use `smolvm sandbox …` commands across all examples.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->