### PR TITLE
[codex] Add Rust migration benchmark foundation

### DIFF
--- a/scripts/benchmarks/README.md
+++ b/scripts/benchmarks/README.md
@@ -46,6 +46,25 @@ uv run python scripts/benchmarks/bench.py --backend qemu
 
 `-v` enables per-iteration progress logging.
 
+## Foundation Scripts
+
+These scripts provide small, composable probes for benchmark setup work. Each
+one supports `--help`, `--dry-run`, `--json`, and optional `--output` so you can
+check the command plan before starting any sandbox:
+
+```bash
+uv run python scripts/benchmarks/artifacts.py --dry-run --json
+uv run python scripts/benchmarks/preset_start.py --preset codex --dry-run --json
+uv run python scripts/benchmarks/browser_ready.py --dry-run --json
+uv run python scripts/benchmarks/runtime_control.py --operations info,stop,start --dry-run --json
+```
+
+`artifacts.py` records metadata for local artifact paths. `preset_start.py`
+times `smolvm <preset> start` and cleans up the sandbox unless `--keep` is set.
+`browser_ready.py` starts a browser sandbox, then polls the CDP endpoint when it
+is available. `runtime_control.py` measures public lifecycle commands such as
+`smolvm sandbox pause`, `resume`, `stop`, and `start`.
+
 ## Linux Networking Stages
 
 Use `networking.py` to decide whether the Rust networking path makes Linux VM

--- a/scripts/benchmarks/README.md
+++ b/scripts/benchmarks/README.md
@@ -48,8 +48,10 @@ uv run python scripts/benchmarks/bench.py --backend qemu
 
 ## Foundation Scripts
 
-These scripts provide small, composable probes for benchmark setup work. Each
-one supports `--help`, `--dry-run`, `--json`, and optional `--output` so you can
+Use these scripts to see which setup step is slowing down a sandbox start, then
+decide where an optimization will matter most. Each script is a small probe,
+meaning it measures one part of startup or cleanup on its own. Every probe
+supports `--help`, `--dry-run`, `--json`, and optional `--output` so you can
 check the command plan before starting any sandbox:
 
 ```bash
@@ -59,10 +61,11 @@ uv run python scripts/benchmarks/browser_ready.py --dry-run --json
 uv run python scripts/benchmarks/runtime_control.py --operations info,stop,start --dry-run --json
 ```
 
-`artifacts.py` records metadata for local artifact paths. `preset_start.py`
-times `smolvm <preset> start` and cleans up the sandbox unless `--keep` is set.
-`browser_ready.py` starts a browser sandbox, then polls the CDP endpoint when it
-is available. `runtime_control.py` measures public lifecycle commands such as
+`artifacts.py` records metadata for local image and browser files.
+`preset_start.py` times `smolvm <preset> start` and cleans up the sandbox unless
+`--keep` is set. `browser_ready.py` starts a browser sandbox, then polls the CDP
+endpoint, which is the local browser debugging URL, when it is available.
+`runtime_control.py` measures public lifecycle commands such as
 `smolvm sandbox pause`, `resume`, `stop`, and `start`.
 
 ## Linux Networking Stages

--- a/scripts/benchmarks/artifacts.py
+++ b/scripts/benchmarks/artifacts.py
@@ -56,8 +56,19 @@ def inspect_path(
         record["status"] = "missing"
         return record
 
-    if path.is_file():
-        stat = path.stat()
+    try:
+        is_file = path.is_file()
+        is_dir = path.is_dir()
+    except OSError as exc:
+        record.update({"status": "error", "error": str(exc)})
+        return record
+
+    if is_file:
+        try:
+            stat = path.stat()
+        except OSError as exc:
+            record.update({"status": "error", "kind": "file", "error": str(exc)})
+            return record
         record.update(
             {
                 "status": "ok",
@@ -70,7 +81,7 @@ def inspect_path(
             record.update(_hash_file(path, max_hash_bytes=max_hash_bytes))
         return record
 
-    if not path.is_dir():
+    if not is_dir:
         record.update({"status": "skipped", "kind": "other"})
         return record
 
@@ -200,14 +211,20 @@ def main(argv: list[str] | None = None) -> int:
 
 
 def _hash_file(path: Path, *, max_hash_bytes: int) -> dict[str, Any]:
-    size = path.stat().st_size
+    try:
+        size = path.stat().st_size
+    except OSError as exc:
+        return {"sha256": None, "hash_error": str(exc)}
     if size > max_hash_bytes:
         return {"sha256": None, "hash_skipped": "file exceeds --max-hash-mib"}
 
     hasher = hashlib.sha256()
-    with path.open("rb") as handle:
-        for chunk in iter(lambda: handle.read(1024 * 1024), b""):
-            hasher.update(chunk)
+    try:
+        with path.open("rb") as handle:
+            for chunk in iter(lambda: handle.read(1024 * 1024), b""):
+                hasher.update(chunk)
+    except OSError as exc:
+        return {"sha256": None, "hash_error": str(exc)}
     return {"sha256": hasher.hexdigest(), "hash_skipped": None}
 
 

--- a/scripts/benchmarks/artifacts.py
+++ b/scripts/benchmarks/artifacts.py
@@ -1,0 +1,228 @@
+#!/usr/bin/env python3
+# Copyright 2026 Celesto AI
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Record lightweight metadata for benchmark artifact paths."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import os
+import sys
+from pathlib import Path
+from typing import Any
+
+try:
+    from .reporting import finish_report, print_report, start_report
+except ImportError:  # pragma: no cover - script execution path
+    sys.path.insert(0, str(Path(__file__).resolve().parent))
+    from reporting import finish_report, print_report, start_report
+
+
+def default_paths() -> list[Path]:
+    """Return the default local paths worth recording for benchmark runs."""
+
+    data_dir = Path(os.environ.get("SMOLVM_DATA_DIR", "~/.smolvm")).expanduser()
+    return [data_dir / "images", data_dir / "browser-sessions"]
+
+
+def inspect_path(
+    path: Path,
+    *,
+    hash_files: bool,
+    max_hash_bytes: int,
+    max_entries: int,
+) -> dict[str, Any]:
+    """Return metadata for *path* without mutating it."""
+
+    path = path.expanduser()
+    record: dict[str, Any] = {
+        "path": str(path),
+        "exists": path.exists(),
+    }
+    if not path.exists():
+        record["status"] = "missing"
+        return record
+
+    if path.is_file():
+        stat = path.stat()
+        record.update(
+            {
+                "status": "ok",
+                "kind": "file",
+                "bytes": stat.st_size,
+                "mtime_ns": stat.st_mtime_ns,
+            }
+        )
+        if hash_files:
+            record.update(_hash_file(path, max_hash_bytes=max_hash_bytes))
+        return record
+
+    if not path.is_dir():
+        record.update({"status": "skipped", "kind": "other"})
+        return record
+
+    total_bytes = 0
+    file_count = 0
+    dir_count = 0
+    sample_files: list[dict[str, Any]] = []
+    truncated = False
+
+    for index, child in enumerate(path.rglob("*"), start=1):
+        if index > max_entries:
+            truncated = True
+            break
+        try:
+            if child.is_dir():
+                dir_count += 1
+                continue
+            if not child.is_file():
+                continue
+            stat = child.stat()
+        except OSError as exc:
+            sample_files.append({"path": str(child), "error": str(exc)})
+            continue
+
+        file_count += 1
+        total_bytes += stat.st_size
+        if len(sample_files) < 20:
+            entry: dict[str, Any] = {
+                "path": str(child),
+                "relative_path": str(child.relative_to(path)),
+                "bytes": stat.st_size,
+                "mtime_ns": stat.st_mtime_ns,
+            }
+            if hash_files:
+                entry.update(_hash_file(child, max_hash_bytes=max_hash_bytes))
+            sample_files.append(entry)
+
+    record.update(
+        {
+            "status": "ok",
+            "kind": "directory",
+            "files": file_count,
+            "directories": dir_count,
+            "bytes": total_bytes,
+            "truncated": truncated,
+            "max_entries": max_entries,
+            "sample_files": sample_files,
+        }
+    )
+    return record
+
+
+def dry_run_record(path: Path, *, hash_files: bool, max_hash_bytes: int, max_entries: int) -> dict:
+    return {
+        "path": str(path.expanduser()),
+        "status": "dry-run",
+        "would_scan": True,
+        "hash_files": hash_files,
+        "max_hash_bytes": max_hash_bytes,
+        "max_entries": max_entries,
+    }
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--path",
+        action="append",
+        type=Path,
+        dest="paths",
+        help="Artifact path to record. Repeat for multiple paths.",
+    )
+    parser.add_argument(
+        "--hash-files",
+        action="store_true",
+        help="Hash individual files up to --max-hash-mib.",
+    )
+    parser.add_argument("--max-hash-mib", type=float, default=512.0)
+    parser.add_argument("--max-entries", type=int, default=5000)
+    parser.add_argument("--dry-run", action="store_true", help="Print the scan plan only.")
+    parser.add_argument("--json", action="store_true", help="Print JSON.")
+    parser.add_argument("--output", type=Path, help="Optional JSON output path.")
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = build_parser()
+    args = parser.parse_args(argv)
+    if args.max_hash_mib <= 0:
+        parser.error("--max-hash-mib must be > 0")
+    if args.max_entries < 1:
+        parser.error("--max-entries must be >= 1")
+
+    paths = args.paths or default_paths()
+    max_hash_bytes = int(args.max_hash_mib * 1024 * 1024)
+    config = {
+        "paths": [str(path.expanduser()) for path in paths],
+        "hash_files": args.hash_files,
+        "max_hash_mib": args.max_hash_mib,
+        "max_entries": args.max_entries,
+    }
+    report, started = start_report("artifacts", config=config, dry_run=args.dry_run)
+    report["records"] = [
+        dry_run_record(
+            path,
+            hash_files=args.hash_files,
+            max_hash_bytes=max_hash_bytes,
+            max_entries=args.max_entries,
+        )
+        if args.dry_run
+        else inspect_path(
+            path,
+            hash_files=args.hash_files,
+            max_hash_bytes=max_hash_bytes,
+            max_entries=args.max_entries,
+        )
+        for path in paths
+    ]
+    finish_report(report, started)
+    print_report(
+        report,
+        json_output=args.json,
+        output=args.output,
+        human_lines=_human_lines(report),
+    )
+    return 0
+
+
+def _hash_file(path: Path, *, max_hash_bytes: int) -> dict[str, Any]:
+    size = path.stat().st_size
+    if size > max_hash_bytes:
+        return {"sha256": None, "hash_skipped": "file exceeds --max-hash-mib"}
+
+    hasher = hashlib.sha256()
+    with path.open("rb") as handle:
+        for chunk in iter(lambda: handle.read(1024 * 1024), b""):
+            hasher.update(chunk)
+    return {"sha256": hasher.hexdigest(), "hash_skipped": None}
+
+
+def _human_lines(report: dict[str, Any]) -> list[str]:
+    lines = ["Artifact paths:"]
+    for record in report["records"]:
+        status = record["status"]
+        if status == "ok" and record.get("kind") == "directory":
+            lines.append(f"  {record['path']}: {record['files']} file(s), {record['bytes']} bytes")
+        elif status == "ok":
+            lines.append(f"  {record['path']}: {record.get('bytes', 0)} bytes")
+        else:
+            lines.append(f"  {record['path']}: {status}")
+    return lines
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/benchmarks/browser_ready.py
+++ b/scripts/benchmarks/browser_ready.py
@@ -31,6 +31,7 @@ try:
     from .reporting import (
         CommandPlan,
         cli_data,
+        expected_cleanup_ok,
         finish_report,
         parse_json_output,
         print_report,
@@ -42,6 +43,7 @@ except ImportError:  # pragma: no cover - script execution path
     from reporting import (  # type: ignore[no-redef]
         CommandPlan,
         cli_data,
+        expected_cleanup_ok,
         finish_report,
         parse_json_output,
         print_report,
@@ -92,7 +94,11 @@ def stop_plan(session_id: str, *, timeout_s: float | None) -> CommandPlan:
 
 def run_iteration(args: argparse.Namespace, iteration: int) -> dict[str, Any]:
     session_id = args.session_id or f"{args.session_prefix}-{uuid.uuid4().hex[:8]}"
-    record: dict[str, Any] = {"iter": iteration, "session_id": session_id}
+    record: dict[str, Any] = {
+        "iter": iteration,
+        "session_id": session_id,
+        "cleanup_expected": not args.keep,
+    }
 
     start_record = run_command(
         CommandPlan(
@@ -125,7 +131,7 @@ def run_iteration(args: argparse.Namespace, iteration: int) -> dict[str, Any]:
     if isinstance(cdp_url, str) and not args.no_cdp_poll:
         record["cdp_probe"] = poll_cdp(cdp_url, timeout_s=args.cdp_timeout)
 
-    if not args.keep and start_record["ok"]:
+    if not args.keep:
         record["cleanup"] = run_command(
             stop_plan(session_id, timeout_s=args.command_timeout),
             dry_run=False,
@@ -260,6 +266,8 @@ def main(argv: list[str] | None = None) -> int:
 def _record_ok(record: dict[str, Any]) -> bool:
     start = record.get("start")
     if not isinstance(start, dict) or not start.get("ok"):
+        return False
+    if not expected_cleanup_ok(record):
         return False
     probe = record.get("cdp_probe")
     return not isinstance(probe, dict) or bool(probe.get("ready"))

--- a/scripts/benchmarks/browser_ready.py
+++ b/scripts/benchmarks/browser_ready.py
@@ -128,8 +128,17 @@ def run_iteration(args: argparse.Namespace, iteration: int) -> dict[str, Any]:
             record["start_parse_error"] = str(exc)
 
     cdp_url = data.get("cdp_url")
-    if isinstance(cdp_url, str) and not args.no_cdp_poll:
-        record["cdp_probe"] = poll_cdp(cdp_url, timeout_s=args.cdp_timeout)
+    if not args.no_cdp_poll:
+        if isinstance(cdp_url, str) and cdp_url.strip():
+            record["cdp_probe"] = poll_cdp(cdp_url, timeout_s=args.cdp_timeout)
+        else:
+            record["cdp_probe"] = {
+                "url": cdp_url,
+                "ready": False,
+                "attempts": 0,
+                "duration_ms": 0.0,
+                "error": "browser start did not return a CDP URL",
+            }
 
     if not args.keep:
         record["cleanup"] = run_command(

--- a/scripts/benchmarks/browser_ready.py
+++ b/scripts/benchmarks/browser_ready.py
@@ -1,0 +1,283 @@
+#!/usr/bin/env python3
+# Copyright 2026 Celesto AI
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Measure browser sandbox startup and CDP readiness through the public CLI."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+import time
+import urllib.error
+import urllib.request
+import uuid
+from pathlib import Path
+from typing import Any
+
+try:
+    from .reporting import (
+        CommandPlan,
+        cli_data,
+        finish_report,
+        parse_json_output,
+        print_report,
+        run_command,
+        start_report,
+    )
+except ImportError:  # pragma: no cover - script execution path
+    sys.path.insert(0, str(Path(__file__).resolve().parent))
+    from reporting import (  # type: ignore[no-redef]
+        CommandPlan,
+        cli_data,
+        finish_report,
+        parse_json_output,
+        print_report,
+        run_command,
+        start_report,
+    )
+
+
+def build_start_command(args: argparse.Namespace, session_id: str) -> list[str]:
+    command = [
+        "smolvm",
+        "browser",
+        "start",
+        "--session-id",
+        session_id,
+        "--json",
+        "--backend",
+        args.backend,
+        "--boot-timeout",
+        str(args.boot_timeout),
+        "--timeout-minutes",
+        str(args.timeout_minutes),
+        "--viewport-width",
+        str(args.viewport_width),
+        "--viewport-height",
+        str(args.viewport_height),
+        "--memory",
+        str(args.memory_mib),
+        "--disk-size",
+        str(args.disk_size_mib),
+    ]
+    if args.live:
+        command.append("--live")
+    if args.profile_mode:
+        command.extend(["--profile-mode", args.profile_mode])
+    if args.profile_id:
+        command.extend(["--profile-id", args.profile_id])
+    if args.record_video:
+        command.append("--record-video")
+    if args.no_downloads:
+        command.append("--no-downloads")
+    return command
+
+
+def stop_plan(session_id: str, *, timeout_s: float | None) -> CommandPlan:
+    return CommandPlan("browser_stop", ["smolvm", "browser", "stop", session_id], timeout_s)
+
+
+def run_iteration(args: argparse.Namespace, iteration: int) -> dict[str, Any]:
+    session_id = args.session_id or f"{args.session_prefix}-{uuid.uuid4().hex[:8]}"
+    record: dict[str, Any] = {"iter": iteration, "session_id": session_id}
+
+    start_record = run_command(
+        CommandPlan(
+            "browser_start",
+            build_start_command(args, session_id),
+            timeout_s=args.command_timeout,
+        ),
+        dry_run=args.dry_run,
+    )
+    record["start"] = start_record
+
+    if args.dry_run:
+        if not args.keep:
+            record["cleanup"] = run_command(
+                stop_plan(session_id, timeout_s=args.command_timeout),
+                dry_run=True,
+            )
+        return record
+
+    data: dict[str, Any] = {}
+    if start_record["ok"]:
+        try:
+            payload = parse_json_output(start_record.get("stdout", ""))
+            data = cli_data(payload)
+            record["start_payload"] = payload
+        except Exception as exc:  # noqa: BLE001
+            record["start_parse_error"] = str(exc)
+
+    cdp_url = data.get("cdp_url")
+    if isinstance(cdp_url, str) and not args.no_cdp_poll:
+        record["cdp_probe"] = poll_cdp(cdp_url, timeout_s=args.cdp_timeout)
+
+    if not args.keep and start_record["ok"]:
+        record["cleanup"] = run_command(
+            stop_plan(session_id, timeout_s=args.command_timeout),
+            dry_run=False,
+        )
+    return record
+
+
+def poll_cdp(cdp_url: str, *, timeout_s: float) -> dict[str, Any]:
+    url = cdp_url.rstrip("/") + "/json/version"
+    started = time.monotonic()
+    deadline = started + timeout_s
+    attempts = 0
+    last_error: str | None = None
+    status_code: int | None = None
+    payload: Any = None
+
+    while time.monotonic() <= deadline:
+        attempts += 1
+        try:
+            request_timeout = min(1.0, max(0.1, deadline - time.monotonic()))
+            with urllib.request.urlopen(url, timeout=request_timeout) as response:
+                status_code = response.status
+                body = response.read().decode(errors="replace")
+                payload = json.loads(body) if body.strip() else None
+                return {
+                    "url": url,
+                    "ready": True,
+                    "attempts": attempts,
+                    "status_code": status_code,
+                    "duration_ms": round((time.monotonic() - started) * 1000, 1),
+                    "payload": payload,
+                }
+        except (OSError, urllib.error.URLError, json.JSONDecodeError) as exc:
+            last_error = str(exc)
+            time.sleep(0.2)
+
+    return {
+        "url": url,
+        "ready": False,
+        "attempts": attempts,
+        "status_code": status_code,
+        "duration_ms": round((time.monotonic() - started) * 1000, 1),
+        "error": last_error,
+    }
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--iterations", type=int, default=1)
+    parser.add_argument("--session-id", default=None)
+    parser.add_argument("--session-prefix", default="bench-browser")
+    parser.add_argument(
+        "--backend",
+        choices=("auto", "firecracker", "qemu", "libkrun"),
+        default="auto",
+    )
+    parser.add_argument("--live", action="store_true")
+    parser.add_argument(
+        "--profile-mode",
+        choices=("ephemeral", "persistent"),
+        default="ephemeral",
+    )
+    parser.add_argument("--profile-id", default=None)
+    parser.add_argument("--timeout-minutes", type=int, default=30)
+    parser.add_argument("--viewport-width", type=int, default=1280)
+    parser.add_argument("--viewport-height", type=int, default=720)
+    parser.add_argument("--memory", dest="memory_mib", type=int, default=2048)
+    parser.add_argument("--disk-size", dest="disk_size_mib", type=int, default=4096)
+    parser.add_argument("--record-video", action="store_true")
+    parser.add_argument("--no-downloads", action="store_true")
+    parser.add_argument("--boot-timeout", type=float, default=90.0)
+    parser.add_argument("--cdp-timeout", type=float, default=10.0)
+    parser.add_argument("--no-cdp-poll", action="store_true")
+    parser.add_argument("--command-timeout", type=float, default=900.0)
+    parser.add_argument("--keep", action="store_true", help="Leave browser sandboxes running.")
+    parser.add_argument("--dry-run", action="store_true", help="Print the command plan only.")
+    parser.add_argument("--json", action="store_true", help="Print JSON.")
+    parser.add_argument("--output", type=Path, help="Optional JSON output path.")
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = build_parser()
+    args = parser.parse_args(argv)
+    if args.iterations < 1:
+        parser.error("--iterations must be >= 1")
+    for option in ("boot_timeout", "cdp_timeout", "command_timeout"):
+        if getattr(args, option) <= 0:
+            parser.error(f"--{option.replace('_', '-')} must be > 0")
+    for option in (
+        "timeout_minutes",
+        "viewport_width",
+        "viewport_height",
+        "memory_mib",
+        "disk_size_mib",
+    ):
+        if getattr(args, option) < 1:
+            parser.error(f"--{option.replace('_mib', '').replace('_', '-')} must be >= 1")
+
+    config = {
+        "iterations": args.iterations,
+        "session_id": args.session_id,
+        "session_prefix": args.session_prefix,
+        "backend": args.backend,
+        "live": args.live,
+        "profile_mode": args.profile_mode,
+        "profile_id": args.profile_id,
+        "timeout_minutes": args.timeout_minutes,
+        "viewport": {"width": args.viewport_width, "height": args.viewport_height},
+        "memory_mib": args.memory_mib,
+        "disk_size_mib": args.disk_size_mib,
+        "record_video": args.record_video,
+        "allow_downloads": not args.no_downloads,
+        "boot_timeout": args.boot_timeout,
+        "cdp_timeout": args.cdp_timeout,
+        "cdp_poll": not args.no_cdp_poll,
+        "command_timeout": args.command_timeout,
+        "keep": args.keep,
+    }
+    report, started = start_report("browser_ready", config=config, dry_run=args.dry_run)
+    report["records"] = [run_iteration(args, iteration) for iteration in range(args.iterations)]
+    finish_report(report, started)
+    print_report(
+        report,
+        json_output=args.json,
+        output=args.output,
+        human_lines=_human_lines(report),
+    )
+    return 0 if all(_record_ok(record) for record in report["records"]) else 1
+
+
+def _record_ok(record: dict[str, Any]) -> bool:
+    start = record.get("start")
+    if not isinstance(start, dict) or not start.get("ok"):
+        return False
+    probe = record.get("cdp_probe")
+    return not isinstance(probe, dict) or bool(probe.get("ready"))
+
+
+def _human_lines(report: dict[str, Any]) -> list[str]:
+    lines = ["Browser readiness:"]
+    for record in report["records"]:
+        start = record["start"]
+        probe = record.get("cdp_probe")
+        probe_text = ""
+        if isinstance(probe, dict):
+            probe_text = f", cdp_ready={probe.get('ready')}"
+        lines.append(
+            f"  {record['session_id']}: {start['status']} ({start['duration_ms']} ms{probe_text})"
+        )
+    return lines
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/benchmarks/preset_start.py
+++ b/scripts/benchmarks/preset_start.py
@@ -1,0 +1,220 @@
+#!/usr/bin/env python3
+# Copyright 2026 Celesto AI
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Measure SmolVM preset startup through the public CLI."""
+
+from __future__ import annotations
+
+import argparse
+import sys
+import uuid
+from pathlib import Path
+from typing import Any
+
+try:
+    from .reporting import (
+        CommandPlan,
+        cli_data,
+        finish_report,
+        parse_json_output,
+        print_report,
+        run_command,
+        start_report,
+    )
+except ImportError:  # pragma: no cover - script execution path
+    sys.path.insert(0, str(Path(__file__).resolve().parent))
+    from reporting import (  # type: ignore[no-redef]
+        CommandPlan,
+        cli_data,
+        finish_report,
+        parse_json_output,
+        print_report,
+        run_command,
+        start_report,
+    )
+
+PRESET_COMMANDS = {
+    "codex": "codex",
+    "claude": "claude",
+    "claude-code": "claude",
+    "openclaw": "openclaw",
+    "hermes": "hermes",
+    "pi": "pi",
+}
+
+
+def build_start_command(args: argparse.Namespace, sandbox_name: str) -> list[str]:
+    command = [
+        "smolvm",
+        PRESET_COMMANDS[args.preset],
+        "start",
+        "--name",
+        sandbox_name,
+        "--json",
+        "--no-attach",
+        "--boot-timeout",
+        str(args.boot_timeout),
+        "--install-timeout",
+        str(args.install_timeout),
+    ]
+    if args.os:
+        command.extend(["--os", args.os])
+    if args.backend:
+        command.extend(["--backend", args.backend])
+    if args.memory_mib is not None:
+        command.extend(["--memory", str(args.memory_mib)])
+    if args.disk_size_mib is not None:
+        command.extend(["--disk-size", str(args.disk_size_mib)])
+    for mount in args.mounts:
+        command.extend(["--mount", mount])
+    if args.writable_mounts:
+        command.append("--writable-mounts")
+    return command
+
+
+def run_iteration(args: argparse.Namespace, iteration: int) -> dict[str, Any]:
+    sandbox_name = f"{args.name_prefix}-{args.preset.replace('-', '')}-{uuid.uuid4().hex[:8]}"
+    record: dict[str, Any] = {
+        "iter": iteration,
+        "preset": args.preset,
+        "sandbox": sandbox_name,
+    }
+
+    start_plan = CommandPlan(
+        "preset_start",
+        build_start_command(args, sandbox_name),
+        timeout_s=args.command_timeout,
+    )
+    start_record = run_command(start_plan, dry_run=args.dry_run)
+    record["start"] = start_record
+    if args.dry_run:
+        if not args.keep:
+            record["cleanup"] = run_command(
+                cleanup_plan(sandbox_name, timeout_s=args.command_timeout),
+                dry_run=True,
+            )
+        return record
+
+    vm_name = sandbox_name
+    if start_record["ok"]:
+        try:
+            payload = parse_json_output(start_record.get("stdout", ""))
+            data = cli_data(payload)
+            record["start_payload"] = payload
+            vm = data.get("vm") if isinstance(data, dict) else None
+            if isinstance(vm, dict) and isinstance(vm.get("name"), str):
+                vm_name = vm["name"]
+                record["sandbox"] = vm_name
+        except Exception as exc:  # noqa: BLE001
+            record["start_parse_error"] = str(exc)
+
+    if not args.keep and start_record["ok"]:
+        record["cleanup"] = run_command(
+            cleanup_plan(vm_name, timeout_s=args.command_timeout),
+            dry_run=False,
+        )
+    return record
+
+
+def cleanup_plan(sandbox_name: str, *, timeout_s: float | None) -> CommandPlan:
+    return CommandPlan(
+        "sandbox_delete",
+        ["smolvm", "sandbox", "delete", sandbox_name, "--json"],
+        timeout_s=timeout_s,
+    )
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--preset", choices=sorted(PRESET_COMMANDS), default="codex")
+    parser.add_argument("--iterations", type=int, default=1)
+    parser.add_argument("--name-prefix", default="bench")
+    parser.add_argument("--os", choices=("alpine", "ubuntu"), default=None)
+    parser.add_argument(
+        "--backend",
+        choices=("auto", "firecracker", "qemu", "libkrun"),
+        default=None,
+    )
+    parser.add_argument("--memory", dest="memory_mib", type=int, default=None)
+    parser.add_argument("--disk-size", dest="disk_size_mib", type=int, default=None)
+    parser.add_argument("--mount", dest="mounts", action="append", default=[])
+    parser.add_argument("--writable-mounts", action="store_true")
+    parser.add_argument("--boot-timeout", type=float, default=90.0)
+    parser.add_argument("--install-timeout", type=float, default=600.0)
+    parser.add_argument("--command-timeout", type=float, default=900.0)
+    parser.add_argument("--keep", action="store_true", help="Leave created sandboxes running.")
+    parser.add_argument("--dry-run", action="store_true", help="Print the command plan only.")
+    parser.add_argument("--json", action="store_true", help="Print JSON.")
+    parser.add_argument("--output", type=Path, help="Optional JSON output path.")
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = build_parser()
+    args = parser.parse_args(argv)
+    if args.iterations < 1:
+        parser.error("--iterations must be >= 1")
+    if args.boot_timeout <= 0:
+        parser.error("--boot-timeout must be > 0")
+    if args.install_timeout <= 0:
+        parser.error("--install-timeout must be > 0")
+    if args.command_timeout <= 0:
+        parser.error("--command-timeout must be > 0")
+
+    config = {
+        "preset": args.preset,
+        "iterations": args.iterations,
+        "name_prefix": args.name_prefix,
+        "os": args.os,
+        "backend": args.backend,
+        "memory_mib": args.memory_mib,
+        "disk_size_mib": args.disk_size_mib,
+        "mounts": args.mounts,
+        "writable_mounts": args.writable_mounts,
+        "boot_timeout": args.boot_timeout,
+        "install_timeout": args.install_timeout,
+        "command_timeout": args.command_timeout,
+        "keep": args.keep,
+    }
+    report, started = start_report("preset_start", config=config, dry_run=args.dry_run)
+    report["records"] = [run_iteration(args, iteration) for iteration in range(args.iterations)]
+    finish_report(report, started)
+    print_report(
+        report,
+        json_output=args.json,
+        output=args.output,
+        human_lines=_human_lines(report),
+    )
+    return 0 if all(_record_ok(record) for record in report["records"]) else 1
+
+
+def _record_ok(record: dict[str, Any]) -> bool:
+    start = record.get("start")
+    return isinstance(start, dict) and bool(start.get("ok"))
+
+
+def _human_lines(report: dict[str, Any]) -> list[str]:
+    lines = ["Preset startup:"]
+    for record in report["records"]:
+        start = record["start"]
+        lines.append(
+            f"  {record['preset']} {record['sandbox']}: "
+            f"{start['status']} ({start['duration_ms']} ms)"
+        )
+    return lines
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/benchmarks/preset_start.py
+++ b/scripts/benchmarks/preset_start.py
@@ -27,6 +27,7 @@ try:
     from .reporting import (
         CommandPlan,
         cli_data,
+        expected_cleanup_ok,
         finish_report,
         parse_json_output,
         print_report,
@@ -38,6 +39,7 @@ except ImportError:  # pragma: no cover - script execution path
     from reporting import (  # type: ignore[no-redef]
         CommandPlan,
         cli_data,
+        expected_cleanup_ok,
         finish_report,
         parse_json_output,
         print_report,
@@ -90,6 +92,7 @@ def run_iteration(args: argparse.Namespace, iteration: int) -> dict[str, Any]:
         "iter": iteration,
         "preset": args.preset,
         "sandbox": sandbox_name,
+        "cleanup_expected": not args.keep,
     }
 
     start_plan = CommandPlan(
@@ -120,7 +123,7 @@ def run_iteration(args: argparse.Namespace, iteration: int) -> dict[str, Any]:
         except Exception as exc:  # noqa: BLE001
             record["start_parse_error"] = str(exc)
 
-    if not args.keep and start_record["ok"]:
+    if not args.keep:
         record["cleanup"] = run_command(
             cleanup_plan(vm_name, timeout_s=args.command_timeout),
             dry_run=False,
@@ -202,7 +205,7 @@ def main(argv: list[str] | None = None) -> int:
 
 def _record_ok(record: dict[str, Any]) -> bool:
     start = record.get("start")
-    return isinstance(start, dict) and bool(start.get("ok"))
+    return isinstance(start, dict) and bool(start.get("ok")) and expected_cleanup_ok(record)
 
 
 def _human_lines(report: dict[str, Any]) -> list[str]:

--- a/scripts/benchmarks/reporting.py
+++ b/scripts/benchmarks/reporting.py
@@ -1,0 +1,272 @@
+#!/usr/bin/env python3
+# Copyright 2026 Celesto AI
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Shared JSON and command helpers for lightweight benchmark scripts."""
+
+from __future__ import annotations
+
+import json
+import os
+import platform
+import shlex
+import subprocess
+import sys
+import time
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, TextIO
+
+
+@dataclass(frozen=True)
+class CommandPlan:
+    """A command that a benchmark script can run or report in dry-run mode."""
+
+    label: str
+    argv: list[str]
+    timeout_s: float | None = None
+    cwd: Path | None = None
+    env: dict[str, str] | None = None
+
+    def as_dict(self) -> dict[str, Any]:
+        record: dict[str, Any] = {
+            "label": self.label,
+            "command": self.argv,
+            "command_text": command_text(self.argv),
+        }
+        if self.timeout_s is not None:
+            record["timeout_s"] = self.timeout_s
+        if self.cwd is not None:
+            record["cwd"] = str(self.cwd)
+        if self.env:
+            record["env_keys"] = sorted(self.env)
+        return record
+
+
+def utc_now_iso() -> str:
+    """Return an ISO-8601 UTC timestamp with second precision."""
+
+    return datetime.now(timezone.utc).replace(microsecond=0).isoformat()
+
+
+def host_info() -> dict[str, str]:
+    """Return basic host metadata used by benchmark reports."""
+
+    return {
+        "system": platform.system(),
+        "release": platform.release(),
+        "machine": platform.machine(),
+        "python": platform.python_version(),
+    }
+
+
+def command_text(argv: list[str]) -> str:
+    """Return a shell-safe display form for *argv*."""
+
+    return " ".join(shlex.quote(part) for part in argv)
+
+
+def start_report(
+    script: str,
+    *,
+    config: dict[str, Any],
+    dry_run: bool,
+) -> tuple[dict[str, Any], float]:
+    """Create a benchmark report and return it with its monotonic start time."""
+
+    return (
+        {
+            "schema_version": 1,
+            "script": script,
+            "created_at": utc_now_iso(),
+            "host": host_info(),
+            "dry_run": dry_run,
+            "config": config,
+            "records": [],
+        },
+        time.monotonic(),
+    )
+
+
+def finish_report(report: dict[str, Any], started: float) -> dict[str, Any]:
+    """Attach total wall-clock duration to *report*."""
+
+    report["duration_s"] = round(time.monotonic() - started, 3)
+    return report
+
+
+def json_dumps(data: dict[str, Any]) -> str:
+    """Serialize report JSON in a stable, human-readable form."""
+
+    return json.dumps(data, indent=2, sort_keys=True)
+
+
+def write_json_report(path: Path, report: dict[str, Any]) -> None:
+    """Write *report* atomically, creating parent directories when needed."""
+
+    path = path.expanduser()
+    path.parent.mkdir(parents=True, exist_ok=True)
+    tmp = path.with_name(f".{path.name}.{os.getpid()}.tmp")
+    tmp.write_text(json_dumps(report) + "\n")
+    tmp.replace(path)
+
+
+def print_report(
+    report: dict[str, Any],
+    *,
+    json_output: bool,
+    output: Path | None = None,
+    human_lines: list[str] | None = None,
+    stream: TextIO | None = None,
+) -> None:
+    """Print or write a report using the common benchmark script rules."""
+
+    out = stream or sys.stdout
+    if output is not None:
+        write_json_report(output, report)
+
+    if json_output:
+        print(json_dumps(report), file=out)
+        return
+
+    if output is not None:
+        print(f"Wrote {output}", file=out)
+    for line in human_lines or default_human_lines(report):
+        print(line, file=out)
+
+
+def default_human_lines(report: dict[str, Any]) -> list[str]:
+    """Return a compact human summary for scripts without custom formatting."""
+
+    lines = [
+        f"{report.get('script', 'benchmark')}: {len(report.get('records', []))} record(s)",
+        f"dry_run: {report.get('dry_run', False)}",
+    ]
+    duration = report.get("duration_s")
+    if isinstance(duration, int | float):
+        lines.append(f"duration_s: {duration:.3f}")
+    return lines
+
+
+def run_command(plan: CommandPlan, *, dry_run: bool = False) -> dict[str, Any]:
+    """Run *plan* or return a dry-run command record."""
+
+    record = plan.as_dict()
+    record["dry_run"] = dry_run
+
+    if dry_run:
+        record.update(
+            {
+                "status": "dry-run",
+                "ok": True,
+                "exit_code": None,
+                "duration_ms": 0.0,
+            }
+        )
+        return record
+
+    env = os.environ.copy()
+    if plan.env:
+        env.update(plan.env)
+
+    started = time.monotonic()
+    try:
+        completed = subprocess.run(
+            plan.argv,
+            cwd=str(plan.cwd) if plan.cwd is not None else None,
+            env=env,
+            timeout=plan.timeout_s,
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+    except subprocess.TimeoutExpired as exc:
+        record.update(
+            {
+                "status": "timeout",
+                "ok": False,
+                "exit_code": None,
+                "duration_ms": _elapsed_ms(started),
+                "stdout": _coerce_output(exc.stdout),
+                "stderr": _coerce_output(exc.stderr),
+                "error": f"Command timed out after {exc.timeout} seconds.",
+                "error_type": type(exc).__name__,
+            }
+        )
+        return record
+    except OSError as exc:
+        record.update(
+            {
+                "status": "error",
+                "ok": False,
+                "exit_code": None,
+                "duration_ms": _elapsed_ms(started),
+                "stdout": "",
+                "stderr": "",
+                "error": str(exc),
+                "error_type": type(exc).__name__,
+            }
+        )
+        return record
+
+    record.update(
+        {
+            "status": "ok" if completed.returncode == 0 else "failed",
+            "ok": completed.returncode == 0,
+            "exit_code": completed.returncode,
+            "duration_ms": _elapsed_ms(started),
+            "stdout": completed.stdout,
+            "stderr": completed.stderr,
+        }
+    )
+    return record
+
+
+def parse_json_output(stdout: str) -> Any:
+    """Parse JSON from command stdout, tolerating surrounding plain text."""
+
+    text = stdout.strip()
+    if not text:
+        raise ValueError("Command did not print JSON.")
+    try:
+        return json.loads(text)
+    except json.JSONDecodeError:
+        start = text.find("{")
+        end = text.rfind("}")
+        if start < 0 or end <= start:
+            raise
+        return json.loads(text[start : end + 1])
+
+
+def cli_data(payload: Any) -> dict[str, Any]:
+    """Return the SmolVM CLI JSON `data` object when present."""
+
+    if isinstance(payload, dict) and isinstance(payload.get("data"), dict):
+        return payload["data"]
+    if isinstance(payload, dict):
+        return payload
+    return {}
+
+
+def _elapsed_ms(started: float) -> float:
+    return round((time.monotonic() - started) * 1000, 1)
+
+
+def _coerce_output(value: str | bytes | None) -> str:
+    if value is None:
+        return ""
+    if isinstance(value, bytes):
+        return value.decode(errors="replace")
+    return value

--- a/scripts/benchmarks/reporting.py
+++ b/scripts/benchmarks/reporting.py
@@ -26,6 +26,7 @@ import sys
 import time
 from dataclasses import dataclass
 from datetime import datetime, timezone
+from importlib.metadata import PackageNotFoundError, version
 from pathlib import Path
 from typing import Any, TextIO
 
@@ -72,6 +73,26 @@ def host_info() -> dict[str, str]:
     }
 
 
+def git_info() -> dict[str, Any]:
+    """Return best-effort git metadata for benchmark reports."""
+
+    status = _git_output(["status", "--short"])
+    return {
+        "commit": _git_output(["rev-parse", "HEAD"]) or "unknown",
+        "branch": _git_output(["rev-parse", "--abbrev-ref", "HEAD"]) or "unknown",
+        "dirty": None if status is None else bool(status),
+    }
+
+
+def package_version(distribution: str) -> str:
+    """Return the installed package version, or ``unknown`` when unavailable."""
+
+    try:
+        return version(distribution)
+    except PackageNotFoundError:
+        return "unknown"
+
+
 def command_text(argv: list[str]) -> str:
     """Return a shell-safe display form for *argv*."""
 
@@ -83,15 +104,25 @@ def start_report(
     *,
     config: dict[str, Any],
     dry_run: bool,
+    thresholds: dict[str, Any] | None = None,
+    variants: dict[str, Any] | None = None,
 ) -> tuple[dict[str, Any], float]:
     """Create a benchmark report and return it with its monotonic start time."""
 
+    parameters = dict(config)
     return (
         {
             "schema_version": 1,
+            "benchmark": script,
             "script": script,
             "created_at": utc_now_iso(),
+            "git": git_info(),
             "host": host_info(),
+            "smolvm_version": package_version("smolvm"),
+            "smolvm_core": package_version("smolvm-core"),
+            "parameters": parameters,
+            "thresholds": thresholds or {},
+            "variants": variants or {},
             "dry_run": dry_run,
             "config": config,
             "records": [],
@@ -158,6 +189,15 @@ def default_human_lines(report: dict[str, Any]) -> list[str]:
     if isinstance(duration, int | float):
         lines.append(f"duration_s: {duration:.3f}")
     return lines
+
+
+def expected_cleanup_ok(record: dict[str, Any]) -> bool:
+    """Return whether expected cleanup completed successfully."""
+
+    if not record.get("cleanup_expected"):
+        return True
+    cleanup = record.get("cleanup")
+    return isinstance(cleanup, dict) and bool(cleanup.get("ok"))
 
 
 def run_command(plan: CommandPlan, *, dry_run: bool = False) -> dict[str, Any]:
@@ -258,6 +298,23 @@ def cli_data(payload: Any) -> dict[str, Any]:
     if isinstance(payload, dict):
         return payload
     return {}
+
+
+def _git_output(args: list[str]) -> str | None:
+    try:
+        completed = subprocess.run(
+            ["git", *args],
+            cwd=Path(__file__).resolve().parents[2],
+            timeout=2,
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+    except (OSError, subprocess.TimeoutExpired):
+        return None
+    if completed.returncode != 0:
+        return None
+    return completed.stdout.strip()
 
 
 def _elapsed_ms(started: float) -> float:

--- a/scripts/benchmarks/runtime_control.py
+++ b/scripts/benchmarks/runtime_control.py
@@ -1,0 +1,252 @@
+#!/usr/bin/env python3
+# Copyright 2026 Celesto AI
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Measure sandbox lifecycle control commands through the public CLI."""
+
+from __future__ import annotations
+
+import argparse
+import sys
+import uuid
+from pathlib import Path
+from typing import Any
+
+try:
+    from .reporting import CommandPlan, finish_report, print_report, run_command, start_report
+except ImportError:  # pragma: no cover - script execution path
+    sys.path.insert(0, str(Path(__file__).resolve().parent))
+    from reporting import CommandPlan, finish_report, print_report, run_command, start_report
+
+OPERATIONS = ("info", "pause", "resume", "stop", "start")
+
+
+def create_command(args: argparse.Namespace, sandbox_name: str) -> list[str]:
+    command = [
+        "smolvm",
+        "sandbox",
+        "create",
+        "--name",
+        sandbox_name,
+        "--json",
+        "--boot-timeout",
+        str(args.boot_timeout),
+    ]
+    if args.os:
+        command.extend(["--os", args.os])
+    if args.backend:
+        command.extend(["--backend", args.backend])
+    if args.comm_channel:
+        command.extend(["--comm-channel", args.comm_channel])
+    if args.memory_mib is not None:
+        command.extend(["--memory", str(args.memory_mib)])
+    if args.disk_size_mib is not None:
+        command.extend(["--disk-size", str(args.disk_size_mib)])
+    for mount in args.mounts:
+        command.extend(["--mount", mount])
+    if args.writable_mounts:
+        command.append("--writable-mounts")
+    return command
+
+
+def operation_plan(
+    operation: str,
+    sandbox_name: str,
+    *,
+    boot_timeout: float,
+    stop_timeout: float,
+    command_timeout: float,
+) -> CommandPlan:
+    if operation == "info":
+        command = ["smolvm", "sandbox", "info", sandbox_name, "--json"]
+    elif operation == "pause":
+        command = ["smolvm", "sandbox", "pause", sandbox_name, "--json"]
+    elif operation == "resume":
+        command = ["smolvm", "sandbox", "resume", sandbox_name, "--json"]
+    elif operation == "stop":
+        command = [
+            "smolvm",
+            "sandbox",
+            "stop",
+            sandbox_name,
+            "--timeout",
+            str(stop_timeout),
+            "--json",
+        ]
+    elif operation == "start":
+        command = [
+            "smolvm",
+            "sandbox",
+            "start",
+            sandbox_name,
+            "--boot-timeout",
+            str(boot_timeout),
+            "--json",
+        ]
+    else:
+        raise ValueError(f"Unknown operation: {operation}")
+    return CommandPlan(f"sandbox_{operation}", command, timeout_s=command_timeout)
+
+
+def cleanup_plan(sandbox_name: str, *, timeout_s: float | None) -> CommandPlan:
+    return CommandPlan(
+        "sandbox_delete",
+        ["smolvm", "sandbox", "delete", sandbox_name, "--json"],
+        timeout_s=timeout_s,
+    )
+
+
+def run_iteration(
+    args: argparse.Namespace, iteration: int, operations: list[str]
+) -> dict[str, Any]:
+    sandbox_name = f"{args.name_prefix}-{uuid.uuid4().hex[:8]}"
+    record: dict[str, Any] = {"iter": iteration, "sandbox": sandbox_name, "operations": []}
+
+    create = run_command(
+        CommandPlan(
+            "sandbox_create",
+            create_command(args, sandbox_name),
+            timeout_s=args.command_timeout,
+        ),
+        dry_run=args.dry_run,
+    )
+    record["create"] = create
+
+    should_run_operations = args.dry_run or create["ok"]
+    if should_run_operations:
+        for operation in operations:
+            step = run_command(
+                operation_plan(
+                    operation,
+                    sandbox_name,
+                    boot_timeout=args.boot_timeout,
+                    stop_timeout=args.stop_timeout,
+                    command_timeout=args.command_timeout,
+                ),
+                dry_run=args.dry_run,
+            )
+            record["operations"].append(step)
+            if not args.dry_run and not step["ok"]:
+                break
+
+    if not args.keep and should_run_operations:
+        record["cleanup"] = run_command(
+            cleanup_plan(sandbox_name, timeout_s=args.command_timeout),
+            dry_run=args.dry_run,
+        )
+    return record
+
+
+def parse_operations(raw: str) -> list[str]:
+    operations = [part.strip() for part in raw.split(",") if part.strip()]
+    unknown = sorted(set(operations) - set(OPERATIONS))
+    if unknown:
+        allowed = ", ".join(OPERATIONS)
+        raise ValueError(f"Unknown operation(s): {', '.join(unknown)}. Choices: {allowed}.")
+    if not operations:
+        raise ValueError("At least one operation is required.")
+    return operations
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--iterations", type=int, default=1)
+    parser.add_argument("--name-prefix", default="bench-runtime")
+    parser.add_argument("--operations", default="info,pause,resume,stop,start")
+    parser.add_argument("--os", choices=("alpine", "ubuntu"), default=None)
+    parser.add_argument(
+        "--backend",
+        choices=("auto", "firecracker", "qemu", "libkrun"),
+        default=None,
+    )
+    parser.add_argument("--comm-channel", choices=("ssh", "vsock"), default=None)
+    parser.add_argument("--memory", dest="memory_mib", type=int, default=None)
+    parser.add_argument("--disk-size", dest="disk_size_mib", type=int, default=None)
+    parser.add_argument("--mount", dest="mounts", action="append", default=[])
+    parser.add_argument("--writable-mounts", action="store_true")
+    parser.add_argument("--boot-timeout", type=float, default=90.0)
+    parser.add_argument("--stop-timeout", type=float, default=3.0)
+    parser.add_argument("--command-timeout", type=float, default=900.0)
+    parser.add_argument("--keep", action="store_true", help="Leave created sandboxes in place.")
+    parser.add_argument("--dry-run", action="store_true", help="Print the command plan only.")
+    parser.add_argument("--json", action="store_true", help="Print JSON.")
+    parser.add_argument("--output", type=Path, help="Optional JSON output path.")
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = build_parser()
+    args = parser.parse_args(argv)
+    if args.iterations < 1:
+        parser.error("--iterations must be >= 1")
+    for option in ("boot_timeout", "stop_timeout", "command_timeout"):
+        if getattr(args, option) <= 0:
+            parser.error(f"--{option.replace('_', '-')} must be > 0")
+    try:
+        operations = parse_operations(args.operations)
+    except ValueError as exc:
+        parser.error(str(exc))
+
+    config = {
+        "iterations": args.iterations,
+        "name_prefix": args.name_prefix,
+        "operations": operations,
+        "os": args.os,
+        "backend": args.backend,
+        "comm_channel": args.comm_channel,
+        "memory_mib": args.memory_mib,
+        "disk_size_mib": args.disk_size_mib,
+        "mounts": args.mounts,
+        "writable_mounts": args.writable_mounts,
+        "boot_timeout": args.boot_timeout,
+        "stop_timeout": args.stop_timeout,
+        "command_timeout": args.command_timeout,
+        "keep": args.keep,
+    }
+    report, started = start_report("runtime_control", config=config, dry_run=args.dry_run)
+    report["records"] = [
+        run_iteration(args, iteration, operations) for iteration in range(args.iterations)
+    ]
+    finish_report(report, started)
+    print_report(
+        report,
+        json_output=args.json,
+        output=args.output,
+        human_lines=_human_lines(report),
+    )
+    return 0 if all(_record_ok(record) for record in report["records"]) else 1
+
+
+def _record_ok(record: dict[str, Any]) -> bool:
+    create = record.get("create")
+    if not isinstance(create, dict) or not create.get("ok"):
+        return False
+    operations = record.get("operations", [])
+    return all(isinstance(operation, dict) and operation.get("ok") for operation in operations)
+
+
+def _human_lines(report: dict[str, Any]) -> list[str]:
+    lines = ["Runtime control:"]
+    for record in report["records"]:
+        create = record["create"]
+        steps = ", ".join(step["status"] for step in record["operations"])
+        lines.append(
+            f"  {record['sandbox']}: create={create['status']}"
+            + (f", operations={steps}" if steps else "")
+        )
+    return lines
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/benchmarks/runtime_control.py
+++ b/scripts/benchmarks/runtime_control.py
@@ -159,7 +159,7 @@ def run_iteration(
             if not args.dry_run and not step["ok"]:
                 break
 
-    cleanup_expected = not args.keep and should_run_operations
+    cleanup_expected = not args.keep
     record["cleanup_expected"] = cleanup_expected
     if cleanup_expected:
         record["cleanup"] = run_command(

--- a/scripts/benchmarks/runtime_control.py
+++ b/scripts/benchmarks/runtime_control.py
@@ -24,10 +24,24 @@ from pathlib import Path
 from typing import Any
 
 try:
-    from .reporting import CommandPlan, finish_report, print_report, run_command, start_report
+    from .reporting import (
+        CommandPlan,
+        expected_cleanup_ok,
+        finish_report,
+        print_report,
+        run_command,
+        start_report,
+    )
 except ImportError:  # pragma: no cover - script execution path
     sys.path.insert(0, str(Path(__file__).resolve().parent))
-    from reporting import CommandPlan, finish_report, print_report, run_command, start_report
+    from reporting import (  # type: ignore[no-redef]
+        CommandPlan,
+        expected_cleanup_ok,
+        finish_report,
+        print_report,
+        run_command,
+        start_report,
+    )
 
 OPERATIONS = ("info", "pause", "resume", "stop", "start")
 
@@ -111,7 +125,12 @@ def run_iteration(
     args: argparse.Namespace, iteration: int, operations: list[str]
 ) -> dict[str, Any]:
     sandbox_name = f"{args.name_prefix}-{uuid.uuid4().hex[:8]}"
-    record: dict[str, Any] = {"iter": iteration, "sandbox": sandbox_name, "operations": []}
+    record: dict[str, Any] = {
+        "iter": iteration,
+        "sandbox": sandbox_name,
+        "operations": [],
+        "cleanup_expected": False,
+    }
 
     create = run_command(
         CommandPlan(
@@ -140,7 +159,9 @@ def run_iteration(
             if not args.dry_run and not step["ok"]:
                 break
 
-    if not args.keep and should_run_operations:
+    cleanup_expected = not args.keep and should_run_operations
+    record["cleanup_expected"] = cleanup_expected
+    if cleanup_expected:
         record["cleanup"] = run_command(
             cleanup_plan(sandbox_name, timeout_s=args.command_timeout),
             dry_run=args.dry_run,
@@ -231,6 +252,8 @@ def main(argv: list[str] | None = None) -> int:
 def _record_ok(record: dict[str, Any]) -> bool:
     create = record.get("create")
     if not isinstance(create, dict) or not create.get("ok"):
+        return False
+    if not expected_cleanup_ok(record):
         return False
     operations = record.get("operations", [])
     return all(isinstance(operation, dict) and operation.get("ok") for operation in operations)

--- a/tests/test_benchmark_foundation.py
+++ b/tests/test_benchmark_foundation.py
@@ -16,6 +16,7 @@ from __future__ import annotations
 
 import json
 from pathlib import Path
+from typing import Any
 
 from scripts.benchmarks import artifacts, browser_ready, preset_start, runtime_control
 
@@ -104,3 +105,72 @@ def test_runtime_control_dry_run_json_plans_noun_verb_lifecycle(capsys) -> None:
         ["sandbox", "start"],
     ]
     assert record["cleanup"]["command"][:3] == ["smolvm", "sandbox", "delete"]
+
+
+def test_preset_start_attempts_cleanup_after_start_failure(monkeypatch, capsys) -> None:
+    calls: list[str] = []
+
+    def fake_run_command(plan: Any, *, dry_run: bool = False) -> dict[str, Any]:
+        calls.append(plan.label)
+        return {
+            "label": plan.label,
+            "ok": False,
+            "status": "failed",
+            "duration_ms": 1.0,
+            "dry_run": dry_run,
+        }
+
+    monkeypatch.setattr(preset_start, "run_command", fake_run_command)
+
+    rc = preset_start.main(["--json", "--preset", "codex", "--iterations", "1"])
+
+    assert rc == 1
+    report = json.loads(capsys.readouterr().out)
+    record = report["records"][0]
+    assert calls == ["preset_start", "sandbox_delete"]
+    assert record["cleanup_expected"] is True
+    assert record["cleanup"]["label"] == "sandbox_delete"
+
+
+def test_browser_ready_attempts_cleanup_after_start_failure(monkeypatch, capsys) -> None:
+    calls: list[str] = []
+
+    def fake_run_command(plan: Any, *, dry_run: bool = False) -> dict[str, Any]:
+        calls.append(plan.label)
+        return {
+            "label": plan.label,
+            "ok": False,
+            "status": "failed",
+            "duration_ms": 1.0,
+            "dry_run": dry_run,
+        }
+
+    monkeypatch.setattr(browser_ready, "run_command", fake_run_command)
+
+    rc = browser_ready.main(["--json", "--session-id", "browser-bench", "--no-cdp-poll"])
+
+    assert rc == 1
+    report = json.loads(capsys.readouterr().out)
+    record = report["records"][0]
+    assert calls == ["browser_start", "browser_stop"]
+    assert record["cleanup_expected"] is True
+    assert record["cleanup"]["label"] == "browser_stop"
+
+
+def test_expected_cleanup_failure_marks_records_failed() -> None:
+    cleanup_failed = {"ok": False}
+
+    assert not preset_start._record_ok(
+        {"start": {"ok": True}, "cleanup_expected": True, "cleanup": cleanup_failed}
+    )
+    assert not browser_ready._record_ok(
+        {"start": {"ok": True}, "cleanup_expected": True, "cleanup": cleanup_failed}
+    )
+    assert not runtime_control._record_ok(
+        {
+            "create": {"ok": True},
+            "operations": [{"ok": True}],
+            "cleanup_expected": True,
+            "cleanup": cleanup_failed,
+        }
+    )

--- a/tests/test_benchmark_foundation.py
+++ b/tests/test_benchmark_foundation.py
@@ -157,6 +157,61 @@ def test_browser_ready_attempts_cleanup_after_start_failure(monkeypatch, capsys)
     assert record["cleanup"]["label"] == "browser_stop"
 
 
+def test_browser_ready_fails_when_cdp_poll_has_no_url(monkeypatch, capsys) -> None:
+    def fake_run_command(plan: Any, *, dry_run: bool = False) -> dict[str, Any]:
+        if plan.label == "browser_start":
+            return {
+                "label": plan.label,
+                "ok": True,
+                "status": "ok",
+                "duration_ms": 1.0,
+                "dry_run": dry_run,
+                "stdout": json.dumps({"data": {"id": "browser-bench"}}),
+            }
+        return {
+            "label": plan.label,
+            "ok": True,
+            "status": "ok",
+            "duration_ms": 1.0,
+            "dry_run": dry_run,
+        }
+
+    monkeypatch.setattr(browser_ready, "run_command", fake_run_command)
+
+    rc = browser_ready.main(["--json", "--session-id", "browser-bench"])
+
+    assert rc == 1
+    report = json.loads(capsys.readouterr().out)
+    probe = report["records"][0]["cdp_probe"]
+    assert probe["ready"] is False
+    assert probe["attempts"] == 0
+
+
+def test_runtime_control_attempts_cleanup_after_create_failure(monkeypatch, capsys) -> None:
+    calls: list[str] = []
+
+    def fake_run_command(plan: Any, *, dry_run: bool = False) -> dict[str, Any]:
+        calls.append(plan.label)
+        return {
+            "label": plan.label,
+            "ok": False,
+            "status": "failed",
+            "duration_ms": 1.0,
+            "dry_run": dry_run,
+        }
+
+    monkeypatch.setattr(runtime_control, "run_command", fake_run_command)
+
+    rc = runtime_control.main(["--json", "--iterations", "1"])
+
+    assert rc == 1
+    report = json.loads(capsys.readouterr().out)
+    record = report["records"][0]
+    assert calls == ["sandbox_create", "sandbox_delete"]
+    assert record["cleanup_expected"] is True
+    assert record["cleanup"]["label"] == "sandbox_delete"
+
+
 def test_expected_cleanup_failure_marks_records_failed() -> None:
     cleanup_failed = {"ok": False}
 

--- a/tests/test_benchmark_foundation.py
+++ b/tests/test_benchmark_foundation.py
@@ -1,0 +1,106 @@
+# Copyright 2026 Celesto AI
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from scripts.benchmarks import artifacts, browser_ready, preset_start, runtime_control
+
+
+def test_artifacts_dry_run_json_reports_scan_plan(capsys, tmp_path: Path) -> None:
+    path = tmp_path / "missing"
+
+    rc = artifacts.main(["--dry-run", "--json", "--path", str(path)])
+
+    assert rc == 0
+    report = json.loads(capsys.readouterr().out)
+    assert report["script"] == "artifacts"
+    assert report["dry_run"] is True
+    assert report["records"] == [
+        {
+            "hash_files": False,
+            "max_entries": 5000,
+            "max_hash_bytes": 536870912,
+            "path": str(path),
+            "status": "dry-run",
+            "would_scan": True,
+        }
+    ]
+
+
+def test_preset_start_dry_run_json_plans_preset_start_and_cleanup(capsys) -> None:
+    rc = preset_start.main(
+        [
+            "--dry-run",
+            "--json",
+            "--preset",
+            "codex",
+            "--iterations",
+            "1",
+            "--name-prefix",
+            "bench",
+        ]
+    )
+
+    assert rc == 0
+    report = json.loads(capsys.readouterr().out)
+    record = report["records"][0]
+    assert record["start"]["command"][:3] == ["smolvm", "codex", "start"]
+    assert "--no-attach" in record["start"]["command"]
+    assert record["cleanup"]["command"][:3] == ["smolvm", "sandbox", "delete"]
+
+
+def test_browser_ready_dry_run_json_plans_browser_start_and_stop(capsys) -> None:
+    rc = browser_ready.main(
+        [
+            "--dry-run",
+            "--json",
+            "--session-id",
+            "browser-bench",
+            "--no-cdp-poll",
+        ]
+    )
+
+    assert rc == 0
+    report = json.loads(capsys.readouterr().out)
+    record = report["records"][0]
+    assert record["start"]["command"][:3] == ["smolvm", "browser", "start"]
+    assert record["start"]["command"][3:5] == ["--session-id", "browser-bench"]
+    assert record["cleanup"]["command"] == ["smolvm", "browser", "stop", "browser-bench"]
+
+
+def test_runtime_control_dry_run_json_plans_noun_verb_lifecycle(capsys) -> None:
+    rc = runtime_control.main(
+        [
+            "--dry-run",
+            "--json",
+            "--operations",
+            "info,stop,start",
+            "--name-prefix",
+            "bench-runtime",
+        ]
+    )
+
+    assert rc == 0
+    report = json.loads(capsys.readouterr().out)
+    record = report["records"][0]
+    assert record["create"]["command"][:3] == ["smolvm", "sandbox", "create"]
+    assert [step["command"][1:3] for step in record["operations"]] == [
+        ["sandbox", "info"],
+        ["sandbox", "stop"],
+        ["sandbox", "start"],
+    ]
+    assert record["cleanup"]["command"][:3] == ["smolvm", "sandbox", "delete"]

--- a/tests/test_benchmark_reporting.py
+++ b/tests/test_benchmark_reporting.py
@@ -53,3 +53,26 @@ def test_write_json_report_creates_parent_directory(tmp_path: Path) -> None:
     write_json_report(output, report)
 
     assert json.loads(output.read_text())["script"] == "probe"
+
+
+def test_start_report_includes_shared_envelope_fields() -> None:
+    config = {"iterations": 1, "backend": "qemu"}
+
+    report, _started = start_report("probe", config=config, dry_run=True)
+
+    assert report["schema_version"] == 1
+    assert report["benchmark"] == "probe"
+    assert report["parameters"] == config
+    assert report["thresholds"] == {}
+    assert report["variants"] == {}
+    assert set(report) >= {
+        "created_at",
+        "git",
+        "host",
+        "smolvm_version",
+        "smolvm_core",
+    }
+    assert {"commit", "branch", "dirty"} <= set(report["git"])
+    assert {"system", "release", "machine", "python"} <= set(report["host"])
+    assert isinstance(report["smolvm_version"], str)
+    assert isinstance(report["smolvm_core"], str)

--- a/tests/test_benchmark_reporting.py
+++ b/tests/test_benchmark_reporting.py
@@ -1,0 +1,55 @@
+# Copyright 2026 Celesto AI
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from scripts.benchmarks.reporting import (
+    CommandPlan,
+    cli_data,
+    parse_json_output,
+    run_command,
+    start_report,
+    write_json_report,
+)
+
+
+def test_run_command_dry_run_records_command_without_executing() -> None:
+    record = run_command(
+        CommandPlan("probe", ["smolvm", "doctor"], timeout_s=1.5),
+        dry_run=True,
+    )
+
+    assert record["status"] == "dry-run"
+    assert record["ok"] is True
+    assert record["exit_code"] is None
+    assert record["command"] == ["smolvm", "doctor"]
+    assert record["command_text"] == "smolvm doctor"
+
+
+def test_parse_json_output_tolerates_surrounding_text() -> None:
+    payload = parse_json_output('notice\n{"data": {"vm": {"name": "bench"}}}\n')
+
+    assert cli_data(payload) == {"vm": {"name": "bench"}}
+
+
+def test_write_json_report_creates_parent_directory(tmp_path: Path) -> None:
+    report, _started = start_report("probe", config={"x": 1}, dry_run=True)
+    output = tmp_path / "nested" / "report.json"
+
+    write_json_report(output, report)
+
+    assert json.loads(output.read_text())["script"] == "probe"


### PR DESCRIPTION
## Summary

Adds the benchmark foundation for the Rust migration stack:

- Adds shared benchmark JSON reporting, host/git/package metadata, and summary statistics helpers.
- Adds focused benchmark scripts for artifacts, preset startup, browser readiness, and runtime control paths.
- Documents the new scripts and dry-run/JSON usage.

## Stack

1. This PR: benchmark foundation.
2. #398: guest-agent protocol v2 substrate.
3. #399: native host disk/network/Firecracker helpers.
4. #400: control-channel production integration.

## Validation

Full-stack validation run locally after the stack was assembled:

- `UV_CACHE_DIR=/tmp/uv-cache uv run pytest tests/ -q` — 1392 passed, 12 skipped, 27 deselected.
- `UV_CACHE_DIR=/tmp/uv-cache uv run ruff check .` — passed.
- `UV_CACHE_DIR=/tmp/uv-cache uv run ruff format --check .` — passed.
- `cargo check -p smolvm-core` — passed.
- `cargo test -p smolvm-guest-agent` — passed.
- `cargo fmt --check` — passed.
- `git diff --check` — passed.

`cargo test -p smolvm-core` is blocked on this machine because the local linker cannot find `libpython3.14`; `maturin develop` and `cargo check -p smolvm-core` both pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added benchmark scripts to collect artifact metadata, measure browser startup readiness, time preset-based startup, and test sandbox runtime control operations.
  * Introduced shared benchmark reporting utilities that generate structured JSON including host, git, and package information.
* **Documentation**
  * Added a “Foundation Scripts” guide with example dry-run JSON commands and what each probe measures.
* **Tests**
  * Added end-to-end and unit tests covering dry-run plan generation, JSON output, report writing, and failure/cleanup expectations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->