### PR TITLE
[codex] Release smolvm-core with CalVer

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -100,8 +100,8 @@ jobs:
       - name: Smoke test built wheels
         run: |
           # Read smolvm version and the smolvm-core version it depends on.
-          # smolvm and smolvm-core are released independently within the
-          # 0.0.x series, so we pull the expected core version from the
+          # smolvm and smolvm-core are released independently, so we pull the
+          # expected core version from the
           # pyproject dependency string rather than assuming lockstep.
           eval "$(python3 - <<'PY'
           import re

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -878,7 +878,7 @@ checksum = "8ed6a63f02c8539c91a8685a86f4099661ba3da017932f6ebbea6de3f0fa7c90"
 
 [[package]]
 name = "smolvm-core"
-version = "0.0.15"
+version = "2026.6.22"
 dependencies = [
  "futures-util",
  "libc",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,7 @@ classifiers = [
 ]
 dependencies = [
     "click>=8.0",
-    "smolvm-core~=0.0.15",
+    "smolvm-core~=2026.6.22",
     "paramiko>=3.0",
     "pycdlib>=1.14.0",
     "pydantic>=2.0",

--- a/smolvm-core/Cargo.toml
+++ b/smolvm-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "smolvm-core"
-version = "0.0.15"
+version = "2026.6.22"
 description = "Rust-native core package for SmolVM"
 documentation = "https://docs.rs/smolvm-core"
 readme = "README.md"

--- a/smolvm-core/README.md
+++ b/smolvm-core/README.md
@@ -12,6 +12,19 @@ That install pulls in the matching `smolvm-core` wheel automatically on supporte
 
 Install `smolvm-core` directly only if you are developing the native extension or testing package releases.
 
+## Versioning and release tags
+
+`smolvm-core` uses date-based versions in `YYYY.M.D` form, such as `2026.6.22`. This keeps the same version valid for Cargo, maturin, and Python package metadata.
+
+Release tags use the same version with a `core-v` prefix:
+
+```bash
+git tag core-v2026.6.22
+git push origin core-v2026.6.22
+```
+
+The publish workflow checks that the tag matches `smolvm-core/Cargo.toml` before it builds wheels and publishes them to PyPI.
+
 ## When the native extension is used
 
 SmolVM uses `smolvm-core` for two host-side jobs when they are available:


### PR DESCRIPTION
## Summary

- switch `smolvm-core` from `0.0.15` to Cargo-compatible CalVer `2026.6.22`
- update the main `smolvm` package dependency to `smolvm-core~=2026.6.22`
- document the `core-vYYYY.M.D` release tag format and update stale package-smoke comments

## Release step after merge

```bash
git checkout main
git pull origin main
git tag core-v2026.6.22
git push origin core-v2026.6.22
```

The `Publish smolvm-core` workflow verifies that `core-v2026.6.22` matches `smolvm-core/Cargo.toml` before building and publishing wheels.

## Validation

- `cargo metadata --no-deps --format-version 1`
- `cargo check -p smolvm-core`
- `uv build --package smolvm-core --wheel --out-dir /tmp/smolvm-core-calver-dist`
- `LIBRARY_PATH=/tmp/smolvm-python-libs cargo test -p smolvm-core`
- `uv build --package smolvm-core --sdist --out-dir /tmp/smolvm-core-calver-dist`
- `uv build --package smolvm --wheel --out-dir /tmp/smolvm-calver-dist`
- local publish preflight with `GITHUB_REF_NAME=core-v2026.6.22`
- wheel metadata check: `smolvm-core` version is `2026.6.22`; `smolvm` requires `smolvm-core~=2026.6.22`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated smolvm-core dependency to version 2026.6.22.

* **Documentation**
  * Added documentation describing the date-based versioning format and release tag requirements for the core component.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->