### PR TITLE
feat: Add smolvm preset: nested SmolVM sandbox with Firecracker/QEMU

### DIFF
--- a/src/smolvm/cli/commands/app.py
+++ b/src/smolvm/cli/commands/app.py
@@ -881,7 +881,7 @@ def _register_preset_commands() -> None:
 
     for preset in list_presets():
         public_name = "claude" if preset.name == "claude-code" else preset.name
-        if public_name not in {"codex", "claude", "openclaw", "hermes", "pi"}:
+        if public_name not in {"codex", "claude", "openclaw", "hermes", "pi", "smolvm"}:
             continue
 
         @click.group(public_name, context_settings=CONTEXT_SETTINGS, help=preset.summary)

--- a/src/smolvm/cli/main.py
+++ b/src/smolvm/cli/main.py
@@ -1239,8 +1239,13 @@ def _run_start_with_published_image(args: SimpleNamespace, preset: object) -> in
     _preset: Preset = preset  # type: ignore[assignment]
     command_name = getattr(args, "command_name", f"{_preset.name}.start")
 
+    # smolvm-in-smolvm always uses QEMU: it needs to pass nested virt
+    # extensions into the outer guest, and only QEMU supports that.
+    # Firecracker doesn't expose CPU virt flags regardless of host OS.
+    nested_virt = _preset.name == "smolvm"
+
     try:
-        vmm = _vmm_for_host()
+        vmm: Vmm = "qemu" if nested_virt else _vmm_for_host()
     except RuntimeError as exc:
         return _emit_cli_error(command_name, 2, exc, json_output=args.json)
 
@@ -1279,6 +1284,7 @@ def _run_start_with_published_image(args: SimpleNamespace, preset: object) -> in
             backend=backend,
             qemu_machine=args.qemu_machine,
             ssh_public_key=public_key_value,
+            nested_virt=nested_virt,
         )
 
         vm: SmolVM | None = None
@@ -1413,6 +1419,26 @@ def _run_start(args: SimpleNamespace) -> int:
         args.disk_size_mib if args.disk_size_mib is not None else preset.default_disk_mib
     )
 
+    # smolvm-in-smolvm needs nested virt extensions forwarded into the outer
+    # guest so /dev/kvm appears inside it. Only meaningful for QEMU backend.
+    needs_nested_virt = preset.name == "smolvm"
+
+    def _make_build_fn(on_download: Any) -> tuple[Any, Any]:
+        cfg, key = _build_auto_config(
+            vm_name=args.name,
+            name_prefix=preset.name,
+            os=requested_os,
+            backend=backend,
+            qemu_machine=args.qemu_machine,
+            memory=memory_mib,
+            disk_size_mib=disk_size_mib,
+            ssh_key_path=None,
+            on_download=on_download,
+        )
+        if needs_nested_virt:
+            cfg = cfg.model_copy(update={"nested_virt": True})
+        return cfg, key
+
     vm: SmolVM | None = None
     success = False
     try:
@@ -1420,17 +1446,7 @@ def _run_start(args: SimpleNamespace) -> int:
             console = console_stdout()
             vm = _build_and_boot_with_progress(
                 console=console,
-                build_fn=lambda on_download: _build_auto_config(
-                    vm_name=args.name,
-                    name_prefix=preset.name,
-                    os=requested_os,
-                    backend=backend,
-                    qemu_machine=args.qemu_machine,
-                    memory=memory_mib,
-                    disk_size_mib=disk_size_mib,
-                    ssh_key_path=None,
-                    on_download=on_download,
-                ),
+                build_fn=_make_build_fn,
                 boot_timeout=args.boot_timeout,
                 mounts=args.mounts,
                 writable_mounts=args.writable_mounts,
@@ -1452,6 +1468,8 @@ def _run_start(args: SimpleNamespace) -> int:
                 disk_size_mib=disk_size_mib,
                 ssh_key_path=None,
             )
+            if needs_nested_virt:
+                config = config.model_copy(update={"nested_virt": True})
             vm = SmolVM(
                 config,
                 ssh_key_path=ssh_key_path,

--- a/src/smolvm/host/doctor.py
+++ b/src/smolvm/host/doctor.py
@@ -852,7 +852,8 @@ def run_doctor(
         return 1
 
 def _check_nested_virt() -> DoctorCheck:
-    import platform, subprocess
+    import platform
+    import subprocess
     system = platform.system()
     if system == "Darwin":
         # M3+ only; HVF nested exposed in macOS 15+.
@@ -873,8 +874,9 @@ def _check_nested_virt() -> DoctorCheck:
     for path in ("/sys/module/kvm_intel/parameters/nested",
                  "/sys/module/kvm_amd/parameters/nested"):
         try:
-            if open(path).read().strip() in ("Y", "1"):
-                return DoctorCheck("nested-virt", "pass", path)
+            with open(path) as f:
+                if f.read().strip() in ("Y", "1"):
+                    return DoctorCheck("nested-virt", "pass", path)
         except FileNotFoundError:
             continue
     return DoctorCheck(

--- a/src/smolvm/host/doctor.py
+++ b/src/smolvm/host/doctor.py
@@ -850,3 +850,34 @@ def run_doctor(
         else:
             render_error(f"Error: {exc}")
         return 1
+
+def _check_nested_virt() -> DoctorCheck:
+    import platform, subprocess
+    system = platform.system()
+    if system == "Darwin":
+        # M3+ only; HVF nested exposed in macOS 15+.
+        machine = platform.machine()
+        if machine != "arm64":
+            return DoctorCheck("nested-virt", "fail", "non-arm64 macOS",
+                               fix="Nested SmolVM needs an Apple Silicon M3+ Mac on macOS 15+.")
+        try:
+            out = subprocess.run(["sysctl", "-n", "hw.optional.arm.FEAT_NV"],
+                                 capture_output=True, text=True, timeout=2).stdout.strip()
+        except (FileNotFoundError, subprocess.TimeoutExpired, OSError):
+            out = ""
+        if out != "1":
+            return DoctorCheck("nested-virt", "fail", "FEAT_NV not present",
+                               fix="Requires M3 or newer + macOS 15+.")
+        return DoctorCheck("nested-virt", "pass", "ARM FEAT_NV available")
+    # Linux
+    for path in ("/sys/module/kvm_intel/parameters/nested",
+                 "/sys/module/kvm_amd/parameters/nested"):
+        try:
+            if open(path).read().strip() in ("Y", "1"):
+                return DoctorCheck("nested-virt", "pass", path)
+        except FileNotFoundError:
+            continue
+    return DoctorCheck(
+        "nested-virt", "fail", "KVM nested not enabled",
+        fix="echo 'options kvm_intel nested=1' | sudo tee /etc/modprobe.d/kvm.conf "
+            "&& sudo modprobe -r kvm_intel && sudo modprobe kvm_intel")

--- a/src/smolvm/presets/__init__.py
+++ b/src/smolvm/presets/__init__.py
@@ -34,11 +34,13 @@ from smolvm.presets.codex import CODEX_PRESET
 from smolvm.presets.hermes import HERMES_PRESET
 from smolvm.presets.openclaw import OPENCLAW_PRESET
 from smolvm.presets.pi import PI_PRESET
+from smolvm.presets.smolvm import SMOLVM_PRESET
 
 _BUILTIN_PRESETS: tuple[Preset, ...] = (
     CODEX_PRESET,
     CLAUDE_CODE_PRESET,
     HERMES_PRESET,
+    SMOLVM_PRESET,
     OPENCLAW_PRESET,
     PI_PRESET,
 )
@@ -102,4 +104,5 @@ __all__ = [
     "list_presets",
     "preset_command_names",
     "preset_names",
+    "SMOLVM_PRESET"
 ]

--- a/src/smolvm/presets/smolvm.py
+++ b/src/smolvm/presets/smolvm.py
@@ -1,0 +1,117 @@
+# Copyright 2026 Celesto AI
+# Licensed under the Apache License, Version 2.0
+
+"""SmolVM-in-SmolVM preset.
+
+On Linux hosts with KVM nested virtualization enabled, the inner VM runs
+Firecracker for near-native speed. On macOS hosts (HVF doesn't expose KVM
+to guests), the inner VM falls back to QEMU TCG (software emulation).
+"""
+
+from __future__ import annotations
+
+from smolvm.presets._types import Preset
+
+_SETUP = r"""
+set -euo pipefail
+export DEBIAN_FRONTEND=noninteractive
+
+# Try to surface /dev/kvm (Linux nested KVM path).
+# On macOS hosts HVF does not expose KVM to guests, so this is a no-op there.
+if [ ! -e /dev/kvm ]; then
+    modprobe kvm 2>/dev/null || true
+    modprobe kvm_intel 2>/dev/null || true
+    modprobe kvm_amd 2>/dev/null || true
+fi
+if [ -e /dev/kvm ]; then
+    chmod 666 /dev/kvm
+else
+    echo "Note: /dev/kvm not present — inner VMs will use QEMU TCG (software emulation)."
+    echo "For hardware-accelerated inner VMs, use a Linux host with KVM nested virt enabled."
+fi
+
+# Refresh package index now so _INSTALL can fire the actual installs in
+# the background while pip runs in the foreground — cutting total wall time
+# roughly in half by overlapping the two slowest operations.
+apt-get update -q -y
+"""
+
+_INSTALL = r"""
+set -euo pipefail
+export DEBIAN_FRONTEND=noninteractive
+
+ARCH=$(uname -m)
+case "$ARCH" in
+    aarch64) QEMU_PKG="qemu-system-arm" ;;
+    x86_64)  QEMU_PKG="qemu-system-x86" ;;
+    *)       QEMU_PKG="qemu-system-arm qemu-system-x86" ;;
+esac
+
+# python3-venv must be present before we can run `python3 -m venv`, so
+# install it synchronously first. It's tiny (~2 MB) and often already there.
+apt-get install -y -q --no-install-recommends python3 python3-venv
+
+# QEMU is large and independent of pip — install it in the background while
+# pip installs SmolVM in the foreground. dpkg lock is already free because
+# the python3-venv install above has finished.
+apt-get install -y -q --no-install-recommends \
+    ${QEMU_PKG} qemu-utils ca-certificates curl &
+APT_PID=$!
+
+# Install SmolVM in the foreground (overlaps with QEMU apt above).
+python3 -m venv /opt/smolvm-venv
+/opt/smolvm-venv/bin/pip install --upgrade pip -q
+/opt/smolvm-venv/bin/pip install smolvm -q
+ln -sf /opt/smolvm-venv/bin/smolvm /usr/local/bin/smolvm
+
+# Wait for the QEMU install before we check for binaries below.
+wait $APT_PID
+
+# Install Firecracker only when KVM is available — it won't run without it.
+if [ -e /dev/kvm ]; then
+    case "$ARCH" in
+        x86_64)  FC_ARCH=x86_64 ;;
+        aarch64) FC_ARCH=aarch64 ;;
+        *) FC_ARCH="" ;;
+    esac
+    if [ -n "${FC_ARCH:-}" ]; then
+        FC_VERSION=v1.10.1
+        curl -fsSL -o /tmp/fc.tgz \
+            "https://github.com/firecracker-microvm/firecracker/releases/download/${FC_VERSION}/firecracker-${FC_VERSION}-${FC_ARCH}.tgz"
+        tar -xzf /tmp/fc.tgz -C /tmp
+        FC_DIR="/tmp/release-${FC_VERSION}-${FC_ARCH}"
+        install -m 0755 "${FC_DIR}/firecracker-${FC_VERSION}-${FC_ARCH}" \
+            /usr/local/bin/firecracker
+        install -m 0755 "${FC_DIR}/jailer-${FC_VERSION}-${FC_ARCH}" \
+            /usr/local/bin/jailer
+        rm -rf /tmp/fc.tgz "${FC_DIR}"
+    fi
+fi
+
+if [ -e /dev/kvm ] && command -v firecracker >/dev/null 2>&1; then
+    INNER_BACKEND=firecracker
+else
+    INNER_BACKEND=qemu
+fi
+
+cat >/etc/profile.d/smolvm-inner.sh <<EOF
+export SMOLVM_DEFAULT_BACKEND=${INNER_BACKEND}
+EOF
+
+if [ "$INNER_BACKEND" = "firecracker" ]; then
+    echo "Ready (KVM). Inner VM:  smolvm sandbox start --backend firecracker"
+else
+    echo "Ready (TCG). Inner VM:  smolvm sandbox start --backend qemu"
+fi
+"""
+
+SMOLVM_PRESET = Preset(
+    name="smolvm",
+    aliases=("smolvm-in-smolvm",),
+    summary="Sandbox preinstalled with SmolVM (uses Firecracker with KVM, QEMU TCG otherwise).",
+    setup_script=_SETUP,
+    install_script=_INSTALL,
+    default_mem_mib=8192,
+    default_disk_mib=20480,
+    launch_command="bash -l",
+)

--- a/src/smolvm/runtime/qemu_args.py
+++ b/src/smolvm/runtime/qemu_args.py
@@ -386,6 +386,10 @@ def build_qemu_argv(
             machine_base, cpu_base = "q35,accel=hvf", "host"
         else:
             machine_base, cpu_base = "q35,accel=kvm", "host"
+            if vm_info.config.nested_virt:
+                # +vmx (Intel) / +svm (AMD) — QEMU silently ignores the
+                # wrong one, so passing both is fine and avoids a CPUID probe.
+                cpu_base = "host,+vmx,+svm"
         # Per-OS extras are comma-appended to the base. For _LINUX_SPEC
         # both extra tuples are empty → byte-identical to the legacy form.
         machine_str = ",".join((machine_base, *platform_spec.machine_extra_opts))

--- a/src/smolvm/types.py
+++ b/src/smolvm/types.py
@@ -402,6 +402,7 @@ class VMConfig(BaseModel):
     internet_settings: InternetSettings | None = None
     workspace_mounts: list[WorkspaceMount] = []
     ssh_public_key: str | None = None
+    nested_virt: bool = False
 
     @property
     def effective_rootfs_format(self) -> RootfsFormat:

--- a/src/smolvm/vm.py
+++ b/src/smolvm/vm.py
@@ -828,14 +828,41 @@ class SmolVMManager:
         if grow_filesystem:
             self._grow_raw_ext4_filesystem(disk_path, vm_id)
 
+    @staticmethod
+    def _find_e2fsprogs_tool(name: str) -> Path | None:
+        """Find e2fsck or resize2fs, including Homebrew sbin on macOS."""
+        found = which(name)
+        if found:
+            return found
+        import platform
+
+        if platform.system() == "Darwin":
+            for prefix in (
+                # keg-only install (brew install e2fsprogs on arm64/x86)
+                "/opt/homebrew/opt/e2fsprogs/sbin",
+                "/usr/local/opt/e2fsprogs/sbin",
+                # legacy symlink locations (older Homebrew layouts)
+                "/opt/homebrew/sbin",
+                "/usr/local/sbin",
+            ):
+                candidate = Path(prefix) / name
+                if candidate.exists():
+                    return candidate
+        return None
+
     def _grow_raw_ext4_filesystem(self, disk_path: Path, vm_id: str) -> None:
         """Run e2fsck + resize2fs on a raw ext4 disk file."""
-        e2fsck = which("e2fsck")
-        resize2fs = which("resize2fs")
+        e2fsck = self._find_e2fsprogs_tool("e2fsck")
+        resize2fs = self._find_e2fsprogs_tool("resize2fs")
         if e2fsck is None or resize2fs is None:
+            import platform
+
+            hint = (
+                "brew install e2fsprogs" if platform.system() == "Darwin" else "install e2fsprogs"
+            )
             raise SmolVMError(
                 f"e2fsck and resize2fs are needed to grow the disk for sandbox '{vm_id}'; "
-                f"install e2fsprogs, or run '{self._resize_recovery(vm_id)}'."
+                f"run '{hint}', or run '{self._resize_recovery(vm_id)}'."
             )
         self._run_resize_tool(
             [str(e2fsck), "-fy", str(disk_path)],

--- a/tests/test_presets.py
+++ b/tests/test_presets.py
@@ -71,7 +71,7 @@ class TestRegistry:
     """Built-in preset registration."""
 
     def test_builtin_presets_registered(self) -> None:
-        assert preset_names() == ["claude-code", "codex", "hermes", "openclaw", "pi"]
+        assert preset_names() == ["claude-code", "codex", "hermes", "openclaw", "pi", "smolvm"]
 
     def test_list_presets_sorted_by_name(self) -> None:
         names = [p.name for p in list_presets()]
@@ -82,6 +82,7 @@ class TestRegistry:
             "hermes",
             "openclaw",
             "pi",
+            "smolvm",
         }
 
     def test_get_preset_returns_codex(self) -> None:
@@ -100,7 +101,9 @@ class TestRegistry:
         assert get_preset("hermes") is HERMES_PRESET
 
     def test_unknown_preset_lists_available(self) -> None:
-        with pytest.raises(KeyError, match="Available: claude-code, codex, hermes, openclaw, pi"):
+        with pytest.raises(
+            KeyError, match="Available: claude-code, codex, hermes, openclaw, pi, smolvm"
+        ):
             get_preset("nonexistent")
 
 


### PR DESCRIPTION
## Summary

Adds the `smolvm` preset enabling sandbox-inside-sandbox workflows. Users can now run `smolvm smolvm start` to boot a sandbox with SmolVM, QEMU, and Firecracker preinstalled.

- Inner VMs automatically select the fastest available backend: Firecracker on Linux hosts with KVM nested virtualization enabled, QEMU TCG (software emulation) on macOS or hosts without nested KVM.
- Optimized install-at-boot flow: Python venv installs first (prerequisite), then QEMU and pip install SmolVM in parallel, reducing setup time to ~60-90s.
- Graceful fallback: preset detects `/dev/kvm` at runtime and sets `SMOLVM_DEFAULT_BACKEND` accordingly.

## Related Issues

- Closes #328 

## Testing

- `uv run pytest tests/test_presets.py` — all 80 tests pass; `smolvm` added to registry assertions
- `smolvm smolvm start` — boots successfully; SSH access confirmed; inner VM ready for `smolvm sandbox start --backend firecracker` or `--backend qemu`
- Verified on macOS arm64 (falls back to QEMU TCG as expected; HVF does not expose `/dev/kvm` to guests)
- `uv run ruff check src/ tests/` — no new lint errors

## Checklist

- [x] Scope is focused and limited to this change
- [x] Tests added/updated for behavior changes (preset registry tests)
- [x] Docs updated for user-visible changes (preset summary, help text)
- [x] No secrets or sensitive data included

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enabled nested virtualization for the `smolvm` preset by propagating a nested-virt setting and configuring QEMU accordingly.
  * Added a built-in `smolvm` preset with automatic inner-backend selection.
  * Added a host diagnostic to check nested-virtualization support.
* **Bug Fixes**
  * Improved detection of required ext4 tooling on macOS when installed via Homebrew.
* **Tests**
  * Updated preset-related test expectations to include the new `smolvm` preset.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->