### PR TITLE
[codex] Migrate TAP networking to native Rust helper

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -878,7 +878,7 @@ checksum = "8ed6a63f02c8539c91a8685a86f4099661ba3da017932f6ebbea6de3f0fa7c90"
 
 [[package]]
 name = "smolvm-core"
-version = "0.0.14"
+version = "0.0.15"
 dependencies = [
  "futures-util",
  "libc",

--- a/docs/deep-dive/smolvm-core.md
+++ b/docs/deep-dive/smolvm-core.md
@@ -42,10 +42,13 @@ smolvm_core.delete_tap(name: str) -> None
 smolvm_core.flush_addrs(name: str) -> None
 smolvm_core.add_addr(name: str, ip: str, prefix_len: int) -> None
 smolvm_core.set_link_up(name: str) -> None
+smolvm_core.configure_tap(name: str, host_ip: str, prefix_len: int) -> None
 smolvm_core.add_route(dest: str, prefix_len: int, dev: str) -> None
 smolvm_core.get_default_interface() -> str
 smolvm_core.write_sysctl(key: str, value: str) -> None
 ```
+
+Use `configure_tap()` for normal TAP setup. It combines address flush, address assignment, and link-up into one native operation. SmolVM still writes the per-TAP sysctl from Python after this call.
 
 On macOS, the networking helpers raise `OSError("Not available on this platform")`. That is expected. SmolVM uses QEMU user-mode networking on macOS, so it does not need TAP setup there.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,7 @@ classifiers = [
 ]
 dependencies = [
     "click>=8.0",
-    "smolvm-core~=0.0.14",
+    "smolvm-core~=0.0.15",
     "paramiko>=3.0",
     "pycdlib>=1.14.0",
     "pydantic>=2.0",

--- a/scripts/benchmarks/README.md
+++ b/scripts/benchmarks/README.md
@@ -64,10 +64,12 @@ uv run python scripts/benchmarks/networking.py --include-full-start --output /tm
 
 This benchmark is Linux-only and touches real host networking. It expects the
 same privileges as Firecracker TAP networking. The `native` mode uses Rust
-helpers when direct TAP privileges are available, `forced-off` sets
-`SMOLVM_DISABLE_NATIVE_NETWORKING=1`, and `unprivileged-fallback` is skipped
-unless native can be attempted without direct TAP privileges and the existing
-sudo fallback is available.
+helpers when direct TAP privileges are available; rerun the benchmark with
+`sudo` or another root/CAP_NET_ADMIN launch path to measure that speedup.
+`forced-off` sets `SMOLVM_DISABLE_NATIVE_NETWORKING=1`, and
+`unprivileged-fallback` is skipped unless native can be attempted without
+direct TAP privileges and the existing sudo fallback is available. Run
+`smolvm setup` first if the sudo fallback is missing.
 
 ## Ubuntu Transport Comparison
 

--- a/scripts/benchmarks/README.md
+++ b/scripts/benchmarks/README.md
@@ -48,8 +48,14 @@ uv run python scripts/benchmarks/bench.py --backend qemu
 
 ## Linux Networking Stages
 
-Use `networking.py` when comparing native Rust networking helpers with the
-subprocess fallback for TAP setup, routes, sysctls, and nftables-backed NAT:
+Use `networking.py` to decide whether the Rust networking path makes Linux VM
+startup faster on your machine. It records each host networking stage, then
+compares the native path with the subprocess fallback.
+
+The measured stages include TAP setup (the virtual network device used by
+Firecracker), routes (the host paths for guest IPs), sysctls (kernel networking
+settings), and nftables-backed NAT (the firewall rules that give the guest
+network access):
 
 ```bash
 uv run python scripts/benchmarks/networking.py --json
@@ -58,9 +64,10 @@ uv run python scripts/benchmarks/networking.py --include-full-start --output /tm
 
 This benchmark is Linux-only and touches real host networking. It expects the
 same privileges as Firecracker TAP networking. The `native` mode uses Rust
-helpers when available, `forced-off` sets `SMOLVM_DISABLE_NATIVE_NETWORKING=1`,
-and `unprivileged-fallback` is skipped unless native can be attempted without
-root and the existing sudo fallback is available.
+helpers when direct TAP privileges are available, `forced-off` sets
+`SMOLVM_DISABLE_NATIVE_NETWORKING=1`, and `unprivileged-fallback` is skipped
+unless native can be attempted without direct TAP privileges and the existing
+sudo fallback is available.
 
 ## Ubuntu Transport Comparison
 

--- a/scripts/benchmarks/README.md
+++ b/scripts/benchmarks/README.md
@@ -23,7 +23,7 @@ Firecracker on macOS errors out at startup.
 3. Linux only: `smolvm setup` configured the host networking and your user can
    talk to Firecracker.
 
-The bench never escalates with `sudo`. Set things up first.
+The lifecycle benchmark never escalates with `sudo`. Set things up first.
 
 ## Running
 
@@ -45,6 +45,22 @@ uv run python scripts/benchmarks/bench.py --backend qemu
 ```
 
 `-v` enables per-iteration progress logging.
+
+## Linux Networking Stages
+
+Use `networking.py` when comparing native Rust networking helpers with the
+subprocess fallback for TAP setup, routes, sysctls, and nftables-backed NAT:
+
+```bash
+uv run python scripts/benchmarks/networking.py --json
+uv run python scripts/benchmarks/networking.py --include-full-start --output /tmp/smolvm-networking.json
+```
+
+This benchmark is Linux-only and touches real host networking. It expects the
+same privileges as Firecracker TAP networking. The `native` mode uses Rust
+helpers when available, `forced-off` sets `SMOLVM_DISABLE_NATIVE_NETWORKING=1`,
+and `unprivileged-fallback` is skipped unless native can be attempted without
+root and the existing sudo fallback is available.
 
 ## Ubuntu Transport Comparison
 

--- a/scripts/benchmarks/networking.py
+++ b/scripts/benchmarks/networking.py
@@ -1,0 +1,285 @@
+#!/usr/bin/env python3
+# Copyright 2026 Celesto AI
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Measure Linux host networking setup stages for TAP-backed sandboxes."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import logging
+import os
+import random
+import subprocess
+import sys
+import time
+from collections.abc import Iterator
+from contextlib import contextmanager, suppress
+from pathlib import Path
+from typing import Any
+
+_REPO_ROOT = Path(__file__).resolve().parent.parent.parent
+sys.path.insert(0, str(_REPO_ROOT / "src"))
+
+logger = logging.getLogger("smolvm.bench.networking")
+
+MODES = ("native", "forced-off", "unprivileged-fallback")
+NATIVE_DISABLE_ENV = "SMOLVM_DISABLE_NATIVE_NETWORKING"
+_NETWORK_MODULE: Any | None = None
+
+
+def _load_network_module() -> Any:
+    global _NETWORK_MODULE
+    if _NETWORK_MODULE is None:
+        import smolvm.host.network as network_module
+
+        _NETWORK_MODULE = network_module
+    return _NETWORK_MODULE
+
+
+@contextmanager
+def _native_mode(mode: str) -> Iterator[None]:
+    network_module = _load_network_module()
+    old_env = os.environ.get(NATIVE_DISABLE_ENV)
+    old_latch = network_module._native_unprivileged
+    network_module._native_unprivileged = False
+    try:
+        if mode == "forced-off":
+            os.environ[NATIVE_DISABLE_ENV] = "1"
+        else:
+            os.environ.pop(NATIVE_DISABLE_ENV, None)
+        yield
+    finally:
+        if old_env is None:
+            os.environ.pop(NATIVE_DISABLE_ENV, None)
+        else:
+            os.environ[NATIVE_DISABLE_ENV] = old_env
+        network_module._native_unprivileged = old_latch
+
+
+def _time_stage(record: dict[str, Any], name: str, fn) -> Any:
+    started = time.perf_counter()
+    try:
+        return fn()
+    finally:
+        record[f"{name}_ms"] = round((time.perf_counter() - started) * 1000, 1)
+
+
+def _run(cmd: list[str], *, check: bool = True) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(cmd, capture_output=True, text=True, check=check)
+
+
+def _run_json(cmd: list[str]) -> Any:
+    return json.loads(_run(cmd).stdout or "[]")
+
+
+def _tap_exists(tap_name: str) -> bool:
+    return _run(["ip", "link", "show", "dev", tap_name], check=False).returncode == 0
+
+
+def _assert_tap_configured(tap_name: str, host_ip: str, prefix_len: int) -> None:
+    links = _run_json(["ip", "-j", "addr", "show", "dev", tap_name])
+    if not links:
+        raise RuntimeError(f"TAP {tap_name} does not exist")
+    link = links[0]
+    if "UP" not in link.get("flags", []):
+        raise RuntimeError(f"TAP {tap_name} is not up")
+    addr_info = link.get("addr_info", [])
+    expected = {"local": host_ip, "prefixlen": prefix_len}
+    if not any(
+        item.get("family") == "inet"
+        and item.get("local") == expected["local"]
+        and item.get("prefixlen") == expected["prefixlen"]
+        for item in addr_info
+    ):
+        raise RuntimeError(f"TAP {tap_name} does not have {host_ip}/{prefix_len}")
+
+
+def _assert_route(guest_ip: str, tap_name: str) -> None:
+    routes = _run_json(["ip", "-j", "route", "show", f"{guest_ip}/32"])
+    if not any(route.get("dev") == tap_name for route in routes):
+        raise RuntimeError(f"Route {guest_ip}/32 does not use {tap_name}")
+
+
+def _assert_sysctl(key_path: str, expected: str) -> None:
+    value = Path("/proc/sys", key_path).read_text().strip()
+    if value != expected:
+        raise RuntimeError(f"sysctl {key_path} is {value}, expected {expected}")
+
+
+def _sudo_fallback_available() -> bool:
+    from smolvm.exceptions import SmolVMError
+    from smolvm.utils import run_command
+
+    try:
+        run_command(["ip", "link", "show"], use_sudo=True)
+        return True
+    except SmolVMError:
+        return False
+
+
+def _should_skip_mode(mode: str) -> str | None:
+    if mode != "unprivileged-fallback":
+        return None
+    network_module = _load_network_module()
+    if os.geteuid() == 0:
+        return "unprivileged fallback needs a non-root process"
+    if not network_module.HAS_NETLINK:
+        return "native networking is unavailable, so EPERM fallback cannot be tested"
+    if not _sudo_fallback_available():
+        return "sudo fallback is unavailable"
+    return None
+
+
+def _benchmark_network_stages(
+    mode: str, *, include_full_start: bool, boot_timeout: float
+) -> dict[str, Any]:
+    suffix = f"{os.getpid() % 10000}{random.randint(10, 99)}"
+    tap_name = f"svmb{suffix}"[:15]
+    vm_id = f"bench-{suffix}"
+    host_ip = "172.31.255.1"
+    guest_ip = "172.31.255.2"
+    host_port = 20000 + random.randint(0, 20000)
+    record: dict[str, Any] = {
+        "mode": mode,
+        "tap_name": tap_name,
+        "guest_ip": guest_ip,
+        "host_port": host_port,
+    }
+    nm = _load_network_module().NetworkManager(host_ip=host_ip)
+
+    with _native_mode(mode):
+        skip_reason = _should_skip_mode(mode)
+        if skip_reason is not None:
+            record["skipped"] = skip_reason
+            return record
+
+        try:
+            _time_stage(record, "default_interface", lambda: nm._detect_outbound_interface())
+            _time_stage(
+                record, "create_tap", lambda: nm.create_tap(tap_name, os.environ.get("USER"))
+            )
+            _time_stage(record, "configure_tap", lambda: nm.configure_tap(tap_name, host_ip, "32"))
+            _assert_tap_configured(tap_name, host_ip, 32)
+            _assert_sysctl(f"net/ipv4/conf/{tap_name}/route_localnet", "1")
+
+            _time_stage(record, "add_route", lambda: nm.add_route(guest_ip, tap_name))
+            _assert_route(guest_ip, tap_name)
+
+            _time_stage(record, "enable_ip_forwarding", nm.enable_ip_forwarding)
+            _assert_sysctl("net/ipv4/ip_forward", "1")
+
+            _time_stage(record, "setup_nat_firewall", lambda: nm.setup_nat(tap_name))
+            _time_stage(
+                record,
+                "setup_ssh_port_forward",
+                lambda: nm.setup_ssh_port_forward(vm_id, guest_ip, host_port),
+            )
+            _time_stage(
+                record,
+                "cleanup_ssh_port_forward",
+                lambda: nm.cleanup_ssh_port_forward(vm_id, guest_ip, host_port),
+            )
+        finally:
+            with suppress(Exception):
+                nm.cleanup_ssh_port_forward(vm_id, guest_ip, host_port)
+            with suppress(Exception):
+                nm.cleanup_nat_rules(tap_name)
+            _time_stage(record, "delete_tap", lambda: nm.cleanup_tap(tap_name))
+
+        if _tap_exists(tap_name):
+            raise RuntimeError(f"TAP {tap_name} still exists after cleanup")
+
+        if include_full_start:
+            record["full_start_ms"] = _benchmark_full_start(boot_timeout)
+
+    return record
+
+
+def _benchmark_full_start(boot_timeout: float) -> float:
+    from smolvm.facade import SmolVM
+
+    vm = SmolVM(backend="firecracker", os="alpine", comm_channel="ssh")
+    started = time.perf_counter()
+    try:
+        vm.start(boot_timeout=boot_timeout)
+        vm.wait_for_ssh(timeout=boot_timeout)
+        return round((time.perf_counter() - started) * 1000, 1)
+    finally:
+        with suppress(Exception):
+            vm.stop(timeout=15.0)
+        with suppress(Exception):
+            vm.delete()
+
+
+def _parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--modes",
+        default="native,forced-off,unprivileged-fallback",
+        help="Comma-separated modes to run: native, forced-off, unprivileged-fallback.",
+    )
+    parser.add_argument(
+        "--include-full-start",
+        action="store_true",
+        help="Also boot one Firecracker TAP-backed sandbox per mode.",
+    )
+    parser.add_argument("--boot-timeout", type=float, default=180.0)
+    parser.add_argument("--json", action="store_true", help="Print machine-readable JSON only.")
+    parser.add_argument("--output", type=Path, help="Optional JSON output path.")
+    return parser.parse_args()
+
+
+def main() -> int:
+    if sys.platform != "linux":
+        raise SystemExit("This benchmark only runs on Linux.")
+
+    args = _parse_args()
+    logging.basicConfig(level=logging.INFO, format="%(levelname)s %(name)s: %(message)s")
+    modes = [mode.strip() for mode in args.modes.split(",") if mode.strip()]
+    unknown = sorted(set(modes) - set(MODES))
+    if unknown:
+        raise SystemExit(f"Unknown mode(s): {', '.join(unknown)}")
+
+    records = [
+        _benchmark_network_stages(
+            mode,
+            include_full_start=args.include_full_start,
+            boot_timeout=args.boot_timeout,
+        )
+        for mode in modes
+    ]
+    report = {
+        "created_at": time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime()),
+        "records": records,
+    }
+    if args.output:
+        args.output.write_text(json.dumps(report, indent=2, sort_keys=True) + "\n")
+    if args.json:
+        print(json.dumps(report, indent=2, sort_keys=True))
+    else:
+        for record in records:
+            if "skipped" in record:
+                print(f"{record['mode']}: skipped - {record['skipped']}")
+                continue
+            print(f"{record['mode']}:")
+            for key, value in record.items():
+                if key.endswith("_ms"):
+                    print(f"  {key}: {value}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/benchmarks/networking.py
+++ b/scripts/benchmarks/networking.py
@@ -158,15 +158,18 @@ def _should_skip_mode(mode: str) -> str | None:
         if network_module._native_unprivileged:
             return (
                 "native networking hit EPERM and fell back; "
-                "use unprivileged-fallback to measure fallback"
+                "rerun this benchmark with sudo to measure the native speedup"
             )
         if _has_direct_tap_privileges():
             return None
         if not _sudo_fallback_available():
-            return "native mode needs direct TAP privileges and sudo fallback is unavailable"
+            return (
+                "native mode needs root or CAP_NET_ADMIN; rerun this benchmark "
+                "with sudo for native speed, or run `smolvm setup` to enable fallback"
+            )
         return (
-            "native mode needs direct TAP privileges; "
-            "use unprivileged-fallback to measure EPERM fallback"
+            "native mode needs root or CAP_NET_ADMIN; rerun this benchmark "
+            "with sudo to measure the native speedup"
         )
     if mode != "unprivileged-fallback":
         return None
@@ -177,7 +180,7 @@ def _should_skip_mode(mode: str) -> str | None:
     if os.geteuid() == 0:
         return "unprivileged fallback needs a non-root process"
     if not _sudo_fallback_available():
-        return "sudo fallback is unavailable"
+        return "sudo fallback is unavailable; run `smolvm setup` before measuring fallback"
     return None
 
 

--- a/scripts/benchmarks/networking.py
+++ b/scripts/benchmarks/networking.py
@@ -144,7 +144,7 @@ def _has_direct_tap_privileges() -> bool:
                 effective_caps = int(line.split(":", 1)[1].strip(), 16)
                 return bool(effective_caps & (1 << CAP_NET_ADMIN))
     except (OSError, ValueError):
-        pass
+        logger.debug("Could not read effective capabilities from /proc/self/status", exc_info=True)
     return os.geteuid() == 0
 
 

--- a/scripts/benchmarks/networking.py
+++ b/scripts/benchmarks/networking.py
@@ -37,6 +37,7 @@ logger = logging.getLogger("smolvm.bench.networking")
 
 MODES = ("native", "forced-off", "unprivileged-fallback")
 NATIVE_DISABLE_ENV = "SMOLVM_DISABLE_NATIVE_NETWORKING"
+CAP_NET_ADMIN = 12
 _NETWORK_MODULE: Any | None = None
 
 
@@ -123,21 +124,58 @@ def _sudo_fallback_available() -> bool:
     from smolvm.exceptions import SmolVMError
     from smolvm.utils import run_command
 
+    checks = [
+        ["ip", "link", "show"],
+        ["sysctl", "net.ipv4.ip_forward"],
+        ["nft", "list", "tables"],
+    ]
+    for cmd in checks:
+        try:
+            run_command(cmd, use_sudo=True)
+        except SmolVMError:
+            return False
+    return True
+
+
+def _has_direct_tap_privileges() -> bool:
     try:
-        run_command(["ip", "link", "show"], use_sudo=True)
-        return True
-    except SmolVMError:
-        return False
+        for line in Path("/proc/self/status").read_text().splitlines():
+            if line.startswith("CapEff:"):
+                effective_caps = int(line.split(":", 1)[1].strip(), 16)
+                return bool(effective_caps & (1 << CAP_NET_ADMIN))
+    except (OSError, ValueError):
+        pass
+    return os.geteuid() == 0
 
 
 def _should_skip_mode(mode: str) -> str | None:
-    if mode != "unprivileged-fallback":
+    if mode == "forced-off":
         return None
     network_module = _load_network_module()
-    if os.geteuid() == 0:
-        return "unprivileged fallback needs a non-root process"
+    if mode == "native":
+        if not network_module.HAS_NETLINK:
+            return "native networking is unavailable"
+        if network_module._native_unprivileged:
+            return (
+                "native networking hit EPERM and fell back; "
+                "use unprivileged-fallback to measure fallback"
+            )
+        if _has_direct_tap_privileges():
+            return None
+        if not _sudo_fallback_available():
+            return "native mode needs direct TAP privileges and sudo fallback is unavailable"
+        return (
+            "native mode needs direct TAP privileges; "
+            "use unprivileged-fallback to measure EPERM fallback"
+        )
+    if mode != "unprivileged-fallback":
+        return None
     if not network_module.HAS_NETLINK:
         return "native networking is unavailable, so EPERM fallback cannot be tested"
+    if _has_direct_tap_privileges():
+        return "unprivileged fallback needs a process without direct TAP privileges"
+    if os.geteuid() == 0:
+        return "unprivileged fallback needs a non-root process"
     if not _sudo_fallback_available():
         return "sudo fallback is unavailable"
     return None
@@ -202,8 +240,18 @@ def _benchmark_network_stages(
         if _tap_exists(tap_name):
             raise RuntimeError(f"TAP {tap_name} still exists after cleanup")
 
+        skip_reason = _should_skip_mode(mode)
+        if skip_reason is not None:
+            record["skipped"] = skip_reason
+            return record
+
         if include_full_start:
-            record["full_start_ms"] = _benchmark_full_start(boot_timeout)
+            full_start_ms = _benchmark_full_start(boot_timeout)
+            skip_reason = _should_skip_mode(mode)
+            if skip_reason is None:
+                record["full_start_ms"] = full_start_ms
+            else:
+                record["full_start_skipped"] = skip_reason
 
     return record
 

--- a/smolvm-core/Cargo.toml
+++ b/smolvm-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "smolvm-core"
-version = "0.0.14"
+version = "0.0.15"
 description = "Rust-native core package for SmolVM"
 documentation = "https://docs.rs/smolvm-core"
 readme = "README.md"

--- a/smolvm-core/README.md
+++ b/smolvm-core/README.md
@@ -19,16 +19,17 @@ SmolVM uses `smolvm-core` for two host-side jobs when they are available:
 - Linux sandbox networking setup — creating TAP devices (virtual network cards), adding routes, and writing sysctls (kernel settings)
 - QEMU sandbox control on Linux and macOS — speaking QMP, QEMU's JSON control protocol, over a Unix socket
 
-When native host networking is unavailable, SmolVM falls back to running `ip`, `nft`, and `sysctl` as subprocesses. When native QMP is unavailable, SmolVM falls back to its pure-Python QMP client. Both fallback paths produce the same result; the native paths are faster and keep low-level protocol handling out of the main Python API.
+When native host networking is unavailable, or when the SmolVM process lacks permission to change Linux networking directly, SmolVM falls back to running `ip`, `nft`, and `sysctl` as subprocesses. When native QMP is unavailable, SmolVM falls back to its pure-Python QMP client. Both fallback paths produce the same result; the native paths are faster and keep low-level protocol handling out of the main Python API.
 
 | Scenario | Path used | What happens |
 |---|---|---|
-| Linux + `smolvm-core` wheel installed | Native networking + native QMP | Direct kernel calls for networking and native QMP for QEMU control. |
+| Linux + `smolvm-core` wheel installed + root/CAP_NET_ADMIN | Native networking + native QMP | Direct kernel calls for networking and native QMP for QEMU control. |
+| Linux + wheel installed, but no direct networking permission | Subprocess networking + native QMP | SmolVM falls back to `ip`/`nft`/`sysctl` subprocesses for networking; native QMP still works. |
 | Linux + wheel missing or broken | Subprocess networking + Python QMP | Fully functional, but networking falls back to `ip`/`nft`/`sysctl` subprocesses and QMP uses the Python client. |
 | macOS + `smolvm-core` wheel installed | Native QMP only | macOS uses QEMU user-mode networking (SLIRP), so host networking is not exercised; QEMU control uses native QMP. |
 | macOS + wheel missing or broken | Python QMP | QEMU control uses the pure-Python QMP client. |
 
-On Linux, if SmolVM falls back to subprocess, it logs a warning at startup:
+On Linux, missing native support and missing networking permission produce different warnings. If the native wheel is missing or broken, SmolVM logs:
 
 ```
 WARNING smolvm.host._accel: smolvm-core native extension is unavailable;
@@ -37,6 +38,8 @@ which is significantly slower. Reinstall smolvm to pick up the native wheel.
 ```
 
 The fix is to reinstall `smolvm` so pip picks up the matching wheel for your platform.
+
+If the wheel is installed but the process cannot change Linux networking directly, SmolVM logs a permission warning and uses the slower sudo fallback. Run `smolvm setup` if the fallback is missing, or start the same SmolVM command as root or with CAP_NET_ADMIN to use the native networking speedup.
 
 ## Public Python interface
 

--- a/smolvm-core/README.md
+++ b/smolvm-core/README.md
@@ -58,10 +58,13 @@ smolvm_core.delete_tap(name: str) -> None
 smolvm_core.flush_addrs(name: str) -> None
 smolvm_core.add_addr(name: str, ip: str, prefix_len: int) -> None
 smolvm_core.set_link_up(name: str) -> None
+smolvm_core.configure_tap(name: str, host_ip: str, prefix_len: int) -> None
 smolvm_core.add_route(dest: str, prefix_len: int, dev: str) -> None
 smolvm_core.get_default_interface() -> str
 smolvm_core.write_sysctl(key: str, value: str) -> None
 ```
+
+`configure_tap()` is the preferred helper when setting up a TAP for a sandbox. It flushes addresses, assigns the host IP, and brings the link up in one native call. SmolVM still writes per-TAP sysctls from Python so fallback behavior stays the same.
 
 These helpers raise `OSError("Not available on this platform")` when the operation does not exist on the current operating system. SmolVM catches that and uses the portable fallback path where one exists.
 

--- a/smolvm-core/python/smolvm_core/__init__.py
+++ b/smolvm-core/python/smolvm_core/__init__.py
@@ -17,6 +17,9 @@ from ._smolvm_core import (
     add_route as _native_add_route,
 )
 from ._smolvm_core import (
+    configure_tap as _native_configure_tap,
+)
+from ._smolvm_core import (
     create_tap as _native_create_tap,
 )
 from ._smolvm_core import (
@@ -114,6 +117,12 @@ def add_addr(name: str, ip: str, prefix_len: int) -> None:
     _native_add_addr(name, ip, prefix_len)
 
 
+def configure_tap(name: str, host_ip: str, prefix_len: int) -> None:
+    """Assign an IPv4 address to a TAP link and bring it up."""
+
+    _native_configure_tap(name, host_ip, prefix_len)
+
+
 def add_route(dest: str, prefix_len: int, dev: str) -> None:
     """Add a route for ``dest/prefix_len`` through ``dev``."""
 
@@ -149,6 +158,7 @@ __all__ = [
     "set_link_up",
     "flush_addrs",
     "add_addr",
+    "configure_tap",
     "add_route",
     "get_default_interface",
     "write_sysctl",

--- a/smolvm-core/src/error.rs
+++ b/smolvm-core/src/error.rs
@@ -53,10 +53,76 @@ impl NetlinkError {
 
 fn is_permission_denied_message(message: &str) -> bool {
     message.contains("Operation not permitted")
-        || message.contains("errno 1")
-        || message.contains("os error 1")
-        || message.contains("code: -1")
-        || message.contains("EPERM")
+        || contains_number_after_marker(message, "errno", libc::EPERM)
+        || contains_number_after_marker(message, "os error", libc::EPERM)
+        || contains_number_after_marker(message, "code:", -libc::EPERM)
+        || contains_word(message, "EPERM")
+}
+
+fn contains_number_after_marker(message: &str, marker: &str, expected: i32) -> bool {
+    let mut search_start = 0;
+    while let Some(relative_start) = message[search_start..].find(marker) {
+        let marker_start = search_start + relative_start;
+        let number_start = search_start + relative_start + marker.len();
+        if !is_marker_boundary(message, marker_start) {
+            search_start = number_start;
+            continue;
+        }
+        let after_marker = &message[number_start..];
+        if !marker.ends_with(':')
+            && !after_marker
+                .chars()
+                .next()
+                .is_some_and(|ch| ch.is_ascii_whitespace())
+        {
+            search_start = number_start;
+            continue;
+        }
+        let trimmed = after_marker.trim_start();
+        if let Some((value, consumed)) = parse_i32_prefix(trimmed) {
+            if value == expected && is_number_boundary(trimmed, consumed) {
+                return true;
+            }
+        }
+        search_start = number_start;
+    }
+    false
+}
+
+fn is_marker_boundary(message: &str, marker_start: usize) -> bool {
+    message[..marker_start]
+        .chars()
+        .next_back()
+        .is_none_or(|ch| !ch.is_ascii_alphanumeric())
+}
+
+fn parse_i32_prefix(input: &str) -> Option<(i32, usize)> {
+    let bytes = input.as_bytes();
+    let mut end = 0;
+    if matches!(bytes.first(), Some(b'-' | b'+')) {
+        end = 1;
+    }
+    let digit_start = end;
+    while end < bytes.len() && bytes[end].is_ascii_digit() {
+        end += 1;
+    }
+    if end == digit_start {
+        return None;
+    }
+    input[..end].parse().ok().map(|value| (value, end))
+}
+
+fn is_number_boundary(input: &str, consumed: usize) -> bool {
+    input[consumed..]
+        .chars()
+        .next()
+        .is_none_or(|ch| !ch.is_ascii_alphanumeric())
+}
+
+fn contains_word(message: &str, word: &str) -> bool {
+    message
+        .split(|ch: char| !ch.is_ascii_alphanumeric() && ch != '_')
+        .any(|part| part == word)
 }
 
 /// Convert a NetlinkError to a Python exception.
@@ -101,5 +167,22 @@ mod tests {
         let error = NetlinkError::from_kernel_message("set_link_up tap0", "No such device");
 
         assert_eq!(error.to_string(), "set_link_up tap0: No such device");
+    }
+
+    #[test]
+    fn from_kernel_message_does_not_overmatch_other_errno_values() {
+        for message in [
+            "tap0: errno 13",
+            "tap0: errno 100",
+            "tap0: errno1",
+            "Permission denied (os error 13)",
+            "NetlinkError { code: -17, message: None }",
+            "NetlinkError { postcode: -1, message: None }",
+            "NOEPERM",
+        ] {
+            let error = NetlinkError::from_kernel_message("set_link_up tap0", message);
+
+            assert!(matches!(error, NetlinkError::Other(_)), "{message}");
+        }
     }
 }

--- a/smolvm-core/src/error.rs
+++ b/smolvm-core/src/error.rs
@@ -11,6 +11,9 @@ pub enum NetlinkError {
     #[error("Device or resource busy")]
     DeviceBusy,
 
+    #[error("Operation not permitted")]
+    PermissionDenied,
+
     #[error("Cannot find device \"{0}\"")]
     DeviceNotFound(String),
 
@@ -33,13 +36,70 @@ impl NetlinkError {
         match errno {
             libc::EEXIST => NetlinkError::AlreadyExists,
             libc::EBUSY => NetlinkError::DeviceBusy,
+            libc::EPERM => NetlinkError::PermissionDenied,
             libc::ENODEV | libc::ENXIO => NetlinkError::NoSuchDevice(context.to_string()),
             _ => NetlinkError::Other(format!("{}: errno {}", context, errno)),
         }
     }
+
+    /// Normalize kernel/netlink permission failures to a stable Python message.
+    pub fn from_kernel_message(context: &str, message: &str) -> Self {
+        if is_permission_denied_message(message) {
+            return NetlinkError::PermissionDenied;
+        }
+        NetlinkError::Other(format!("{}: {}", context, message))
+    }
+}
+
+fn is_permission_denied_message(message: &str) -> bool {
+    message.contains("Operation not permitted")
+        || message.contains("errno 1")
+        || message.contains("os error 1")
+        || message.contains("code: -1")
+        || message.contains("EPERM")
 }
 
 /// Convert a NetlinkError to a Python exception.
 pub fn to_py_err(e: NetlinkError) -> PyErr {
     PyOSError::new_err(e.to_string())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn from_errno_normalizes_eperm() {
+        assert!(matches!(
+            NetlinkError::from_errno(libc::EPERM, "tap0"),
+            NetlinkError::PermissionDenied
+        ));
+        assert_eq!(
+            NetlinkError::from_errno(libc::EPERM, "tap0").to_string(),
+            "Operation not permitted"
+        );
+    }
+
+    #[test]
+    fn from_kernel_message_normalizes_netlink_eperm_shapes() {
+        for message in [
+            "Operation not permitted",
+            "tap0: errno 1",
+            "Permission denied (os error 1)",
+            "NetlinkError { code: -1, message: None }",
+            "EPERM",
+        ] {
+            assert!(matches!(
+                NetlinkError::from_kernel_message("set_link_up tap0", message),
+                NetlinkError::PermissionDenied
+            ));
+        }
+    }
+
+    #[test]
+    fn from_kernel_message_keeps_context_for_other_errors() {
+        let error = NetlinkError::from_kernel_message("set_link_up tap0", "No such device");
+
+        assert_eq!(error.to_string(), "set_link_up tap0: No such device");
+    }
 }

--- a/smolvm-core/src/lib.rs
+++ b/smolvm-core/src/lib.rs
@@ -107,6 +107,20 @@ fn add_addr(_name: &str, _ip: &str, _prefix_len: u8) -> PyResult<()> {
 
 #[cfg(target_os = "linux")]
 #[pyfunction]
+fn configure_tap(name: &str, host_ip: &str, prefix_len: u8) -> PyResult<()> {
+    route::configure_tap(name, host_ip, prefix_len).map_err(error::to_py_err)
+}
+
+#[cfg(not(target_os = "linux"))]
+#[pyfunction]
+fn configure_tap(_name: &str, _host_ip: &str, _prefix_len: u8) -> PyResult<()> {
+    Err(pyo3::exceptions::PyOSError::new_err(
+        "Not available on this platform",
+    ))
+}
+
+#[cfg(target_os = "linux")]
+#[pyfunction]
 fn add_route(dest: &str, prefix_len: u8, dev: &str) -> PyResult<()> {
     route::add_route(dest, prefix_len, dev).map_err(error::to_py_err)
 }
@@ -160,6 +174,7 @@ fn _smolvm_core(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_function(wrap_pyfunction!(set_link_up, m)?)?;
     m.add_function(wrap_pyfunction!(flush_addrs, m)?)?;
     m.add_function(wrap_pyfunction!(add_addr, m)?)?;
+    m.add_function(wrap_pyfunction!(configure_tap, m)?)?;
     m.add_function(wrap_pyfunction!(add_route, m)?)?;
     m.add_function(wrap_pyfunction!(get_default_interface, m)?)?;
     m.add_function(wrap_pyfunction!(write_sysctl, m)?)?;

--- a/smolvm-core/src/route.rs
+++ b/smolvm-core/src/route.rs
@@ -40,22 +40,98 @@ async fn get_link_index(handle: &rtnetlink::Handle, name: &str) -> Result<u32, N
         .ok_or_else(|| NetlinkError::DeviceNotFound(name.to_string()))
 }
 
-/// Set a network interface to UP state.
-pub fn set_link_up(name: &str) -> Result<(), NetlinkError> {
+fn parse_ipv4(ip: &str, label: &str) -> Result<Ipv4Addr, NetlinkError> {
+    ip.parse()
+        .map_err(|e| NetlinkError::Other(format!("invalid {} {}: {}", label, ip, e)))
+}
+
+fn validate_ipv4_prefix(prefix_len: u8) -> Result<(), NetlinkError> {
+    if prefix_len > 32 {
+        return Err(NetlinkError::Other(format!(
+            "invalid IPv4 prefix length: {}",
+            prefix_len
+        )));
+    }
+    Ok(())
+}
+
+fn map_netlink_error(context: &str, error: impl std::fmt::Display) -> NetlinkError {
+    let message = error.to_string();
+    if message.contains("File exists") || message.contains("EEXIST") {
+        NetlinkError::RouteExists
+    } else {
+        NetlinkError::from_kernel_message(context, &message)
+    }
+}
+
+async fn flush_addrs_by_index(
+    handle: &rtnetlink::Handle,
+    index: u32,
+    name: &str,
+) -> Result<(), NetlinkError> {
+    use futures_util::TryStreamExt;
+
+    let mut addrs = handle
+        .address()
+        .get()
+        .set_link_index_filter(index)
+        .execute();
+    while let Some(addr) = addrs.try_next().await.map_err(|e| {
+        NetlinkError::from_kernel_message(&format!("list addrs {}", name), &e.to_string())
+    })? {
+        handle.address().del(addr).execute().await.map_err(|e| {
+            NetlinkError::from_kernel_message(&format!("del addr {}", name), &e.to_string())
+        })?;
+    }
+
+    Ok(())
+}
+
+async fn add_addr_by_index(
+    handle: &rtnetlink::Handle,
+    index: u32,
+    name: &str,
+    addr: Ipv4Addr,
+    prefix_len: u8,
+) -> Result<(), NetlinkError> {
+    handle
+        .address()
+        .add(index, std::net::IpAddr::V4(addr), prefix_len)
+        .execute()
+        .await
+        .map_err(|e| map_netlink_error(&format!("add_addr {} on {}", addr, name), e))?;
+
+    Ok(())
+}
+
+async fn set_link_up_by_index(
+    handle: &rtnetlink::Handle,
+    index: u32,
+    name: &str,
+) -> Result<(), NetlinkError> {
     use rtnetlink::LinkUnspec;
 
+    handle
+        .link()
+        .set(LinkUnspec::new_with_index(index).up().build())
+        .execute()
+        .await
+        .map_err(|e| {
+            NetlinkError::from_kernel_message(&format!("set_link_up {}", name), &e.to_string())
+        })?;
+
+    Ok(())
+}
+
+/// Set a network interface to UP state.
+pub fn set_link_up(name: &str) -> Result<(), NetlinkError> {
     with_netlink(async {
         let (connection, handle, _) = rtnetlink::new_connection()
             .map_err(|e| NetlinkError::Other(format!("netlink: {}", e)))?;
         tokio::spawn(connection);
 
         let index = get_link_index(&handle, name).await?;
-        handle
-            .link()
-            .set(LinkUnspec::new_with_index(index).up().build())
-            .execute()
-            .await
-            .map_err(|e| NetlinkError::Other(format!("set_link_up {}: {}", name, e)))?;
+        set_link_up_by_index(&handle, index, name).await?;
 
         log::debug!("Link {} set UP", name);
         Ok(())
@@ -71,24 +147,7 @@ pub fn flush_addrs(name: &str) -> Result<(), NetlinkError> {
 
         let index = get_link_index(&handle, name).await?;
 
-        use futures_util::TryStreamExt;
-        let mut addrs = handle
-            .address()
-            .get()
-            .set_link_index_filter(index)
-            .execute();
-        while let Some(addr) = addrs
-            .try_next()
-            .await
-            .map_err(|e| NetlinkError::Other(format!("list addrs {}: {}", name, e)))?
-        {
-            handle
-                .address()
-                .del(addr)
-                .execute()
-                .await
-                .map_err(|e| NetlinkError::Other(format!("del addr {}: {}", name, e)))?;
-        }
+        flush_addrs_by_index(&handle, index, name).await?;
 
         log::debug!("Flushed addresses on {}", name);
         Ok(())
@@ -97,9 +156,8 @@ pub fn flush_addrs(name: &str) -> Result<(), NetlinkError> {
 
 /// Add an IP address to an interface.
 pub fn add_addr(name: &str, ip: &str, prefix_len: u8) -> Result<(), NetlinkError> {
-    let addr: Ipv4Addr = ip
-        .parse()
-        .map_err(|e| NetlinkError::Other(format!("invalid IP {}: {}", ip, e)))?;
+    validate_ipv4_prefix(prefix_len)?;
+    let addr = parse_ipv4(ip, "IP")?;
 
     with_netlink(async {
         let (connection, handle, _) = rtnetlink::new_connection()
@@ -107,21 +165,29 @@ pub fn add_addr(name: &str, ip: &str, prefix_len: u8) -> Result<(), NetlinkError
         tokio::spawn(connection);
 
         let index = get_link_index(&handle, name).await?;
-        handle
-            .address()
-            .add(index, std::net::IpAddr::V4(addr), prefix_len)
-            .execute()
-            .await
-            .map_err(|e| {
-                let msg = format!("{}", e);
-                if msg.contains("File exists") || msg.contains("EEXIST") {
-                    NetlinkError::RouteExists
-                } else {
-                    NetlinkError::Other(format!("add_addr {} on {}: {}", ip, name, e))
-                }
-            })?;
+        add_addr_by_index(&handle, index, name, addr, prefix_len).await?;
 
         log::debug!("Added {}/{} to {}", ip, prefix_len, name);
+        Ok(())
+    })
+}
+
+/// Flush addresses, add host IP, and set the TAP link UP in one netlink session.
+pub fn configure_tap(name: &str, host_ip: &str, prefix_len: u8) -> Result<(), NetlinkError> {
+    validate_ipv4_prefix(prefix_len)?;
+    let addr = parse_ipv4(host_ip, "host IP")?;
+
+    with_netlink(async {
+        let (connection, handle, _) = rtnetlink::new_connection()
+            .map_err(|e| NetlinkError::Other(format!("netlink: {}", e)))?;
+        tokio::spawn(connection);
+
+        let index = get_link_index(&handle, name).await?;
+        flush_addrs_by_index(&handle, index, name).await?;
+        add_addr_by_index(&handle, index, name, addr, prefix_len).await?;
+        set_link_up_by_index(&handle, index, name).await?;
+
+        log::debug!("Configured TAP {} with {}/{}", name, host_ip, prefix_len);
         Ok(())
     })
 }
@@ -130,9 +196,8 @@ pub fn add_addr(name: &str, ip: &str, prefix_len: u8) -> Result<(), NetlinkError
 pub fn add_route(dest: &str, prefix_len: u8, dev: &str) -> Result<(), NetlinkError> {
     use rtnetlink::RouteMessageBuilder;
 
-    let dest_addr: Ipv4Addr = dest
-        .parse()
-        .map_err(|e| NetlinkError::Other(format!("invalid dest {}: {}", dest, e)))?;
+    validate_ipv4_prefix(prefix_len)?;
+    let dest_addr = parse_ipv4(dest, "dest")?;
 
     with_netlink(async {
         let (connection, handle, _) = rtnetlink::new_connection()
@@ -145,20 +210,49 @@ pub fn add_route(dest: &str, prefix_len: u8, dev: &str) -> Result<(), NetlinkErr
             .output_interface(index)
             .build();
         handle.route().add(route).execute().await.map_err(|e| {
-            let msg = format!("{}", e);
-            if msg.contains("File exists") || msg.contains("EEXIST") {
-                NetlinkError::RouteExists
-            } else {
-                NetlinkError::Other(format!(
-                    "add_route {}/{} dev {}: {}",
-                    dest, prefix_len, dev, e
-                ))
-            }
+            map_netlink_error(&format!("add_route {}/{} dev {}", dest, prefix_len, dev), e)
         })?;
 
         log::debug!("Route {}/{} via {}", dest, prefix_len, dev);
         Ok(())
     })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn rejects_invalid_ipv4_prefix() {
+        let error = configure_tap("tap0", "172.16.0.1", 33).unwrap_err();
+
+        assert_eq!(error.to_string(), "invalid IPv4 prefix length: 33");
+    }
+
+    #[test]
+    fn rejects_invalid_configure_tap_ip() {
+        let error = configure_tap("tap0", "not-an-ip", 32).unwrap_err();
+
+        assert!(error.to_string().contains("invalid host IP not-an-ip"));
+    }
+
+    #[test]
+    fn maps_route_exists_messages() {
+        let error = map_netlink_error("add_route 172.16.0.2/32 dev tap0", "File exists");
+
+        assert!(matches!(error, NetlinkError::RouteExists));
+    }
+
+    #[test]
+    fn maps_netlink_eperm_messages() {
+        let error = map_netlink_error(
+            "set_link_up tap0",
+            "NetlinkError { code: -1, message: None }",
+        );
+
+        assert!(matches!(error, NetlinkError::PermissionDenied));
+        assert_eq!(error.to_string(), "Operation not permitted");
+    }
 }
 
 /// Get the default outbound network interface name.

--- a/src/smolvm/host/network.py
+++ b/src/smolvm/host/network.py
@@ -26,7 +26,9 @@ import os
 import re
 import socket
 import time
+from collections.abc import Callable
 from pathlib import Path
+from typing import TypeVar
 from urllib.parse import urlparse
 
 from smolvm.exceptions import NetworkError, SmolVMError
@@ -41,6 +43,9 @@ DEFAULT_NETMASK = "16"
 
 # Matches the native EPERM signal precisely (\b prevents "errno 13" matching).
 _EPERM_RE = re.compile(r"\berrno 1\b|Operation not permitted")
+_NATIVE_DISABLE_ENV = "SMOLVM_DISABLE_NATIVE_NETWORKING"
+_TRUE_ENV_VALUES = {"1", "true", "yes"}
+_T = TypeVar("_T")
 
 
 def _is_eperm(err: str) -> bool:
@@ -55,7 +60,30 @@ _native_unprivileged = False
 
 
 def _native_available() -> bool:
-    return HAS_NETLINK and not _native_unprivileged
+    disabled = os.environ.get(_NATIVE_DISABLE_ENV, "").strip().lower() in _TRUE_ENV_VALUES
+    return HAS_NETLINK and native is not None and not _native_unprivileged and not disabled
+
+
+def _log_native_timing(operation: str, start: float, *, is_async: bool = False) -> None:
+    elapsed_ms = (time.monotonic() - start) * 1000
+    suffix = " (async)" if is_async else ""
+    logger.info("NATIVE %-16s %.1fms%s", operation, elapsed_ms, suffix)
+
+
+def _call_native(operation: str, func: Callable[..., _T], *args: object) -> _T:
+    start = time.monotonic()
+    try:
+        return func(*args)
+    finally:
+        _log_native_timing(operation, start)
+
+
+async def _async_call_native(operation: str, func: Callable[..., _T], *args: object) -> _T:
+    start = time.monotonic()
+    try:
+        return await asyncio.to_thread(func, *args)
+    finally:
+        _log_native_timing(operation, start, is_async=True)
 
 
 def _mark_native_unprivileged() -> None:
@@ -109,12 +137,14 @@ class NetworkManager:
 
     def _detect_outbound_interface(self) -> str:
         """Detect outbound interface from default route."""
-        if HAS_NETLINK:
+        if _native_available():
             try:
-                iface = native.get_default_interface()
+                iface = _call_native("default_iface", native.get_default_interface)
                 logger.info("Detected outbound interface: %s", iface)
                 return iface
             except OSError as e:
+                if _is_eperm(str(e)):
+                    _mark_native_unprivileged()
                 logger.error(
                     "Native get_default_interface failed, falling back to subprocess: %s", e
                 )
@@ -135,6 +165,18 @@ class NetworkManager:
 
     async def _async_detect_outbound_interface(self) -> str:
         """Detect outbound interface from default route (async)."""
+        if _native_available():
+            try:
+                iface = await _async_call_native("default_iface", native.get_default_interface)
+                logger.info("Detected outbound interface: %s", iface)
+                return iface
+            except OSError as e:
+                if _is_eperm(str(e)):
+                    _mark_native_unprivileged()
+                logger.error(
+                    "Native get_default_interface failed, falling back to subprocess: %s", e
+                )
+
         try:
             result = await async_run_command(["ip", "route", "show", "default"], use_sudo=False)
             parts = result.stdout.strip().split()
@@ -173,7 +215,7 @@ class NetworkManager:
             max_busy_retries = 3
             for attempt in range(max_busy_retries + 1):
                 try:
-                    native.create_tap(tap_name, uid)
+                    _call_native("create_tap", native.create_tap, tap_name, uid)
                     return
                 except OSError as e:
                     err = str(e)
@@ -234,6 +276,41 @@ class NetworkManager:
 
         logger.info("Creating TAP device: %s (user: %s)", tap_name, user)
 
+        if _native_available():
+            import pwd
+
+            try:
+                uid = pwd.getpwnam(user).pw_uid
+            except KeyError:
+                uid = os.getuid()
+            max_busy_retries = 3
+            for attempt in range(max_busy_retries + 1):
+                try:
+                    await _async_call_native("create_tap", native.create_tap, tap_name, uid)
+                    return
+                except OSError as e:
+                    err = str(e)
+                    if "File exists" in err:
+                        logger.debug("TAP device %s already exists", tap_name)
+                        return
+                    if "Device or resource busy" in err and attempt < max_busy_retries:
+                        delay = 0.1 * (attempt + 1)
+                        logger.warning(
+                            "TAP %s busy (attempt %d/%d), retrying in %.2fs",
+                            tap_name,
+                            attempt + 1,
+                            max_busy_retries + 1,
+                            delay,
+                        )
+                        await asyncio.sleep(delay)
+                        continue
+                    if _is_eperm(err):
+                        _mark_native_unprivileged()
+                        break
+                    raise SmolVMError(err) from e
+            else:
+                return
+
         max_busy_retries = 3
         for attempt in range(max_busy_retries + 1):
             try:
@@ -278,9 +355,7 @@ class NetworkManager:
 
         if _native_available():
             try:
-                native.flush_addrs(tap_name)
-                native.add_addr(tap_name, host_ip, int(netmask))
-                native.set_link_up(tap_name)
+                _call_native("configure_tap", native.configure_tap, tap_name, host_ip, int(netmask))
                 self._write_sysctl(f"net/ipv4/conf/{tap_name}/route_localnet", "1")
                 return
             except OSError as e:
@@ -322,6 +397,27 @@ class NetworkManager:
 
         logger.info("Configuring TAP %s with IP %s/%s", tap_name, host_ip, netmask)
 
+        if _native_available():
+            try:
+                await _async_call_native(
+                    "configure_tap",
+                    native.configure_tap,
+                    tap_name,
+                    host_ip,
+                    int(netmask),
+                )
+                await self._async_write_sysctl(f"net/ipv4/conf/{tap_name}/route_localnet", "1")
+                return
+            except OSError as e:
+                err = str(e)
+                if "RTNETLINK answers: File exists" in err or "File exists" in err:
+                    await self._async_write_sysctl(f"net/ipv4/conf/{tap_name}/route_localnet", "1")
+                    return
+                if _is_eperm(err):
+                    _mark_native_unprivileged()
+                else:
+                    raise SmolVMError(err) from e
+
         batch = [
             f"addr flush dev {tap_name}",
             f"addr add {host_ip}/{netmask} dev {tap_name}",
@@ -348,7 +444,7 @@ class NetworkManager:
 
         if _native_available():
             try:
-                native.add_route(ip_address, 32, device)
+                _call_native("add_route", native.add_route, ip_address, 32, device)
                 return
             except OSError as e:
                 err = str(e)
@@ -373,6 +469,19 @@ class NetworkManager:
             raise ValueError("device cannot be empty")
 
         logger.info("Adding route: %s via %s", ip_address, device)
+        if _native_available():
+            try:
+                await _async_call_native("add_route", native.add_route, ip_address, 32, device)
+                return
+            except OSError as e:
+                err = str(e)
+                if "File exists" in err:
+                    return
+                if _is_eperm(err):
+                    _mark_native_unprivileged()
+                else:
+                    raise SmolVMError(err) from e
+
         try:
             await async_run_command(["ip", "route", "add", f"{ip_address}/32", "dev", device])
         except SmolVMError as e:
@@ -388,7 +497,7 @@ class NetworkManager:
 
         if _native_available():
             try:
-                native.delete_tap(tap_name)
+                _call_native("delete_tap", native.delete_tap, tap_name)
                 return
             except OSError as e:
                 err = str(e)
@@ -412,6 +521,20 @@ class NetworkManager:
             raise ValueError("tap_name cannot be empty")
 
         logger.info("Cleaning up TAP device: %s", tap_name)
+        if _native_available():
+            try:
+                await _async_call_native("delete_tap", native.delete_tap, tap_name)
+                return
+            except OSError as e:
+                err = str(e)
+                if "Cannot find device" in err or "No such device" in err:
+                    return
+                if _is_eperm(err):
+                    _mark_native_unprivileged()
+                else:
+                    logger.warning("Failed to delete TAP %s: %s", tap_name, e)
+                    return
+
         try:
             await async_run_command(["ip", "link", "delete", tap_name])
         except SmolVMError as e:
@@ -440,11 +563,13 @@ class NetworkManager:
 
     def _write_sysctl(self, key_path: str, value: str) -> bool:
         """Write /proc/sys key, with sudo sysctl fallback."""
-        if HAS_NETLINK:
+        if _native_available():
             try:
-                native.write_sysctl(key_path.replace("/", "."), value)
+                _call_native("write_sysctl", native.write_sysctl, key_path.replace("/", "."), value)
                 return True
-            except OSError:
+            except OSError as e:
+                if _is_eperm(str(e)):
+                    _mark_native_unprivileged()
                 pass  # Fall through to Python path
 
         path = Path(f"/proc/sys/{key_path}")
@@ -465,6 +590,19 @@ class NetworkManager:
 
     async def _async_write_sysctl(self, key_path: str, value: str) -> bool:
         """Write /proc/sys key, with sudo sysctl fallback (async)."""
+        if _native_available():
+            try:
+                await _async_call_native(
+                    "write_sysctl",
+                    native.write_sysctl,
+                    key_path.replace("/", "."),
+                    value,
+                )
+                return True
+            except OSError as e:
+                if _is_eperm(str(e)):
+                    _mark_native_unprivileged()
+
         path = Path(f"/proc/sys/{key_path}")
 
         try:
@@ -1833,7 +1971,7 @@ def check_network_prerequisites() -> list[str]:
     """Validate required host networking binaries and sudo access."""
     errors: list[str] = []
 
-    for binary in ["ip", "nft"]:
+    for binary in ["ip", "nft", "sysctl"]:
         try:
             run_command(["which", binary], use_sudo=False)
         except SmolVMError:

--- a/src/smolvm/host/network.py
+++ b/src/smolvm/host/network.py
@@ -91,9 +91,10 @@ def _mark_native_unprivileged() -> None:
     if not _native_unprivileged:
         _native_unprivileged = True
         logger.warning(
-            "Using the slower networking path. VMs will still work; "
-            "each is a fraction of a second slower to start. "
-            "Run with sudo to use the faster path."
+            "Fast Rust networking needs permission to change Linux networking "
+            "directly (root or CAP_NET_ADMIN). SmolVM is using the slower sudo "
+            "fallback; run `smolvm setup` if sudo fallback is missing, or start "
+            "the same SmolVM command with sudo to get the Rust networking speedup."
         )
 
 

--- a/tests/test_network.py
+++ b/tests/test_network.py
@@ -14,6 +14,7 @@
 
 """Tests for SmolVM network module."""
 
+import logging
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -187,12 +188,16 @@ class TestTapManagement:
     @patch("smolvm.host.network.run_command")
     @patch("smolvm.host.network.native")
     def test_create_tap_falls_back_to_subprocess_on_eperm(
-        self, mock_native: MagicMock, mock_run_command: MagicMock
+        self,
+        mock_native: MagicMock,
+        mock_run_command: MagicMock,
+        caplog: pytest.LogCaptureFixture,
     ) -> None:
         """When the native ioctl returns EPERM, fall through to sudo ip path."""
         mock_native.create_tap.side_effect = OSError("tap2: errno 1")
         mock_run_command.return_value = MagicMock(stdout="")
 
+        caplog.set_level(logging.WARNING, logger="smolvm.host.network")
         with patch("smolvm.host.network.HAS_NETLINK", True):
             nm = NetworkManager()
             nm.create_tap("tap2", "alice")
@@ -201,6 +206,11 @@ class TestTapManagement:
         mock_run_command.assert_called_once_with(
             ["ip", "tuntap", "add", "tap2", "mode", "tap", "user", "alice"]
         )
+        warning = caplog.text
+        assert "Fast Rust networking needs permission" in warning
+        assert "root or CAP_NET_ADMIN" in warning
+        assert "smolvm setup" in warning
+        assert "same SmolVM command with sudo" in warning
 
     @patch("smolvm.host.network.run_command")
     @patch("smolvm.host.network.native")

--- a/tests/test_network.py
+++ b/tests/test_network.py
@@ -14,7 +14,7 @@
 
 """Tests for SmolVM network module."""
 
-from unittest.mock import MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
@@ -165,6 +165,27 @@ class TestTapManagement:
 
     @patch("smolvm.host.network.run_command")
     @patch("smolvm.host.network.native")
+    def test_native_can_be_forced_off_with_env_var(
+        self,
+        mock_native: MagicMock,
+        mock_run_command: MagicMock,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """SMOLVM_DISABLE_NATIVE_NETWORKING should leave subprocess commands unchanged."""
+        mock_run_command.return_value = MagicMock(stdout="")
+        monkeypatch.setenv("SMOLVM_DISABLE_NATIVE_NETWORKING", "yes")
+
+        with patch("smolvm.host.network.HAS_NETLINK", True):
+            nm = NetworkManager()
+            nm.create_tap("tap2", "alice")
+
+        mock_native.create_tap.assert_not_called()
+        mock_run_command.assert_called_once_with(
+            ["ip", "tuntap", "add", "tap2", "mode", "tap", "user", "alice"]
+        )
+
+    @patch("smolvm.host.network.run_command")
+    @patch("smolvm.host.network.native")
     def test_create_tap_falls_back_to_subprocess_on_eperm(
         self, mock_native: MagicMock, mock_run_command: MagicMock
     ) -> None:
@@ -200,6 +221,111 @@ class TestTapManagement:
         # add_route both short-circuited before touching the native module.
         assert mock_native.create_tap.call_count == 1
         mock_native.add_route.assert_not_called()
+
+    @patch("smolvm.host.network.run_command")
+    @patch("smolvm.host.network.Path.write_text", side_effect=PermissionError)
+    @patch("smolvm.host.network.native")
+    def test_native_sysctl_eperm_disables_subsequent_native_attempts(
+        self,
+        mock_native: MagicMock,
+        mock_write_text: MagicMock,
+        mock_run_command: MagicMock,
+    ) -> None:
+        """A native EPERM from sysctl should latch fallback for later helpers."""
+        mock_native.write_sysctl.side_effect = OSError("Operation not permitted")
+        mock_run_command.return_value = MagicMock(stdout="")
+
+        with patch("smolvm.host.network.HAS_NETLINK", True):
+            nm = NetworkManager()
+            nm.enable_ip_forwarding()
+            nm.add_route("172.16.0.5", "tap3")
+
+        mock_native.write_sysctl.assert_called_once()
+        mock_native.add_route.assert_not_called()
+        mock_write_text.assert_called_once_with("1")
+        commands = [call.args[0] for call in mock_run_command.call_args_list]
+        assert ["sysctl", "-w", "net.ipv4.ip_forward=1"] in commands
+        assert ["ip", "route", "add", "172.16.0.5/32", "dev", "tap3"] in commands
+
+
+class TestNativeTapManagement:
+    """Tests for native TAP/configure/route parity."""
+
+    @patch("smolvm.host.network.run_command")
+    @patch("smolvm.host.network.native")
+    def test_configure_tap_uses_composite_native_helper(
+        self, mock_native: MagicMock, mock_run_command: MagicMock
+    ) -> None:
+        """Sync configure should use one native helper plus the route_localnet sysctl."""
+        with patch("smolvm.host.network.HAS_NETLINK", True):
+            nm = NetworkManager()
+            nm.configure_tap("tap9", host_ip="172.16.0.1", netmask="32")
+
+        mock_native.configure_tap.assert_called_once_with("tap9", "172.16.0.1", 32)
+        mock_native.flush_addrs.assert_not_called()
+        mock_native.add_addr.assert_not_called()
+        mock_native.set_link_up.assert_not_called()
+        mock_native.write_sysctl.assert_called_once_with("net.ipv4.conf.tap9.route_localnet", "1")
+        mock_run_command.assert_not_called()
+
+    @patch("smolvm.host.network.run_command")
+    @patch("smolvm.host.network.native")
+    def test_default_interface_uses_native_when_available(
+        self, mock_native: MagicMock, mock_run_command: MagicMock
+    ) -> None:
+        """Default interface detection should honor the same native gate."""
+        mock_native.get_default_interface.return_value = "eth0"
+
+        with patch("smolvm.host.network.HAS_NETLINK", True):
+            nm = NetworkManager()
+            assert nm.outbound_interface == "eth0"
+
+        mock_native.get_default_interface.assert_called_once_with()
+        mock_run_command.assert_not_called()
+
+    @pytest.mark.asyncio
+    @patch("smolvm.host.network.async_run_command", new_callable=AsyncMock)
+    @patch("smolvm.host.network.native")
+    async def test_async_tap_route_and_delete_use_native_helpers(
+        self,
+        mock_native: MagicMock,
+        mock_async_run_command: AsyncMock,
+    ) -> None:
+        """Async TAP setup should use native helpers through to_thread when available."""
+        with patch("smolvm.host.network.HAS_NETLINK", True):
+            nm = NetworkManager()
+            await nm.async_create_tap("tap9", "__missing_user__")
+            await nm.async_configure_tap("tap9", host_ip="172.16.0.1", netmask="32")
+            await nm.async_add_route("172.16.0.5", "tap9")
+            await nm.async_cleanup_tap("tap9")
+
+        mock_native.create_tap.assert_called_once()
+        mock_native.configure_tap.assert_called_once_with("tap9", "172.16.0.1", 32)
+        mock_native.add_route.assert_called_once_with("172.16.0.5", 32, "tap9")
+        mock_native.delete_tap.assert_called_once_with("tap9")
+        mock_native.write_sysctl.assert_called_once_with("net.ipv4.conf.tap9.route_localnet", "1")
+        mock_async_run_command.assert_not_called()
+
+    @pytest.mark.asyncio
+    @patch("smolvm.host.network.async_run_command", new_callable=AsyncMock)
+    @patch("smolvm.host.network.native")
+    async def test_async_native_eperm_falls_back_to_subprocess(
+        self,
+        mock_native: MagicMock,
+        mock_async_run_command: AsyncMock,
+    ) -> None:
+        """Async native EPERM should use the existing subprocess fallback command."""
+        mock_native.add_route.side_effect = OSError("Operation not permitted")
+        mock_async_run_command.return_value = MagicMock(stdout="")
+
+        with patch("smolvm.host.network.HAS_NETLINK", True):
+            nm = NetworkManager()
+            await nm.async_add_route("172.16.0.5", "tap9")
+
+        mock_native.add_route.assert_called_once_with("172.16.0.5", 32, "tap9")
+        mock_async_run_command.assert_awaited_once_with(
+            ["ip", "route", "add", "172.16.0.5/32", "dev", "tap9"]
+        )
 
 
 class TestEpermDetector:
@@ -385,6 +511,9 @@ class TestNetworkPrerequisites:
 
         assert errors == []
         commands = [call.args[0] for call in mock_run_command.call_args_list]
+        assert ["which", "ip"] in commands
+        assert ["which", "nft"] in commands
+        assert ["which", "sysctl"] in commands
         assert ["ip", "link", "show"] in commands
         assert ["nft", "list", "tables"] in commands
         assert ["sysctl", "net.ipv4.ip_forward"] in commands

--- a/tests/test_smolvm_core.py
+++ b/tests/test_smolvm_core.py
@@ -28,6 +28,14 @@ def test_public_network_functions_have_python_signatures() -> None:
     assert signature.return_annotation is None
     assert "Create a TAP network device" in inspect.getdoc(smolvm_core.create_tap)
 
+    configure_signature = inspect.signature(smolvm_core.configure_tap)
+    assert list(configure_signature.parameters) == ["name", "host_ip", "prefix_len"]
+    assert configure_signature.parameters["name"].annotation is str
+    assert configure_signature.parameters["host_ip"].annotation is str
+    assert configure_signature.parameters["prefix_len"].annotation is int
+    assert configure_signature.return_annotation is None
+    assert "Assign an IPv4 address" in inspect.getdoc(smolvm_core.configure_tap)
+
 
 def test_qmp_native_class_stays_private() -> None:
     """QMP users should go through smolvm.qmp.QMPClient, not smolvm_core."""


### PR DESCRIPTION
## Summary

Migrate the low-risk Linux TAP/routes/sysctl networking path to use native Rust helpers where available, while keeping nftables subprocess-based.

## Changes

- Add `smolvm_core.configure_tap(name, host_ip, prefix_len)` to flush TAP addresses, assign the host IP, and bring the link up in one rtnetlink path.
- Normalize native EPERM failures to `Operation not permitted` so Python can reliably latch native fallback for the process.
- Add `SMOLVM_DISABLE_NATIVE_NETWORKING=1` developer fallback mode.
- Route sync and async TAP/create/configure/route/delete/sysctl/default-interface paths through the same native gate, with async native calls running via `asyncio.to_thread(...)`.
- Keep nftables subprocess-based for NAT/firewall/forwarding.
- Add `scripts/benchmarks/networking.py` for Linux TAP-stage timing and state validation across native, forced-off, and unprivileged-fallback modes.
- Update smolvm-core docs, Python shim exports, and focused tests.

## Benchmark Results

Privileged run supplied from:

```bash
sudo /home/celesto/celesto/SmolVM/.venv/bin/python \
  scripts/benchmarks/networking.py \
  --modes native,forced-off \
  --json --output /tmp/smolvm-networking-sudo.json
```

Comparison: `native` runs the Rust helpers as root; `forced-off` sets `SMOLVM_DISABLE_NATIVE_NETWORKING=1` and uses the subprocess path. Negative percentages are faster than forced-off.

| Stage | Native | Forced-off | Change | Speedup |
| --- | ---: | ---: | ---: | ---: |
| default interface detection | 0.2 ms | 1.0 ms | -80.0% | 5.0x |
| create TAP | 0.3 ms | 1.2 ms | -75.0% | 4.0x |
| configure TAP | 0.3 ms | 2.2 ms | -86.4% | 7.3x |
| add route | 0.1 ms | 1.1 ms | -90.9% | 11.0x |
| enable IP forwarding | 0.0 ms | 0.0 ms | 0.0% | n/a |
| setup NAT/firewall | 25.8 ms | 24.9 ms | +3.6% | 1.0x |
| setup SSH port forward | 3.6 ms | 3.4 ms | +5.9% | 0.9x |
| cleanup SSH port forward | 48.1 ms | 61.3 ms | -21.5% | 1.3x |
| delete TAP | 15.7 ms | 19.3 ms | -18.7% | 1.2x |
| total measured stages | 94.1 ms | 114.4 ms | -17.7% | 1.2x |

Native-migrated stages only (`default_interface`, `create_tap`, `configure_tap`, `add_route`, `enable_ip_forwarding`, `delete_tap`) were 16.6 ms native vs 24.8 ms forced-off: **33.1% faster**. Mutating TAP/route/sysctl stages excluding default-interface detection were 16.4 ms native vs 23.8 ms forced-off: **31.1% faster**.

Interpretation: the Rust path materially speeds up the TAP/configure/route work when the SmolVM process has root/CAP_NET_ADMIN. nftables remains subprocess-based in this PR, so NAT/firewall and port-forward stages are not expected to improve from this migration and small deltas there are run-to-run noise.

Fallback sanity check from this non-root shell: five `forced-off` vs `unprivileged-fallback` runs were effectively flat overall (median total 237.7 ms vs 237.5 ms, -0.1%; mean total +0.6%), confirming that without direct networking privileges SmolVM falls back to the subprocess path rather than partially reporting native gains.

## Validation

- `maturin develop --manifest-path smolvm-core/Cargo.toml --features extension-module`
- `.venv/bin/ruff check smolvm-core/python/smolvm_core/__init__.py src/smolvm/host/network.py tests/test_network.py tests/test_smolvm_core.py scripts/benchmarks/networking.py`
- `.venv/bin/python -m pytest tests/test_network.py -q`
- `.venv/bin/python -m pytest tests/test_smolvm_core.py -q`
- `cargo test -p smolvm-core` with a temporary `LIBRARY_PATH` symlink for this host's missing `libpython3.14.so` linker name
- `.venv/bin/python scripts/benchmarks/networking.py --help`
- benchmark skip guidance monkeypatch check

Firecracker full-start smoke was not run as part of this benchmark pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `smolvm_core.configure_tap()` for one-call native TAP setup (flush/add IPv4 address and bring the link up).
  * Added `SMOLVM_DISABLE_NATIVE_NETWORKING` to force non-native networking behavior.
  * Added a Linux networking benchmark to compare native vs fallback stage timings, with JSON output.
* **Bug Fixes**
  * Improved permission-denied handling for netlink operations, with more consistent fallback behavior for subsequent networking steps.
* **Documentation**
  * Updated `smolvm-core` docs/README with `configure_tap()` usage and native-vs-fallback behavior details.
* **Tests**
  * Expanded coverage for native/fallback gating, EPERM fallback behavior, and `configure_tap()` signature metadata.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->