### PR TITLE
[codex] Add dedicated guest sync endpoint

### DIFF
--- a/guest-agent/src/files.rs
+++ b/guest-agent/src/files.rs
@@ -144,6 +144,9 @@ pub async fn get_file(query: FileGetQuery) -> FileGetResponse {
 mod tests {
     use super::*;
     use std::fs;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+
+    static TEMPFILE_COUNTER: AtomicUsize = AtomicUsize::new(0);
 
     #[tokio::test]
     async fn put_and_get_file_preserves_mode() {
@@ -257,10 +260,7 @@ mod tests {
         let path = std::env::temp_dir().join(format!(
             "smolvm-agent-test-{}-{}",
             std::process::id(),
-            std::time::SystemTime::now()
-                .duration_since(std::time::UNIX_EPOCH)
-                .unwrap_or_default()
-                .as_nanos()
+            TEMPFILE_COUNTER.fetch_add(1, Ordering::Relaxed)
         ));
         fs::create_dir(&path).unwrap();
         path

--- a/guest-agent/src/handler.rs
+++ b/guest-agent/src/handler.rs
@@ -21,6 +21,7 @@ pub fn router() -> Router {
         .route("/version", get(handle_version))
         .route("/capabilities", get(handle_capabilities))
         .route("/exec", post(handle_exec))
+        .route("/sync", post(handle_sync))
         .route(
             "/files/put",
             post(handle_file_put).layer(DefaultBodyLimit::max(FILE_PUT_BODY_LIMIT_BYTES)),
@@ -33,6 +34,7 @@ pub fn extension_router() -> Router {
     Router::new()
         .route("/version", get(handle_version))
         .route("/capabilities", get(handle_capabilities))
+        .route("/sync", post(handle_sync))
         .route(
             "/files/put",
             post(handle_file_put).layer(DefaultBodyLimit::max(FILE_PUT_BODY_LIMIT_BYTES)),
@@ -93,6 +95,7 @@ pub async fn handle_capabilities() -> Json<CapabilitiesResponse> {
             "GET /version",
             "GET /capabilities",
             "POST /exec",
+            "POST /sync",
             "POST /files/put",
             "GET /files/get",
         ],
@@ -104,6 +107,27 @@ pub async fn handle_capabilities() -> Json<CapabilitiesResponse> {
 
 pub async fn handle_exec(Json(req): Json<ExecRequest>) -> Json<ExecResponse> {
     Json(exec::run_command(req).await)
+}
+
+#[derive(Serialize)]
+pub struct SyncResponse {
+    pub ok: bool,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub error: Option<String>,
+}
+
+pub async fn handle_sync() -> Json<SyncResponse> {
+    let result = tokio::task::spawn_blocking(|| unsafe { libc::sync() }).await;
+    match result {
+        Ok(()) => Json(SyncResponse {
+            ok: true,
+            error: None,
+        }),
+        Err(error) => Json(SyncResponse {
+            ok: false,
+            error: Some(format!("sync task failed: {error}")),
+        }),
+    }
 }
 
 pub async fn handle_file_put(Json(req): Json<FilePutRequest>) -> Json<FilePutResponse> {
@@ -148,6 +172,7 @@ mod tests {
         assert_eq!(capabilities.body["prod_metrics_enabled"], false);
         let endpoints = capabilities.body["endpoints"].as_array().unwrap();
         assert!(endpoints.contains(&json!("POST /exec")));
+        assert!(endpoints.contains(&json!("POST /sync")));
         assert!(endpoints.contains(&json!("POST /files/put")));
         assert!(endpoints.contains(&json!("GET /files/get")));
     }
@@ -174,6 +199,15 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn public_router_sync_flushes_filesystems() {
+        let response = request_json(router(), "POST", "/sync", None).await;
+
+        assert_eq!(response.status, StatusCode::OK);
+        assert_eq!(response.body["ok"], true);
+        assert_eq!(response.body.get("error"), None);
+    }
+
+    #[tokio::test]
     async fn extension_router_leaves_private_health_and_exec_routes_to_consumer() {
         let version = request_json(extension_router(), "GET", "/version", None).await;
         assert_eq!(version.status, StatusCode::OK);
@@ -189,6 +223,10 @@ mod tests {
         )
         .await;
         assert_eq!(exec.status(), StatusCode::NOT_FOUND);
+
+        let sync = request_json(extension_router(), "POST", "/sync", None).await;
+        assert_eq!(sync.status, StatusCode::OK);
+        assert_eq!(sync.body["ok"], true);
     }
 
     struct JsonResponse {

--- a/guest-agent/src/server.rs
+++ b/guest-agent/src/server.rs
@@ -1,5 +1,4 @@
 use axum::Router;
-use tracing::info;
 
 pub const DEFAULT_LISTEN: &str = "vsock://1024";
 
@@ -29,7 +28,7 @@ pub async fn serve_vsock(app: Router, port: u32) {
 
     let addr = VsockAddr::new(u32::MAX, port);
     let mut listener = VsockListener::bind(addr).expect("failed to bind vsock");
-    info!("Listening on vsock://{port}");
+    tracing::info!("Listening on vsock://{port}");
 
     loop {
         match listener.accept().await {
@@ -62,7 +61,7 @@ pub async fn serve_vsock(_app: Router, _port: u32) {
 
 #[cfg(feature = "tcp")]
 pub async fn serve_tcp(app: Router, addr: &str) {
-    info!("Listening on tcp://{addr}");
+    tracing::info!("Listening on tcp://{addr}");
     let listener = tokio::net::TcpListener::bind(addr)
         .await
         .expect("failed to bind TCP listener");

--- a/src/smolvm/comm/base.py
+++ b/src/smolvm/comm/base.py
@@ -59,6 +59,10 @@ class CommChannel(Protocol):
         """Execute *command* on the guest and return its result."""
         ...
 
+    def sync(self, timeout: float = 10) -> None:
+        """Flush guest filesystem buffers."""
+        ...
+
     def put_file(self, local_path: str | Path, remote_path: str) -> None:
         """Upload a local file to *remote_path* in the guest."""
         ...

--- a/src/smolvm/comm/base.py
+++ b/src/smolvm/comm/base.py
@@ -61,7 +61,7 @@ class CommChannel(Protocol):
 
     def sync(self, timeout: float = 10) -> None:
         """Flush guest filesystem buffers."""
-        ...
+        pass
 
     def put_file(self, local_path: str | Path, remote_path: str) -> None:
         """Upload a local file to *remote_path* in the guest."""

--- a/src/smolvm/comm/rust_http_vsock_channel.py
+++ b/src/smolvm/comm/rust_http_vsock_channel.py
@@ -208,6 +208,13 @@ class RustHttpVsockChannel:
             stderr=str(resp.get("stderr", "")),
         )
 
+    def sync(self, timeout: float = 10) -> None:
+        if timeout <= 0:
+            raise ValueError("timeout must be > 0")
+        resp = self._request_json("POST", "/sync", timeout=float(timeout + self.connect_timeout))
+        if not resp.get("ok"):
+            raise SmolVMError(f"guest agent error during sync: {resp.get('error', resp)}")
+
     def put_file(self, local_path: str | Path, remote_path: str) -> None:
         if not remote_path:
             raise ValueError("remote_path cannot be empty")

--- a/src/smolvm/facade.py
+++ b/src/smolvm/facade.py
@@ -1683,6 +1683,8 @@ class SmolVM:
         channel = self._ensure_control_for_operation(action="create a disk snapshot", timeout=10.0)
         try:
             channel.sync(timeout=10)
+        except OperationTimeoutError:
+            raise
         except Exception as exc:
             raise SmolVMError(
                 f"Cannot create disk snapshot for sandbox '{self._vm_id}' because syncing "

--- a/src/smolvm/facade.py
+++ b/src/smolvm/facade.py
@@ -1681,13 +1681,14 @@ class SmolVM:
         if self._info.status != VMState.RUNNING:
             return
         channel = self._ensure_control_for_operation(action="create a disk snapshot", timeout=10.0)
-        result = channel.run("sync", timeout=10, shell="raw")
-        if result.exit_code != 0:
+        try:
+            channel.sync(timeout=10)
+        except Exception as exc:
             raise SmolVMError(
                 f"Cannot create disk snapshot for sandbox '{self._vm_id}' because syncing "
                 f"files inside it failed; retry with 'smolvm sandbox snapshot create "
                 f"{self._vm_id} --snapshot-type disk'."
-            )
+            ) from exc
 
     def delete(self) -> None:
         """Delete the VM and release all resources."""

--- a/src/smolvm/ssh.py
+++ b/src/smolvm/ssh.py
@@ -22,6 +22,7 @@ eliminating the ~170ms overhead of forking a new ``ssh`` process per call.
 
 import base64
 import logging
+import math
 import shlex
 import socket
 import stat
@@ -393,6 +394,15 @@ class SSHClient:
             raise SmolVMError(f"SSH command failed: {e}") from e
         except Exception as e:
             raise SmolVMError(f"SSH command failed: {e}") from e
+
+    def sync(self, timeout: float = 10) -> None:
+        """Flush guest filesystem buffers through the SSH control channel."""
+        if timeout <= 0:
+            raise ValueError("timeout must be > 0")
+        result = self.run("sync", timeout=math.ceil(timeout), shell="raw")
+        if result.exit_code != 0:
+            detail = result.stderr.strip() or result.stdout.strip() or "no output"
+            raise SmolVMError(f"guest sync failed over SSH: {detail}")
 
     # ── Readiness detection ─────────────────────────────────────
 

--- a/tests/test_facade.py
+++ b/tests/test_facade.py
@@ -676,6 +676,23 @@ class TestSnapshot:
         ):
             vm._sync_guest_for_disk_snapshot()
 
+    def test_disk_snapshot_sync_timeout_preserves_operation_context(self) -> None:
+        """Timeouts should keep the low-level operation name visible to callers."""
+        vm = SmolVM.__new__(SmolVM)
+        vm._vm_id = "vm001"
+        vm._info = MagicMock(status=VMState.RUNNING)
+        vm._refresh_info = MagicMock()
+
+        channel = MagicMock()
+        channel.sync.side_effect = OperationTimeoutError(
+            "guest agent request: POST /sync",
+            10.0,
+        )
+        vm._ensure_control_for_operation = MagicMock(return_value=channel)
+
+        with pytest.raises(OperationTimeoutError, match=r"POST /sync"):
+            vm._sync_guest_for_disk_snapshot()
+
 
 class TestFromBootImage:
     """Tests for SmolVM.from_image()."""

--- a/tests/test_facade.py
+++ b/tests/test_facade.py
@@ -28,7 +28,6 @@ from smolvm.exceptions import (
 from smolvm.facade import SmolVM, _build_auto_config
 from smolvm.images import BootImage, DirectKernelBoot, FirmwareBoot
 from smolvm.types import (
-    CommandResult,
     GuestOS,
     PortForwardConfig,
     SnapshotType,
@@ -635,14 +634,13 @@ class TestSnapshot:
         vm._reset_runtime_state = MagicMock()
 
         channel = MagicMock()
-        channel.run.return_value = CommandResult(exit_code=0, stdout="", stderr="")
         vm._ensure_control_for_operation = MagicMock(return_value=channel)
         vm._sdk = MagicMock()
         snapshot = MagicMock()
         vm._sdk.create_snapshot.return_value = snapshot
 
         order = MagicMock()
-        order.attach_mock(channel.run, "sync")
+        order.attach_mock(channel.sync, "sync")
         order.attach_mock(vm._sdk.create_snapshot, "create_snapshot")
 
         assert vm.snapshot(snapshot_type=SnapshotType.DISK) is snapshot
@@ -652,7 +650,7 @@ class TestSnapshot:
             timeout=10.0,
         )
         assert order.mock_calls == [
-            call.sync("sync", timeout=10, shell="raw"),
+            call.sync(timeout=10),
             call.create_snapshot(
                 "vm001",
                 snapshot_id=None,
@@ -669,7 +667,7 @@ class TestSnapshot:
         vm._refresh_info = MagicMock()
 
         channel = MagicMock()
-        channel.run.return_value = CommandResult(exit_code=1, stdout="", stderr="sync failed")
+        channel.sync.side_effect = SmolVMError("sync failed")
         vm._ensure_control_for_operation = MagicMock(return_value=channel)
 
         with pytest.raises(

--- a/tests/test_rust_http_vsock_channel.py
+++ b/tests/test_rust_http_vsock_channel.py
@@ -20,6 +20,7 @@ import base64
 import json
 import queue
 import socket
+import tempfile
 import threading
 from collections.abc import Callable
 from pathlib import Path
@@ -119,8 +120,9 @@ def test_wait_ready_polls_quickly_during_early_boot(monkeypatch: pytest.MonkeyPa
     assert sleeps == [0.02, 0.02]
 
 
-def test_from_uds_closes_socket_when_connect_rejected(tmp_path: Path) -> None:
-    uds = str(tmp_path / "vsock.sock")
+def test_from_uds_closes_socket_when_connect_rejected() -> None:
+    sock_dir = tempfile.TemporaryDirectory(prefix="svsock-", dir="/tmp")
+    uds = str(Path(sock_dir.name) / "vsock.sock")
     server = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
     server.bind(uds)
     server.listen(1)
@@ -150,6 +152,7 @@ def test_from_uds_closes_socket_when_connect_rejected(tmp_path: Path) -> None:
     finally:
         server.close()
         thread.join(timeout=5)
+        sock_dir.cleanup()
 
 
 def test_run_maps_command_result() -> None:
@@ -200,6 +203,23 @@ def test_run_timeout_maps_to_operation_timeout() -> None:
     )
     with pytest.raises(OperationTimeoutError):
         channel.run("sleep 10", timeout=1)
+
+
+def test_sync_posts_dedicated_endpoint() -> None:
+    def _handler(method: str, path: str, body: bytes) -> dict:
+        assert method == "POST"
+        assert path == "/sync"
+        assert body == b""
+        return {"ok": True}
+
+    FakeRustChannel([_handler]).sync(timeout=10)
+
+
+def test_sync_error_maps_to_smolvm_error() -> None:
+    channel = FakeRustChannel([lambda method, path, body: {"ok": False, "error": "busy"}])
+
+    with pytest.raises(SmolVMError, match="busy"):
+        channel.sync()
 
 
 def test_put_and_get_file(tmp_path: Path) -> None:

--- a/tests/test_ssh.py
+++ b/tests/test_ssh.py
@@ -238,6 +238,30 @@ class TestSSHClientRun:
         remote_command = mock_client.exec_command.call_args.args[0]
         assert remote_command == "uname -r"
 
+    @patch.object(SSHClient, "_ensure_connected")
+    def test_sync_uses_raw_sync_command(self, mock_connected: MagicMock) -> None:
+        mock_client = MagicMock()
+        mock_client.exec_command.return_value = _mock_exec_result(0, "", "")
+        mock_connected.return_value = mock_client
+
+        client = SSHClient("172.16.0.2")
+        client.sync(timeout=10.1)
+
+        remote_command = mock_client.exec_command.call_args.args[0]
+        timeout = mock_client.exec_command.call_args.kwargs["timeout"]
+        assert remote_command == "sync"
+        assert timeout == 11
+
+    @patch.object(SSHClient, "_ensure_connected")
+    def test_sync_nonzero_raises(self, mock_connected: MagicMock) -> None:
+        mock_client = MagicMock()
+        mock_client.exec_command.return_value = _mock_exec_result(1, "", "sync failed")
+        mock_connected.return_value = mock_client
+
+        client = SSHClient("172.16.0.2")
+        with pytest.raises(SmolVMError, match="sync failed"):
+            client.sync()
+
 
 class TestSSHClientWaitForSSH:
     """Tests for SSH readiness polling."""


### PR DESCRIPTION
## Summary

- Add `POST /sync` to the Rust guest-agent router and extension router.
- Implement sync with `libc::sync()` behind `tokio::task::spawn_blocking`, avoiding shell/process exec.
- Add `RustHttpVsockChannel.sync()` and route disk snapshot preflight through the dedicated sync API.
- Keep SSH/raw channels on the channel-level `sync()` abstraction for non-vsock paths.

## Why

Disk snapshot preflight should not depend on generic guest exec. A dedicated sync endpoint makes the snapshot failure boundary explicit and avoids shelling out through `/exec` just to flush filesystems.

## Validation

- `cargo test -p smolvm-guest-agent`
- `uv run pytest tests/test_rust_http_vsock_channel.py tests/test_facade.py::TestSnapshot tests/test_ssh.py::TestSSHClientRun tests/test_comm.py` — 25 passed
- `uv run ruff check src/smolvm/comm/base.py src/smolvm/comm/rust_http_vsock_channel.py src/smolvm/ssh.py src/smolvm/facade.py tests/test_facade.py tests/test_rust_http_vsock_channel.py tests/test_ssh.py`

## Companion

Dataplane PR: https://github.com/CelestoAI/data-plane/pull/92

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added filesystem sync capability to ensure guest buffers are flushed before disk snapshots.

* **Refactor**
  * Updated guest filesystem sync logic to use a dedicated protocol method instead of shell commands.

* **Tests**
  * Added comprehensive test coverage for sync functionality across communication channels.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->