### PR TITLE
[codex] Add guest agent protocol v2 substrate

### DIFF
--- a/guest-agent/src/boot.rs
+++ b/guest-agent/src/boot.rs
@@ -1,4 +1,5 @@
 use serde::Serialize;
+use std::collections::HashSet;
 use std::fs;
 use std::path::Path;
 
@@ -51,6 +52,7 @@ pub fn read_boot_milestones() -> BootMilestonesResponse {
             }
         }
     }
+    let milestones = dedupe_boot_milestones(milestones);
     BootMilestonesResponse {
         ok: true,
         milestones,
@@ -110,6 +112,22 @@ fn parse_smolvm_ts_line(line: &str) -> Option<BootMilestone> {
     })
 }
 
+fn dedupe_boot_milestones(milestones: Vec<BootMilestone>) -> Vec<BootMilestone> {
+    let mut seen = HashSet::new();
+    let mut deduped = Vec::new();
+    for milestone in milestones {
+        let key = (
+            milestone.stage.clone(),
+            milestone.epoch_s.map(f64::to_bits),
+            milestone.uptime_s.map(f64::to_bits),
+        );
+        if seen.insert(key) {
+            deduped.push(milestone);
+        }
+    }
+    deduped
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -128,5 +146,30 @@ unrelated line
         assert_eq!(milestones[0].uptime_s, Some(0.10));
         assert_eq!(milestones[1].stage, "guest-agent-started");
         assert_eq!(milestones[1].uptime_s, Some(0.24));
+    }
+
+    #[test]
+    fn dedupes_same_stage_and_timestamp_keeping_first_source() {
+        let first = BootMilestone {
+            stage: "guest-agent-started".to_string(),
+            epoch_s: Some(1781280001.0),
+            uptime_s: Some(0.24),
+            raw: "canonical".to_string(),
+        };
+        let duplicate = BootMilestone {
+            raw: "duplicate".to_string(),
+            ..first.clone()
+        };
+        let later_same_stage = BootMilestone {
+            stage: "guest-agent-started".to_string(),
+            epoch_s: Some(1781280002.0),
+            uptime_s: Some(1.24),
+            raw: "later".to_string(),
+        };
+
+        let milestones =
+            dedupe_boot_milestones(vec![first.clone(), duplicate, later_same_stage.clone()]);
+
+        assert_eq!(milestones, vec![first, later_same_stage]);
     }
 }

--- a/guest-agent/src/boot.rs
+++ b/guest-agent/src/boot.rs
@@ -1,0 +1,132 @@
+use serde::Serialize;
+use std::fs;
+use std::path::Path;
+
+const BOOT_MILESTONE_PATHS: &[&str] = &[
+    "/run/smolvm/milestones.jsonl",
+    "/run/smolvm/boot-milestones.jsonl",
+    "/var/log/smolvm-boot.log",
+    "/var/log/boot.log",
+];
+
+#[derive(Debug, Clone, Serialize, PartialEq)]
+pub struct BootMilestone {
+    pub stage: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub epoch_s: Option<f64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub uptime_s: Option<f64>,
+    pub raw: String,
+}
+
+#[derive(Debug, Serialize)]
+pub struct BootMilestonesResponse {
+    pub ok: bool,
+    pub milestones: Vec<BootMilestone>,
+    pub sources: Vec<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub error: Option<String>,
+}
+
+pub fn read_boot_milestones() -> BootMilestonesResponse {
+    let mut milestones = Vec::new();
+    let mut sources = Vec::new();
+    for path in BOOT_MILESTONE_PATHS {
+        let path_obj = Path::new(path);
+        if !path_obj.exists() {
+            continue;
+        }
+        match fs::read_to_string(path_obj) {
+            Ok(content) => {
+                sources.push((*path).to_string());
+                milestones.extend(parse_boot_milestones(&content));
+            }
+            Err(error) => {
+                return BootMilestonesResponse {
+                    ok: false,
+                    milestones,
+                    sources,
+                    error: Some(format!("cannot read boot milestones: {error}")),
+                };
+            }
+        }
+    }
+    BootMilestonesResponse {
+        ok: true,
+        milestones,
+        sources,
+        error: None,
+    }
+}
+
+fn parse_boot_milestones(content: &str) -> Vec<BootMilestone> {
+    content
+        .lines()
+        .filter_map(parse_boot_milestone_line)
+        .collect()
+}
+
+fn parse_boot_milestone_line(line: &str) -> Option<BootMilestone> {
+    if let Some(json) = parse_json_milestone(line) {
+        return Some(json);
+    }
+    parse_smolvm_ts_line(line)
+}
+
+fn parse_json_milestone(line: &str) -> Option<BootMilestone> {
+    let value = serde_json::from_str::<serde_json::Value>(line).ok()?;
+    let stage = value.get("stage")?.as_str()?.to_string();
+    Some(BootMilestone {
+        stage,
+        epoch_s: value.get("epoch_s").and_then(serde_json::Value::as_f64),
+        uptime_s: value.get("uptime_s").and_then(serde_json::Value::as_f64),
+        raw: line.to_string(),
+    })
+}
+
+fn parse_smolvm_ts_line(line: &str) -> Option<BootMilestone> {
+    let marker = "SMOLVM_TS ";
+    let start = line.find(marker)? + marker.len();
+    let fields = &line[start..];
+    let mut stage = None;
+    let mut epoch_s = None;
+    let mut uptime_s = None;
+    for field in fields.split_whitespace() {
+        let Some((key, value)) = field.split_once('=') else {
+            continue;
+        };
+        match key {
+            "stage" => stage = Some(value.to_string()),
+            "epoch_s" => epoch_s = value.parse::<f64>().ok(),
+            "uptime_s" => uptime_s = value.parse::<f64>().ok(),
+            _ => {}
+        }
+    }
+    Some(BootMilestone {
+        stage: stage?,
+        epoch_s,
+        uptime_s,
+        raw: line.to_string(),
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parses_console_and_json_boot_milestones() {
+        let content = "\
+SMOLVM_TS stage=init-start epoch_s=1781280000 uptime_s=0.10
+{\"stage\":\"guest-agent-started\",\"epoch_s\":1781280001,\"uptime_s\":0.24}
+unrelated line
+";
+        let milestones = parse_boot_milestones(content);
+        assert_eq!(milestones.len(), 2);
+        assert_eq!(milestones[0].stage, "init-start");
+        assert_eq!(milestones[0].epoch_s, Some(1781280000.0));
+        assert_eq!(milestones[0].uptime_s, Some(0.10));
+        assert_eq!(milestones[1].stage, "guest-agent-started");
+        assert_eq!(milestones[1].uptime_s, Some(0.24));
+    }
+}

--- a/guest-agent/src/env.rs
+++ b/guest-agent/src/env.rs
@@ -1,0 +1,255 @@
+//! Managed Linux environment file endpoints.
+
+use serde::{Deserialize, Serialize};
+use std::collections::BTreeMap;
+use std::fs;
+use std::os::unix::fs::PermissionsExt;
+use std::path::{Path, PathBuf};
+
+const ENV_FILE: &str = "/etc/profile.d/smolvm_env.sh";
+
+#[derive(Debug, Serialize)]
+pub struct EnvResponse {
+    pub ok: bool,
+    pub vars: BTreeMap<String, String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub error: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct EnvPutRequest {
+    pub vars: BTreeMap<String, String>,
+    #[serde(default = "default_merge")]
+    pub merge: bool,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct EnvDeleteRequest {
+    pub keys: Vec<String>,
+}
+
+fn default_merge() -> bool {
+    true
+}
+
+pub async fn read_managed() -> EnvResponse {
+    match read_env_file(Path::new(ENV_FILE)) {
+        Ok(vars) => EnvResponse {
+            ok: true,
+            vars,
+            error: None,
+        },
+        Err(error) => EnvResponse {
+            ok: false,
+            vars: BTreeMap::new(),
+            error: Some(error),
+        },
+    }
+}
+
+pub async fn put_managed(req: EnvPutRequest) -> EnvResponse {
+    for key in req.vars.keys() {
+        if let Err(error) = validate_key(key) {
+            return error_response(error);
+        }
+    }
+    let mut vars = if req.merge {
+        match read_env_file(Path::new(ENV_FILE)) {
+            Ok(vars) => vars,
+            Err(error) => return error_response(error),
+        }
+    } else {
+        BTreeMap::new()
+    };
+    vars.extend(req.vars);
+    match atomic_write_env(Path::new(ENV_FILE), &vars) {
+        Ok(()) => EnvResponse {
+            ok: true,
+            vars,
+            error: None,
+        },
+        Err(error) => error_response(error),
+    }
+}
+
+pub async fn delete_managed(req: EnvDeleteRequest) -> EnvResponse {
+    for key in &req.keys {
+        if let Err(error) = validate_key(key) {
+            return error_response(error);
+        }
+    }
+    let mut vars = match read_env_file(Path::new(ENV_FILE)) {
+        Ok(vars) => vars,
+        Err(error) => return error_response(error),
+    };
+    for key in req.keys {
+        vars.remove(&key);
+    }
+    match atomic_write_env(Path::new(ENV_FILE), &vars) {
+        Ok(()) => EnvResponse {
+            ok: true,
+            vars,
+            error: None,
+        },
+        Err(error) => error_response(error),
+    }
+}
+
+fn error_response(error: impl Into<String>) -> EnvResponse {
+    EnvResponse {
+        ok: false,
+        vars: BTreeMap::new(),
+        error: Some(error.into()),
+    }
+}
+
+fn validate_key(key: &str) -> Result<(), String> {
+    let mut chars = key.chars();
+    match chars.next() {
+        Some(ch) if ch == '_' || ch.is_ascii_alphabetic() => {}
+        _ => return Err(format!("invalid environment variable key: {key}")),
+    }
+    if chars.any(|ch| ch != '_' && !ch.is_ascii_alphanumeric()) {
+        return Err(format!("invalid environment variable key: {key}"));
+    }
+    Ok(())
+}
+
+fn read_env_file(path: &Path) -> Result<BTreeMap<String, String>, String> {
+    if !path.exists() {
+        return Ok(BTreeMap::new());
+    }
+    let content = fs::read_to_string(path).map_err(|error| error.to_string())?;
+    let mut vars = BTreeMap::new();
+    for line in content.lines() {
+        let line = line.trim();
+        if !line.starts_with("export ") {
+            continue;
+        }
+        let rest = &line["export ".len()..];
+        if let Some((key, value)) = rest.split_once('=') {
+            if validate_key(key).is_ok() {
+                vars.insert(key.to_string(), parse_shell_value(value));
+            }
+        }
+    }
+    Ok(vars)
+}
+
+fn parse_shell_value(value: &str) -> String {
+    let mut out = String::new();
+    let mut chars = value.chars().peekable();
+    while let Some(ch) = chars.next() {
+        match ch {
+            '\'' => {
+                for inner in chars.by_ref() {
+                    if inner == '\'' {
+                        break;
+                    }
+                    out.push(inner);
+                }
+            }
+            '"' => {
+                while let Some(inner) = chars.next() {
+                    if inner == '"' {
+                        break;
+                    }
+                    if inner == '\\' {
+                        if let Some(escaped) = chars.next() {
+                            out.push(escaped);
+                        }
+                    } else {
+                        out.push(inner);
+                    }
+                }
+            }
+            '\\' => {
+                if let Some(escaped) = chars.next() {
+                    out.push(escaped);
+                }
+            }
+            ch if ch.is_whitespace() => break,
+            other => out.push(other),
+        }
+    }
+    out
+}
+
+fn atomic_write_env(path: &Path, vars: &BTreeMap<String, String>) -> Result<(), String> {
+    let content = build_env_script(vars)?;
+    let parent = path.parent().unwrap_or_else(|| Path::new("/"));
+    fs::create_dir_all(parent).map_err(|error| error.to_string())?;
+    let tmp = tmp_path(parent);
+    fs::write(&tmp, content).map_err(|error| error.to_string())?;
+    fs::set_permissions(&tmp, fs::Permissions::from_mode(0o644))
+        .map_err(|error| error.to_string())?;
+    fs::rename(&tmp, path).map_err(|error| {
+        let _ = fs::remove_file(&tmp);
+        error.to_string()
+    })
+}
+
+fn build_env_script(vars: &BTreeMap<String, String>) -> Result<String, String> {
+    if vars.is_empty() {
+        return Ok("# SmolVM environment variables (empty)\n".to_string());
+    }
+    let mut lines = vec![
+        "#!/bin/sh".to_string(),
+        "# SmolVM managed environment variables".to_string(),
+        String::new(),
+    ];
+    for (key, value) in vars {
+        validate_key(key)?;
+        lines.push(format!("export {key}={}", shell_quote(value)));
+    }
+    lines.push(String::new());
+    Ok(lines.join("\n"))
+}
+
+fn shell_quote(value: &str) -> String {
+    if value.is_empty() {
+        return "''".to_string();
+    }
+    if value
+        .chars()
+        .all(|ch| ch.is_ascii_alphanumeric() || "@%_+=:,./-".contains(ch))
+    {
+        return value.to_string();
+    }
+    format!("'{}'", value.replace('\'', "'\\''"))
+}
+
+fn tmp_path(parent: &Path) -> PathBuf {
+    parent.join(format!(
+        ".smolvm-env-{}-{}",
+        std::process::id(),
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap_or_default()
+            .as_nanos()
+    ))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn shell_quote_round_trips_single_quotes_for_reader() {
+        let mut vars = BTreeMap::new();
+        vars.insert("TOKEN".to_string(), "a'b c".to_string());
+        let script = build_env_script(&vars).unwrap();
+        assert!(script.contains("export TOKEN='a'\\''b c'"));
+        let parsed = parse_shell_value("'a'\\''b c'");
+        assert_eq!(parsed, "a'b c");
+        let parsed = parse_shell_value("'a'\"'\"'b c'");
+        assert_eq!(parsed, "a'b c");
+    }
+
+    #[test]
+    fn validates_posix_keys() {
+        assert!(validate_key("OPENAI_API_KEY").is_ok());
+        assert!(validate_key("1_BAD").is_err());
+        assert!(validate_key("BAD-DASH").is_err());
+    }
+}

--- a/guest-agent/src/env.rs
+++ b/guest-agent/src/env.rs
@@ -1,12 +1,16 @@
 //! Managed Linux environment file endpoints.
 
+use once_cell::sync::Lazy;
 use serde::{Deserialize, Serialize};
 use std::collections::BTreeMap;
-use std::fs;
+use std::fs::{self, File, OpenOptions};
+use std::io::Write;
 use std::os::unix::fs::PermissionsExt;
 use std::path::{Path, PathBuf};
+use std::sync::Mutex;
 
 const ENV_FILE: &str = "/etc/profile.d/smolvm_env.sh";
+static ENV_UPDATE_LOCK: Lazy<Mutex<()>> = Lazy::new(|| Mutex::new(()));
 
 #[derive(Debug, Serialize)]
 pub struct EnvResponse {
@@ -48,13 +52,21 @@ pub async fn read_managed() -> EnvResponse {
 }
 
 pub async fn put_managed(req: EnvPutRequest) -> EnvResponse {
+    put_managed_at(Path::new(ENV_FILE), req)
+}
+
+fn put_managed_at(path: &Path, req: EnvPutRequest) -> EnvResponse {
     for key in req.vars.keys() {
         if let Err(error) = validate_key(key) {
             return error_response(error);
         }
     }
+    let _guard = match ENV_UPDATE_LOCK.lock() {
+        Ok(guard) => guard,
+        Err(_) => return error_response("environment update lock is unavailable"),
+    };
     let mut vars = if req.merge {
-        match read_env_file(Path::new(ENV_FILE)) {
+        match read_env_file(path) {
             Ok(vars) => vars,
             Err(error) => return error_response(error),
         }
@@ -62,7 +74,7 @@ pub async fn put_managed(req: EnvPutRequest) -> EnvResponse {
         BTreeMap::new()
     };
     vars.extend(req.vars);
-    match atomic_write_env(Path::new(ENV_FILE), &vars) {
+    match atomic_write_env(path, &vars) {
         Ok(()) => EnvResponse {
             ok: true,
             vars,
@@ -73,19 +85,27 @@ pub async fn put_managed(req: EnvPutRequest) -> EnvResponse {
 }
 
 pub async fn delete_managed(req: EnvDeleteRequest) -> EnvResponse {
+    delete_managed_at(Path::new(ENV_FILE), req)
+}
+
+fn delete_managed_at(path: &Path, req: EnvDeleteRequest) -> EnvResponse {
     for key in &req.keys {
         if let Err(error) = validate_key(key) {
             return error_response(error);
         }
     }
-    let mut vars = match read_env_file(Path::new(ENV_FILE)) {
+    let _guard = match ENV_UPDATE_LOCK.lock() {
+        Ok(guard) => guard,
+        Err(_) => return error_response("environment update lock is unavailable"),
+    };
+    let mut vars = match read_env_file(path) {
         Ok(vars) => vars,
         Err(error) => return error_response(error),
     };
     for key in req.keys {
         vars.remove(&key);
     }
-    match atomic_write_env(Path::new(ENV_FILE), &vars) {
+    match atomic_write_env(path, &vars) {
         Ok(()) => EnvResponse {
             ok: true,
             vars,
@@ -179,14 +199,25 @@ fn atomic_write_env(path: &Path, vars: &BTreeMap<String, String>) -> Result<(), 
     let content = build_env_script(vars)?;
     let parent = path.parent().unwrap_or_else(|| Path::new("/"));
     fs::create_dir_all(parent).map_err(|error| error.to_string())?;
-    let tmp = tmp_path(parent);
-    fs::write(&tmp, content).map_err(|error| error.to_string())?;
-    fs::set_permissions(&tmp, fs::Permissions::from_mode(0o644))
-        .map_err(|error| error.to_string())?;
+    let (mut file, tmp) = create_temp_file(parent)?;
+    if let Err(error) = file.write_all(content.as_bytes()) {
+        let _ = fs::remove_file(&tmp);
+        return Err(error.to_string());
+    }
+    if let Err(error) = file.set_permissions(fs::Permissions::from_mode(0o644)) {
+        let _ = fs::remove_file(&tmp);
+        return Err(error.to_string());
+    }
+    if let Err(error) = file.sync_all() {
+        let _ = fs::remove_file(&tmp);
+        return Err(error.to_string());
+    }
+    drop(file);
     fs::rename(&tmp, path).map_err(|error| {
         let _ = fs::remove_file(&tmp);
         error.to_string()
-    })
+    })?;
+    sync_parent_dir(parent)
 }
 
 fn build_env_script(vars: &BTreeMap<String, String>) -> Result<String, String> {
@@ -219,20 +250,43 @@ fn shell_quote(value: &str) -> String {
     format!("'{}'", value.replace('\'', "'\\''"))
 }
 
-fn tmp_path(parent: &Path) -> PathBuf {
+fn create_temp_file(parent: &Path) -> Result<(File, PathBuf), String> {
+    for attempt in 0..100 {
+        let path = tmp_path(parent, attempt);
+        match OpenOptions::new().write(true).create_new(true).open(&path) {
+            Ok(file) => return Ok((file, path)),
+            Err(error) if error.kind() == std::io::ErrorKind::AlreadyExists => continue,
+            Err(error) => return Err(error.to_string()),
+        }
+    }
+    Err("cannot create temporary environment file".to_string())
+}
+
+fn sync_parent_dir(parent: &Path) -> Result<(), String> {
+    File::open(parent)
+        .and_then(|file| file.sync_all())
+        .map_err(|error| error.to_string())
+}
+
+fn tmp_path(parent: &Path, attempt: u32) -> PathBuf {
     parent.join(format!(
-        ".smolvm-env-{}-{}",
+        ".smolvm-env-{}-{}-{}",
         std::process::id(),
         std::time::SystemTime::now()
             .duration_since(std::time::UNIX_EPOCH)
             .unwrap_or_default()
-            .as_nanos()
+            .as_nanos(),
+        attempt
     ))
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::fs;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+
+    static TEMPFILE_COUNTER: AtomicUsize = AtomicUsize::new(0);
 
     #[test]
     fn shell_quote_round_trips_single_quotes_for_reader() {
@@ -251,5 +305,45 @@ mod tests {
         assert!(validate_key("OPENAI_API_KEY").is_ok());
         assert!(validate_key("1_BAD").is_err());
         assert!(validate_key("BAD-DASH").is_err());
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+    async fn concurrent_merges_keep_all_variables() {
+        let dir = tempfile_dir();
+        let path = dir.join("env.sh");
+        let mut handles = Vec::new();
+
+        for index in 0..32 {
+            let path = path.clone();
+            handles.push(tokio::spawn(async move {
+                let mut vars = BTreeMap::new();
+                vars.insert(format!("KEY_{index}"), format!("value-{index}"));
+                let response = put_managed_at(&path, EnvPutRequest { vars, merge: true });
+                assert!(response.ok, "{:?}", response.error);
+            }));
+        }
+
+        for handle in handles {
+            handle.await.unwrap();
+        }
+
+        let vars = read_env_file(&path).unwrap();
+        assert_eq!(vars.len(), 32);
+        for index in 0..32 {
+            assert_eq!(
+                vars.get(&format!("KEY_{index}")),
+                Some(&format!("value-{index}"))
+            );
+        }
+    }
+
+    fn tempfile_dir() -> PathBuf {
+        let path = std::env::temp_dir().join(format!(
+            "smolvm-env-test-{}-{}",
+            std::process::id(),
+            TEMPFILE_COUNTER.fetch_add(1, Ordering::Relaxed)
+        ));
+        fs::create_dir(&path).unwrap();
+        path
     }
 }

--- a/guest-agent/src/files.rs
+++ b/guest-agent/src/files.rs
@@ -475,18 +475,26 @@ fn create_safe_directory(root: &Path, target: &Path) -> Result<(), String> {
     let mut cursor = root.to_path_buf();
     for component in relative.components() {
         cursor.push(component.as_os_str());
-        if fs::symlink_metadata(&cursor)
-            .map(|metadata| metadata.file_type().is_symlink())
-            .unwrap_or(false)
-        {
-            return Err(format!(
-                "tar entry would write through a symlink: {}",
-                cursor.display()
-            ));
+        match fs::symlink_metadata(&cursor) {
+            Ok(metadata) => {
+                if metadata.file_type().is_symlink() {
+                    return Err(format!(
+                        "tar entry would write through a symlink: {}",
+                        cursor.display()
+                    ));
+                }
+                if !metadata.is_dir() {
+                    return Err(format!(
+                        "tar entry path collides with a non-directory: {}",
+                        cursor.display()
+                    ));
+                }
+                continue;
+            }
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => {}
+            Err(error) => return Err(format!("cannot inspect directory: {error}")),
         }
-        if let Err(error) = fs::create_dir(&cursor)
-            && error.kind() != std::io::ErrorKind::AlreadyExists
-        {
+        if let Err(error) = fs::create_dir(&cursor) {
             return Err(format!("cannot create directory: {error}"));
         }
     }
@@ -701,6 +709,20 @@ mod tests {
         let extract = extract_directory_tar(target.to_str().unwrap(), &archive);
         assert!(!extract.ok);
         assert!(extract.error.unwrap().contains("symlink"));
+    }
+
+    #[test]
+    fn directory_tar_rejects_directory_collision_with_regular_file() {
+        let target = tempfile_dir();
+        fs::write(target.join("collision"), b"file").unwrap();
+
+        let mut archive = Vec::new();
+        append_tar_header(&mut archive, "collision", 0o755, 0, b'5').unwrap();
+        archive.extend_from_slice(&[0u8; 1024]);
+
+        let extract = extract_directory_tar(target.to_str().unwrap(), &archive);
+        assert!(!extract.ok);
+        assert!(extract.error.unwrap().contains("non-directory"));
     }
 
     fn tempfile_dir() -> PathBuf {

--- a/guest-agent/src/files.rs
+++ b/guest-agent/src/files.rs
@@ -1,6 +1,6 @@
 use base64::Engine;
 use serde::{Deserialize, Serialize};
-use std::fs;
+use std::fs::{self, File, OpenOptions};
 use std::io::Write;
 use std::os::unix::fs::PermissionsExt;
 use std::path::{Component, Path, PathBuf};
@@ -95,35 +95,72 @@ fn resolve_put_target(path: &str, name: Option<&str>) -> Result<PathBuf, String>
 }
 
 fn write_file_atomically(target: &Path, mode: Option<u32>, data: &[u8]) -> FilePutResponse {
-    let parent = target.parent().unwrap_or_else(|| Path::new("/"));
-    let tmp_name = format!(
-        ".smolvm-put-{}-{}",
-        std::process::id(),
-        std::time::SystemTime::now()
-            .duration_since(std::time::UNIX_EPOCH)
-            .unwrap_or_default()
-            .as_nanos()
-    );
-    let tmp_path = parent.join(tmp_name);
+    match durable_atomic_write(target, mode, data, ".smolvm-put") {
+        Ok(()) => FilePutResponse {
+            ok: true,
+            error: None,
+        },
+        Err(error) => response_error(error),
+    }
+}
 
-    if let Err(error) = fs::write(&tmp_path, data) {
-        return response_error(format!("cannot write file: {error}"));
+fn durable_atomic_write(
+    target: &Path,
+    mode: Option<u32>,
+    data: &[u8],
+    prefix: &str,
+) -> Result<(), String> {
+    let parent = target.parent().unwrap_or_else(|| Path::new("/"));
+    let (mut file, tmp_path) = create_temp_file(parent, prefix)?;
+
+    if let Err(error) = file.write_all(data) {
+        let _ = fs::remove_file(&tmp_path);
+        return Err(format!("cannot write file: {error}"));
     }
     if let Some(mode) = mode {
-        if let Err(error) = fs::set_permissions(&tmp_path, fs::Permissions::from_mode(mode)) {
+        if let Err(error) = file.set_permissions(fs::Permissions::from_mode(mode)) {
             let _ = fs::remove_file(&tmp_path);
-            return response_error(format!("cannot set file mode: {error}"));
+            return Err(format!("cannot set file mode: {error}"));
         }
     }
+    if let Err(error) = file.sync_all() {
+        let _ = fs::remove_file(&tmp_path);
+        return Err(format!("cannot sync file: {error}"));
+    }
+    drop(file);
     if let Err(error) = fs::rename(&tmp_path, target) {
         let _ = fs::remove_file(&tmp_path);
-        return response_error(format!("cannot replace file: {error}"));
+        return Err(format!("cannot replace file: {error}"));
     }
+    sync_parent_dir(parent).map_err(|error| format!("cannot sync file directory: {error}"))
+}
 
-    FilePutResponse {
-        ok: true,
-        error: None,
+fn create_temp_file(parent: &Path, prefix: &str) -> Result<(File, PathBuf), String> {
+    for attempt in 0..100 {
+        let tmp_path = parent.join(format!(
+            "{prefix}-{}-{}-{}",
+            std::process::id(),
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap_or_default()
+                .as_nanos(),
+            attempt
+        ));
+        match OpenOptions::new()
+            .write(true)
+            .create_new(true)
+            .open(&tmp_path)
+        {
+            Ok(file) => return Ok((file, tmp_path)),
+            Err(error) if error.kind() == std::io::ErrorKind::AlreadyExists => continue,
+            Err(error) => return Err(format!("cannot create temporary file: {error}")),
+        }
     }
+    Err("cannot create temporary file".to_string())
+}
+
+fn sync_parent_dir(parent: &Path) -> Result<(), std::io::Error> {
+    File::open(parent).and_then(|file| file.sync_all())
 }
 
 pub fn put_file_bytes(
@@ -359,15 +396,12 @@ fn extract_tar_into(root: &Path, archive: &[u8]) -> Result<(), String> {
                     .ok_or_else(|| "tar entry has no parent directory".to_string())?;
                 create_safe_directory(root, parent)?;
                 reject_symlink_path(root, &target)?;
-                let mut file = fs::OpenOptions::new()
-                    .create(true)
-                    .truncate(true)
-                    .write(true)
-                    .open(&target)
-                    .map_err(|error| format!("cannot write tar entry: {error}"))?;
-                file.write_all(&archive[offset..offset + size_usize])
-                    .map_err(|error| format!("cannot write tar entry: {error}"))?;
-                let _ = fs::set_permissions(&target, fs::Permissions::from_mode(mode & 0o777));
+                durable_atomic_write(
+                    &target,
+                    Some(mode & 0o777),
+                    &archive[offset..offset + size_usize],
+                    ".smolvm-tar",
+                )?;
             }
             _ => return Err(format!("unsupported tar entry type: {}", typeflag as char)),
         }

--- a/guest-agent/src/files.rs
+++ b/guest-agent/src/files.rs
@@ -1,8 +1,9 @@
 use base64::Engine;
 use serde::{Deserialize, Serialize};
 use std::fs;
+use std::io::Write;
 use std::os::unix::fs::PermissionsExt;
-use std::path::{Path, PathBuf};
+use std::path::{Component, Path, PathBuf};
 
 #[derive(Debug, Deserialize)]
 pub struct FilePutRequest {
@@ -32,6 +33,25 @@ pub struct FileGetResponse {
     pub data_base64: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub error: Option<String>,
+}
+
+#[derive(Debug)]
+pub struct RawFile {
+    pub mode: u32,
+    pub size: u64,
+    pub data: Vec<u8>,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct FileRawPutQuery {
+    pub path: String,
+    pub name: Option<String>,
+    pub mode: Option<u32>,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct DirectoryTarQuery {
+    pub path: String,
 }
 
 fn response_error(error: impl Into<String>) -> FilePutResponse {
@@ -74,16 +94,7 @@ fn resolve_put_target(path: &str, name: Option<&str>) -> Result<PathBuf, String>
     Ok(target)
 }
 
-pub async fn put_file(req: FilePutRequest) -> FilePutResponse {
-    let target = match resolve_put_target(&req.path, req.name.as_deref()) {
-        Ok(target) => target,
-        Err(error) => return response_error(error),
-    };
-    let data = match base64::engine::general_purpose::STANDARD.decode(req.data_base64.as_bytes()) {
-        Ok(data) => data,
-        Err(error) => return response_error(format!("invalid base64 data: {error}")),
-    };
-
+fn write_file_atomically(target: &Path, mode: Option<u32>, data: &[u8]) -> FilePutResponse {
     let parent = target.parent().unwrap_or_else(|| Path::new("/"));
     let tmp_name = format!(
         ".smolvm-put-{}-{}",
@@ -98,13 +109,13 @@ pub async fn put_file(req: FilePutRequest) -> FilePutResponse {
     if let Err(error) = fs::write(&tmp_path, data) {
         return response_error(format!("cannot write file: {error}"));
     }
-    if let Some(mode) = req.mode {
+    if let Some(mode) = mode {
         if let Err(error) = fs::set_permissions(&tmp_path, fs::Permissions::from_mode(mode)) {
             let _ = fs::remove_file(&tmp_path);
             return response_error(format!("cannot set file mode: {error}"));
         }
     }
-    if let Err(error) = fs::rename(&tmp_path, &target) {
+    if let Err(error) = fs::rename(&tmp_path, target) {
         let _ = fs::remove_file(&tmp_path);
         return response_error(format!("cannot replace file: {error}"));
     }
@@ -115,29 +126,360 @@ pub async fn put_file(req: FilePutRequest) -> FilePutResponse {
     }
 }
 
-pub async fn get_file(query: FileGetQuery) -> FileGetResponse {
-    if query.path.is_empty() {
-        return get_response_error("missing path");
+pub fn put_file_bytes(
+    path: &str,
+    name: Option<&str>,
+    mode: Option<u32>,
+    data: &[u8],
+) -> FilePutResponse {
+    let target = match resolve_put_target(path, name) {
+        Ok(target) => target,
+        Err(error) => return response_error(error),
+    };
+    write_file_atomically(&target, mode, data)
+}
+
+pub async fn put_file(req: FilePutRequest) -> FilePutResponse {
+    let data = match base64::engine::general_purpose::STANDARD.decode(req.data_base64.as_bytes()) {
+        Ok(data) => data,
+        Err(error) => return response_error(format!("invalid base64 data: {error}")),
+    };
+    put_file_bytes(&req.path, req.name.as_deref(), req.mode, &data)
+}
+
+pub fn read_file_bytes(path: &str) -> Result<RawFile, String> {
+    if path.is_empty() {
+        return Err("missing path".to_string());
     }
-    let path = Path::new(&query.path);
+    let path = Path::new(path);
     let metadata = match fs::metadata(path) {
         Ok(metadata) => metadata,
-        Err(error) => return get_response_error(error.to_string()),
+        Err(error) => return Err(error.to_string()),
     };
     if !metadata.is_file() {
-        return get_response_error("not a regular file");
+        return Err("not a regular file".to_string());
     }
     let data = match fs::read(path) {
         Ok(data) => data,
-        Err(error) => return get_response_error(error.to_string()),
+        Err(error) => return Err(error.to_string()),
+    };
+    Ok(RawFile {
+        mode: metadata.permissions().mode() & 0o777,
+        size: data.len() as u64,
+        data,
+    })
+}
+
+pub async fn get_file(query: FileGetQuery) -> FileGetResponse {
+    let file = match read_file_bytes(&query.path) {
+        Ok(file) => file,
+        Err(error) => return get_response_error(error),
     };
     FileGetResponse {
         ok: true,
-        mode: Some(metadata.permissions().mode() & 0o777),
-        size: Some(data.len() as u64),
-        data_base64: Some(base64::engine::general_purpose::STANDARD.encode(data)),
+        mode: Some(file.mode),
+        size: Some(file.size),
+        data_base64: Some(base64::engine::general_purpose::STANDARD.encode(file.data)),
         error: None,
     }
+}
+
+pub fn create_directory_tar(path: &str) -> Result<Vec<u8>, String> {
+    if path.is_empty() {
+        return Err("missing path".to_string());
+    }
+    let root = Path::new(path);
+    let metadata = fs::metadata(root).map_err(|error| error.to_string())?;
+    if !metadata.is_dir() {
+        return Err("not a directory".to_string());
+    }
+
+    let mut out = Vec::new();
+    append_directory_entries(root, root, &mut out)?;
+    out.extend_from_slice(&[0u8; 1024]);
+    Ok(out)
+}
+
+pub fn extract_directory_tar(path: &str, data: &[u8]) -> FilePutResponse {
+    if path.is_empty() {
+        return response_error("missing path");
+    }
+    let target = PathBuf::from(path);
+    if let Err(error) = fs::create_dir_all(&target) {
+        return response_error(format!("cannot create directory: {error}"));
+    }
+    if !target.is_dir() {
+        return response_error("destination is not a directory");
+    }
+
+    match extract_tar_into(&target, data) {
+        Ok(()) => FilePutResponse {
+            ok: true,
+            error: None,
+        },
+        Err(error) => response_error(error),
+    }
+}
+
+fn append_directory_entries(root: &Path, current: &Path, out: &mut Vec<u8>) -> Result<(), String> {
+    let mut entries = fs::read_dir(current)
+        .map_err(|error| error.to_string())?
+        .collect::<Result<Vec<_>, _>>()
+        .map_err(|error| error.to_string())?;
+    entries.sort_by_key(|entry| entry.file_name());
+
+    for entry in entries {
+        let path = entry.path();
+        let metadata = fs::symlink_metadata(&path).map_err(|error| error.to_string())?;
+        let file_type = metadata.file_type();
+        if file_type.is_symlink() {
+            continue;
+        }
+        let relative = path
+            .strip_prefix(root)
+            .map_err(|error| error.to_string())?
+            .to_string_lossy()
+            .replace('\\', "/");
+        if file_type.is_dir() {
+            let entry_name = format!("{}/", relative.trim_end_matches('/'));
+            append_tar_header(
+                out,
+                &entry_name,
+                metadata.permissions().mode() & 0o777,
+                0,
+                b'5',
+            )?;
+            append_directory_entries(root, &path, out)?;
+        } else if file_type.is_file() {
+            let data = fs::read(&path).map_err(|error| error.to_string())?;
+            append_tar_header(
+                out,
+                &relative,
+                metadata.permissions().mode() & 0o777,
+                data.len() as u64,
+                b'0',
+            )?;
+            out.extend_from_slice(&data);
+            pad_tar_entry(out, data.len() as u64);
+        }
+    }
+    Ok(())
+}
+
+fn append_tar_header(
+    out: &mut Vec<u8>,
+    path: &str,
+    mode: u32,
+    size: u64,
+    typeflag: u8,
+) -> Result<(), String> {
+    let mut header = [0u8; 512];
+    let (name, prefix) = split_tar_path(path)?;
+    write_bytes(&mut header[0..100], name.as_bytes());
+    write_octal(&mut header[100..108], mode as u64);
+    write_octal(&mut header[108..116], 0);
+    write_octal(&mut header[116..124], 0);
+    write_octal(&mut header[124..136], size);
+    write_octal(&mut header[136..148], 0);
+    for byte in &mut header[148..156] {
+        *byte = b' ';
+    }
+    header[156] = typeflag;
+    write_bytes(&mut header[257..263], b"ustar\0");
+    write_bytes(&mut header[263..265], b"00");
+    write_bytes(&mut header[345..500], prefix.as_bytes());
+    let checksum = header.iter().map(|byte| *byte as u32).sum::<u32>();
+    let checksum_text = format!("{checksum:06o}\0 ");
+    write_bytes(&mut header[148..156], checksum_text.as_bytes());
+    out.extend_from_slice(&header);
+    Ok(())
+}
+
+fn split_tar_path(path: &str) -> Result<(String, String), String> {
+    let path = path.trim_start_matches("./");
+    let bytes = path.as_bytes();
+    if bytes.len() <= 100 {
+        return Ok((path.to_string(), String::new()));
+    }
+    for index in path.match_indices('/').map(|(index, _)| index).rev() {
+        let prefix = &path[..index];
+        let name = &path[index + 1..];
+        if !name.is_empty() && prefix.as_bytes().len() <= 155 && name.as_bytes().len() <= 100 {
+            return Ok((name.to_string(), prefix.to_string()));
+        }
+    }
+    Err(format!("tar path is too long: {path}"))
+}
+
+fn write_bytes(target: &mut [u8], value: &[u8]) {
+    let len = target.len().min(value.len());
+    target[..len].copy_from_slice(&value[..len]);
+}
+
+fn write_octal(target: &mut [u8], value: u64) {
+    let text = format!("{value:0width$o}\0", width = target.len() - 1);
+    write_bytes(target, text.as_bytes());
+}
+
+fn pad_tar_entry(out: &mut Vec<u8>, size: u64) {
+    let remainder = (size % 512) as usize;
+    if remainder != 0 {
+        out.extend(std::iter::repeat_n(0u8, 512 - remainder));
+    }
+}
+
+fn extract_tar_into(root: &Path, archive: &[u8]) -> Result<(), String> {
+    let mut offset = 0usize;
+    while offset + 512 <= archive.len() {
+        let header = &archive[offset..offset + 512];
+        offset += 512;
+        if header.iter().all(|byte| *byte == 0) {
+            return Ok(());
+        }
+
+        let entry_name = parse_tar_path(header)?;
+        let relative = validate_relative_archive_path(&entry_name)?;
+        let mode = parse_octal(&header[100..108]).unwrap_or(0o644) as u32;
+        let size = parse_octal(&header[124..136]).ok_or("invalid tar entry size")?;
+        let typeflag = header[156];
+        let size_usize = usize::try_from(size).map_err(|_| "tar entry is too large".to_string())?;
+        if offset + size_usize > archive.len() {
+            return Err("tar entry extends past archive end".to_string());
+        }
+        let target = root.join(&relative);
+
+        match typeflag {
+            b'5' => {
+                create_safe_directory(root, &target)?;
+                let _ = fs::set_permissions(&target, fs::Permissions::from_mode(mode & 0o777));
+            }
+            b'0' | 0 => {
+                let parent = target
+                    .parent()
+                    .ok_or_else(|| "tar entry has no parent directory".to_string())?;
+                create_safe_directory(root, parent)?;
+                reject_symlink_path(root, &target)?;
+                let mut file = fs::OpenOptions::new()
+                    .create(true)
+                    .truncate(true)
+                    .write(true)
+                    .open(&target)
+                    .map_err(|error| format!("cannot write tar entry: {error}"))?;
+                file.write_all(&archive[offset..offset + size_usize])
+                    .map_err(|error| format!("cannot write tar entry: {error}"))?;
+                let _ = fs::set_permissions(&target, fs::Permissions::from_mode(mode & 0o777));
+            }
+            _ => return Err(format!("unsupported tar entry type: {}", typeflag as char)),
+        }
+
+        offset += size_usize;
+        let remainder = offset % 512;
+        if remainder != 0 {
+            offset += 512 - remainder;
+        }
+    }
+
+    Err("tar archive ended before end marker".to_string())
+}
+
+fn parse_tar_path(header: &[u8]) -> Result<String, String> {
+    let name = parse_string_field(&header[0..100]);
+    let prefix = parse_string_field(&header[345..500]);
+    let path = if prefix.is_empty() {
+        name
+    } else {
+        format!("{prefix}/{name}")
+    };
+    if path.is_empty() {
+        Err("tar entry has an empty path".to_string())
+    } else {
+        Ok(path)
+    }
+}
+
+fn parse_string_field(field: &[u8]) -> String {
+    let len = field
+        .iter()
+        .position(|byte| *byte == 0)
+        .unwrap_or(field.len());
+    String::from_utf8_lossy(&field[..len]).into_owned()
+}
+
+fn parse_octal(field: &[u8]) -> Option<u64> {
+    let text = parse_string_field(field);
+    let text = text.trim_matches(char::from(0)).trim();
+    if text.is_empty() {
+        return Some(0);
+    }
+    u64::from_str_radix(text, 8).ok()
+}
+
+fn validate_relative_archive_path(path: &str) -> Result<PathBuf, String> {
+    let mut relative = PathBuf::new();
+    for component in Path::new(path).components() {
+        match component {
+            Component::Normal(part) => relative.push(part),
+            Component::CurDir => {}
+            Component::ParentDir | Component::RootDir | Component::Prefix(_) => {
+                return Err(format!("tar entry path is not safe: {path}"));
+            }
+        }
+    }
+    if relative.as_os_str().is_empty() {
+        return Err("tar entry has an empty path".to_string());
+    }
+    Ok(relative)
+}
+
+fn create_safe_directory(root: &Path, target: &Path) -> Result<(), String> {
+    let relative = target.strip_prefix(root).map_err(|_| {
+        format!(
+            "tar entry escaped destination directory: {}",
+            target.display()
+        )
+    })?;
+    let mut cursor = root.to_path_buf();
+    for component in relative.components() {
+        cursor.push(component.as_os_str());
+        if fs::symlink_metadata(&cursor)
+            .map(|metadata| metadata.file_type().is_symlink())
+            .unwrap_or(false)
+        {
+            return Err(format!(
+                "tar entry would write through a symlink: {}",
+                cursor.display()
+            ));
+        }
+        if let Err(error) = fs::create_dir(&cursor)
+            && error.kind() != std::io::ErrorKind::AlreadyExists
+        {
+            return Err(format!("cannot create directory: {error}"));
+        }
+    }
+    Ok(())
+}
+
+fn reject_symlink_path(root: &Path, target: &Path) -> Result<(), String> {
+    let relative = target.strip_prefix(root).map_err(|_| {
+        format!(
+            "tar entry escaped destination directory: {}",
+            target.display()
+        )
+    })?;
+    let mut cursor = root.to_path_buf();
+    for component in relative.components() {
+        cursor.push(component.as_os_str());
+        if fs::symlink_metadata(&cursor)
+            .map(|metadata| metadata.file_type().is_symlink())
+            .unwrap_or(false)
+        {
+            return Err(format!(
+                "tar entry would write through a symlink: {}",
+                cursor.display()
+            ));
+        }
+    }
+    Ok(())
 }
 
 #[cfg(test)]
@@ -254,6 +596,77 @@ mod tests {
         .await;
         assert!(!directory.ok);
         assert_eq!(directory.error.as_deref(), Some("not a regular file"));
+    }
+
+    #[test]
+    fn raw_file_helpers_put_and_read_bytes_without_base64() {
+        let dir = tempfile_dir();
+        let path = dir.join("payload.bin");
+
+        let put = put_file_bytes(path.to_str().unwrap(), None, Some(0o600), b"raw payload");
+        assert!(put.ok, "{:?}", put.error);
+
+        let file = read_file_bytes(path.to_str().unwrap()).unwrap();
+        assert_eq!(file.data, b"raw payload");
+        assert_eq!(file.mode, 0o600);
+        assert_eq!(file.size, 11);
+    }
+
+    #[test]
+    fn directory_tar_round_trips_regular_files_and_modes() {
+        let source = tempfile_dir();
+        fs::create_dir(source.join("sub")).unwrap();
+        fs::write(source.join("sub").join("note.txt"), b"hello").unwrap();
+        fs::set_permissions(
+            source.join("sub").join("note.txt"),
+            fs::Permissions::from_mode(0o640),
+        )
+        .unwrap();
+
+        let archive = create_directory_tar(source.to_str().unwrap()).unwrap();
+        let target = tempfile_dir();
+        let extract = extract_directory_tar(target.to_str().unwrap(), &archive);
+        assert!(extract.ok, "{:?}", extract.error);
+
+        let extracted = target.join("sub").join("note.txt");
+        assert_eq!(fs::read(&extracted).unwrap(), b"hello");
+        assert_eq!(
+            fs::metadata(extracted).unwrap().permissions().mode() & 0o777,
+            0o640
+        );
+    }
+
+    #[test]
+    fn directory_tar_rejects_path_traversal() {
+        let target = tempfile_dir();
+        let mut archive = Vec::new();
+        append_tar_header(&mut archive, "../escape.txt", 0o644, 4, b'0').unwrap();
+        archive.extend_from_slice(b"nope");
+        pad_tar_entry(&mut archive, 4);
+        archive.extend_from_slice(&[0u8; 1024]);
+
+        let extract = extract_directory_tar(target.to_str().unwrap(), &archive);
+        assert!(!extract.ok);
+        assert!(extract.error.unwrap().contains("not safe"));
+        assert!(!target.parent().unwrap().join("escape.txt").exists());
+    }
+
+    #[test]
+    fn directory_tar_rejects_symlink_targets() {
+        let target = tempfile_dir();
+        fs::create_dir(target.join("safe")).unwrap();
+        #[cfg(unix)]
+        std::os::unix::fs::symlink("/tmp", target.join("safe").join("link")).unwrap();
+
+        let mut archive = Vec::new();
+        append_tar_header(&mut archive, "safe/link/escape.txt", 0o644, 4, b'0').unwrap();
+        archive.extend_from_slice(b"nope");
+        pad_tar_entry(&mut archive, 4);
+        archive.extend_from_slice(&[0u8; 1024]);
+
+        let extract = extract_directory_tar(target.to_str().unwrap(), &archive);
+        assert!(!extract.ok);
+        assert!(extract.error.unwrap().contains("symlink"));
     }
 
     fn tempfile_dir() -> PathBuf {

--- a/guest-agent/src/handler.rs
+++ b/guest-agent/src/handler.rs
@@ -1,17 +1,28 @@
 use axum::{
     Json, Router,
-    extract::DefaultBodyLimit,
+    body::{Body, Bytes},
+    extract::{DefaultBodyLimit, Query},
+    http::{HeaderValue, StatusCode, header},
+    response::{IntoResponse, Response},
     routing::{get, post},
 };
 use once_cell::sync::Lazy;
 use serde::Serialize;
 use std::time::Instant;
 
+use crate::boot::{self, BootMilestonesResponse};
+use crate::env::{self, EnvDeleteRequest, EnvPutRequest, EnvResponse};
 use crate::exec::{self, ExecRequest, ExecResponse};
-use crate::files::{self, FileGetQuery, FileGetResponse, FilePutRequest, FilePutResponse};
+use crate::files::{
+    self, DirectoryTarQuery, FileGetQuery, FileGetResponse, FilePutRequest, FilePutResponse,
+    FileRawPutQuery,
+};
+use crate::ports::{self, PortsWaitRequest, PortsWaitResponse};
 
-pub const PROTOCOL_VERSION: u32 = 1;
+pub const PROTOCOL_VERSION: u32 = 2;
 const FILE_PUT_BODY_LIMIT_BYTES: usize = 50 * 1024 * 1024;
+const FILE_RAW_BODY_LIMIT_BYTES: usize = 256 * 1024 * 1024;
+const DIRECTORY_TAR_BODY_LIMIT_BYTES: usize = 512 * 1024 * 1024;
 static START_TIME: Lazy<Instant> = Lazy::new(Instant::now);
 
 pub fn router() -> Router {
@@ -27,6 +38,44 @@ pub fn router() -> Router {
             post(handle_file_put).layer(DefaultBodyLimit::max(FILE_PUT_BODY_LIMIT_BYTES)),
         )
         .route("/files/get", get(handle_file_get))
+        .route(
+            "/files/raw",
+            get(handle_file_raw_get)
+                .put(handle_file_raw_put)
+                .layer(DefaultBodyLimit::max(FILE_RAW_BODY_LIMIT_BYTES)),
+        )
+        .route(
+            "/files/content",
+            get(handle_file_raw_get)
+                .put(handle_file_raw_put)
+                .layer(DefaultBodyLimit::max(FILE_RAW_BODY_LIMIT_BYTES)),
+        )
+        .route(
+            "/dirs/tar",
+            get(handle_dir_tar_get)
+                .put(handle_dir_tar_put)
+                .layer(DefaultBodyLimit::max(DIRECTORY_TAR_BODY_LIMIT_BYTES)),
+        )
+        .route(
+            "/directories/tar",
+            get(handle_dir_tar_get)
+                .put(handle_dir_tar_put)
+                .layer(DefaultBodyLimit::max(DIRECTORY_TAR_BODY_LIMIT_BYTES)),
+        )
+        .route(
+            "/env",
+            get(handle_env_list)
+                .put(handle_env_set)
+                .delete(handle_env_unset),
+        )
+        .route(
+            "/env/managed",
+            get(handle_env_list)
+                .put(handle_env_set)
+                .delete(handle_env_unset),
+        )
+        .route("/boot/milestones", get(handle_boot_milestones))
+        .route("/ports/wait", post(handle_ports_wait))
 }
 
 pub fn extension_router() -> Router {
@@ -40,6 +89,44 @@ pub fn extension_router() -> Router {
             post(handle_file_put).layer(DefaultBodyLimit::max(FILE_PUT_BODY_LIMIT_BYTES)),
         )
         .route("/files/get", get(handle_file_get))
+        .route(
+            "/files/raw",
+            get(handle_file_raw_get)
+                .put(handle_file_raw_put)
+                .layer(DefaultBodyLimit::max(FILE_RAW_BODY_LIMIT_BYTES)),
+        )
+        .route(
+            "/files/content",
+            get(handle_file_raw_get)
+                .put(handle_file_raw_put)
+                .layer(DefaultBodyLimit::max(FILE_RAW_BODY_LIMIT_BYTES)),
+        )
+        .route(
+            "/dirs/tar",
+            get(handle_dir_tar_get)
+                .put(handle_dir_tar_put)
+                .layer(DefaultBodyLimit::max(DIRECTORY_TAR_BODY_LIMIT_BYTES)),
+        )
+        .route(
+            "/directories/tar",
+            get(handle_dir_tar_get)
+                .put(handle_dir_tar_put)
+                .layer(DefaultBodyLimit::max(DIRECTORY_TAR_BODY_LIMIT_BYTES)),
+        )
+        .route(
+            "/env",
+            get(handle_env_list)
+                .put(handle_env_set)
+                .delete(handle_env_unset),
+        )
+        .route(
+            "/env/managed",
+            get(handle_env_list)
+                .put(handle_env_set)
+                .delete(handle_env_unset),
+        )
+        .route("/boot/milestones", get(handle_boot_milestones))
+        .route("/ports/wait", post(handle_ports_wait))
 }
 
 #[derive(Serialize)]
@@ -82,9 +169,49 @@ pub async fn handle_version() -> Json<VersionResponse> {
 pub struct CapabilitiesResponse {
     pub protocol_version: u32,
     pub endpoints: Vec<&'static str>,
+    pub features: CapabilityFeatures,
+    pub limits: CapabilityLimits,
     pub tcp_enabled: bool,
     pub terminal_enabled: bool,
     pub prod_metrics_enabled: bool,
+}
+
+#[derive(Serialize)]
+pub struct CapabilityFeatures {
+    pub exec: bool,
+    pub sync: bool,
+    pub file_base64: bool,
+    pub file_raw: bool,
+    #[serde(rename = "files.stream")]
+    pub files_stream: bool,
+    pub dir_tar: bool,
+    #[serde(rename = "files.directory_tar")]
+    pub files_directory_tar: bool,
+    pub env_managed: bool,
+    #[serde(rename = "env.managed")]
+    pub env_managed_v2: bool,
+    pub boot_milestones: bool,
+    #[serde(rename = "boot.milestones")]
+    pub boot_milestones_v2: bool,
+    pub ports_wait: bool,
+    #[serde(rename = "ports.wait")]
+    pub ports_wait_v2: bool,
+    #[serde(rename = "browser.status")]
+    pub browser_status: bool,
+    pub tcp_listener: bool,
+    pub terminal: bool,
+    pub prod_metrics: bool,
+}
+
+#[derive(Serialize)]
+pub struct CapabilityLimits {
+    pub file_put_json_bytes: usize,
+    pub file_raw_put_bytes: usize,
+    pub max_stream_size_bytes: usize,
+    pub directory_tar_put_bytes: usize,
+    pub max_tar_size_bytes: usize,
+    pub default_operation_timeout_ms: u64,
+    pub port_wait_timeout_seconds: u64,
 }
 
 pub async fn handle_capabilities() -> Json<CapabilitiesResponse> {
@@ -98,7 +225,51 @@ pub async fn handle_capabilities() -> Json<CapabilitiesResponse> {
             "POST /sync",
             "POST /files/put",
             "GET /files/get",
+            "PUT /files/content",
+            "GET /files/content",
+            "PUT /directories/tar",
+            "GET /directories/tar",
+            "PUT /files/raw",
+            "GET /files/raw",
+            "PUT /dirs/tar",
+            "GET /dirs/tar",
+            "GET /env",
+            "PUT /env",
+            "DELETE /env",
+            "GET /env/managed",
+            "PUT /env/managed",
+            "DELETE /env/managed",
+            "GET /boot/milestones",
+            "POST /ports/wait",
         ],
+        features: CapabilityFeatures {
+            exec: true,
+            sync: true,
+            file_base64: true,
+            file_raw: true,
+            files_stream: true,
+            dir_tar: true,
+            files_directory_tar: true,
+            env_managed: true,
+            env_managed_v2: true,
+            boot_milestones: true,
+            boot_milestones_v2: true,
+            ports_wait: true,
+            ports_wait_v2: true,
+            browser_status: false,
+            tcp_listener: cfg!(feature = "tcp"),
+            terminal: false,
+            prod_metrics: false,
+        },
+        limits: CapabilityLimits {
+            file_put_json_bytes: FILE_PUT_BODY_LIMIT_BYTES,
+            file_raw_put_bytes: FILE_RAW_BODY_LIMIT_BYTES,
+            max_stream_size_bytes: FILE_RAW_BODY_LIMIT_BYTES,
+            directory_tar_put_bytes: DIRECTORY_TAR_BODY_LIMIT_BYTES,
+            max_tar_size_bytes: DIRECTORY_TAR_BODY_LIMIT_BYTES,
+            default_operation_timeout_ms: 120_000,
+            port_wait_timeout_seconds: 300,
+        },
         tcp_enabled: cfg!(feature = "tcp"),
         terminal_enabled: false,
         prod_metrics_enabled: false,
@@ -134,10 +305,98 @@ pub async fn handle_file_put(Json(req): Json<FilePutRequest>) -> Json<FilePutRes
     Json(files::put_file(req).await)
 }
 
-pub async fn handle_file_get(
-    axum::extract::Query(query): axum::extract::Query<FileGetQuery>,
-) -> Json<FileGetResponse> {
+pub async fn handle_file_get(Query(query): Query<FileGetQuery>) -> Json<FileGetResponse> {
     Json(files::get_file(query).await)
+}
+
+pub async fn handle_file_raw_put(
+    Query(query): Query<FileRawPutQuery>,
+    body: Bytes,
+) -> Json<FilePutResponse> {
+    Json(files::put_file_bytes(
+        &query.path,
+        query.name.as_deref(),
+        query.mode,
+        &body,
+    ))
+}
+
+pub async fn handle_file_raw_get(Query(query): Query<FileGetQuery>) -> Response {
+    match files::read_file_bytes(&query.path) {
+        Ok(file) => binary_response("application/octet-stream", file.mode, file.size, file.data),
+        Err(error) => json_error(StatusCode::BAD_REQUEST, error),
+    }
+}
+
+pub async fn handle_dir_tar_put(
+    Query(query): Query<DirectoryTarQuery>,
+    body: Bytes,
+) -> Json<FilePutResponse> {
+    Json(files::extract_directory_tar(&query.path, &body))
+}
+
+pub async fn handle_dir_tar_get(Query(query): Query<DirectoryTarQuery>) -> Response {
+    match files::create_directory_tar(&query.path) {
+        Ok(data) => binary_response("application/x-tar", 0o644, data.len() as u64, data),
+        Err(error) => json_error(StatusCode::BAD_REQUEST, error),
+    }
+}
+
+pub async fn handle_env_list() -> Json<EnvResponse> {
+    Json(env::read_managed().await)
+}
+
+pub async fn handle_env_set(Json(req): Json<EnvPutRequest>) -> Json<EnvResponse> {
+    Json(env::put_managed(req).await)
+}
+
+pub async fn handle_env_unset(Json(req): Json<EnvDeleteRequest>) -> Json<EnvResponse> {
+    Json(env::delete_managed(req).await)
+}
+
+pub async fn handle_boot_milestones() -> Json<BootMilestonesResponse> {
+    Json(boot::read_boot_milestones())
+}
+
+pub async fn handle_ports_wait(Json(req): Json<PortsWaitRequest>) -> Json<PortsWaitResponse> {
+    Json(ports::wait_for_ports(req).await)
+}
+
+#[derive(Serialize)]
+struct ErrorResponse {
+    ok: bool,
+    error: String,
+}
+
+fn json_error(error_status: StatusCode, error: impl Into<String>) -> Response {
+    (
+        error_status,
+        Json(ErrorResponse {
+            ok: false,
+            error: error.into(),
+        }),
+    )
+        .into_response()
+}
+
+fn binary_response(content_type: &'static str, mode: u32, size: u64, data: Vec<u8>) -> Response {
+    let mut response = Response::new(Body::from(data));
+    *response.status_mut() = StatusCode::OK;
+    let headers = response.headers_mut();
+    headers.insert(header::CONTENT_TYPE, HeaderValue::from_static(content_type));
+    headers.insert(
+        "x-smolvm-file-mode",
+        HeaderValue::from_str(&format!("{mode:o}")).expect("mode header is valid ASCII"),
+    );
+    headers.insert(
+        "x-smolvm-file-size",
+        HeaderValue::from_str(&size.to_string()).expect("size header is valid ASCII"),
+    );
+    headers.insert(
+        header::CONTENT_LENGTH,
+        HeaderValue::from_str(&size.to_string()).expect("size header is valid ASCII"),
+    );
+    response
 }
 
 #[cfg(test)]
@@ -170,11 +429,46 @@ mod tests {
         assert_eq!(capabilities.body["tcp_enabled"], cfg!(feature = "tcp"));
         assert_eq!(capabilities.body["terminal_enabled"], false);
         assert_eq!(capabilities.body["prod_metrics_enabled"], false);
+        assert_eq!(capabilities.body["features"]["file_base64"], true);
+        assert_eq!(capabilities.body["features"]["file_raw"], true);
+        assert_eq!(capabilities.body["features"]["files.stream"], true);
+        assert_eq!(capabilities.body["features"]["dir_tar"], true);
+        assert_eq!(capabilities.body["features"]["files.directory_tar"], true);
+        assert_eq!(capabilities.body["features"]["env_managed"], true);
+        assert_eq!(capabilities.body["features"]["env.managed"], true);
+        assert_eq!(capabilities.body["features"]["boot_milestones"], true);
+        assert_eq!(capabilities.body["features"]["boot.milestones"], true);
+        assert_eq!(capabilities.body["features"]["ports_wait"], true);
+        assert_eq!(capabilities.body["features"]["ports.wait"], true);
+        assert_eq!(capabilities.body["features"]["browser.status"], false);
+        assert_eq!(
+            capabilities.body["limits"]["file_put_json_bytes"],
+            FILE_PUT_BODY_LIMIT_BYTES
+        );
+        assert_eq!(
+            capabilities.body["limits"]["max_stream_size_bytes"],
+            FILE_RAW_BODY_LIMIT_BYTES
+        );
+        assert_eq!(
+            capabilities.body["limits"]["max_tar_size_bytes"],
+            DIRECTORY_TAR_BODY_LIMIT_BYTES
+        );
         let endpoints = capabilities.body["endpoints"].as_array().unwrap();
         assert!(endpoints.contains(&json!("POST /exec")));
         assert!(endpoints.contains(&json!("POST /sync")));
         assert!(endpoints.contains(&json!("POST /files/put")));
         assert!(endpoints.contains(&json!("GET /files/get")));
+        assert!(endpoints.contains(&json!("PUT /files/content")));
+        assert!(endpoints.contains(&json!("GET /files/content")));
+        assert!(endpoints.contains(&json!("PUT /directories/tar")));
+        assert!(endpoints.contains(&json!("GET /directories/tar")));
+        assert!(endpoints.contains(&json!("PUT /files/raw")));
+        assert!(endpoints.contains(&json!("GET /files/raw")));
+        assert!(endpoints.contains(&json!("PUT /dirs/tar")));
+        assert!(endpoints.contains(&json!("GET /dirs/tar")));
+        assert!(endpoints.contains(&json!("GET /env")));
+        assert!(endpoints.contains(&json!("GET /boot/milestones")));
+        assert!(endpoints.contains(&json!("POST /ports/wait")));
     }
 
     #[tokio::test]
@@ -205,6 +499,35 @@ mod tests {
         assert_eq!(response.status, StatusCode::OK);
         assert_eq!(response.body["ok"], true);
         assert_eq!(response.body.get("error"), None);
+    }
+
+    #[tokio::test]
+    async fn public_router_raw_file_put_and_get_transfer_bytes() {
+        let dir = tempfile_dir();
+        let path = dir.join("payload.bin");
+        let uri = format!(
+            "/files/content?path={}&mode=384",
+            url_escape(path.to_str().unwrap())
+        );
+        let put = raw_bytes_request(
+            router(),
+            "PUT",
+            &uri,
+            b"raw payload".to_vec(),
+            "application/octet-stream",
+        )
+        .await;
+        assert_eq!(put.status(), StatusCode::OK);
+        let put_body = to_bytes(put.into_body(), usize::MAX).await.unwrap();
+        let put_json: Value = serde_json::from_slice(&put_body).unwrap();
+        assert_eq!(put_json["ok"], true);
+
+        let get_uri = format!("/files/content?path={}", url_escape(path.to_str().unwrap()));
+        let get = raw_request(router(), "GET", &get_uri, None).await;
+        assert_eq!(get.status(), StatusCode::OK);
+        assert_eq!(get.headers().get("x-smolvm-file-mode").unwrap(), "600");
+        let get_body = to_bytes(get.into_body(), usize::MAX).await.unwrap();
+        assert_eq!(&get_body[..], b"raw payload");
     }
 
     #[tokio::test]
@@ -264,5 +587,46 @@ mod tests {
             None => Body::empty(),
         };
         app.oneshot(builder.body(body).unwrap()).await.unwrap()
+    }
+
+    async fn raw_bytes_request(
+        app: Router,
+        method: &str,
+        uri: &str,
+        body: Vec<u8>,
+        content_type: &str,
+    ) -> axum::response::Response {
+        let response = Request::builder()
+            .method(method)
+            .uri(uri)
+            .header("content-type", content_type)
+            .body(Body::from(body))
+            .unwrap();
+        app.oneshot(response).await.unwrap()
+    }
+
+    fn tempfile_dir() -> std::path::PathBuf {
+        let path = std::env::temp_dir().join(format!(
+            "smolvm-agent-handler-test-{}-{}",
+            std::process::id(),
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap_or_default()
+                .as_nanos()
+        ));
+        std::fs::create_dir(&path).unwrap();
+        path
+    }
+
+    fn url_escape(value: &str) -> String {
+        value
+            .bytes()
+            .flat_map(|byte| match byte {
+                b'A'..=b'Z' | b'a'..=b'z' | b'0'..=b'9' | b'-' | b'_' | b'.' | b'~' => {
+                    vec![byte as char]
+                }
+                other => format!("%{other:02X}").chars().collect(),
+            })
+            .collect()
     }
 }

--- a/guest-agent/src/lib.rs
+++ b/guest-agent/src/lib.rs
@@ -1,6 +1,9 @@
+pub mod boot;
+pub mod env;
 pub mod exec;
 pub mod files;
 pub mod handler;
+pub mod ports;
 pub mod server;
 
 pub use handler::router;

--- a/guest-agent/src/ports.rs
+++ b/guest-agent/src/ports.rs
@@ -1,7 +1,7 @@
 //! Port readiness helper.
 
 use serde::{Deserialize, Serialize};
-use std::net::{IpAddr, Ipv4Addr, SocketAddr, TcpStream};
+use std::net::{IpAddr, SocketAddr, TcpStream};
 use std::time::{Duration, Instant};
 
 const MAX_TIMEOUT_MS: u64 = 300_000;
@@ -50,9 +50,16 @@ pub async fn wait_for_ports(req: PortsWaitRequest) -> PortsWaitResponse {
         };
     }
     let host = req.host.unwrap_or_else(|| "127.0.0.1".to_string());
-    let ip = host
-        .parse::<IpAddr>()
-        .unwrap_or(IpAddr::V4(Ipv4Addr::LOCALHOST));
+    let ip = match host.parse::<IpAddr>() {
+        Ok(ip) => ip,
+        Err(_) => {
+            return PortsWaitResponse {
+                ok: false,
+                ready_ports: Vec::new(),
+                error: Some(format!("invalid host: {host}")),
+            };
+        }
+    };
     let timeout = Duration::from_millis(req.timeout_ms.max(1));
     let ports = req.ports;
 
@@ -144,5 +151,19 @@ mod tests {
             response.error.as_deref(),
             Some("too many ports; maximum is 256")
         );
+    }
+
+    #[tokio::test]
+    async fn rejects_invalid_hosts() {
+        let response = wait_for_ports(PortsWaitRequest {
+            ports: vec![80],
+            timeout_ms: 1,
+            host: Some("not-an-ip".to_string()),
+        })
+        .await;
+
+        assert!(!response.ok);
+        assert_eq!(response.ready_ports, Vec::<u16>::new());
+        assert_eq!(response.error.as_deref(), Some("invalid host: not-an-ip"));
     }
 }

--- a/guest-agent/src/ports.rs
+++ b/guest-agent/src/ports.rs
@@ -4,6 +4,9 @@ use serde::{Deserialize, Serialize};
 use std::net::{IpAddr, Ipv4Addr, SocketAddr, TcpStream};
 use std::time::{Duration, Instant};
 
+const MAX_TIMEOUT_MS: u64 = 300_000;
+const MAX_PORTS: usize = 256;
+
 #[derive(Debug, Deserialize)]
 pub struct PortsWaitRequest {
     pub ports: Vec<u16>,
@@ -32,6 +35,20 @@ pub async fn wait_for_ports(req: PortsWaitRequest) -> PortsWaitResponse {
             error: Some("missing ports".to_string()),
         };
     }
+    if req.ports.len() > MAX_PORTS {
+        return PortsWaitResponse {
+            ok: false,
+            ready_ports: Vec::new(),
+            error: Some(format!("too many ports; maximum is {MAX_PORTS}")),
+        };
+    }
+    if req.timeout_ms > MAX_TIMEOUT_MS {
+        return PortsWaitResponse {
+            ok: false,
+            ready_ports: Vec::new(),
+            error: Some(format!("timeout_ms must be at most {MAX_TIMEOUT_MS}")),
+        };
+    }
     let host = req.host.unwrap_or_else(|| "127.0.0.1".to_string());
     let ip = host
         .parse::<IpAddr>()
@@ -50,13 +67,24 @@ pub async fn wait_for_ports(req: PortsWaitRequest) -> PortsWaitResponse {
 }
 
 fn wait_blocking(ip: IpAddr, ports: Vec<u16>, timeout: Duration) -> PortsWaitResponse {
-    let deadline = Instant::now() + timeout;
+    let Some(deadline) = Instant::now().checked_add(timeout) else {
+        return PortsWaitResponse {
+            ok: false,
+            ready_ports: Vec::new(),
+            error: Some("timeout is too large".to_string()),
+        };
+    };
     let mut ready = Vec::new();
     while Instant::now() < deadline {
         ready.clear();
         for port in &ports {
+            let remaining = deadline.saturating_duration_since(Instant::now());
+            if remaining.is_zero() {
+                break;
+            }
             let addr = SocketAddr::new(ip, *port);
-            if TcpStream::connect_timeout(&addr, Duration::from_millis(100)).is_ok() {
+            if TcpStream::connect_timeout(&addr, remaining.min(Duration::from_millis(100))).is_ok()
+            {
                 ready.push(*port);
             }
         }
@@ -67,11 +95,54 @@ fn wait_blocking(ip: IpAddr, ports: Vec<u16>, timeout: Duration) -> PortsWaitRes
                 error: None,
             };
         }
-        std::thread::sleep(Duration::from_millis(25));
+        let remaining = deadline.saturating_duration_since(Instant::now());
+        if remaining.is_zero() {
+            break;
+        }
+        std::thread::sleep(remaining.min(Duration::from_millis(25)));
     }
     PortsWaitResponse {
         ok: false,
         ready_ports: ready,
         error: Some("timed out waiting for ports".to_string()),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn rejects_timeout_over_advertised_limit() {
+        let response = wait_for_ports(PortsWaitRequest {
+            ports: vec![80],
+            timeout_ms: MAX_TIMEOUT_MS + 1,
+            host: None,
+        })
+        .await;
+
+        assert!(!response.ok);
+        assert_eq!(response.ready_ports, Vec::<u16>::new());
+        assert_eq!(
+            response.error.as_deref(),
+            Some("timeout_ms must be at most 300000")
+        );
+    }
+
+    #[tokio::test]
+    async fn rejects_unbounded_port_lists() {
+        let response = wait_for_ports(PortsWaitRequest {
+            ports: vec![80; MAX_PORTS + 1],
+            timeout_ms: 1,
+            host: None,
+        })
+        .await;
+
+        assert!(!response.ok);
+        assert_eq!(response.ready_ports, Vec::<u16>::new());
+        assert_eq!(
+            response.error.as_deref(),
+            Some("too many ports; maximum is 256")
+        );
     }
 }

--- a/guest-agent/src/ports.rs
+++ b/guest-agent/src/ports.rs
@@ -1,0 +1,77 @@
+//! Port readiness helper.
+
+use serde::{Deserialize, Serialize};
+use std::net::{IpAddr, Ipv4Addr, SocketAddr, TcpStream};
+use std::time::{Duration, Instant};
+
+#[derive(Debug, Deserialize)]
+pub struct PortsWaitRequest {
+    pub ports: Vec<u16>,
+    #[serde(default = "default_timeout_ms")]
+    pub timeout_ms: u64,
+    pub host: Option<String>,
+}
+
+#[derive(Debug, Serialize)]
+pub struct PortsWaitResponse {
+    pub ok: bool,
+    pub ready_ports: Vec<u16>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub error: Option<String>,
+}
+
+fn default_timeout_ms() -> u64 {
+    30_000
+}
+
+pub async fn wait_for_ports(req: PortsWaitRequest) -> PortsWaitResponse {
+    if req.ports.is_empty() {
+        return PortsWaitResponse {
+            ok: false,
+            ready_ports: Vec::new(),
+            error: Some("missing ports".to_string()),
+        };
+    }
+    let host = req.host.unwrap_or_else(|| "127.0.0.1".to_string());
+    let ip = host
+        .parse::<IpAddr>()
+        .unwrap_or(IpAddr::V4(Ipv4Addr::LOCALHOST));
+    let timeout = Duration::from_millis(req.timeout_ms.max(1));
+    let ports = req.ports;
+
+    match tokio::task::spawn_blocking(move || wait_blocking(ip, ports, timeout)).await {
+        Ok(response) => response,
+        Err(error) => PortsWaitResponse {
+            ok: false,
+            ready_ports: Vec::new(),
+            error: Some(format!("port wait task failed: {error}")),
+        },
+    }
+}
+
+fn wait_blocking(ip: IpAddr, ports: Vec<u16>, timeout: Duration) -> PortsWaitResponse {
+    let deadline = Instant::now() + timeout;
+    let mut ready = Vec::new();
+    while Instant::now() < deadline {
+        ready.clear();
+        for port in &ports {
+            let addr = SocketAddr::new(ip, *port);
+            if TcpStream::connect_timeout(&addr, Duration::from_millis(100)).is_ok() {
+                ready.push(*port);
+            }
+        }
+        if ready.len() == ports.len() {
+            return PortsWaitResponse {
+                ok: true,
+                ready_ports: ready,
+                error: None,
+            };
+        }
+        std::thread::sleep(Duration::from_millis(25));
+    }
+    PortsWaitResponse {
+        ok: false,
+        ready_ports: ready,
+        error: Some("timed out waiting for ports".to_string()),
+    }
+}

--- a/scripts/ci/preset-init.sh
+++ b/scripts/ci/preset-init.sh
@@ -46,7 +46,18 @@ ts_epoch() {
 
 log_ts() {
     STAGE="$1"
-    echo "SMOLVM_TS stage=${STAGE} epoch_s=$(ts_epoch) uptime_s=$(ts_uptime)"
+    EPOCH="$(ts_epoch)"
+    UPTIME="$(ts_uptime)"
+    LINE="SMOLVM_TS stage=${STAGE} epoch_s=${EPOCH} uptime_s=${UPTIME}"
+    echo "$LINE"
+    if [ -d /run ]; then
+        mkdir -p /run/smolvm 2>/dev/null || true
+        printf '{"stage":"%s","epoch_s":%s,"uptime_s":%s}\n' "$STAGE" "$EPOCH" "$UPTIME" >> /run/smolvm/milestones.jsonl 2>/dev/null || true
+        printf '{"stage":"%s","epoch_s":%s,"uptime_s":%s}\n' "$STAGE" "$EPOCH" "$UPTIME" >> /run/smolvm/boot-milestones.jsonl 2>/dev/null || true
+    fi
+    if [ -d /var/log ]; then
+        echo "$LINE" >> /var/log/smolvm-boot.log 2>/dev/null || true
+    fi
 }
 
 log_ts "init-start"

--- a/src/smolvm/comm/rust_http_vsock_channel.py
+++ b/src/smolvm/comm/rust_http_vsock_channel.py
@@ -789,7 +789,7 @@ class RustHttpVsockChannel:
         )
         if not resp.get("ok"):
             error = str(resp.get("error") or "")
-            if error and "timed out" not in error.lower() and "timeout" not in error.lower():
+            if error and "timed out" not in error.lower():
                 raise SmolVMError(f"guest agent error during port wait: {error}")
             raise OperationTimeoutError(
                 f"waiting for guest ports {', '.join(map(str, ports))}", timeout

--- a/src/smolvm/comm/rust_http_vsock_channel.py
+++ b/src/smolvm/comm/rust_http_vsock_channel.py
@@ -75,6 +75,12 @@ class ControlCapabilities:
 
     def enabled(self, *names: str) -> bool:
         for name in names:
+            value = self.features.get(name)
+            if value is True:
+                return True
+            if isinstance(value, str) and value.lower() == "true":
+                return True
+
             value: Any = self.features
             for part in name.split("."):
                 if not isinstance(value, dict) or part not in value:

--- a/src/smolvm/comm/rust_http_vsock_channel.py
+++ b/src/smolvm/comm/rust_http_vsock_channel.py
@@ -19,6 +19,7 @@ from __future__ import annotations
 import base64
 import http.client
 import io
+import ipaddress
 import json
 import logging
 import math
@@ -47,6 +48,11 @@ SMOLVM_AGENT_PORT = 1024
 
 _READY_FAST_POLL_WINDOW = 1.0
 _READY_FAST_POLL_INTERVAL = 0.02
+_DEFAULT_MAX_AGENT_RESPONSE_BYTES = 1024 * 1024
+_DEFAULT_MAX_STREAM_SIZE_BYTES = 256 * 1024 * 1024
+_DEFAULT_MAX_TAR_SIZE_BYTES = 512 * 1024 * 1024
+_MAX_PORTS_WAIT = 256
+_MAX_PORT_WAIT_TIMEOUT_SECONDS = 300.0
 
 _LEGACY_CAPABILITIES: dict[str, Any] = {
     "protocol_version": 1,
@@ -115,6 +121,18 @@ def _endpoint_missing(exc: BaseException, method: str, path: str) -> bool:
 def _parse_mode_header(value: str) -> int:
     value = value.strip().removeprefix("0o")
     return int(value, 8)
+
+
+def _parse_size_header(value: str, *, header: str, method: str, path: str) -> int:
+    try:
+        size = int(value.strip())
+    except ValueError as exc:
+        raise SmolVMError(
+            f"guest agent returned invalid {header} for {method} {path}: {value!r}"
+        ) from exc
+    if size < 0:
+        raise SmolVMError(f"guest agent returned negative {header} for {method} {path}")
+    return size
 
 
 def _directory_to_tar(source: Path) -> bytes:
@@ -355,6 +373,7 @@ class RustHttpVsockChannel:
         body: bytes = b"",
         *,
         content_type: str | None = None,
+        max_bytes: int | None = _DEFAULT_MAX_AGENT_RESPONSE_BYTES,
         timeout: float | None = None,
     ) -> tuple[http.client.HTTPResponse, bytes]:
         headers = {"Connection": "close"}
@@ -367,7 +386,28 @@ class RustHttpVsockChannel:
         try:
             conn.request(method, path, body=body, headers=headers)
             resp = conn.getresponse()
-            data = resp.read()
+            if max_bytes is not None:
+                for header in ("Content-Length", "x-smolvm-file-size"):
+                    value = resp.getheader(header)
+                    if value is None:
+                        continue
+                    declared_size = _parse_size_header(
+                        value,
+                        header=header,
+                        method=method,
+                        path=path,
+                    )
+                    if declared_size > max_bytes:
+                        raise SmolVMError(
+                            f"guest agent response for {method} {path} exceeded {max_bytes} bytes"
+                        )
+                data = resp.read(max_bytes + 1)
+                if len(data) > max_bytes:
+                    raise SmolVMError(
+                        f"guest agent response for {method} {path} exceeded {max_bytes} bytes"
+                    )
+            else:
+                data = resp.read()
             if resp.status >= 400:
                 detail = data.decode("utf-8", errors="replace")
                 raise SmolVMError(f"guest agent HTTP {resp.status} for {method} {path}: {detail}")
@@ -400,6 +440,14 @@ class RustHttpVsockChannel:
 
     def supports(self, *features: str) -> bool:
         return self.capabilities.enabled(*features)
+
+    def _limit_bytes(self, name: str, default: int) -> int:
+        value = self.capabilities.limits.get(name)
+        try:
+            limit = int(value)
+        except (TypeError, ValueError):
+            return default
+        return limit if limit > 0 else default
 
     def run(
         self,
@@ -500,7 +548,14 @@ class RustHttpVsockChannel:
         query = urllib.parse.urlencode({"path": remote_path})
         if self.supports("file_raw", "files.stream"):
             try:
-                resp, data = self._request_bytes("GET", f"/files/content?{query}")
+                resp, data = self._request_bytes(
+                    "GET",
+                    f"/files/content?{query}",
+                    max_bytes=self._limit_bytes(
+                        "max_stream_size_bytes",
+                        _DEFAULT_MAX_STREAM_SIZE_BYTES,
+                    ),
+                )
                 expected_size = resp.getheader("x-smolvm-file-size")
                 if expected_size is not None and int(expected_size) != len(data):
                     raise SmolVMError(
@@ -574,7 +629,11 @@ class RustHttpVsockChannel:
         destination.mkdir(parents=True, exist_ok=True)
         query = urllib.parse.urlencode({"path": remote_path})
         try:
-            _resp, data = self._request_bytes("GET", f"/directories/tar?{query}")
+            _resp, data = self._request_bytes(
+                "GET",
+                f"/directories/tar?{query}",
+                max_bytes=self._limit_bytes("max_tar_size_bytes", _DEFAULT_MAX_TAR_SIZE_BYTES),
+            )
         except SmolVMError as exc:
             if not _endpoint_missing(exc, "GET", "/directories/tar"):
                 raise
@@ -582,17 +641,28 @@ class RustHttpVsockChannel:
         _safe_extract_tar(data, destination)
         return destination
 
+    def _remote_temp_archive(self) -> str:
+        result = self.run("mktemp /tmp/smolvm-dir.XXXXXX.tar", timeout=10, shell="raw")
+        remote_tmp = result.stdout.strip()
+        if not result.ok or not remote_tmp:
+            raise SmolVMError(
+                "Failed to create temporary archive path in guest: "
+                f"{result.stderr.strip() or result.stdout}"
+            )
+        return remote_tmp
+
     def _put_directory_legacy(self, source: Path, remote_path: str) -> None:
         data = _directory_to_tar(source)
         local_tmp = _write_temp_tar(data)
-        remote_tmp = f"/tmp/smolvm-dir-{os.getpid()}-{time.monotonic_ns()}.tar"
+        remote_tmp = self._remote_temp_archive()
         try:
             self.put_file(local_tmp, remote_tmp)
             result = self.run(
                 "set -e; "
+                f"remote_tmp={shlex.quote(remote_tmp)}; "
+                "trap 'rm -f -- \"$remote_tmp\"' EXIT; "
                 f"mkdir -p -- {shlex.quote(remote_path)}; "
-                f"tar -xf {shlex.quote(remote_tmp)} -C {shlex.quote(remote_path)}; "
-                f"rm -f -- {shlex.quote(remote_tmp)}",
+                f'tar -xf "$remote_tmp" -C {shlex.quote(remote_path)}',
                 timeout=120,
                 shell="raw",
             )
@@ -603,18 +673,18 @@ class RustHttpVsockChannel:
                 )
         finally:
             local_tmp.unlink(missing_ok=True)
+            with suppress(SmolVMError):
+                self.run(f"rm -f -- {shlex.quote(remote_tmp)}", timeout=10, shell="raw")
 
     def _get_directory_legacy(self, remote_path: str, destination: Path) -> Path:
         destination.mkdir(parents=True, exist_ok=True)
-        remote_tmp = f"/tmp/smolvm-dir-{os.getpid()}-{time.monotonic_ns()}.tar"
+        remote_tmp = self._remote_temp_archive()
         local_fd, local_name = tempfile.mkstemp(prefix="smolvm-dir-", suffix=".tar")
         os.close(local_fd)
         local_tmp = Path(local_name)
         try:
             result = self.run(
-                "set -e; "
-                f"rm -f -- {shlex.quote(remote_tmp)}; "
-                f"tar -cf {shlex.quote(remote_tmp)} -C {shlex.quote(remote_path)} .",
+                f"set -e; tar -cf {shlex.quote(remote_tmp)} -C {shlex.quote(remote_path)} .",
                 timeout=120,
                 shell="raw",
             )
@@ -694,6 +764,23 @@ class RustHttpVsockChannel:
         timeout: float = 30,
         host: str = "127.0.0.1",
     ) -> list[int]:
+        if not ports:
+            raise ValueError("ports cannot be empty")
+        if len(ports) > _MAX_PORTS_WAIT:
+            raise ValueError(f"ports cannot contain more than {_MAX_PORTS_WAIT} entries")
+        invalid_ports = [
+            port for port in ports if not isinstance(port, int) or port < 1 or port > 65535
+        ]
+        if invalid_ports:
+            raise ValueError("ports must be integers between 1 and 65535")
+        if timeout <= 0:
+            raise ValueError("timeout must be > 0")
+        if timeout > _MAX_PORT_WAIT_TIMEOUT_SECONDS:
+            raise ValueError(f"timeout must be <= {_MAX_PORT_WAIT_TIMEOUT_SECONDS:g} seconds")
+        try:
+            ipaddress.ip_address(host)
+        except ValueError as exc:
+            raise ValueError("host must be a valid IP address") from exc
         resp = self._request_json(
             "POST",
             "/ports/wait",
@@ -701,6 +788,9 @@ class RustHttpVsockChannel:
             timeout=timeout + self.connect_timeout,
         )
         if not resp.get("ok"):
+            error = str(resp.get("error") or "")
+            if error and "timed out" not in error.lower() and "timeout" not in error.lower():
+                raise SmolVMError(f"guest agent error during port wait: {error}")
             raise OperationTimeoutError(
                 f"waiting for guest ports {', '.join(map(str, ports))}", timeout
             )

--- a/src/smolvm/comm/rust_http_vsock_channel.py
+++ b/src/smolvm/comm/rust_http_vsock_channel.py
@@ -18,16 +18,22 @@ from __future__ import annotations
 
 import base64
 import http.client
+import io
 import json
 import logging
 import math
 import os
+import shlex
 import socket
 import stat
+import tarfile
+import tempfile
 import time
 import urllib.parse
 from collections.abc import Callable
-from pathlib import Path
+from contextlib import suppress
+from dataclasses import dataclass
+from pathlib import Path, PurePosixPath
 from typing import Any
 
 from smolvm.comm.base import CommChannelKind, ShellMode
@@ -41,6 +47,152 @@ SMOLVM_AGENT_PORT = 1024
 
 _READY_FAST_POLL_WINDOW = 1.0
 _READY_FAST_POLL_INTERVAL = 0.02
+
+_LEGACY_CAPABILITIES: dict[str, Any] = {
+    "protocol_version": 1,
+    "features": {
+        "exec": True,
+        "sync": False,
+        "file_base64": True,
+        "file_raw": False,
+        "dir_tar": False,
+        "env_managed": False,
+        "boot_milestones": False,
+        "ports_wait": False,
+    },
+    "limits": {},
+    "endpoints": ["POST /exec", "POST /files/put", "GET /files/get"],
+}
+
+
+@dataclass(frozen=True)
+class ControlCapabilities:
+    """Cached guest-agent capability flags."""
+
+    protocol_version: int
+    features: dict[str, Any]
+    limits: dict[str, Any]
+
+    def enabled(self, *names: str) -> bool:
+        for name in names:
+            value: Any = self.features
+            for part in name.split("."):
+                if not isinstance(value, dict) or part not in value:
+                    value = None
+                    break
+                value = value[part]
+            if value is True:
+                return True
+            if isinstance(value, str) and value.lower() == "true":
+                return True
+        return False
+
+
+def _legacy_control_capabilities() -> ControlCapabilities:
+    features = _LEGACY_CAPABILITIES["features"]
+    limits = _LEGACY_CAPABILITIES["limits"]
+    return ControlCapabilities(
+        protocol_version=1,
+        features=dict(features) if isinstance(features, dict) else {},
+        limits=dict(limits) if isinstance(limits, dict) else {},
+    )
+
+
+def _endpoint_missing(exc: BaseException, method: str, path: str) -> bool:
+    text = str(exc)
+    return (
+        f"guest agent HTTP 404 for {method} {path}" in text
+        or f"guest agent HTTP 405 for {method} {path}" in text
+    )
+
+
+def _parse_mode_header(value: str) -> int:
+    value = value.strip().removeprefix("0o")
+    return int(value, 8)
+
+
+def _directory_to_tar(source: Path) -> bytes:
+    buffer = io.BytesIO()
+    with tarfile.open(fileobj=buffer, mode="w") as archive:
+        for child in sorted(source.iterdir()):
+            _add_tar_path(archive, child, PurePosixPath(child.name))
+    return buffer.getvalue()
+
+
+def _write_temp_tar(data: bytes) -> Path:
+    fd, path = tempfile.mkstemp(prefix="smolvm-dir-", suffix=".tar")
+    with os.fdopen(fd, "wb") as handle:
+        handle.write(data)
+    return Path(path)
+
+
+def _add_tar_path(archive: tarfile.TarFile, path: Path, arcname: PurePosixPath) -> None:
+    if path.is_symlink():
+        return
+    archive.add(path, arcname=str(arcname), recursive=False)
+    if path.is_dir():
+        for child in sorted(path.iterdir()):
+            _add_tar_path(archive, child, arcname / child.name)
+
+
+def _safe_extract_tar(data: bytes, destination: Path) -> None:
+    destination.mkdir(parents=True, exist_ok=True)
+    with tarfile.open(fileobj=io.BytesIO(data), mode="r:*") as archive:
+        for member in archive.getmembers():
+            relative = _safe_tar_member_path(member.name)
+            if relative is None:
+                continue
+            target = destination / relative
+            if member.isdir():
+                _safe_mkdir(destination, target)
+                if member.mode:
+                    os.chmod(target, stat.S_IMODE(member.mode))
+                continue
+            if not member.isfile():
+                raise SmolVMError(f"Refusing unsupported tar entry: {member.name}")
+            parent = target.parent
+            _safe_mkdir(destination, parent)
+            _reject_symlink_path(destination, target)
+            source = archive.extractfile(member)
+            if source is None:
+                raise SmolVMError(f"Tar entry has no data: {member.name}")
+            target.write_bytes(source.read())
+            if member.mode:
+                os.chmod(target, stat.S_IMODE(member.mode))
+
+
+def _safe_tar_member_path(name: str) -> Path | None:
+    if name.startswith(("/", "\\")):
+        raise SmolVMError(f"Refusing absolute tar entry: {name}")
+    parts: list[str] = []
+    for part in PurePosixPath(name).parts:
+        if part in {"", "."}:
+            continue
+        if part == "..":
+            raise SmolVMError(f"Refusing tar entry outside destination: {name}")
+        parts.append(part)
+    if not parts:
+        return None
+    return Path(*parts)
+
+
+def _safe_mkdir(root: Path, target: Path) -> None:
+    relative = target.relative_to(root)
+    cursor = root
+    for part in relative.parts:
+        cursor = cursor / part
+        if cursor.is_symlink():
+            raise SmolVMError(f"Refusing tar extraction through symlink: {cursor}")
+        cursor.mkdir(exist_ok=True)
+
+
+def _reject_symlink_path(root: Path, target: Path) -> None:
+    relative = target.relative_to(root)
+    cursor = root
+    for part in relative.parts:
+        cursor = cursor / part
+        if cursor.is_symlink():
+            raise SmolVMError(f"Refusing tar extraction through symlink: {cursor}")
 
 
 class _SocketHTTPConnection(http.client.HTTPConnection):
@@ -82,6 +234,7 @@ class RustHttpVsockChannel:
         self.agent_port = agent_port
         self.connect_timeout = connect_timeout
         self._ready = False
+        self._capabilities: ControlCapabilities | None = None
 
     @classmethod
     def from_cid(
@@ -153,18 +306,26 @@ class RustHttpVsockChannel:
         path: str,
         payload: dict[str, Any] | None = None,
         *,
+        body: bytes | None = None,
+        content_type: str | None = None,
         timeout: float | None = None,
     ) -> dict[str, Any]:
-        body = b"" if payload is None else json.dumps(payload).encode("utf-8")
+        if payload is not None and body is not None:
+            raise ValueError("provide payload or body, not both")
+        request_body = b"" if payload is None and body is None else body
+        if payload is not None:
+            request_body = json.dumps(payload).encode("utf-8")
         headers = {"Accept": "application/json", "Connection": "close"}
         if payload is not None:
             headers["Content-Type"] = "application/json"
+        elif content_type is not None:
+            headers["Content-Type"] = content_type
         conn = _SocketHTTPConnection(
             self._open,
             timeout=float(timeout if timeout is not None else self.connect_timeout),
         )
         try:
-            conn.request(method, path, body=body, headers=headers)
+            conn.request(method, path, body=request_body, headers=headers)
             resp = conn.getresponse()
             data = resp.read()
             if resp.status >= 400:
@@ -180,6 +341,59 @@ class RustHttpVsockChannel:
             ) from exc
         finally:
             conn.close()
+
+    def _request_bytes(
+        self,
+        method: str,
+        path: str,
+        body: bytes = b"",
+        *,
+        content_type: str | None = None,
+        timeout: float | None = None,
+    ) -> tuple[http.client.HTTPResponse, bytes]:
+        headers = {"Connection": "close"}
+        if content_type:
+            headers["Content-Type"] = content_type
+        conn = _SocketHTTPConnection(
+            self._open,
+            timeout=float(timeout if timeout is not None else self.connect_timeout),
+        )
+        try:
+            conn.request(method, path, body=body, headers=headers)
+            resp = conn.getresponse()
+            data = resp.read()
+            if resp.status >= 400:
+                detail = data.decode("utf-8", errors="replace")
+                raise SmolVMError(f"guest agent HTTP {resp.status} for {method} {path}: {detail}")
+            return resp, data
+        except TimeoutError as exc:
+            raise OperationTimeoutError(
+                f"guest agent request: {method} {path}", timeout or 0
+            ) from exc
+        finally:
+            conn.close()
+
+    @property
+    def capabilities(self) -> ControlCapabilities:
+        if self._capabilities is None:
+            try:
+                resp = self._request_json("GET", "/capabilities")
+                features = resp.get("features") if isinstance(resp.get("features"), dict) else {}
+                limits = resp.get("limits") if isinstance(resp.get("limits"), dict) else {}
+                protocol_version = int(resp.get("protocol_version", 1))
+                if protocol_version < 2 and not features:
+                    features = _LEGACY_CAPABILITIES["features"]
+                self._capabilities = ControlCapabilities(
+                    protocol_version=protocol_version,
+                    features=dict(features),
+                    limits=dict(limits),
+                )
+            except (OSError, SmolVMError, ValueError, OperationTimeoutError):
+                self._capabilities = _legacy_control_capabilities()
+        return self._capabilities
+
+    def supports(self, *features: str) -> bool:
+        return self.capabilities.enabled(*features)
 
     def run(
         self,
@@ -239,6 +453,27 @@ class RustHttpVsockChannel:
         if not source.is_file():
             raise ValueError(f"local_path is not a file: {source}")
         mode = stat.S_IMODE(source.stat().st_mode)
+        if self.supports("file_raw", "files.stream"):
+            try:
+                query = urllib.parse.urlencode(
+                    {"path": remote_path, "name": source.name, "mode": mode}
+                )
+                resp, data = self._request_bytes(
+                    "PUT",
+                    f"/files/content?{query}",
+                    source.read_bytes(),
+                    content_type="application/octet-stream",
+                )
+                decoded = json.loads(data.decode("utf-8")) if data else {}
+                if resp.status >= 400 or not decoded.get("ok"):
+                    raise SmolVMError(
+                        f"Failed to upload file to guest '{remote_path}': {decoded.get('error')}"
+                    )
+                return
+            except SmolVMError as exc:
+                if not _endpoint_missing(exc, "PUT", "/files/content"):
+                    raise
+                self._capabilities = _legacy_control_capabilities()
         payload = {
             "path": remote_path,
             "name": source.name,
@@ -257,6 +492,24 @@ class RustHttpVsockChannel:
         destination = Path(local_path)
         destination.parent.mkdir(parents=True, exist_ok=True)
         query = urllib.parse.urlencode({"path": remote_path})
+        if self.supports("file_raw", "files.stream"):
+            try:
+                resp, data = self._request_bytes("GET", f"/files/content?{query}")
+                expected_size = resp.getheader("x-smolvm-file-size")
+                if expected_size is not None and int(expected_size) != len(data):
+                    raise SmolVMError(
+                        f"Guest file response for '{remote_path}' had size {expected_size}, "
+                        f"got {len(data)} bytes"
+                    )
+                destination.write_bytes(data)
+                mode = resp.getheader("x-smolvm-file-mode")
+                if mode is not None:
+                    os.chmod(destination, _parse_mode_header(mode))
+                return destination
+            except SmolVMError as exc:
+                if not _endpoint_missing(exc, "GET", "/files/content"):
+                    raise
+                self._capabilities = _legacy_control_capabilities()
         resp = self._request_json("GET", f"/files/get?{query}")
         if not resp.get("ok"):
             raise SmolVMError(f"Failed to download guest file '{remote_path}': {resp.get('error')}")
@@ -274,6 +527,188 @@ class RustHttpVsockChannel:
         if mode is not None:
             os.chmod(destination, int(mode))
         return destination
+
+    def put_directory(self, local_path: str | Path, remote_path: str) -> None:
+        """Upload a directory as a tar stream when the guest supports it."""
+        if not remote_path:
+            raise ValueError("remote_path cannot be empty")
+        source = Path(local_path)
+        if not source.is_dir():
+            raise ValueError(f"local_path is not a directory: {source}")
+        if not self.supports("dir_tar", "files.directory_tar"):
+            self._put_directory_legacy(source, remote_path)
+            return
+        data = _directory_to_tar(source)
+        query = urllib.parse.urlencode({"path": remote_path})
+        try:
+            _resp, response_data = self._request_bytes(
+                "PUT",
+                f"/directories/tar?{query}",
+                data,
+                content_type="application/x-tar",
+            )
+        except SmolVMError as exc:
+            if not _endpoint_missing(exc, "PUT", "/directories/tar"):
+                raise
+            self._put_directory_legacy(source, remote_path)
+            return
+        decoded = json.loads(response_data.decode("utf-8")) if response_data else {}
+        if not decoded.get("ok"):
+            raise SmolVMError(
+                f"Failed to upload directory to guest '{remote_path}': {decoded.get('error')}"
+            )
+
+    def get_directory(self, remote_path: str, local_path: str | Path) -> Path:
+        """Download a directory tar stream when the guest supports it."""
+        if not remote_path:
+            raise ValueError("remote_path cannot be empty")
+        if not self.supports("dir_tar", "files.directory_tar"):
+            return self._get_directory_legacy(remote_path, Path(local_path))
+        destination = Path(local_path)
+        destination.mkdir(parents=True, exist_ok=True)
+        query = urllib.parse.urlencode({"path": remote_path})
+        try:
+            _resp, data = self._request_bytes("GET", f"/directories/tar?{query}")
+        except SmolVMError as exc:
+            if not _endpoint_missing(exc, "GET", "/directories/tar"):
+                raise
+            return self._get_directory_legacy(remote_path, destination)
+        _safe_extract_tar(data, destination)
+        return destination
+
+    def _put_directory_legacy(self, source: Path, remote_path: str) -> None:
+        data = _directory_to_tar(source)
+        local_tmp = _write_temp_tar(data)
+        remote_tmp = f"/tmp/smolvm-dir-{os.getpid()}-{time.monotonic_ns()}.tar"
+        try:
+            self.put_file(local_tmp, remote_tmp)
+            result = self.run(
+                "set -e; "
+                f"mkdir -p -- {shlex.quote(remote_path)}; "
+                f"tar -xf {shlex.quote(remote_tmp)} -C {shlex.quote(remote_path)}; "
+                f"rm -f -- {shlex.quote(remote_tmp)}",
+                timeout=120,
+                shell="raw",
+            )
+            if not result.ok:
+                raise SmolVMError(
+                    "Failed to extract directory in guest: "
+                    f"{result.stderr.strip() or result.stdout}"
+                )
+        finally:
+            local_tmp.unlink(missing_ok=True)
+
+    def _get_directory_legacy(self, remote_path: str, destination: Path) -> Path:
+        destination.mkdir(parents=True, exist_ok=True)
+        remote_tmp = f"/tmp/smolvm-dir-{os.getpid()}-{time.monotonic_ns()}.tar"
+        local_fd, local_name = tempfile.mkstemp(prefix="smolvm-dir-", suffix=".tar")
+        os.close(local_fd)
+        local_tmp = Path(local_name)
+        try:
+            result = self.run(
+                "set -e; "
+                f"rm -f -- {shlex.quote(remote_tmp)}; "
+                f"tar -cf {shlex.quote(remote_tmp)} -C {shlex.quote(remote_path)} .",
+                timeout=120,
+                shell="raw",
+            )
+            if not result.ok:
+                raise SmolVMError(
+                    f"Failed to archive guest directory: {result.stderr.strip() or result.stdout}"
+                )
+            self.get_file(remote_tmp, local_tmp)
+            _safe_extract_tar(local_tmp.read_bytes(), destination)
+            return destination
+        finally:
+            local_tmp.unlink(missing_ok=True)
+            with suppress(SmolVMError):
+                self.run(f"rm -f -- {shlex.quote(remote_tmp)}", timeout=10, shell="raw")
+
+    def set_managed_env(self, env_vars: dict[str, str], *, merge: bool = True) -> dict[str, str]:
+        resp = self._request_json("PUT", "/env", {"vars": env_vars, "merge": merge})
+        if not resp.get("ok"):
+            raise SmolVMError(f"guest agent error during env update: {resp.get('error', resp)}")
+        vars_value = resp.get("vars")
+        return dict(vars_value) if isinstance(vars_value, dict) else {}
+
+    def unset_managed_env(self, keys: list[str]) -> dict[str, str]:
+        resp = self._request_json("DELETE", "/env", {"keys": keys})
+        if not resp.get("ok"):
+            raise SmolVMError(f"guest agent error during env update: {resp.get('error', resp)}")
+        vars_value = resp.get("vars")
+        return dict(vars_value) if isinstance(vars_value, dict) else {}
+
+    def list_managed_env(self) -> dict[str, str]:
+        resp = self._request_json("GET", "/env")
+        if not resp.get("ok"):
+            raise SmolVMError(f"guest agent error during env read: {resp.get('error', resp)}")
+        vars_value = resp.get("vars")
+        return dict(vars_value) if isinstance(vars_value, dict) else {}
+
+    def set_env_vars(self, env_vars: dict[str, str], *, merge: bool = True) -> list[str]:
+        if not env_vars:
+            return []
+        try:
+            return sorted(self.set_managed_env(env_vars, merge=merge))
+        except SmolVMError as exc:
+            if self.supports("env_managed") and not _endpoint_missing(exc, "PUT", "/env"):
+                raise
+            from smolvm.env import inject_env_vars
+
+            return inject_env_vars(self, env_vars, merge=merge)
+
+    def unset_env_vars(self, keys: list[str]) -> dict[str, str]:
+        if not keys:
+            return {}
+        try:
+            before = self.list_managed_env()
+            after = self.unset_managed_env(keys)
+            return {key: before[key] for key in keys if key in before and key not in after}
+        except SmolVMError as exc:
+            if self.supports("env_managed") and not _endpoint_missing(exc, "DELETE", "/env"):
+                raise
+            from smolvm.env import remove_env_vars
+
+            return remove_env_vars(self, keys)
+
+    def list_env_vars(self) -> dict[str, str]:
+        try:
+            return self.list_managed_env()
+        except SmolVMError as exc:
+            if self.supports("env_managed") and not _endpoint_missing(exc, "GET", "/env"):
+                raise
+            from smolvm.env import read_env_vars
+
+            return read_env_vars(self)
+
+    def wait_for_ports(
+        self,
+        ports: list[int],
+        *,
+        timeout: float = 30,
+        host: str = "127.0.0.1",
+    ) -> list[int]:
+        resp = self._request_json(
+            "POST",
+            "/ports/wait",
+            {"ports": ports, "timeout_ms": int(timeout * 1000), "host": host},
+            timeout=timeout + self.connect_timeout,
+        )
+        if not resp.get("ok"):
+            raise OperationTimeoutError(
+                f"waiting for guest ports {', '.join(map(str, ports))}", timeout
+            )
+        ready = resp.get("ready_ports")
+        return [int(port) for port in ready] if isinstance(ready, list) else []
+
+    def boot_milestones(self) -> list[dict[str, Any]]:
+        resp = self._request_json("GET", "/boot/milestones")
+        if not resp.get("ok"):
+            raise SmolVMError(
+                f"guest agent error during boot milestone read: {resp.get('error', resp)}"
+            )
+        milestones = resp.get("milestones")
+        return list(milestones) if isinstance(milestones, list) else []
 
     def wait_ready(self, timeout: float = 60.0, interval: float = 0.1) -> None:
         if timeout <= 0:
@@ -295,6 +730,9 @@ class RustHttpVsockChannel:
                 resp = self._request_json("GET", "/health", timeout=max(1.0, poll_interval))
                 if resp.get("status") == "ok":
                     self._ready = True
+                    with suppress(Exception):
+                        self._capabilities = None
+                        _ = self.capabilities
                     logger.info("Rust guest agent is ready on vsock %s", target)
                     return
                 last_error = str(resp)
@@ -311,6 +749,7 @@ class RustHttpVsockChannel:
 
     def close(self) -> None:
         self._ready = False
+        self._capabilities = None
 
     @property
     def connected(self) -> bool:

--- a/src/smolvm/images/builder.py
+++ b/src/smolvm/images/builder.py
@@ -1491,7 +1491,20 @@ ts_epoch() {{
 
 log_ts() {{
     STAGE="$1"
-    echo "SMOLVM_TS stage=${{STAGE}} epoch_s=$(ts_epoch) uptime_s=$(ts_uptime)"
+    EPOCH="$(ts_epoch)"
+    UPTIME="$(ts_uptime)"
+    LINE="SMOLVM_TS stage=${{STAGE}} epoch_s=${{EPOCH}} uptime_s=${{UPTIME}}"
+    echo "$LINE"
+    if [ -d /run ]; then
+        mkdir -p /run/smolvm 2>/dev/null || true
+        printf '{{"stage":"%s","epoch_s":%s,"uptime_s":%s}}\n' "$STAGE" "$EPOCH" "$UPTIME" \
+            >> /run/smolvm/milestones.jsonl 2>/dev/null || true
+        printf '{{"stage":"%s","epoch_s":%s,"uptime_s":%s}}\n' "$STAGE" "$EPOCH" "$UPTIME" \
+            >> /run/smolvm/boot-milestones.jsonl 2>/dev/null || true
+    fi
+    if [ -d /var/log ]; then
+        echo "$LINE" >> /var/log/smolvm-boot.log 2>/dev/null || true
+    fi
 }}
 
 log_ts "init-start"

--- a/tests/test_rust_http_vsock_channel.py
+++ b/tests/test_rust_http_vsock_channel.py
@@ -33,6 +33,7 @@ import pytest
 from smolvm.comm.base import CommChannel
 from smolvm.comm.rust_http_vsock_channel import ControlCapabilities, RustHttpVsockChannel
 from smolvm.exceptions import OperationTimeoutError, SmolVMError
+from smolvm.types import CommandResult
 
 Handler = Callable[[str, str, bytes], Any]
 
@@ -397,6 +398,95 @@ def test_get_directory_rejects_unsafe_tar_entries(tmp_path: Path) -> None:
     assert not (tmp_path / "escape.txt").exists()
 
 
+def test_raw_file_download_rejects_declared_size_over_cap(tmp_path: Path) -> None:
+    destination = tmp_path / "download.txt"
+
+    def _raw_get(method: str, path: str, body: bytes) -> tuple[int, bytes, dict[str, str]]:
+        assert method == "GET"
+        assert path == "/files/content?path=%2Ftmp%2Fsource.txt"
+        assert body == b""
+        return (200, b"payload", {"x-smolvm-file-size": "7"})
+
+    channel = FakeRustChannel(
+        [
+            _capabilities(
+                {"file_raw": True},
+                limits={"max_stream_size_bytes": 4},
+            ),
+            _raw_get,
+        ]
+    )
+
+    with pytest.raises(SmolVMError, match="exceeded 4 bytes"):
+        channel.get_file("/tmp/source.txt", destination)
+
+
+def test_legacy_directory_fallback_uses_guest_mktemp(tmp_path: Path) -> None:
+    source = tmp_path / "source"
+    source.mkdir()
+    (source / "note.txt").write_text("hello")
+    commands: list[str] = []
+    uploads: list[str] = []
+
+    channel = RustHttpVsockChannel(guest_cid=42)
+
+    def fake_run(command: str, timeout: float = 30, shell: str = "login") -> CommandResult:
+        commands.append(command)
+        if command.startswith("mktemp "):
+            return CommandResult(exit_code=0, stdout="/tmp/smolvm-dir.ABC123.tar\n", stderr="")
+        return CommandResult(exit_code=0, stdout="", stderr="")
+
+    def fake_put_file(local_path: str | Path, remote_path: str) -> None:
+        uploads.append(remote_path)
+
+    channel.run = fake_run  # type: ignore[method-assign]
+    channel.put_file = fake_put_file  # type: ignore[method-assign]
+
+    channel._put_directory_legacy(source, "/tmp/target")
+
+    assert uploads == ["/tmp/smolvm-dir.ABC123.tar"]
+    assert commands[0].startswith("mktemp /tmp/smolvm-dir.")
+    assert "trap" in commands[1]
+    assert 'tar -xf "$remote_tmp"' in commands[1]
+    assert commands[-1] == "rm -f -- /tmp/smolvm-dir.ABC123.tar"
+
+
+def test_legacy_directory_download_uses_guest_mktemp(tmp_path: Path) -> None:
+    archive = io.BytesIO()
+    with tarfile.open(fileobj=archive, mode="w") as tar:
+        info = tarfile.TarInfo("note.txt")
+        payload = b"hello"
+        info.size = len(payload)
+        tar.addfile(info, io.BytesIO(payload))
+
+    commands: list[str] = []
+    downloads: list[str] = []
+    channel = RustHttpVsockChannel(guest_cid=42)
+
+    def fake_run(command: str, timeout: float = 30, shell: str = "login") -> CommandResult:
+        commands.append(command)
+        if command.startswith("mktemp "):
+            return CommandResult(exit_code=0, stdout="/tmp/smolvm-dir.DEF456.tar\n", stderr="")
+        return CommandResult(exit_code=0, stdout="", stderr="")
+
+    def fake_get_file(remote_path: str, local_path: str | Path) -> Path:
+        downloads.append(remote_path)
+        destination = Path(local_path)
+        destination.write_bytes(archive.getvalue())
+        return destination
+
+    channel.run = fake_run  # type: ignore[method-assign]
+    channel.get_file = fake_get_file  # type: ignore[method-assign]
+
+    destination = channel._get_directory_legacy("/tmp/source", tmp_path / "download")
+
+    assert downloads == ["/tmp/smolvm-dir.DEF456.tar"]
+    assert (destination / "note.txt").read_text() == "hello"
+    assert commands[0].startswith("mktemp /tmp/smolvm-dir.")
+    assert commands[1] == "set -e; tar -cf /tmp/smolvm-dir.DEF456.tar -C /tmp/source ."
+    assert commands[-1] == "rm -f -- /tmp/smolvm-dir.DEF456.tar"
+
+
 def test_env_helpers_use_v2_env_endpoint() -> None:
     def _set(method: str, path: str, body: bytes) -> dict:
         assert method == "PUT"
@@ -443,10 +533,31 @@ def test_wait_for_ports_and_boot_milestones_use_v2_endpoints() -> None:
     assert channel.boot_milestones() == [{"stage": "guest-agent-started", "uptime_s": 0.24}]
 
 
-def _capabilities(features: dict[str, bool]) -> Handler:
+def test_wait_for_ports_validates_inputs_before_request() -> None:
+    channel = FakeRustChannel([])
+
+    with pytest.raises(ValueError, match="ports cannot be empty"):
+        channel.wait_for_ports([])
+    with pytest.raises(ValueError, match="valid IP address"):
+        channel.wait_for_ports([3000], host="localhost")
+
+
+def test_wait_for_ports_preserves_guest_validation_errors() -> None:
+    def _ports(method: str, path: str, body: bytes) -> dict:
+        assert method == "POST"
+        assert path == "/ports/wait"
+        return {"ok": False, "error": "invalid host: not-an-ip"}
+
+    channel = FakeRustChannel([_ports])
+
+    with pytest.raises(SmolVMError, match="invalid host"):
+        channel.wait_for_ports([3000])
+
+
+def _capabilities(features: dict[str, bool], *, limits: dict[str, Any] | None = None) -> Handler:
     def _handler(method: str, path: str, body: bytes) -> dict:
         assert method == "GET"
         assert path == "/capabilities"
-        return {"protocol_version": 2, "features": features, "limits": {}}
+        return {"protocol_version": 2, "features": features, "limits": limits or {}}
 
     return _handler

--- a/tests/test_rust_http_vsock_channel.py
+++ b/tests/test_rust_http_vsock_channel.py
@@ -31,10 +31,22 @@ from typing import Any
 import pytest
 
 from smolvm.comm.base import CommChannel
-from smolvm.comm.rust_http_vsock_channel import RustHttpVsockChannel
+from smolvm.comm.rust_http_vsock_channel import ControlCapabilities, RustHttpVsockChannel
 from smolvm.exceptions import OperationTimeoutError, SmolVMError
 
 Handler = Callable[[str, str, bytes], Any]
+
+
+def test_control_capabilities_accept_flat_dotted_features() -> None:
+    capabilities = ControlCapabilities(
+        protocol_version=2,
+        features={"files.stream": True, "ports": {"wait": "true"}},
+        limits={},
+    )
+
+    assert capabilities.enabled("file_raw", "files.stream")
+    assert capabilities.enabled("ports.wait")
+    assert not capabilities.enabled("env.managed")
 
 
 class FakeRustChannel(RustHttpVsockChannel):

--- a/tests/test_rust_http_vsock_channel.py
+++ b/tests/test_rust_http_vsock_channel.py
@@ -554,6 +554,18 @@ def test_wait_for_ports_preserves_guest_validation_errors() -> None:
         channel.wait_for_ports([3000])
 
 
+def test_wait_for_ports_preserves_guest_timeout_validation_errors() -> None:
+    def _ports(method: str, path: str, body: bytes) -> dict:
+        assert method == "POST"
+        assert path == "/ports/wait"
+        return {"ok": False, "error": "timeout_ms must be at most 300000"}
+
+    channel = FakeRustChannel([_ports])
+
+    with pytest.raises(SmolVMError, match="timeout_ms must be at most"):
+        channel.wait_for_ports([3000])
+
+
 def _capabilities(features: dict[str, bool], *, limits: dict[str, Any] | None = None) -> Handler:
     def _handler(method: str, path: str, body: bytes) -> dict:
         assert method == "GET"

--- a/tests/test_rust_http_vsock_channel.py
+++ b/tests/test_rust_http_vsock_channel.py
@@ -17,13 +17,16 @@
 from __future__ import annotations
 
 import base64
+import io
 import json
 import queue
 import socket
+import tarfile
 import tempfile
 import threading
 from collections.abc import Callable
 from pathlib import Path
+from typing import Any
 
 import pytest
 
@@ -31,7 +34,7 @@ from smolvm.comm.base import CommChannel
 from smolvm.comm.rust_http_vsock_channel import RustHttpVsockChannel
 from smolvm.exceptions import OperationTimeoutError, SmolVMError
 
-Handler = Callable[[str, str, bytes], dict | tuple[int, dict | str]]
+Handler = Callable[[str, str, bytes], Any]
 
 
 class FakeRustChannel(RustHttpVsockChannel):
@@ -51,15 +54,27 @@ class FakeRustChannel(RustHttpVsockChannel):
                 self.requests.append(data)
                 result = handler(method, path, body)
                 status = 200
+                headers: dict[str, str] = {}
                 if isinstance(result, tuple):
-                    status, result = result
-                payload = (
-                    result.encode() if isinstance(result, str) else json.dumps(result).encode()
-                )
+                    if len(result) == 3:
+                        status, result, headers = result
+                    else:
+                        status, result = result
+                if isinstance(result, bytes):
+                    payload = result
+                    headers.setdefault("Content-Type", "application/octet-stream")
+                else:
+                    payload = (
+                        result.encode() if isinstance(result, str) else json.dumps(result).encode()
+                    )
+                    headers.setdefault("Content-Type", "application/json")
                 status_text = "OK" if status < 400 else "ERROR"
+                header_bytes = b"".join(
+                    f"{name}: {value}\r\n".encode() for name, value in headers.items()
+                )
                 guest.sendall(
                     f"HTTP/1.1 {status} {status_text}\r\n".encode()
-                    + b"Content-Type: application/json\r\n"
+                    + header_bytes
                     + f"Content-Length: {len(payload)}\r\n".encode()
                     + b"Connection: close\r\n\r\n"
                     + payload
@@ -264,6 +279,7 @@ def test_sync_fallback_exec_failure_maps_to_smolvm_error() -> None:
 def test_put_and_get_file(tmp_path: Path) -> None:
     source = tmp_path / "source.txt"
     source.write_text("payload")
+    source.chmod(0o644)
     destination = tmp_path / "download.txt"
 
     def _put(method: str, path: str, body: bytes) -> dict:
@@ -284,8 +300,141 @@ def test_put_and_get_file(tmp_path: Path) -> None:
             "data_base64": base64.b64encode(b"payload").decode(),
         }
 
-    channel = FakeRustChannel([_put, _get])
+    channel = FakeRustChannel([_capabilities({"file_base64": True}), _put, _get])
     channel.put_file(source, "/tmp/source.txt")
     channel.get_file("/tmp/source.txt", destination)
     assert destination.read_text() == "payload"
     assert destination.stat().st_mode & 0o777 == 0o640
+
+
+def test_put_and_get_file_prefer_raw_streaming_and_cache_capabilities(tmp_path: Path) -> None:
+    source = tmp_path / "source.txt"
+    source.write_text("payload")
+    source.chmod(0o644)
+    destination = tmp_path / "download.txt"
+
+    def _raw_put(method: str, path: str, body: bytes) -> dict:
+        assert method == "PUT"
+        assert path == "/files/content?path=%2Ftmp%2Fsource.txt&name=source.txt&mode=420"
+        assert body == b"payload"
+        return {"ok": True}
+
+    def _raw_get(method: str, path: str, body: bytes) -> tuple[int, bytes, dict[str, str]]:
+        assert method == "GET"
+        assert path == "/files/content?path=%2Ftmp%2Fsource.txt"
+        assert body == b""
+        return (
+            200,
+            b"payload",
+            {"x-smolvm-file-mode": "640", "x-smolvm-file-size": "7"},
+        )
+
+    channel = FakeRustChannel(
+        [_capabilities({"file_base64": True, "file_raw": True}), _raw_put, _raw_get]
+    )
+    channel.put_file(source, "/tmp/source.txt")
+    channel.get_file("/tmp/source.txt", destination)
+
+    assert destination.read_text() == "payload"
+    assert destination.stat().st_mode & 0o777 == 0o640
+    assert [request[:2] for request in channel.requests] == [
+        ("GET", "/capabilities"),
+        ("PUT", "/files/content?path=%2Ftmp%2Fsource.txt&name=source.txt&mode=420"),
+        ("GET", "/files/content?path=%2Ftmp%2Fsource.txt"),
+    ]
+
+
+def test_put_file_falls_back_to_base64_when_raw_endpoint_missing(tmp_path: Path) -> None:
+    source = tmp_path / "source.txt"
+    source.write_text("payload")
+
+    def _missing_raw(method: str, path: str, body: bytes) -> tuple[int, str]:
+        assert method == "PUT"
+        assert path.startswith("/files/content?")
+        return (404, "")
+
+    def _base64_put(method: str, path: str, body: bytes) -> dict:
+        request = json.loads(body)
+        assert method == "POST"
+        assert path == "/files/put"
+        assert base64.b64decode(request["data_base64"]) == b"payload"
+        return {"ok": True}
+
+    channel = FakeRustChannel(
+        [_capabilities({"file_base64": True, "file_raw": True}), _missing_raw, _base64_put]
+    )
+    channel.put_file(source, "/tmp/source.txt")
+
+
+def test_get_directory_rejects_unsafe_tar_entries(tmp_path: Path) -> None:
+    archive = io.BytesIO()
+    with tarfile.open(fileobj=archive, mode="w") as tar:
+        info = tarfile.TarInfo("../escape.txt")
+        payload = b"nope"
+        info.size = len(payload)
+        tar.addfile(info, io.BytesIO(payload))
+
+    def _tar_get(method: str, path: str, body: bytes) -> tuple[int, bytes, dict[str, str]]:
+        assert method == "GET"
+        assert path == "/directories/tar?path=%2Ftmp%2Fdata"
+        return (200, archive.getvalue(), {"Content-Type": "application/x-tar"})
+
+    channel = FakeRustChannel([_capabilities({"dir_tar": True}), _tar_get])
+    with pytest.raises(SmolVMError, match="outside destination"):
+        channel.get_directory("/tmp/data", tmp_path / "download")
+    assert not (tmp_path / "escape.txt").exists()
+
+
+def test_env_helpers_use_v2_env_endpoint() -> None:
+    def _set(method: str, path: str, body: bytes) -> dict:
+        assert method == "PUT"
+        assert path == "/env"
+        request = json.loads(body)
+        assert request == {"vars": {"FOO": "bar"}, "merge": True}
+        return {"ok": True, "vars": {"FOO": "bar"}}
+
+    def _get(method: str, path: str, body: bytes) -> dict:
+        assert method == "GET"
+        assert path == "/env"
+        return {"ok": True, "vars": {"FOO": "bar"}}
+
+    def _delete(method: str, path: str, body: bytes) -> dict:
+        assert method == "DELETE"
+        assert path == "/env"
+        assert json.loads(body) == {"keys": ["FOO"]}
+        return {"ok": True, "vars": {}}
+
+    channel = FakeRustChannel([_set, _get, _get, _delete])
+    assert channel.set_env_vars({"FOO": "bar"}) == ["FOO"]
+    assert channel.list_env_vars() == {"FOO": "bar"}
+    assert channel.unset_env_vars(["FOO"]) == {"FOO": "bar"}
+
+
+def test_wait_for_ports_and_boot_milestones_use_v2_endpoints() -> None:
+    def _ports(method: str, path: str, body: bytes) -> dict:
+        assert method == "POST"
+        assert path == "/ports/wait"
+        request = json.loads(body)
+        assert request == {"ports": [3000], "timeout_ms": 1000, "host": "127.0.0.1"}
+        return {"ok": True, "ready_ports": [3000]}
+
+    def _milestones(method: str, path: str, body: bytes) -> dict:
+        assert method == "GET"
+        assert path == "/boot/milestones"
+        return {
+            "ok": True,
+            "milestones": [{"stage": "guest-agent-started", "uptime_s": 0.24}],
+        }
+
+    channel = FakeRustChannel([_ports, _milestones])
+    assert channel.wait_for_ports([3000], timeout=1.0) == [3000]
+    assert channel.boot_milestones() == [{"stage": "guest-agent-started", "uptime_s": 0.24}]
+
+
+def _capabilities(features: dict[str, bool]) -> Handler:
+    def _handler(method: str, path: str, body: bytes) -> dict:
+        assert method == "GET"
+        assert path == "/capabilities"
+        return {"protocol_version": 2, "features": features, "limits": {}}
+
+    return _handler


### PR DESCRIPTION
## Summary

Adds the protocol substrate needed to move Linux setup off SSH without changing older-image fallback behavior:

- Keeps `GET /health` as readiness and advertises protocol v2 through `/capabilities`.
- Adds canonical streaming endpoints for raw file content and directory tar transfer, with compatibility aliases.
- Adds managed env, boot milestone, and port-wait guest endpoints.
- Adds host-side capability caching and control-channel helpers in `RustHttpVsockChannel`.
- Emits boot milestone telemetry from image build/init scripts.

## Stack

1. #397: benchmark foundation.
2. This PR: guest-agent protocol v2 substrate.
3. #399: native host disk/network/Firecracker helpers.
4. #400: control-channel production integration.

## Validation

Full-stack validation run locally after the stack was assembled:

- `UV_CACHE_DIR=/tmp/uv-cache uv run pytest tests/ -q` — 1392 passed, 12 skipped, 27 deselected.
- `UV_CACHE_DIR=/tmp/uv-cache uv run ruff check .` — passed.
- `UV_CACHE_DIR=/tmp/uv-cache uv run ruff format --check .` — passed.
- `cargo check -p smolvm-core` — passed.
- `cargo test -p smolvm-guest-agent` — passed.
- `cargo fmt --check` — passed.
- `git diff --check` — passed.

`cargo test -p smolvm-core` is blocked on this machine because the local linker cannot find `libpython3.14`; `maturin develop` and `cargo check -p smolvm-core` both pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Boot milestone tracking across multiple sources with deduplication.
  * Managed environment variable endpoints for listing, setting, and unsetting.
  * Raw binary file transfer plus directory tar create/extract endpoints.
  * TCP port readiness checks.
  * Protocol upgraded to v2 with expanded API endpoints and capability reporting (features/limits).
* **Refactoring**
  * Centralized durable atomic file write path for safer file operations.
* **Bug Fixes**
  * Harder tar extraction safety checks to prevent unsafe paths and symlink traversal.
* **Tests**
  * Expanded protocol, transfer, environment, boot, and port-wait test coverage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->