### PR TITLE
Use QEMU hostfwd for localhost exposure

### DIFF
--- a/src/smolvm/browser.py
+++ b/src/smolvm/browser.py
@@ -641,7 +641,7 @@ class _BrowserSandbox:
         if self._vm is None:
             raise SmolVMError("Browser sandbox VM is unavailable.")
 
-        return self._vm.expose_local(guest_port=guest_port)
+        return self._vm.expose_local(guest_port=guest_port, guest_loopback=True)
 
     def _wait_for_guest_port(self, port: int, *, timeout: float) -> bool:
         if self._vm is None:

--- a/src/smolvm/facade.py
+++ b/src/smolvm/facade.py
@@ -74,6 +74,7 @@ from smolvm.images.cloud_init import (
 )
 from smolvm.images.manager import ImageManager
 from smolvm.kernels import ensure_base_kernel_for_backend
+from smolvm.qmp import QMPClient
 from smolvm.runtime.backends import (
     BACKEND_FIRECRACKER,
     BACKEND_LIBKRUN,
@@ -882,7 +883,7 @@ class _LocalForward:
 
     host_port: int
     guest_port: int
-    transport: Literal["nftables", "ssh_tunnel"]
+    transport: Literal["nftables", "qemu_hostfwd", "ssh_tunnel"]
     tunnel_proc: subprocess.Popen[str] | None = None
 
 
@@ -2228,6 +2229,7 @@ class SmolVM:
         guest_ip = self._info.network.guest_ip
         attempts: list[str] = []
         should_try_nftables = self._should_try_nftables_local_forward()
+        should_try_qemu_hostfwd = self._should_try_qemu_hostfwd_local_forward()
 
         for candidate in candidate_ports:
             key = (candidate, guest_port)
@@ -2278,6 +2280,44 @@ class SmolVM:
                             self._sdk.network.cleanup_local_port_forward(
                                 vm_id=self._vm_id,
                                 guest_ip=guest_ip,
+                                host_port=candidate,
+                                guest_port=guest_port,
+                            )
+
+            qemu_hostfwd_configured = False
+            keep_qemu_hostfwd = False
+            if should_try_qemu_hostfwd:
+                try:
+                    self._add_qemu_hostfwd(host_port=candidate, guest_port=guest_port)
+                    qemu_hostfwd_configured = True
+                    if self._probe_local_forward(candidate):
+                        self._local_forwards[key] = _LocalForward(
+                            host_port=candidate,
+                            guest_port=guest_port,
+                            transport="qemu_hostfwd",
+                        )
+                        keep_qemu_hostfwd = True
+                        logger.info(
+                            "VM %s exposed localhost:%d -> guest:%d "
+                            "(transport=qemu_hostfwd)",
+                            self._vm_id,
+                            candidate,
+                            guest_port,
+                        )
+                        return candidate
+                    attempts.append(
+                        f"qemu hostfwd localhost:{candidate} -> guest:{guest_port} "
+                        "was configured but not reachable"
+                    )
+                except Exception as e:
+                    attempts.append(
+                        f"qemu hostfwd localhost:{candidate} -> guest:{guest_port} "
+                        f"failed: {e}"
+                    )
+                finally:
+                    if qemu_hostfwd_configured and not keep_qemu_hostfwd:
+                        with suppress(Exception):
+                            self._remove_qemu_hostfwd(
                                 host_port=candidate,
                                 guest_port=guest_port,
                             )
@@ -2333,6 +2373,10 @@ class SmolVM:
             return self
 
         self._refresh_info()
+        if self._should_try_qemu_hostfwd_local_forward():
+            self._remove_qemu_hostfwd(host_port=host_port, guest_port=guest_port)
+            return self
+
         if self._info.network is None:
             raise SmolVMError(
                 "Cannot remove local port forward: VM has no network configuration",
@@ -3205,6 +3249,45 @@ modprobe 9pnet_virtio""".strip()
         backend = getattr(config, "backend", None)
         return backend not in {BACKEND_QEMU, BACKEND_LIBKRUN}
 
+    def _should_try_qemu_hostfwd_local_forward(self) -> bool:
+        """Return whether localhost exposure should use QEMU's slirp hostfwd."""
+        config = getattr(self._info, "config", None)
+        backend = getattr(config, "backend", None)
+        qemu_network = getattr(config, "qemu_network", None)
+        return (
+            backend == BACKEND_QEMU
+            and qemu_network == "slirp"
+            and getattr(self._info, "control_socket_path", None) is not None
+        )
+
+    def _execute_qemu_human_monitor_command(self, command_line: str) -> None:
+        """Execute a QEMU human monitor command through the VM's QMP socket."""
+        control_socket_path = getattr(self._info, "control_socket_path", None)
+        if control_socket_path is None:
+            raise SmolVMError(
+                "Cannot update QEMU hostfwd: VM has no QMP control socket",
+                {"vm_id": self._vm_id},
+            )
+
+        with QMPClient(Path(control_socket_path)) as client:
+            client.connect()
+            client.execute(
+                "human-monitor-command",
+                {"command-line": command_line},
+            )
+
+    def _add_qemu_hostfwd(self, host_port: int, guest_port: int) -> None:
+        """Add a QEMU slirp hostfwd rule for localhost exposure."""
+        self._execute_qemu_human_monitor_command(
+            f"hostfwd_add net0 tcp:127.0.0.1:{host_port}-:{guest_port}"
+        )
+
+    def _remove_qemu_hostfwd(self, host_port: int, guest_port: int) -> None:
+        """Remove a QEMU slirp hostfwd rule for localhost exposure."""
+        self._execute_qemu_human_monitor_command(
+            f"hostfwd_remove net0 tcp:127.0.0.1:{host_port}"
+        )
+
     @staticmethod
     def _find_available_local_port() -> int:
         """Return an available TCP port bound on localhost."""
@@ -3356,6 +3439,13 @@ modprobe 9pnet_virtio""".strip()
         """Remove one tracked localhost exposure."""
         if forward.transport == "ssh_tunnel":
             self._stop_local_tunnel(forward.tunnel_proc)
+            return
+
+        if forward.transport == "qemu_hostfwd":
+            self._remove_qemu_hostfwd(
+                host_port=forward.host_port,
+                guest_port=forward.guest_port,
+            )
             return
 
         if guest_ip is None:

--- a/src/smolvm/facade.py
+++ b/src/smolvm/facade.py
@@ -2180,7 +2180,13 @@ class SmolVM:
         command.append(f"{self._ssh_user}@{host}")
         return command
 
-    def expose_local(self, guest_port: int, host_port: int | None = None) -> int:
+    def expose_local(
+        self,
+        guest_port: int,
+        host_port: int | None = None,
+        *,
+        guest_loopback: bool = False,
+    ) -> int:
         """Expose a guest TCP port on localhost only.
 
         Forwards ``127.0.0.1:<host_port>`` on the host to
@@ -2189,6 +2195,9 @@ class SmolVM:
         Args:
             guest_port: Guest TCP port to expose.
             host_port: Host localhost port. If omitted, an available port is chosen.
+            guest_loopback: Route to guest 127.0.0.1 instead of the guest's
+                network address. This uses an SSH tunnel and is required for
+                services that bind guest loopback only.
 
         Returns:
             The host localhost port to connect to.
@@ -2228,8 +2237,10 @@ class SmolVM:
 
         guest_ip = self._info.network.guest_ip
         attempts: list[str] = []
-        should_try_nftables = self._should_try_nftables_local_forward()
-        should_try_qemu_hostfwd = self._should_try_qemu_hostfwd_local_forward()
+        should_try_nftables = not guest_loopback and self._should_try_nftables_local_forward()
+        should_try_qemu_hostfwd = (
+            not guest_loopback and self._should_try_qemu_hostfwd_local_forward()
+        )
 
         for candidate in candidate_ports:
             key = (candidate, guest_port)
@@ -2298,8 +2309,7 @@ class SmolVM:
                         )
                         keep_qemu_hostfwd = True
                         logger.info(
-                            "VM %s exposed localhost:%d -> guest:%d "
-                            "(transport=qemu_hostfwd)",
+                            "VM %s exposed localhost:%d -> guest:%d (transport=qemu_hostfwd)",
                             self._vm_id,
                             candidate,
                             guest_port,
@@ -2311,8 +2321,7 @@ class SmolVM:
                     )
                 except Exception as e:
                     attempts.append(
-                        f"qemu hostfwd localhost:{candidate} -> guest:{guest_port} "
-                        f"failed: {e}"
+                        f"qemu hostfwd localhost:{candidate} -> guest:{guest_port} failed: {e}"
                     )
                 finally:
                     if qemu_hostfwd_configured and not keep_qemu_hostfwd:
@@ -3284,9 +3293,7 @@ modprobe 9pnet_virtio""".strip()
 
     def _remove_qemu_hostfwd(self, host_port: int, guest_port: int) -> None:
         """Remove a QEMU slirp hostfwd rule for localhost exposure."""
-        self._execute_qemu_human_monitor_command(
-            f"hostfwd_remove net0 tcp:127.0.0.1:{host_port}"
-        )
+        self._execute_qemu_human_monitor_command(f"hostfwd_remove net0 tcp:127.0.0.1:{host_port}")
 
     @staticmethod
     def _find_available_local_port() -> int:

--- a/tests/test_browser.py
+++ b/tests/test_browser.py
@@ -473,7 +473,7 @@ def test_browser_sandbox_start_uses_expose_local_for_qemu_cdp(
     session.start()
 
     assert session.cdp_url == "http://127.0.0.1:39222"
-    vm.expose_local.assert_called_once_with(guest_port=9222)
+    vm.expose_local.assert_called_once_with(guest_port=9222, guest_loopback=True)
     session.close()
 
 
@@ -520,8 +520,8 @@ def test_desktop_sandbox_start_exposes_viewer_and_display_only(
     assert session.viewer_url == "http://127.0.0.1:36080/vnc.html?autoconnect=1&resize=scale"
     assert session.display_url == "vnc://127.0.0.1:35900"
     assert [call.kwargs for call in vm.expose_local.call_args_list] == [
-        {"guest_port": 6080},
-        {"guest_port": 5900},
+        {"guest_port": 6080, "guest_loopback": True},
+        {"guest_port": 5900, "guest_loopback": True},
     ]
     session.close()
 

--- a/tests/test_facade.py
+++ b/tests/test_facade.py
@@ -2248,9 +2248,7 @@ class TestVMQemuLocalExpose:
         sample_config: VMConfig,
         tmp_path: Path,
     ) -> SmolVM:
-        config = sample_config.model_copy(
-            update={"backend": "qemu", "qemu_network": "slirp"}
-        )
+        config = sample_config.model_copy(update={"backend": "qemu", "qemu_network": "slirp"})
         mock_network = MagicMock()
         mock_network.guest_ip = "10.0.2.15"
 
@@ -2395,6 +2393,35 @@ class TestVMQemuLocalExpose:
                 {"command-line": "hostfwd_remove net0 tcp:127.0.0.1:18080"},
             ),
         ]
+
+    @patch("smolvm.facade.SmolVMManager")
+    def test_qemu_guest_loopback_exposure_uses_ssh_tunnel(
+        self,
+        mock_sdk_cls: MagicMock,
+        sample_config: VMConfig,
+        tmp_path: Path,
+    ) -> None:
+        tunnel_proc = MagicMock()
+        with (
+            patch("smolvm.facade.QMPClient") as mock_qmp_cls,
+            patch("smolvm.facade.SmolVM._allocate_local_port", return_value=18081),
+            patch(
+                "smolvm.facade.SmolVM._start_local_tunnel",
+                return_value=tunnel_proc,
+            ) as mock_start_tunnel,
+        ):
+            vm = self._running_qemu_vm(mock_sdk_cls, sample_config, tmp_path)
+
+            host_port = vm.expose_local(
+                guest_port=8080,
+                host_port=18080,
+                guest_loopback=True,
+            )
+
+        assert host_port == 18080
+        mock_qmp_cls.assert_not_called()
+        mock_sdk_cls.return_value.network.setup_local_port_forward.assert_not_called()
+        mock_start_tunnel.assert_called_once_with(host_port=18080, guest_port=8080)
 
 
 @pytest.mark.skip(reason="Fails in macOS secure sandboxes due to bind restrictions")

--- a/tests/test_facade.py
+++ b/tests/test_facade.py
@@ -2239,6 +2239,164 @@ class TestVMRun:
             vm.run("echo test")
 
 
+class TestVMQemuLocalExpose:
+    """Tests for QEMU slirp localhost exposure."""
+
+    @staticmethod
+    def _running_qemu_vm(
+        mock_sdk_cls: MagicMock,
+        sample_config: VMConfig,
+        tmp_path: Path,
+    ) -> SmolVM:
+        config = sample_config.model_copy(
+            update={"backend": "qemu", "qemu_network": "slirp"}
+        )
+        mock_network = MagicMock()
+        mock_network.guest_ip = "10.0.2.15"
+
+        mock_info = MagicMock()
+        mock_info.vm_id = "vm001"
+        mock_info.status = VMState.RUNNING
+        mock_info.network = mock_network
+        mock_info.config = config
+        mock_info.control_socket_path = tmp_path / "vm001.qmp"
+
+        mock_sdk = MagicMock()
+        mock_sdk.create.return_value = MagicMock(vm_id="vm001", status=VMState.CREATED)
+        mock_sdk.get.return_value = mock_info
+        mock_sdk.network = MagicMock()
+        mock_sdk_cls.return_value = mock_sdk
+
+        return SmolVM(config)
+
+    @staticmethod
+    def _qmp_client(mock_qmp_cls: MagicMock) -> MagicMock:
+        client = MagicMock()
+        mock_qmp_cls.return_value.__enter__.return_value = client
+        return client
+
+    @patch("smolvm.facade.SmolVMManager")
+    def test_qemu_slirp_expose_local_uses_qmp_hostfwd_before_ssh(
+        self,
+        mock_sdk_cls: MagicMock,
+        sample_config: VMConfig,
+        tmp_path: Path,
+    ) -> None:
+        with (
+            patch("smolvm.facade.QMPClient") as mock_qmp_cls,
+            patch("smolvm.facade.SmolVM._allocate_local_port", return_value=18081),
+            patch("smolvm.facade.SmolVM._probe_local_forward", return_value=True),
+            patch("smolvm.facade.SmolVM._start_local_tunnel") as mock_start_tunnel,
+        ):
+            client = self._qmp_client(mock_qmp_cls)
+            vm = self._running_qemu_vm(mock_sdk_cls, sample_config, tmp_path)
+
+            host_port = vm.expose_local(guest_port=8080, host_port=18080)
+
+        assert host_port == 18080
+        mock_qmp_cls.assert_called_once_with(tmp_path / "vm001.qmp")
+        client.connect.assert_called_once_with()
+        client.execute.assert_called_once_with(
+            "human-monitor-command",
+            {"command-line": "hostfwd_add net0 tcp:127.0.0.1:18080-:8080"},
+        )
+        mock_start_tunnel.assert_not_called()
+        mock_sdk_cls.return_value.network.setup_local_port_forward.assert_not_called()
+
+    @patch("smolvm.facade.SmolVMManager")
+    def test_unexpose_local_removes_qemu_hostfwd(
+        self,
+        mock_sdk_cls: MagicMock,
+        sample_config: VMConfig,
+        tmp_path: Path,
+    ) -> None:
+        with (
+            patch("smolvm.facade.QMPClient") as mock_qmp_cls,
+            patch("smolvm.facade.SmolVM._allocate_local_port", return_value=18081),
+            patch("smolvm.facade.SmolVM._probe_local_forward", return_value=True),
+        ):
+            client = self._qmp_client(mock_qmp_cls)
+            vm = self._running_qemu_vm(mock_sdk_cls, sample_config, tmp_path)
+
+            vm.expose_local(guest_port=8080, host_port=18080)
+            vm.unexpose_local(host_port=18080, guest_port=8080)
+
+        assert client.execute.call_args_list == [
+            call(
+                "human-monitor-command",
+                {"command-line": "hostfwd_add net0 tcp:127.0.0.1:18080-:8080"},
+            ),
+            call(
+                "human-monitor-command",
+                {"command-line": "hostfwd_remove net0 tcp:127.0.0.1:18080"},
+            ),
+        ]
+
+    @patch("smolvm.facade.SmolVMManager")
+    def test_qemu_hostfwd_failure_falls_back_to_ssh_tunnel(
+        self,
+        mock_sdk_cls: MagicMock,
+        sample_config: VMConfig,
+        tmp_path: Path,
+    ) -> None:
+        tunnel_proc = MagicMock()
+        with (
+            patch("smolvm.facade.QMPClient") as mock_qmp_cls,
+            patch("smolvm.facade.SmolVM._allocate_local_port", return_value=18081),
+            patch("smolvm.facade.SmolVM._probe_local_forward", return_value=False),
+            patch(
+                "smolvm.facade.SmolVM._start_local_tunnel",
+                return_value=tunnel_proc,
+            ) as mock_start_tunnel,
+        ):
+            client = self._qmp_client(mock_qmp_cls)
+            client.execute.side_effect = SmolVMError("qmp unavailable")
+            vm = self._running_qemu_vm(mock_sdk_cls, sample_config, tmp_path)
+
+            host_port = vm.expose_local(guest_port=8080, host_port=18080)
+
+        assert host_port == 18080
+        client.execute.assert_called_once_with(
+            "human-monitor-command",
+            {"command-line": "hostfwd_add net0 tcp:127.0.0.1:18080-:8080"},
+        )
+        mock_start_tunnel.assert_called_once_with(host_port=18080, guest_port=8080)
+
+    @patch("smolvm.facade.SmolVMManager")
+    def test_qemu_hostfwd_probe_failure_removes_rule_before_ssh_fallback(
+        self,
+        mock_sdk_cls: MagicMock,
+        sample_config: VMConfig,
+        tmp_path: Path,
+    ) -> None:
+        tunnel_proc = MagicMock()
+        with (
+            patch("smolvm.facade.QMPClient") as mock_qmp_cls,
+            patch("smolvm.facade.SmolVM._allocate_local_port", return_value=18081),
+            patch("smolvm.facade.SmolVM._probe_local_forward", return_value=False),
+            patch(
+                "smolvm.facade.SmolVM._start_local_tunnel",
+                return_value=tunnel_proc,
+            ),
+        ):
+            client = self._qmp_client(mock_qmp_cls)
+            vm = self._running_qemu_vm(mock_sdk_cls, sample_config, tmp_path)
+
+            host_port = vm.expose_local(guest_port=8080, host_port=18080)
+
+        assert host_port == 18080
+        assert client.execute.call_args_list == [
+            call(
+                "human-monitor-command",
+                {"command-line": "hostfwd_add net0 tcp:127.0.0.1:18080-:8080"},
+            ),
+            call(
+                "human-monitor-command",
+                {"command-line": "hostfwd_remove net0 tcp:127.0.0.1:18080"},
+            ),
+        ]
+
+
 @pytest.mark.skip(reason="Fails in macOS secure sandboxes due to bind restrictions")
 class TestVMLocalExpose:
     """Tests for localhost-only port exposure."""


### PR DESCRIPTION
## Summary
- prefer QMP hostfwd for QEMU slirp `expose_local()` before falling back to SSH tunneling
- track `qemu_hostfwd` forwards and remove them during `unexpose_local()`/cleanup
- add facade tests for QMP add/remove, probe cleanup, and SSH fallback

## Tests
- `uv run pytest tests/test_facade.py -q`
- `uv run ruff check src/smolvm/facade.py tests/test_facade.py`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a new optional `guest_loopback` mode for local port exposure, ensuring browser-related ports are routed via the guest loopback path.
  * Enhanced localhost port exposure for QEMU by introducing an additional host forwarding transport (with reachability checks and automatic fallback).

* **Bug Fixes**
  * Improved `unexpose_local()` cleanup to reliably remove QEMU forwarding rules without relying on guest network metadata.

* **Tests**
  * Added QEMU localhost expose/unexpose test coverage, including host forwarding success, error fallback, probe-failure cleanup, and `guest_loopback` behavior.

* **Documentation**
  * Updated browser port exposure to pass `guest_loopback=True` in tests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->