### PR TITLE
[codex] Filter Codex preset config copy

### DIFF
--- a/src/smolvm/presets/_install.py
+++ b/src/smolvm/presets/_install.py
@@ -16,6 +16,7 @@
 
 from __future__ import annotations
 
+import fnmatch
 import getpass
 import logging
 import os
@@ -159,15 +160,24 @@ def _copy_to_guest(
     *,
     file_mode: int | None = None,
     transform: Callable[[bytes], bytes] | None = None,
+    include_patterns: tuple[str, ...] = (),
+    exclude_patterns: tuple[str, ...] = (),
 ) -> None:
     """Copy a host file or directory tree to *guest_path* inside the VM.
 
     *file_mode* applies only to single-file copies; directory copies
     inherit per-file modes from the tar archive. *transform*, when set,
     rewrites a single file's bytes before upload (directory copies have
-    no single byte stream and reject a transform).
+    no single byte stream and reject a transform). *include_patterns*
+    and *exclude_patterns* apply only to directory copies and match
+    POSIX paths relative to the copied directory.
     """
     if local.is_file():
+        if include_patterns or exclude_patterns:
+            raise SmolVMError(
+                f"Directory filters cannot be used with a file: {local}",
+                {"host_path": str(local)},
+            )
         _copy_file(ssh, local, guest_path, file_mode=file_mode, transform=transform)
         return
     if local.is_dir():
@@ -176,7 +186,13 @@ def _copy_to_guest(
                 f"transform is not supported for directory copies: {local}",
                 {"host_path": str(local)},
             )
-        _copy_dir(ssh, local, guest_path)
+        _copy_dir(
+            ssh,
+            local,
+            guest_path,
+            include_patterns=include_patterns,
+            exclude_patterns=exclude_patterns,
+        )
         return
     raise SmolVMError(
         f"Unsupported host path type (not file or directory): {local}",
@@ -242,7 +258,14 @@ def _copy_file(
             )
 
 
-def _copy_dir(ssh: CommChannel, local: Path, guest_path: str) -> None:
+def _copy_dir(
+    ssh: CommChannel,
+    local: Path,
+    guest_path: str,
+    *,
+    include_patterns: tuple[str, ...] = (),
+    exclude_patterns: tuple[str, ...] = (),
+) -> None:
     """Tar a host directory tree and untar it into *guest_path* on the guest.
 
     Strips ownership (uid/gid/uname/gname) on every TarInfo so the guest
@@ -252,10 +275,12 @@ def _copy_dir(ssh: CommChannel, local: Path, guest_path: str) -> None:
     sshd would reject the key with "Bad owner or permissions". File
     modes (the 0o600 we care about for SSH keys) are untouched.
     """
+    has_filters = bool(include_patterns or exclude_patterns)
     put_directory = getattr(ssh, "put_directory", None)
     supports = getattr(ssh, "supports", None)
     if (
-        callable(put_directory)
+        not has_filters
+        and callable(put_directory)
         and callable(supports)
         and supports("dir_tar", "files.directory_tar") is True
     ):
@@ -267,7 +292,11 @@ def _copy_dir(ssh: CommChannel, local: Path, guest_path: str) -> None:
         with tempfile.NamedTemporaryFile(suffix=".tar", delete=False) as tmp:
             tmp_path = Path(tmp.name)
         with tarfile.open(tmp_path, "w") as tf:
-            tf.add(local, arcname=".", filter=_strip_tar_owner)
+            tf.add(
+                local,
+                arcname=".",
+                filter=_make_dir_tar_filter(include_patterns, exclude_patterns),
+            )
 
         guest_tmp = f"/tmp/.smolvm-preset-{uuid4().hex}.tar"
         ssh.put_file(tmp_path, guest_tmp)
@@ -295,6 +324,95 @@ def _strip_tar_owner(ti: tarfile.TarInfo) -> tarfile.TarInfo:
     ti.uname = ""
     ti.gname = ""
     return ti
+
+
+def _make_dir_tar_filter(
+    include_patterns: tuple[str, ...],
+    exclude_patterns: tuple[str, ...],
+) -> Callable[[tarfile.TarInfo], tarfile.TarInfo | None]:
+    """Build a tarfile filter that can include only selected directory entries."""
+    includes = tuple(_normalize_dir_pattern(p) for p in include_patterns if p)
+    excludes = tuple(_normalize_dir_pattern(p) for p in exclude_patterns if p)
+
+    def _filter(ti: tarfile.TarInfo) -> tarfile.TarInfo | None:
+        rel = _tar_member_relative_name(ti.name)
+        if rel and any(_matches_exclude_pattern(rel, pattern) for pattern in excludes):
+            return None
+        if includes and not _matches_include_or_parent(rel, ti.isdir(), includes):
+            return None
+        return _strip_tar_owner(ti)
+
+    return _filter
+
+
+def _tar_member_relative_name(name: str) -> str:
+    """Normalize tar member names from ``./path`` to ``path``."""
+    if name == ".":
+        return ""
+    while name.startswith("./"):
+        name = name[2:]
+    return name.rstrip("/")
+
+
+def _normalize_dir_pattern(pattern: str) -> str:
+    """Normalize directory filter patterns to relative POSIX paths."""
+    pattern = pattern.replace("\\", "/").strip()
+    while pattern.startswith("./"):
+        pattern = pattern[2:]
+    return pattern.lstrip("/")
+
+
+def _matches_exclude_pattern(rel: str, pattern: str) -> bool:
+    """Return True when *pattern* excludes *rel* or one of its parents."""
+    if not pattern:
+        return False
+    if pattern.endswith("/**"):
+        base = pattern[:-3].rstrip("/")
+        return rel == base or rel.startswith(f"{base}/")
+    if "/" not in pattern:
+        first = rel.split("/", 1)[0]
+        basename = rel.rsplit("/", 1)[-1]
+        return fnmatch.fnmatchcase(first, pattern) or fnmatch.fnmatchcase(basename, pattern)
+    return fnmatch.fnmatchcase(rel, pattern)
+
+
+def _matches_include_or_parent(
+    rel: str,
+    is_dir: bool,
+    patterns: tuple[str, ...],
+) -> bool:
+    """Return True when *rel* is explicitly included or needed as a parent."""
+    if not rel:
+        return True
+    if any(_matches_include_pattern(rel, pattern) for pattern in patterns):
+        return True
+    if not is_dir:
+        return False
+    rel_prefix = f"{rel}/"
+    return any(
+        pattern.startswith(rel_prefix) or _literal_pattern_prefix(pattern).startswith(rel_prefix)
+        for pattern in patterns
+    )
+
+
+def _matches_include_pattern(rel: str, pattern: str) -> bool:
+    """Return True when an include pattern selects this relative path."""
+    if not pattern:
+        return False
+    if pattern.endswith("/**"):
+        base = pattern[:-3].rstrip("/")
+        return rel == base or rel.startswith(f"{base}/")
+    if "/" not in pattern and "/" in rel:
+        return False
+    return fnmatch.fnmatchcase(rel, pattern)
+
+
+def _literal_pattern_prefix(pattern: str) -> str:
+    """Return the literal path prefix before the first glob metacharacter."""
+    positions = [idx for marker in ("*", "?", "[") if (idx := pattern.find(marker)) != -1]
+    if not positions:
+        return pattern
+    return pattern[: min(positions)]
 
 
 def _posix_dirname(path: str) -> str:
@@ -432,6 +550,8 @@ def transfer_host_configs(
             cfg.guest_path,
             file_mode=cfg.file_mode,
             transform=cfg.transform,
+            include_patterns=cfg.include_patterns,
+            exclude_patterns=cfg.exclude_patterns,
         )
         copied_configs.append(cfg.guest_path)
     return copied_configs

--- a/src/smolvm/presets/_types.py
+++ b/src/smolvm/presets/_types.py
@@ -44,6 +44,14 @@ class HostConfigCopy:
             auth/onboarding subset. Filtering on the host side keeps the
             host's project history off the sandbox disk entirely.
             ``None`` (default) copies the file verbatim.
+        include_patterns: Optional allowlist for directory copies,
+            expressed as POSIX-style paths relative to ``host_path``.
+            When empty, every entry is included unless excluded.
+        exclude_patterns: Optional denylist for directory copies,
+            expressed as POSIX-style paths relative to ``host_path``.
+            Excludes win over includes. Single-file copies reject
+            directory patterns because there is no directory tree to
+            filter.
     """
 
     host_path: str
@@ -51,6 +59,8 @@ class HostConfigCopy:
     required: bool = False
     file_mode: int | None = None
     transform: Callable[[bytes], bytes] | None = None
+    include_patterns: tuple[str, ...] = ()
+    exclude_patterns: tuple[str, ...] = ()
 
 
 @dataclass(frozen=True)

--- a/src/smolvm/presets/codex.py
+++ b/src/smolvm/presets/codex.py
@@ -19,12 +19,81 @@ from __future__ import annotations
 from smolvm.presets._scripts import NODE20_BOOTSTRAP, npm_install_global
 from smolvm.presets._types import HostConfigCopy, Preset
 
+# Keep ~/.codex transfers to durable auth/config only. Real Codex homes
+# contain large logs, sessions, sqlite WALs, caches, plugins, packages,
+# attachments, and worktrees that are not needed for login or config.
+CODEX_CONFIG_INCLUDE_PATTERNS: tuple[str, ...] = (
+    "auth.json",
+    "config.toml",
+    "*.config.toml",
+    "requirements.toml",
+    "hooks.json",
+    "AGENTS.md",
+    "AGENTS.override.md",
+    "rules",
+    "rules/**",
+    "agents",
+    "agents/*.toml",
+)
+
+CODEX_CONFIG_EXCLUDE_PATTERNS: tuple[str, ...] = (
+    ".tmp",
+    ".tmp/**",
+    "app-server-control",
+    "app-server-control/**",
+    "app-server-daemon",
+    "app-server-daemon/**",
+    "archived_sessions",
+    "archived_sessions/**",
+    "attachments",
+    "attachments/**",
+    "cache",
+    "cache/**",
+    "history.jsonl",
+    "log",
+    "log/**",
+    "logs*",
+    "memories",
+    "memories/**",
+    "models",
+    "models/**",
+    "models_cache.json",
+    "packages",
+    "packages/**",
+    "plugins/.remote-plugin-install-staging",
+    "plugins/.remote-plugin-install-staging/**",
+    "plugins/cache",
+    "plugins/cache/**",
+    "session_index.jsonl",
+    "shell_snapshots",
+    "shell_snapshots/**",
+    "skills",
+    "skills/**",
+    "tmp",
+    "tmp/**",
+    "worktrees",
+    "worktrees/**",
+    "*.db",
+    "*.db-*",
+    "*.sqlite",
+    "*.sqlite-*",
+)
+
+CODEX_HOST_CONFIGS: tuple[HostConfigCopy, ...] = (
+    HostConfigCopy(
+        host_path="~/.codex",
+        guest_path="/root/.codex",
+        include_patterns=CODEX_CONFIG_INCLUDE_PATTERNS,
+        exclude_patterns=CODEX_CONFIG_EXCLUDE_PATTERNS,
+    ),
+)
+
 CODEX_PRESET = Preset(
     name="codex",
     summary="Start a sandbox with OpenAI's codex CLI preinstalled.",
     setup_script=NODE20_BOOTSTRAP,
     install_script=npm_install_global("@openai/codex"),
     host_env_vars=("OPENAI_API_KEY",),
-    host_configs=(HostConfigCopy(host_path="~/.codex", guest_path="/root/.codex"),),
+    host_configs=CODEX_HOST_CONFIGS,
     launch_command="codex",
 )

--- a/src/smolvm/presets/pi.py
+++ b/src/smolvm/presets/pi.py
@@ -19,6 +19,7 @@ from __future__ import annotations
 from smolvm.presets._scripts import NODE20_BOOTSTRAP, npm_install_global
 from smolvm.presets._types import HostConfigCopy, Preset
 from smolvm.presets.claude_code import CLAUDE_CODE_KEYCHAIN_SECRET, minimize_claude_json
+from smolvm.presets.codex import CODEX_HOST_CONFIGS
 
 # Pi is a meta-harness: its `/login` flow lists "OpenAI ChatGPT Plus/Pro
 # (Codex)" and "Anthropic Claude Pro/Max" as subscription providers, and
@@ -41,7 +42,7 @@ PI_PRESET = Preset(
     host_env_vars=("ANTHROPIC_API_KEY", "OPENAI_API_KEY"),
     host_configs=(
         HostConfigCopy(host_path="~/.pi", guest_path="/root/.pi"),
-        HostConfigCopy(host_path="~/.codex", guest_path="/root/.codex"),
+        *CODEX_HOST_CONFIGS,
         HostConfigCopy(
             host_path="~/.claude.json",
             guest_path="/root/.claude.json",

--- a/tests/test_presets.py
+++ b/tests/test_presets.py
@@ -235,9 +235,7 @@ class TestCodexPreset:
         with tarfile.open(staged_tars[0]) as tf:
             members = tf.getmembers()
         names = {
-            member.name.removeprefix("./")
-            for member in members
-            if member.name not in {".", "./"}
+            member.name.removeprefix("./") for member in members if member.name not in {".", "./"}
         }
 
         assert set(allowed_files).issubset(names)

--- a/tests/test_presets.py
+++ b/tests/test_presets.py
@@ -115,9 +115,169 @@ class TestCodexPreset:
             for cfg in CODEX_PRESET.host_configs
         )
 
+    def test_codex_config_copy_is_filtered(self) -> None:
+        from smolvm.presets.codex import (
+            CODEX_CONFIG_EXCLUDE_PATTERNS,
+            CODEX_CONFIG_INCLUDE_PATTERNS,
+        )
+
+        cfg = next(c for c in CODEX_PRESET.host_configs if c.guest_path == "/root/.codex")
+
+        assert cfg.include_patterns == CODEX_CONFIG_INCLUDE_PATTERNS
+        assert {
+            "auth.json",
+            "config.toml",
+            "*.config.toml",
+            "hooks.json",
+            "AGENTS.md",
+            "AGENTS.override.md",
+            "rules/**",
+            "agents/*.toml",
+        }.issubset(cfg.include_patterns)
+        assert cfg.exclude_patterns == CODEX_CONFIG_EXCLUDE_PATTERNS
+        assert {
+            "archived_sessions/**",
+            "attachments/**",
+            "cache/**",
+            "history.jsonl",
+            "logs*",
+            "models_cache.json",
+            "session_index.jsonl",
+            "shell_snapshots/**",
+            "skills/**",
+            "*.sqlite",
+            "*.sqlite-*",
+            "*.db",
+            "*.db-*",
+        }.issubset(cfg.exclude_patterns)
+
     def test_codex_install_runs_npm_install_codex(self) -> None:
         assert "@openai/codex" in CODEX_PRESET.install_script
         assert "npm install -g" in CODEX_PRESET.install_script
+
+    def test_codex_apply_copies_only_auth_and_config_files(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        import tarfile
+        from dataclasses import replace
+
+        monkeypatch.setenv("HOME", str(tmp_path))
+        codex_dir = tmp_path / ".codex"
+        codex_dir.mkdir()
+
+        allowed_files = {
+            "auth.json": "{}",
+            "config.toml": "model = 'gpt-5'\n",
+            "daily.config.toml": "approval_policy = 'on-request'\n",
+            "requirements.toml": "[policies]\n",
+            "hooks.json": "[]\n",
+            "AGENTS.md": "Use concise updates.\n",
+            "AGENTS.override.md": "Temporary override.\n",
+            "rules/default.rules": "prefix_rule(pattern = ['gh'], decision = 'allow')\n",
+            "agents/worker.toml": "name = 'worker'\n",
+        }
+        for rel, content in allowed_files.items():
+            path = codex_dir / rel
+            path.parent.mkdir(parents=True, exist_ok=True)
+            path.write_text(content)
+        (codex_dir / "auth.json").chmod(0o600)
+
+        bulky_files = (
+            "history.jsonl",
+            "session_index.jsonl",
+            "models_cache.json",
+            "logs_2.sqlite",
+            "logs_2.sqlite-shm",
+            "logs_2.sqlite-wal",
+            "state_5.sqlite",
+            "state_5.sqlite-wal",
+            "token.db",
+            "token.db-wal",
+            "archived_sessions/rollout.jsonl",
+            "attachments/clip/image.png",
+            "cache/blob.json",
+            "log/codex.log",
+            "shell_snapshots/shell.sh",
+            "tmp/work/file",
+            ".tmp/scratch/file",
+            "app-server-control/app-server.log",
+            "app-server-daemon/daemon.lock",
+            "memories/MEMORY.md",
+            "packages/standalone/releases/codex",
+            "plugins/cache/plugin.json",
+            "plugins/.remote-plugin-install-staging/plugin.json",
+            "skills/example/SKILL.md",
+            "worktrees/repo/file.py",
+        )
+        for rel in bulky_files:
+            path = codex_dir / rel
+            path.parent.mkdir(parents=True, exist_ok=True)
+            path.write_text("bulk")
+
+        ssh = MagicMock()
+        ssh.run.return_value = _ok()
+        staged_tars: list[Path] = []
+
+        def capture_put(local: object, remote: str) -> None:
+            path = Path(str(local))
+            if remote.endswith(".tar"):
+                snapshot = tmp_path / f"codex-{len(staged_tars)}.tar"
+                snapshot.write_bytes(path.read_bytes())
+                staged_tars.append(snapshot)
+
+        ssh.put_file.side_effect = capture_put
+        preset = replace(CODEX_PRESET, setup_script="", install_script="")
+
+        summary = apply_preset(ssh, preset)
+
+        assert summary["copied_configs"] == ["/root/.codex"]
+        assert len(staged_tars) == 1
+        with tarfile.open(staged_tars[0]) as tf:
+            members = tf.getmembers()
+        names = {
+            member.name.removeprefix("./")
+            for member in members
+            if member.name not in {".", "./"}
+        }
+
+        assert set(allowed_files).issubset(names)
+        assert set(bulky_files).isdisjoint(names)
+        for excluded_root in (
+            ".tmp",
+            "app-server-control",
+            "app-server-daemon",
+            "archived_sessions",
+            "attachments",
+            "cache",
+            "log",
+            "memories",
+            "packages",
+            "plugins",
+            "shell_snapshots",
+            "skills",
+            "tmp",
+            "worktrees",
+        ):
+            assert excluded_root not in names
+            assert not any(name.startswith(f"{excluded_root}/") for name in names)
+
+        auth_member = next(member for member in members if member.name.endswith("auth.json"))
+        assert auth_member.mode & 0o777 == 0o600
+
+    def test_missing_codex_config_dir_skips_silently(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        from dataclasses import replace
+
+        monkeypatch.setenv("HOME", str(tmp_path))
+        ssh = MagicMock()
+        ssh.run.return_value = _ok()
+        preset = replace(CODEX_PRESET, setup_script="", install_script="")
+
+        summary = apply_preset(ssh, preset)
+
+        assert "/root/.codex" not in summary["copied_configs"]
+        ssh.put_file.assert_not_called()
 
 
 class TestClaudeCodePreset:
@@ -230,6 +390,15 @@ class TestPiPreset:
             ("~/.claude.json", "/root/.claude.json"),
             ("~/.claude/.credentials.json", "/root/.claude/.credentials.json"),
         ]
+
+    def test_pi_reuses_filtered_codex_copy_policy(self) -> None:
+        from smolvm.presets.codex import CODEX_HOST_CONFIGS
+
+        pi_codex_cfg = next(
+            cfg for cfg in PI_PRESET.host_configs if cfg.guest_path == "/root/.codex"
+        )
+
+        assert pi_codex_cfg == CODEX_HOST_CONFIGS[0]
 
     def test_pi_pulls_oauth_from_macos_keychain(self) -> None:
         """Pi delegates Claude Pro/Max auth through Claude Code's


### PR DESCRIPTION
## Summary

This PR keeps Codex preset startup from uploading bulky local Codex runtime state into the sandbox. It adds directory include/exclude filters to `HostConfigCopy` and applies a filtered `~/.codex` policy to both the Codex and Pi presets.

## Why

Real developer homes can have very large `~/.codex` directories with logs, archived sessions, sqlite WALs, caches, attachments, shell snapshots, plugin caches, memories, packages, and worktrees. Copying all of that can make preset startup slow or fail with broken pipe errors during credential transfer.

## Impact

The Codex preset now copies durable auth/config surfaces such as `auth.json`, `config.toml`, profile config TOMLs, hooks, AGENTS files, rules, and custom agent TOMLs, while leaving generated runtime state on the host. Missing optional config directories still skip silently.

## Validation

- `PYTHONPATH=$PWD/src uv run pytest tests/test_presets.py -q`
- `uv run ruff check src/smolvm/presets tests/test_presets.py`
- `git diff --check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added include/exclude pattern support for selectively copying directory trees in presets.
  * Codex preset now filters which parts of `~/.codex` are transferred, keeping durable auth/config files while excluding logs, caches, sessions, and other bulky artifacts.
  * Pi preset now reuses Codex’s filtered copy policy for `~/.codex`.
* **Bug Fixes**
  * Prevented directory filters from being used for single-file copies; improved validation for safer copy behavior.
* **Tests**
  * Added/updated tests to verify Codex and Pi filtering, staged tar contents, and behavior when `~/.codex` is missing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->