### PR TITLE
Fallback to raw exec when guest sync route is missing

### DIFF
--- a/src/smolvm/comm/rust_http_vsock_channel.py
+++ b/src/smolvm/comm/rust_http_vsock_channel.py
@@ -211,7 +211,22 @@ class RustHttpVsockChannel:
     def sync(self, timeout: float = 10) -> None:
         if timeout <= 0:
             raise ValueError("timeout must be > 0")
-        resp = self._request_json("POST", "/sync", timeout=float(timeout + self.connect_timeout))
+        try:
+            resp = self._request_json(
+                "POST",
+                "/sync",
+                timeout=float(timeout + self.connect_timeout),
+            )
+        except SmolVMError as exc:
+            if "guest agent HTTP 404 for POST /sync" not in str(exc):
+                raise
+            result = self.run("sync", timeout=timeout, shell="raw")
+            if result.exit_code != 0:
+                raise SmolVMError(
+                    "guest agent error during legacy sync fallback: "
+                    f"exit_code={result.exit_code} stderr={result.stderr!r}"
+                ) from exc
+            return
         if not resp.get("ok"):
             raise SmolVMError(f"guest agent error during sync: {resp.get('error', resp)}")
 

--- a/tests/test_rust_http_vsock_channel.py
+++ b/tests/test_rust_http_vsock_channel.py
@@ -54,9 +54,7 @@ class FakeRustChannel(RustHttpVsockChannel):
                 if isinstance(result, tuple):
                     status, result = result
                 payload = (
-                    result.encode()
-                    if isinstance(result, str)
-                    else json.dumps(result).encode()
+                    result.encode() if isinstance(result, str) else json.dumps(result).encode()
                 )
                 status_text = "OK" if status < 400 else "ERROR"
                 guest.sendall(

--- a/tests/test_rust_http_vsock_channel.py
+++ b/tests/test_rust_http_vsock_channel.py
@@ -31,7 +31,7 @@ from smolvm.comm.base import CommChannel
 from smolvm.comm.rust_http_vsock_channel import RustHttpVsockChannel
 from smolvm.exceptions import OperationTimeoutError, SmolVMError
 
-Handler = Callable[[str, str, bytes], dict]
+Handler = Callable[[str, str, bytes], dict | tuple[int, dict | str]]
 
 
 class FakeRustChannel(RustHttpVsockChannel):
@@ -49,10 +49,19 @@ class FakeRustChannel(RustHttpVsockChannel):
                 data = _read_http_request(guest)
                 method, path, body = data
                 self.requests.append(data)
-                payload = json.dumps(handler(method, path, body)).encode()
+                result = handler(method, path, body)
+                status = 200
+                if isinstance(result, tuple):
+                    status, result = result
+                payload = (
+                    result.encode()
+                    if isinstance(result, str)
+                    else json.dumps(result).encode()
+                )
+                status_text = "OK" if status < 400 else "ERROR"
                 guest.sendall(
-                    b"HTTP/1.1 200 OK\r\n"
-                    b"Content-Type: application/json\r\n"
+                    f"HTTP/1.1 {status} {status_text}\r\n".encode()
+                    + b"Content-Type: application/json\r\n"
                     + f"Content-Length: {len(payload)}\r\n".encode()
                     + b"Connection: close\r\n\r\n"
                     + payload
@@ -220,6 +229,38 @@ def test_sync_error_maps_to_smolvm_error() -> None:
 
     with pytest.raises(SmolVMError, match="busy"):
         channel.sync()
+
+
+def test_sync_falls_back_to_raw_exec_when_endpoint_missing() -> None:
+    def _missing_sync(method: str, path: str, body: bytes) -> tuple[int, str]:
+        assert method == "POST"
+        assert path == "/sync"
+        assert body == b""
+        return (404, "")
+
+    def _legacy_exec(method: str, path: str, body: bytes) -> dict:
+        assert method == "POST"
+        assert path == "/exec"
+        request = json.loads(body)
+        assert request["command"] == "sync"
+        assert request["shell"] == "raw"
+        assert request["timeout_seconds"] == 10
+        return {"ok": True, "exit_code": 0, "stdout": "", "stderr": "", "timed_out": False}
+
+    channel = FakeRustChannel([_missing_sync, _legacy_exec])
+    channel.sync(timeout=10)
+
+
+def test_sync_fallback_exec_failure_maps_to_smolvm_error() -> None:
+    def _missing_sync(method: str, path: str, body: bytes) -> tuple[int, str]:
+        return (404, "")
+
+    def _legacy_exec(method: str, path: str, body: bytes) -> dict:
+        return {"ok": True, "exit_code": 1, "stdout": "", "stderr": "nope", "timed_out": False}
+
+    channel = FakeRustChannel([_missing_sync, _legacy_exec])
+    with pytest.raises(SmolVMError, match="legacy sync fallback"):
+        channel.sync(timeout=10)
 
 
 def test_put_and_get_file(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary
- keep using the dedicated `POST /sync` route for current guests
- fall back to raw `sync` via `/exec` when older running guests return 404 for `POST /sync`
- preserve hard failures for other `/sync` errors and for failed fallback exec

## RCA
Dataplane rolled host SmolVM `0.0.22a1`, whose disk snapshot preflight calls `RustHttpVsockChannel.sync()` / `POST /sync`. Already-running/restored guests from the previous image did not have `/sync`, but still supported raw `/exec`. The host code did not include the intended compatibility fallback, so every snapshot against those guests failed with `guest agent HTTP 404 for POST /sync`.

## Validation
- `uv run pytest tests/test_rust_http_vsock_channel.py -q`
- `uv run ruff check src/smolvm/comm/rust_http_vsock_channel.py tests/test_rust_http_vsock_channel.py`
- live dataplane hot patch validated on prod host: manual disk snapshot succeeded and the next service sweep uploaded 21/21 snapshots.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved `sync` behavior when the dedicated `/sync` endpoint is unavailable by automatically falling back to a legacy “raw exec” sync flow.
  * Ensures fallback results are validated and that failures are surfaced with clearer `SmolVMError` mapping.
* **Tests**
  * Added coverage for missing `/sync` handling and for proper error raising when the legacy fallback execution fails.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->