### PR TITLE
[codex] Move Linux setup paths to control channel

### DIFF
--- a/src/smolvm/browser.py
+++ b/src/smolvm/browser.py
@@ -687,13 +687,22 @@ class _BrowserSandbox:
         url = cdp_url.rstrip("/") + "/json/version"
         deadline = time.monotonic() + timeout
 
-        while time.monotonic() <= deadline:
+        while True:
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                break
             try:
-                request_timeout = min(1.0, max(0.1, deadline - time.monotonic()))
+                request_timeout = min(1.0, max(0.1, remaining))
                 with urllib.request.urlopen(url, timeout=request_timeout) as response:
-                    return 200 <= getattr(response, "status", 200) < 300
+                    if 200 <= getattr(response, "status", 200) < 300:
+                        return True
             except (OSError, urllib.error.URLError):
-                time.sleep(0.2)
+                pass
+
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                break
+            time.sleep(min(0.2, remaining))
 
         return False
 

--- a/src/smolvm/browser.py
+++ b/src/smolvm/browser.py
@@ -7,6 +7,9 @@ import logging
 import platform
 import shlex
 import socket
+import time
+import urllib.error
+import urllib.request
 import uuid
 import webbrowser
 from collections.abc import Callable
@@ -403,6 +406,11 @@ class _BrowserSandbox:
                     )
                 debug_host_port = self._resolve_browser_host_port(_BROWSER_DEBUG_PORT)
                 cdp_url = f"http://127.0.0.1:{debug_host_port}"
+                if not self._wait_for_cdp_http(cdp_url, timeout=boot_timeout):
+                    raise SmolVMError(
+                        f"Browser sandbox '{self.session_id}' did not expose "
+                        "a ready CDP endpoint in time."
+                    )
 
             live_url: str | None = None
             vnc_url: str | None = None
@@ -673,6 +681,21 @@ class _BrowserSandbox:
         with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
             sock.settimeout(0.25)
             return sock.connect_ex(("127.0.0.1", port)) == 0
+
+    @staticmethod
+    def _wait_for_cdp_http(cdp_url: str, *, timeout: float) -> bool:
+        url = cdp_url.rstrip("/") + "/json/version"
+        deadline = time.monotonic() + timeout
+
+        while time.monotonic() <= deadline:
+            try:
+                request_timeout = min(1.0, max(0.1, deadline - time.monotonic()))
+                with urllib.request.urlopen(url, timeout=request_timeout) as response:
+                    return 200 <= getattr(response, "status", 200) < 300
+            except (OSError, urllib.error.URLError):
+                time.sleep(0.2)
+
+        return False
 
     def _session_artifacts_dir(self, session_id: str) -> Path:
         return self._data_dir / "browser-sessions" / session_id

--- a/src/smolvm/browser.py
+++ b/src/smolvm/browser.py
@@ -48,6 +48,7 @@ _BROWSER_GUEST_DOWNLOAD_ROOT = f"{_BROWSER_GUEST_ROOT}/downloads"
 _BROWSER_GUEST_ARTIFACT_ROOT = f"{_BROWSER_GUEST_ROOT}/artifacts"
 _BROWSER_GUEST_LOG_ROOT = "/var/log/smolvm-browser"
 _BROWSER_KERNEL_PROFILE = KernelBootProfile.MICROVM_DIRECT
+_LOCAL_HTTP_OPENER = urllib.request.build_opener(urllib.request.ProxyHandler({}))
 
 
 def _generate_browser_session_id() -> str:
@@ -131,8 +132,23 @@ def _build_browser_vm_config(
         else browser_config.backend
     )
     resolved_backend = resolve_backend(requested_backend)
-    private_key, public_key = ensure_ssh_key()
-    resolved_ssh_key_path = ssh_key_path or str(private_key)
+    private_key, default_public_key = ensure_ssh_key()
+    if ssh_key_path is None:
+        resolved_ssh_key_path = str(private_key)
+        resolved_public_key = default_public_key
+    else:
+        resolved_ssh_key_path = ssh_key_path
+        resolved_public_key = Path(f"{ssh_key_path}.pub")
+    try:
+        public_key_text = resolved_public_key.read_text().strip()
+    except OSError as exc:
+        private_arg = shlex.quote(resolved_ssh_key_path)
+        public_arg = shlex.quote(str(resolved_public_key))
+        raise SmolVMError(
+            "Browser SSH key is missing its matching public key at "
+            f"'{resolved_public_key}'; create it with "
+            f"`ssh-keygen -y -f {private_arg} > {public_arg}`."
+        ) from exc
 
     builder = ImageBuilder()
     kernel_url = builder.qemu_kernel_url_for_host() if resolved_backend == BACKEND_QEMU else None
@@ -149,7 +165,7 @@ def _build_browser_vm_config(
         image_name = f"{image_name}-{browser_config.disk_size_mib}m"
 
     kernel, rootfs = builder.build_browser_rootfs(
-        public_key,
+        public_key_text,
         name=image_name,
         rootfs_size_mb=browser_config.disk_size_mib,
         kernel_profile=_BROWSER_KERNEL_PROFILE,
@@ -168,7 +184,7 @@ def _build_browser_vm_config(
         env_vars=browser_config.env_vars,
         port_forwards=port_forwards,
         workspace_mounts=browser_config.workspace_mounts,
-        ssh_public_key=public_key.read_text().strip(),
+        ssh_public_key=public_key_text,
     )
     return config, resolved_ssh_key_path
 
@@ -408,8 +424,8 @@ class _BrowserSandbox:
                 cdp_url = f"http://127.0.0.1:{debug_host_port}"
                 if not self._wait_for_cdp_http(cdp_url, timeout=boot_timeout):
                     raise SmolVMError(
-                        f"Browser sandbox '{self.session_id}' did not expose "
-                        "a ready CDP endpoint in time."
+                        f"Browser sandbox '{self.session_id}' did not start in time; "
+                        f"to inspect logs, run: smolvm browser logs {self.session_id}."
                     )
 
             live_url: str | None = None
@@ -693,7 +709,7 @@ class _BrowserSandbox:
                 break
             try:
                 request_timeout = min(1.0, max(0.1, remaining))
-                with urllib.request.urlopen(url, timeout=request_timeout) as response:
+                with _LOCAL_HTTP_OPENER.open(url, timeout=request_timeout) as response:
                     if 200 <= getattr(response, "status", 200) < 300:
                         return True
             except (OSError, urllib.error.URLError):

--- a/src/smolvm/browser.py
+++ b/src/smolvm/browser.py
@@ -166,7 +166,6 @@ def _build_browser_vm_config(
         port_forwards=port_forwards,
         workspace_mounts=browser_config.workspace_mounts,
         ssh_public_key=public_key.read_text().strip(),
-        comm_channel="ssh",
     )
     return config, resolved_ssh_key_path
 
@@ -377,7 +376,7 @@ class _BrowserSandbox:
         try:
             if self._vm.status in {VMState.CREATED, VMState.STOPPED}:
                 self._vm.start(boot_timeout=boot_timeout, on_progress=on_progress)
-            self._vm.wait_for_ssh(timeout=boot_timeout, on_progress=on_progress)
+            self._vm.wait_for_ready(timeout=boot_timeout)
 
             expects_browser = self._session_config.mode != "desktop"
             expects_display = self._session_config.mode in {"live", "desktop"}
@@ -513,18 +512,16 @@ class _BrowserSandbox:
         return webbrowser.open(self._info.live_url)
 
     def push_file(self, local_path: str | Path, guest_path: str) -> None:
-        """Upload a file into the guest using the sandbox SSH channel."""
+        """Upload a file into the guest using the sandbox control channel."""
         if self._vm is None:
             raise SmolVMError("Browser sandbox VM is unavailable.")
-        ssh = self._vm._ensure_ssh_for_env()
-        ssh.put_file(local_path, guest_path)
+        self._vm.upload_file(local_path, guest_path)
 
     def pull_file(self, guest_path: str, local_path: str | Path) -> Path:
-        """Download a file from the guest using the sandbox SSH channel."""
+        """Download a file from the guest using the sandbox control channel."""
         if self._vm is None:
             raise SmolVMError("Browser sandbox VM is unavailable.")
-        ssh = self._vm._ensure_ssh_for_env()
-        return ssh.get_file(guest_path, local_path)
+        return Path(self._vm.download_file(guest_path, local_path))
 
     def collect_artifacts(self) -> Path | None:
         """Collect guest logs/downloads/recordings into the local artifacts dir."""
@@ -559,8 +556,7 @@ class _BrowserSandbox:
             )
 
         archive_path = artifacts_dir / "guest-artifacts.tar.gz"
-        ssh = self._vm._ensure_ssh_for_env()
-        return ssh.get_file(remote_archive, archive_path)
+        return Path(self._vm.download_file(remote_archive, archive_path))
 
     def logs(self, tail: int = 100) -> str:
         """Return combined host/guest logs for the browser sandbox."""
@@ -642,15 +638,41 @@ class _BrowserSandbox:
         if self._vm is None:
             raise SmolVMError("Browser sandbox VM is unavailable.")
 
+        configured = self._configured_browser_host_port(guest_port)
+        if configured is not None and self._probe_local_port(configured):
+            return configured
+
         return self._vm.expose_local(guest_port=guest_port, guest_loopback=True)
 
     def _wait_for_guest_port(self, port: int, *, timeout: float) -> bool:
         if self._vm is None:
             raise SmolVMError("Browser sandbox VM is unavailable.")
 
+        wait_for_ports = getattr(self._vm._control_channel, "wait_for_ports", None)
+        if callable(wait_for_ports):
+            try:
+                wait_for_ports([port], timeout=timeout)
+                return True
+            except Exception:
+                pass
+
         command = f"/usr/local/bin/smolvm-browser-wait-port {port} {timeout}"
         result = self._vm.run(command, timeout=max(5, int(timeout) + 5))
         return result.ok
+
+    def _configured_browser_host_port(self, guest_port: int) -> int | None:
+        if self._vm is None:
+            return None
+        for forward in self._vm.info.config.port_forwards:
+            if forward.guest_port == guest_port and forward.host_address == "127.0.0.1":
+                return forward.host_port
+        return None
+
+    @staticmethod
+    def _probe_local_port(port: int) -> bool:
+        with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
+            sock.settimeout(0.25)
+            return sock.connect_ex(("127.0.0.1", port)) == 0
 
     def _session_artifacts_dir(self, session_id: str) -> Path:
         return self._data_dir / "browser-sessions" / session_id

--- a/src/smolvm/browser.py
+++ b/src/smolvm/browser.py
@@ -697,6 +697,7 @@ class _BrowserSandbox:
                     if 200 <= getattr(response, "status", 200) < 300:
                         return True
             except (OSError, urllib.error.URLError):
+                # CDP may not be ready yet; retry until the startup deadline.
                 pass
 
             remaining = deadline - time.monotonic()

--- a/src/smolvm/cli/main.py
+++ b/src/smolvm/cli/main.py
@@ -1634,7 +1634,14 @@ def _preset_control_channel(vm: object, *, timeout: float = 30.0) -> object:
     try:
         channel = _vm._ensure_control_for_operation(action="apply preset", timeout=timeout)
         supports = getattr(channel, "supports", None)
-        if not callable(supports) or supports("file_raw", "dir_tar", "env_managed"):
+        if not callable(supports) or supports(
+            "file_raw",
+            "files.stream",
+            "dir_tar",
+            "files.directory_tar",
+            "env_managed",
+            "env.managed",
+        ):
             return channel
     except Exception:
         # Control-channel setup is an optimization; SSH remains the supported fallback.

--- a/src/smolvm/cli/main.py
+++ b/src/smolvm/cli/main.py
@@ -1645,7 +1645,8 @@ def _preset_control_channel(vm: object, *, timeout: float = 30.0) -> object:
             return channel
     except Exception:
         # Control-channel setup is an optimization; SSH remains the supported fallback.
-        pass
+        _vm.wait_for_ssh(timeout=timeout)
+        return _vm._ensure_ssh_for_env(timeout=timeout)
     _vm.wait_for_ssh(timeout=timeout)
     return _vm._ensure_ssh_for_env(timeout=timeout)
 

--- a/src/smolvm/cli/main.py
+++ b/src/smolvm/cli/main.py
@@ -1637,6 +1637,7 @@ def _preset_control_channel(vm: object, *, timeout: float = 30.0) -> object:
         if not callable(supports) or supports("file_raw", "dir_tar", "env_managed"):
             return channel
     except Exception:
+        # Control-channel setup is an optimization; SSH remains the supported fallback.
         pass
     _vm.wait_for_ssh(timeout=timeout)
     return _vm._ensure_ssh_for_env(timeout=timeout)

--- a/src/smolvm/cli/main.py
+++ b/src/smolvm/cli/main.py
@@ -1459,8 +1459,7 @@ def _run_start(args: SimpleNamespace) -> int:
                 writable_mounts=args.writable_mounts,
             )
             vm.start(boot_timeout=args.boot_timeout)
-            vm.wait_for_ssh(timeout=args.boot_timeout)
-            ssh = vm._ensure_ssh_for_env()
+            ssh = _preset_control_channel(vm, timeout=args.boot_timeout)
             apply_summary = apply_preset(
                 ssh,
                 preset,
@@ -1602,7 +1601,7 @@ def _apply_preset_with_progress(
     _vm: SmolVM = vm  # type: ignore[assignment]
     _preset: Preset = preset  # type: ignore[assignment]
 
-    ssh = _vm._ensure_ssh_for_env()
+    ssh = _preset_control_channel(_vm)
 
     with Progress(
         SpinnerColumn(),
@@ -1625,6 +1624,22 @@ def _apply_preset_with_progress(
         progress.remove_task(task)
 
     return summary
+
+
+def _preset_control_channel(vm: object, *, timeout: float = 30.0) -> object:
+    """Return the fastest channel that can apply preset setup."""
+    from smolvm.facade import SmolVM
+
+    _vm: SmolVM = vm  # type: ignore[assignment]
+    try:
+        channel = _vm._ensure_control_for_operation(action="apply preset", timeout=timeout)
+        supports = getattr(channel, "supports", None)
+        if not callable(supports) or supports("file_raw", "dir_tar", "env_managed"):
+            return channel
+    except Exception:
+        pass
+    _vm.wait_for_ssh(timeout=timeout)
+    return _vm._ensure_ssh_for_env(timeout=timeout)
 
 
 def _render_vm_lifecycle_result(

--- a/src/smolvm/comm/rust_http_vsock_channel.py
+++ b/src/smolvm/comm/rust_http_vsock_channel.py
@@ -143,6 +143,14 @@ def _directory_to_tar(source: Path) -> bytes:
     return buffer.getvalue()
 
 
+def _strip_tar_owner(info: tarfile.TarInfo) -> tarfile.TarInfo:
+    info.uid = 0
+    info.gid = 0
+    info.uname = ""
+    info.gname = ""
+    return info
+
+
 def _write_temp_tar(data: bytes) -> Path:
     fd, path = tempfile.mkstemp(prefix="smolvm-dir-", suffix=".tar")
     with os.fdopen(fd, "wb") as handle:
@@ -153,7 +161,7 @@ def _write_temp_tar(data: bytes) -> Path:
 def _add_tar_path(archive: tarfile.TarFile, path: Path, arcname: PurePosixPath) -> None:
     if path.is_symlink():
         return
-    archive.add(path, arcname=str(arcname), recursive=False)
+    archive.add(path, arcname=str(arcname), recursive=False, filter=_strip_tar_owner)
     if path.is_dir():
         for child in sorted(path.iterdir()):
             _add_tar_path(archive, child, arcname / child.name)
@@ -727,7 +735,9 @@ class RustHttpVsockChannel:
         try:
             return sorted(self.set_managed_env(env_vars, merge=merge))
         except SmolVMError as exc:
-            if self.supports("env_managed") and not _endpoint_missing(exc, "PUT", "/env"):
+            if self.supports("env_managed", "env.managed") and not _endpoint_missing(
+                exc, "PUT", "/env"
+            ):
                 raise
             from smolvm.env import inject_env_vars
 
@@ -741,7 +751,9 @@ class RustHttpVsockChannel:
             after = self.unset_managed_env(keys)
             return {key: before[key] for key in keys if key in before and key not in after}
         except SmolVMError as exc:
-            if self.supports("env_managed") and not _endpoint_missing(exc, "DELETE", "/env"):
+            if self.supports("env_managed", "env.managed") and not _endpoint_missing(
+                exc, "DELETE", "/env"
+            ):
                 raise
             from smolvm.env import remove_env_vars
 
@@ -751,7 +763,9 @@ class RustHttpVsockChannel:
         try:
             return self.list_managed_env()
         except SmolVMError as exc:
-            if self.supports("env_managed") and not _endpoint_missing(exc, "GET", "/env"):
+            if self.supports("env_managed", "env.managed") and not _endpoint_missing(
+                exc, "GET", "/env"
+            ):
                 raise
             from smolvm.env import read_env_vars
 

--- a/src/smolvm/facade.py
+++ b/src/smolvm/facade.py
@@ -1572,9 +1572,13 @@ class SmolVM:
                     "the rootfs at build time.",
                     {"vm_id": self._vm_id},
                 )
-            ssh = self._ensure_ssh_for_env(timeout=boot_timeout)
-            injector = inject_env_vars_windows if self._is_windows_guest() else inject_env_vars
-            injected = injector(ssh, env_vars)
+            control_env = self._control_env_channel(timeout=boot_timeout)
+            if control_env is not None:
+                injected = sorted(control_env.set_managed_env(env_vars).keys())  # type: ignore[attr-defined]
+            else:
+                ssh = self._ensure_ssh_for_env(timeout=boot_timeout)
+                injector = inject_env_vars_windows if self._is_windows_guest() else inject_env_vars
+                injected = injector(ssh, env_vars)
             logger.info(
                 "VM %s: injected %d env var(s): %s",
                 self._vm_id,
@@ -1830,9 +1834,13 @@ class SmolVM:
         if not env_vars:
             return []
 
-        ssh = self._ensure_ssh_for_env()
         if self._is_windows_guest():
+            ssh = self._ensure_ssh_for_env()
             return inject_env_vars_windows(ssh, env_vars, merge=merge)
+        control_env = self._control_env_channel()
+        if control_env is not None:
+            return sorted(control_env.set_managed_env(env_vars, merge=merge).keys())  # type: ignore[attr-defined]
+        ssh = self._ensure_ssh_for_env()
         return inject_env_vars(ssh, env_vars, merge=merge)
 
     def unset_env_vars(self, keys: list[str]) -> dict[str, str]:
@@ -1847,16 +1855,26 @@ class SmolVM:
         if not keys:
             return {}
 
-        ssh = self._ensure_ssh_for_env()
         if self._is_windows_guest():
+            ssh = self._ensure_ssh_for_env()
             return remove_env_vars_windows(ssh, keys)
+        control_env = self._control_env_channel()
+        if control_env is not None:
+            before = control_env.list_managed_env()  # type: ignore[attr-defined]
+            control_env.unset_managed_env(keys)  # type: ignore[attr-defined]
+            return {key: before[key] for key in keys if key in before}
+        ssh = self._ensure_ssh_for_env()
         return remove_env_vars(ssh, keys)
 
     def list_env_vars(self) -> dict[str, str]:
         """Return SmolVM-managed environment variables for a running VM."""
-        ssh = self._ensure_ssh_for_env()
         if self._is_windows_guest():
+            ssh = self._ensure_ssh_for_env()
             return read_env_vars_windows(ssh)
+        control_env = self._control_env_channel()
+        if control_env is not None:
+            return control_env.list_managed_env()  # type: ignore[attr-defined]
+        ssh = self._ensure_ssh_for_env()
         return read_env_vars(ssh)
 
     def upload_file(
@@ -2495,9 +2513,13 @@ class SmolVM:
                     "Cannot inject environment variables: VM image does not support SSH.",
                     {"vm_id": self._vm_id},
                 )
-            ssh = await asyncio.to_thread(self._ensure_ssh_for_env, timeout=boot_timeout)
-            injector = inject_env_vars_windows if self._is_windows_guest() else inject_env_vars
-            await asyncio.to_thread(injector, ssh, env_vars)
+            control_env = await asyncio.to_thread(self._control_env_channel, timeout=boot_timeout)
+            if control_env is not None:
+                await asyncio.to_thread(control_env.set_managed_env, env_vars)
+            else:
+                ssh = await asyncio.to_thread(self._ensure_ssh_for_env, timeout=boot_timeout)
+                injector = inject_env_vars_windows if self._is_windows_guest() else inject_env_vars
+                await asyncio.to_thread(injector, ssh, env_vars)
 
         # Mount workspace directories after boot if configured.
         if self._info.config.workspace_mounts:
@@ -2888,6 +2910,26 @@ modprobe 9pnet_virtio""".strip()
             action="manage environment variables",
             timeout=timeout,
         )
+
+    def _control_env_channel(
+        self,
+        *,
+        timeout: float = _DEFAULT_RUN_READY_TIMEOUT,
+    ) -> CommChannel | None:
+        """Return a control channel with managed-env support for Linux guests."""
+        if self._is_windows_guest():
+            return None
+        try:
+            channel = self._ensure_control_for_operation(
+                action="manage environment variables",
+                timeout=timeout,
+            )
+        except Exception:
+            return None
+        supports = getattr(channel, "supports", None)
+        if callable(supports) and supports("env_managed", "env.managed") is True:
+            return channel
+        return None
 
     def _ensure_control_for_operation(
         self,

--- a/src/smolvm/images/builder.py
+++ b/src/smolvm/images/builder.py
@@ -1041,6 +1041,10 @@ start_session() {
     write_preferences "$profile_dir" "$download_dir"
     stop_session
 
+    if [ "$debug_port" -gt 65534 ]; then
+        echo "debug_port must be <= 65534" >&2
+        exit 2
+    fi
     browser_debug_port=$((debug_port + 1))
     if [ "${mode}" != "desktop" ]; then
         start_cdp_proxy "$debug_port" "$browser_debug_port"

--- a/src/smolvm/images/builder.py
+++ b/src/smolvm/images/builder.py
@@ -930,6 +930,51 @@ preferences = {
 PY
 }
 
+start_cdp_proxy() {
+    listen_port="$1"
+    target_port="$2"
+
+    python3 - "$listen_port" "$target_port" >"${LOG_DIR}/cdp-proxy.log" 2>&1 <<'PY' &
+import select
+import socket
+import socketserver
+import sys
+
+listen_port = int(sys.argv[1])
+target_port = int(sys.argv[2])
+
+
+class ProxyHandler(socketserver.BaseRequestHandler):
+    def handle(self):
+        try:
+            upstream = socket.create_connection(("127.0.0.1", target_port), timeout=5.0)
+        except OSError:
+            return
+        with upstream:
+            sockets = [self.request, upstream]
+            while True:
+                readable, _, _ = select.select(sockets, [], [], 30.0)
+                if not readable:
+                    return
+                for source in readable:
+                    data = source.recv(65536)
+                    if not data:
+                        return
+                    target = upstream if source is self.request else self.request
+                    target.sendall(data)
+
+
+class ThreadingServer(socketserver.ThreadingTCPServer):
+    allow_reuse_address = True
+    daemon_threads = True
+
+
+with ThreadingServer(("0.0.0.0", listen_port), ProxyHandler) as server:
+    server.serve_forever()
+PY
+    echo $! >"${RUNTIME_DIR}/cdp-proxy.pid"
+}
+
 start_live_stack() {
     width="$1"
     height="$2"
@@ -970,6 +1015,7 @@ stop_session() {
     stop_pid_file "${RUNTIME_DIR}/x11vnc.pid"
     stop_pid_file "${RUNTIME_DIR}/openbox.pid"
     stop_pid_file "${RUNTIME_DIR}/xvfb.pid"
+    stop_pid_file "${RUNTIME_DIR}/cdp-proxy.pid"
     stop_pid_file "${RUNTIME_DIR}/chromium.pid"
 }
 
@@ -995,6 +1041,11 @@ start_session() {
     write_preferences "$profile_dir" "$download_dir"
     stop_session
 
+    browser_debug_port=$((debug_port + 1))
+    if [ "${mode}" != "desktop" ]; then
+        start_cdp_proxy "$debug_port" "$browser_debug_port"
+    fi
+
     if [ "${mode}" = "live" ] || [ "${mode}" = "desktop" ]; then
         start_live_stack "$width" "$height" "$live_port" "$record_video" "$artifacts_dir"
     fi
@@ -1019,8 +1070,8 @@ start_session() {
             --password-store=basic \
             --use-mock-keychain \
             --remote-allow-origins=* \
-            --remote-debugging-address=0.0.0.0 \
-            --remote-debugging-port="${debug_port}" \
+            --remote-debugging-address=127.0.0.1 \
+            --remote-debugging-port="${browser_debug_port}" \
             --user-data-dir="${profile_dir}" \
             --window-size="${width},${height}" \
             about:blank \
@@ -1038,8 +1089,8 @@ start_session() {
             --password-store=basic \
             --use-mock-keychain \
             --remote-allow-origins=* \
-            --remote-debugging-address=0.0.0.0 \
-            --remote-debugging-port="${debug_port}" \
+            --remote-debugging-address=127.0.0.1 \
+            --remote-debugging-port="${browser_debug_port}" \
             --user-data-dir="${profile_dir}" \
             --window-size="${width},${height}" \
             about:blank \

--- a/src/smolvm/presets/_install.py
+++ b/src/smolvm/presets/_install.py
@@ -89,7 +89,14 @@ def apply_preset(
     injected_keys: list[str] = []
     if env_vars:
         notify(f"Forwarding {len(env_vars)} environment variable(s)...")
-        injected_keys = inject_env_vars(ssh, env_vars)
+        set_managed_env = getattr(ssh, "set_managed_env", None)
+        supports = getattr(ssh, "supports", None)
+        if callable(set_managed_env) and (
+            callable(supports) and supports("env_managed", "env.managed") is True
+        ):
+            injected_keys = sorted(set_managed_env(env_vars).keys())
+        else:
+            injected_keys = inject_env_vars(ssh, env_vars)
 
     # Setup phase (apt + Node toolchain) runs before install_script so
     # the user sees two distinct progress steps instead of one opaque
@@ -245,6 +252,16 @@ def _copy_dir(ssh: CommChannel, local: Path, guest_path: str) -> None:
     sshd would reject the key with "Bad owner or permissions". File
     modes (the 0o600 we care about for SSH keys) are untouched.
     """
+    put_directory = getattr(ssh, "put_directory", None)
+    supports = getattr(ssh, "supports", None)
+    if (
+        callable(put_directory)
+        and callable(supports)
+        and supports("dir_tar", "files.directory_tar") is True
+    ):
+        put_directory(local, guest_path)
+        return
+
     tmp_path: Path | None = None
     try:
         with tempfile.NamedTemporaryFile(suffix=".tar", delete=False) as tmp:

--- a/tests/test_browser.py
+++ b/tests/test_browser.py
@@ -383,13 +383,52 @@ def test_build_browser_vm_config_passes_pubkey_to_vmconfig(
     )
 
     assert vm_config.ssh_public_key == pubkey_value
+    assert mock_builder.build_browser_rootfs.call_args.args[0] == pubkey_value
+
+
+@patch("smolvm.utils.ensure_ssh_key")
+@patch("smolvm.images.builder.ImageBuilder")
+def test_build_browser_vm_config_uses_custom_key_public_half(
+    mock_builder_cls: MagicMock,
+    mock_ensure_ssh_key: MagicMock,
+    tmp_path: Path,
+) -> None:
+    """Custom SSH fallback keys should provision their matching public key."""
+    kernel = tmp_path / "kernel"
+    rootfs = tmp_path / "rootfs.ext4"
+    default_private_key = tmp_path / "default_id_ed25519"
+    default_public_key = tmp_path / "default_id_ed25519.pub"
+    custom_private_key = tmp_path / "custom_id_ed25519"
+    custom_public_key = tmp_path / "custom_id_ed25519.pub"
+    kernel.touch()
+    rootfs.touch()
+    default_private_key.touch()
+    default_public_key.write_text("ssh-ed25519 AAAADefault user@test\n")
+    custom_private_key.touch()
+    custom_pubkey_value = "ssh-ed25519 AAAACustom user@test"
+    custom_public_key.write_text(f"{custom_pubkey_value}\n")
+
+    mock_ensure_ssh_key.return_value = (default_private_key, default_public_key)
+    mock_builder = MagicMock()
+    mock_builder.build_browser_rootfs.return_value = (kernel, rootfs)
+    mock_builder_cls.return_value = mock_builder
+
+    vm_config, ssh_key_path = _build_browser_vm_config(
+        session_id="browser-custom-key",
+        browser_config=BrowserSessionConfig(session_id="browser-custom-key"),
+        ssh_key_path=str(custom_private_key),
+    )
+
+    assert ssh_key_path == str(custom_private_key)
+    assert vm_config.ssh_public_key == custom_pubkey_value
+    assert mock_builder.build_browser_rootfs.call_args.args[0] == custom_pubkey_value
 
 
 @patch("smolvm.browser.SmolVM")
 @patch("smolvm.browser._build_browser_vm_config")
-@patch("smolvm.browser.urllib.request.urlopen", return_value=_CdpResponse())
+@patch("smolvm.browser._LOCAL_HTTP_OPENER.open", return_value=_CdpResponse())
 def test_browser_session_start_persists_ready_state(
-    mock_urlopen: MagicMock,
+    mock_open: MagicMock,
     mock_build_browser_vm_config: MagicMock,
     mock_vm_cls: MagicMock,
     sample_vm_config: VMConfig,
@@ -433,7 +472,7 @@ def test_browser_session_start_persists_ready_state(
     assert session.status == BrowserSessionState.READY
     assert session.cdp_url == "http://127.0.0.1:39222"
     assert session.browser_cdp_url == "http://127.0.0.1:39222"
-    mock_urlopen.assert_called_once()
+    mock_open.assert_called_once()
     assert session.viewer_url == "http://127.0.0.1:36080/vnc.html?autoconnect=1&resize=scale"
     assert session.display_url == "vnc://127.0.0.1:35900"
     assert session.vm is vm
@@ -449,9 +488,9 @@ def test_browser_session_start_persists_ready_state(
 @patch("smolvm.browser._build_browser_vm_config")
 @patch("smolvm.browser._BrowserSandbox._probe_local_port", return_value=True)
 @patch("smolvm.browser.time.sleep")
-@patch("smolvm.browser.urllib.request.urlopen")
+@patch("smolvm.browser._LOCAL_HTTP_OPENER.open")
 def test_browser_sandbox_start_uses_configured_qemu_cdp_forward(
-    mock_urlopen: MagicMock,
+    mock_open: MagicMock,
     _mock_sleep: MagicMock,
     mock_probe_local_port: MagicMock,
     mock_build_browser_vm_config: MagicMock,
@@ -486,7 +525,7 @@ def test_browser_sandbox_start_uses_configured_qemu_cdp_forward(
 
     vm.run.side_effect = _run_side_effect
     mock_vm_cls.return_value = vm
-    mock_urlopen.side_effect = [
+    mock_open.side_effect = [
         ConnectionResetError("reset"),
         _CdpResponse(status=503),
         _CdpResponse(),
@@ -500,7 +539,7 @@ def test_browser_sandbox_start_uses_configured_qemu_cdp_forward(
     session.start()
 
     assert session.cdp_url == "http://127.0.0.1:39001"
-    assert mock_urlopen.call_count == 3
+    assert mock_open.call_count == 3
     mock_probe_local_port.assert_called_once_with(39001)
     vm.expose_local.assert_not_called()
     session.close()

--- a/tests/test_browser.py
+++ b/tests/test_browser.py
@@ -225,7 +225,7 @@ def test_build_browser_vm_config_uses_persistent_disk_reuse(
 
     assert vm_config.retain_disk_on_delete is True
     assert vm_config.backend == "qemu"
-    assert vm_config.comm_channel == "ssh"
+    assert vm_config.comm_channel is None
     assert vm_config.vm_id.startswith("browser-prof-acct-1-")
     assert ssh_key_path == str(private_key)
     assert len(vm_config.port_forwards) == 1

--- a/tests/test_browser.py
+++ b/tests/test_browser.py
@@ -40,7 +40,8 @@ from smolvm.types import (
 
 
 class _CdpResponse:
-    status = 200
+    def __init__(self, status: int = 200) -> None:
+        self.status = status
 
     def __enter__(self) -> "_CdpResponse":
         return self
@@ -446,17 +447,19 @@ def test_browser_session_start_persists_ready_state(
 
 @patch("smolvm.browser.SmolVM")
 @patch("smolvm.browser._build_browser_vm_config")
+@patch("smolvm.browser._BrowserSandbox._probe_local_port", return_value=True)
 @patch("smolvm.browser.time.sleep")
 @patch("smolvm.browser.urllib.request.urlopen")
-def test_browser_sandbox_start_uses_expose_local_for_qemu_cdp(
+def test_browser_sandbox_start_uses_configured_qemu_cdp_forward(
     mock_urlopen: MagicMock,
     _mock_sleep: MagicMock,
+    mock_probe_local_port: MagicMock,
     mock_build_browser_vm_config: MagicMock,
     mock_vm_cls: MagicMock,
     sample_vm_config: VMConfig,
     tmp_path: Path,
 ) -> None:
-    """QEMU browser sandboxes should expose CDP through the localhost helper path."""
+    """QEMU browser sandboxes should reuse their preconfigured CDP host forward."""
     qemu_vm_config = sample_vm_config.model_copy(
         update={
             "backend": "qemu",
@@ -468,6 +471,7 @@ def test_browser_sandbox_start_uses_expose_local_for_qemu_cdp(
     vm = MagicMock()
     vm.vm_id = "browser-abc123"
     vm.status = VMState.CREATED
+    vm.info.config = qemu_vm_config
     vm.expose_local.return_value = 39222
 
     def _run_side_effect(command: str, timeout: int = 30, shell: str = "login") -> CommandResult:
@@ -482,7 +486,11 @@ def test_browser_sandbox_start_uses_expose_local_for_qemu_cdp(
 
     vm.run.side_effect = _run_side_effect
     mock_vm_cls.return_value = vm
-    mock_urlopen.side_effect = [ConnectionResetError("reset"), _CdpResponse()]
+    mock_urlopen.side_effect = [
+        ConnectionResetError("reset"),
+        _CdpResponse(status=503),
+        _CdpResponse(),
+    ]
 
     session = _BrowserSandbox(
         BrowserSessionConfig(session_id="browser-abc123", backend="qemu"),
@@ -491,9 +499,10 @@ def test_browser_sandbox_start_uses_expose_local_for_qemu_cdp(
 
     session.start()
 
-    assert session.cdp_url == "http://127.0.0.1:39222"
-    assert mock_urlopen.call_count == 2
-    vm.expose_local.assert_called_once_with(guest_port=9222, guest_loopback=True)
+    assert session.cdp_url == "http://127.0.0.1:39001"
+    assert mock_urlopen.call_count == 3
+    mock_probe_local_port.assert_called_once_with(39001)
+    vm.expose_local.assert_not_called()
     session.close()
 
 

--- a/tests/test_browser.py
+++ b/tests/test_browser.py
@@ -39,6 +39,16 @@ from smolvm.types import (
 )
 
 
+class _CdpResponse:
+    status = 200
+
+    def __enter__(self) -> "_CdpResponse":
+        return self
+
+    def __exit__(self, *args: object) -> None:
+        return None
+
+
 @pytest.fixture
 def sample_vm_config(tmp_path: Path) -> VMConfig:
     """Create a sample VMConfig for browser session tests."""
@@ -376,7 +386,9 @@ def test_build_browser_vm_config_passes_pubkey_to_vmconfig(
 
 @patch("smolvm.browser.SmolVM")
 @patch("smolvm.browser._build_browser_vm_config")
+@patch("smolvm.browser.urllib.request.urlopen", return_value=_CdpResponse())
 def test_browser_session_start_persists_ready_state(
+    mock_urlopen: MagicMock,
     mock_build_browser_vm_config: MagicMock,
     mock_vm_cls: MagicMock,
     sample_vm_config: VMConfig,
@@ -420,6 +432,7 @@ def test_browser_session_start_persists_ready_state(
     assert session.status == BrowserSessionState.READY
     assert session.cdp_url == "http://127.0.0.1:39222"
     assert session.browser_cdp_url == "http://127.0.0.1:39222"
+    mock_urlopen.assert_called_once()
     assert session.viewer_url == "http://127.0.0.1:36080/vnc.html?autoconnect=1&resize=scale"
     assert session.display_url == "vnc://127.0.0.1:35900"
     assert session.vm is vm
@@ -433,7 +446,11 @@ def test_browser_session_start_persists_ready_state(
 
 @patch("smolvm.browser.SmolVM")
 @patch("smolvm.browser._build_browser_vm_config")
+@patch("smolvm.browser.time.sleep")
+@patch("smolvm.browser.urllib.request.urlopen")
 def test_browser_sandbox_start_uses_expose_local_for_qemu_cdp(
+    mock_urlopen: MagicMock,
+    _mock_sleep: MagicMock,
     mock_build_browser_vm_config: MagicMock,
     mock_vm_cls: MagicMock,
     sample_vm_config: VMConfig,
@@ -465,6 +482,7 @@ def test_browser_sandbox_start_uses_expose_local_for_qemu_cdp(
 
     vm.run.side_effect = _run_side_effect
     mock_vm_cls.return_value = vm
+    mock_urlopen.side_effect = [ConnectionResetError("reset"), _CdpResponse()]
 
     session = _BrowserSandbox(
         BrowserSessionConfig(session_id="browser-abc123", backend="qemu"),
@@ -474,6 +492,7 @@ def test_browser_sandbox_start_uses_expose_local_for_qemu_cdp(
     session.start()
 
     assert session.cdp_url == "http://127.0.0.1:39222"
+    assert mock_urlopen.call_count == 2
     vm.expose_local.assert_called_once_with(guest_port=9222, guest_loopback=True)
     session.close()
 

--- a/tests/test_build.py
+++ b/tests/test_build.py
@@ -347,7 +347,9 @@ class TestBrowserImageBuilder:
             helper_script = kwargs["extra_files"]["smolvm-browser-session"]
             assert "127.0.0.1:5900" in helper_script
             assert '"${mode}" = "desktop"' in helper_script
-            assert "--remote-debugging-address=0.0.0.0" in helper_script
+            assert "start_cdp_proxy" in helper_script
+            assert 'ThreadingServer(("0.0.0.0", listen_port)' in helper_script
+            assert "--remote-debugging-address=127.0.0.1" in helper_script
             kernel_path.touch()
             rootfs_path.touch()
 

--- a/tests/test_build.py
+++ b/tests/test_build.py
@@ -350,6 +350,7 @@ class TestBrowserImageBuilder:
             assert "start_cdp_proxy" in helper_script
             assert 'ThreadingServer(("0.0.0.0", listen_port)' in helper_script
             assert "--remote-debugging-address=127.0.0.1" in helper_script
+            assert "debug_port must be <= 65534" in helper_script
             kernel_path.touch()
             rootfs_path.touch()
 

--- a/tests/test_rust_http_vsock_channel.py
+++ b/tests/test_rust_http_vsock_channel.py
@@ -31,7 +31,11 @@ from typing import Any
 import pytest
 
 from smolvm.comm.base import CommChannel
-from smolvm.comm.rust_http_vsock_channel import ControlCapabilities, RustHttpVsockChannel
+from smolvm.comm.rust_http_vsock_channel import (
+    ControlCapabilities,
+    RustHttpVsockChannel,
+    _directory_to_tar,
+)
 from smolvm.exceptions import OperationTimeoutError, SmolVMError
 from smolvm.types import CommandResult
 
@@ -449,6 +453,25 @@ def test_legacy_directory_fallback_uses_guest_mktemp(tmp_path: Path) -> None:
     assert "trap" in commands[1]
     assert 'tar -xf "$remote_tmp"' in commands[1]
     assert commands[-1] == "rm -f -- /tmp/smolvm-dir.ABC123.tar"
+
+
+def test_directory_tar_strips_owner_metadata(tmp_path: Path) -> None:
+    source = tmp_path / "source"
+    source.mkdir()
+    private_key = source / "id_ed25519"
+    private_key.write_text("PRIVATE")
+    private_key.chmod(0o600)
+
+    data = _directory_to_tar(source)
+
+    with tarfile.open(fileobj=io.BytesIO(data), mode="r:") as archive:
+        members = archive.getmembers()
+
+    assert members
+    assert all(member.uid == 0 and member.gid == 0 for member in members)
+    assert all(member.uname == "" and member.gname == "" for member in members)
+    key_member = next(member for member in members if member.name == "id_ed25519")
+    assert key_member.mode & 0o777 == 0o600
 
 
 def test_legacy_directory_download_uses_guest_mktemp(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary

Moves production Linux setup paths to prefer the Rust guest-agent control channel when protocol v2 capabilities are available:

- Uses managed env endpoints for Linux vsock guests, while keeping SSH fallback for older images, explicit SSH, and unsupported platforms.
- Lets preset credential/config copy prefer directory streaming when supported.
- Lets browser sandboxes stop forcing SSH by default and use control-channel readiness/port wait where possible.
- Keeps interactive attach, Windows, and SSH-selected flows on the existing SSH-backed behavior.

## Stack

1. #397: benchmark foundation.
2. #398: guest-agent protocol v2 substrate.
3. #399: native host disk/network/Firecracker helpers.
4. This PR: control-channel production integration.

## Validation

Full-stack validation run locally after the stack was assembled:

- `UV_CACHE_DIR=/tmp/uv-cache uv run pytest tests/ -q` — 1392 passed, 12 skipped, 27 deselected.
- `UV_CACHE_DIR=/tmp/uv-cache uv run ruff check .` — passed.
- `UV_CACHE_DIR=/tmp/uv-cache uv run ruff format --check .` — passed.
- `cargo check -p smolvm-core` — passed.
- `cargo test -p smolvm-guest-agent` — passed.
- `cargo fmt --check` — passed.
- `git diff --check` — passed.

`cargo test -p smolvm-core` is blocked on this machine because the local linker cannot find `libpython3.14`; `maturin develop` and `cargo check -p smolvm-core` both pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Faster, more reliable browser startup by polling for CDP readiness and improving loopback port-forward reuse.
  * Improved preset installation by preferring a quicker control-channel path when available.
  * More efficient environment-variable injection/removal using managed environment support when supported.
* **Bug Fixes**
  * More robust guest networking and port waiting behavior, with better fallbacks.
  * Improved file transfer and artifact downloads via VM-based mechanisms.
  * Normalized ownership metadata for directory archive uploads.
* **Tests**
  * Updated browser/build tests to match the new CDP proxy and readiness behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->