### PR TITLE
[codex] Add Rust migration benchmark followups

### DIFF
--- a/scripts/benchmarks/README.md
+++ b/scripts/benchmarks/README.md
@@ -56,17 +56,34 @@ check the command plan before starting any sandbox:
 
 ```bash
 uv run python scripts/benchmarks/artifacts.py --dry-run --json
+uv run python scripts/benchmarks/disk_io.py --dry-run --json
+uv run python scripts/benchmarks/file_transfer.py --dry-run --json
 uv run python scripts/benchmarks/preset_start.py --preset codex --dry-run --json
 uv run python scripts/benchmarks/browser_ready.py --dry-run --json
 uv run python scripts/benchmarks/runtime_control.py --operations info,stop,start --dry-run --json
 ```
 
 `artifacts.py` records metadata for local image and browser files.
+`disk_io.py` measures sparse disk copy and zstd decompression with native Rust
+helpers enabled and forced off. `file_transfer.py` starts one sandbox and times
+upload/download for several file sizes plus a directory tar round trip when the
+selected control channel supports it.
 `preset_start.py` times `smolvm <preset> start` and cleans up the sandbox unless
 `--keep` is set. `browser_ready.py` starts a browser sandbox, then polls the CDP
 endpoint, which is the local browser debugging URL, when it is available.
 `runtime_control.py` measures public lifecycle commands such as
 `smolvm sandbox pause`, `resume`, `stop`, and `start`.
+
+Use the benchmark bundle below when validating Rust migration work after a
+merge. The first command does not start a VM. The others create short-lived
+sandboxes and clean them up unless `--keep` is set:
+
+```bash
+uv run python scripts/benchmarks/disk_io.py --json --output /tmp/smolvm-disk-io.json
+uv run python scripts/benchmarks/file_transfer.py --backend qemu --comm-channel vsock --json --output /tmp/smolvm-file-transfer.json
+uv run python scripts/benchmarks/preset_start.py --preset codex --backend qemu --json --output /tmp/smolvm-preset-codex.json
+uv run python scripts/benchmarks/browser_ready.py --backend qemu --json --output /tmp/smolvm-browser-ready.json
+```
 
 ## Linux Networking Stages
 

--- a/scripts/benchmarks/README.md
+++ b/scripts/benchmarks/README.md
@@ -64,10 +64,13 @@ uv run python scripts/benchmarks/runtime_control.py --operations info,stop,start
 ```
 
 `artifacts.py` records metadata for local image and browser files.
-`disk_io.py` measures sparse disk copy and zstd decompression with native Rust
-helpers enabled and forced off. `file_transfer.py` starts one sandbox and times
-upload/download for several file sizes plus a directory tar round trip when the
-selected control channel supports it.
+`disk_io.py` measures sparse disk copy, which keeps long zero-filled regions
+from using real disk space, and zstd decompression, which expands files
+compressed with the zstd format, with native Rust helpers enabled and forced
+off. `file_transfer.py` starts one sandbox and times upload/download for several
+file sizes plus a directory tar round trip, meaning pack a folder into one tar
+archive, send it, and unpack or fetch it again, when the selected control
+channel supports it.
 `preset_start.py` times `smolvm <preset> start` and cleans up the sandbox unless
 `--keep` is set. `browser_ready.py` starts a browser sandbox, then polls the CDP
 endpoint, which is the local browser debugging URL, when it is available.

--- a/scripts/benchmarks/disk_io.py
+++ b/scripts/benchmarks/disk_io.py
@@ -1,0 +1,308 @@
+#!/usr/bin/env python3
+# Copyright 2026 Celesto AI
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Measure host disk copy and zstd decompression helpers."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import os
+import shutil
+import sys
+import tempfile
+import time
+from collections.abc import Iterator
+from contextlib import contextmanager
+from pathlib import Path
+from typing import Any
+
+try:
+    from .reporting import finish_report, print_report, start_report
+except ImportError:  # pragma: no cover - script execution path
+    sys.path.insert(0, str(Path(__file__).resolve().parent))
+    from reporting import finish_report, print_report, start_report
+
+_REPO_ROOT = Path(__file__).resolve().parent.parent.parent
+sys.path.insert(0, str(_REPO_ROOT / "src"))
+
+DISK_DISABLE_ENV = "SMOLVM_DISABLE_NATIVE_DISK"
+VARIANTS = ("native", "forced-off")
+OPERATIONS = ("copy", "decompress")
+SIZE_SUFFIXES = {
+    "b": 1,
+    "k": 1024,
+    "kb": 1024,
+    "kib": 1024,
+    "m": 1024 * 1024,
+    "mb": 1024 * 1024,
+    "mib": 1024 * 1024,
+    "g": 1024 * 1024 * 1024,
+    "gb": 1024 * 1024 * 1024,
+    "gib": 1024 * 1024 * 1024,
+}
+
+
+@contextmanager
+def disk_variant(variant: str) -> Iterator[None]:
+    old_value = os.environ.get(DISK_DISABLE_ENV)
+    try:
+        if variant == "forced-off":
+            os.environ[DISK_DISABLE_ENV] = "1"
+        else:
+            os.environ.pop(DISK_DISABLE_ENV, None)
+        yield
+    finally:
+        if old_value is None:
+            os.environ.pop(DISK_DISABLE_ENV, None)
+        else:
+            os.environ[DISK_DISABLE_ENV] = old_value
+
+
+def parse_size(raw: str) -> int:
+    text = raw.strip().lower()
+    if not text:
+        raise argparse.ArgumentTypeError("size cannot be empty")
+    number = text.rstrip("abcdefghijklmnopqrstuvwxyz")
+    suffix = text[len(number) :] or "b"
+    if suffix not in SIZE_SUFFIXES:
+        raise argparse.ArgumentTypeError(f"unsupported size suffix in {raw!r}")
+    try:
+        value = float(number)
+    except ValueError as exc:
+        raise argparse.ArgumentTypeError(f"invalid size {raw!r}") from exc
+    size = int(value * SIZE_SUFFIXES[suffix])
+    if size < 1:
+        raise argparse.ArgumentTypeError("size must be at least 1 byte")
+    return size
+
+
+def parse_csv(raw: str, *, allowed: tuple[str, ...]) -> list[str]:
+    values = [item.strip() for item in raw.split(",") if item.strip()]
+    unknown = sorted(set(values) - set(allowed))
+    if unknown:
+        raise argparse.ArgumentTypeError(f"unknown value(s): {', '.join(unknown)}")
+    if not values:
+        raise argparse.ArgumentTypeError("at least one value is required")
+    return values
+
+
+def allocated_bytes(path: Path) -> int | None:
+    try:
+        return path.stat().st_blocks * 512
+    except (AttributeError, OSError):
+        return None
+
+
+def sha256_file(path: Path) -> str:
+    hasher = hashlib.sha256()
+    with path.open("rb") as handle:
+        for chunk in iter(lambda: handle.read(1024 * 1024), b""):
+            hasher.update(chunk)
+    return hasher.hexdigest()
+
+
+def write_sparse_source(path: Path, *, size: int) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    chunk_size = min(1024 * 1024, size)
+    anchors = sorted({0, max(0, size // 2 - chunk_size // 2), max(0, size - chunk_size)})
+    with path.open("wb") as handle:
+        for offset in anchors:
+            handle.seek(offset)
+            handle.write(_deterministic_block(offset, chunk_size))
+        handle.truncate(size)
+
+
+def _deterministic_block(offset: int, size: int) -> bytes:
+    seed = hashlib.sha256(f"smolvm-disk-benchmark:{offset}".encode()).digest()
+    repeats = (size // len(seed)) + 1
+    return (seed * repeats)[:size]
+
+
+def compress_zstd(source: Path, target: Path) -> float:
+    import zstandard
+
+    started = time.monotonic()
+    with source.open("rb") as src, target.open("wb") as dst:
+        compressor = zstandard.ZstdCompressor(level=3)
+        with compressor.stream_writer(dst) as writer:
+            shutil.copyfileobj(src, writer, length=1024 * 1024)
+    return elapsed_ms(started)
+
+
+def elapsed_ms(started: float) -> float:
+    return round((time.monotonic() - started) * 1000, 1)
+
+
+def dry_run_records(
+    args: argparse.Namespace,
+    sizes: list[int],
+    operations: list[str],
+) -> list[dict]:
+    records = []
+    for iteration in range(args.iterations):
+        for size in sizes:
+            for operation in operations:
+                for variant in args.variants:
+                    records.append(
+                        {
+                            "iter": iteration,
+                            "operation": operation,
+                            "variant": variant,
+                            "size_bytes": size,
+                            "status": "dry-run",
+                            "would_generate_sparse_source": True,
+                        }
+                    )
+    return records
+
+
+def run_records(args: argparse.Namespace, sizes: list[int], operations: list[str]) -> list[dict]:
+    from smolvm.host import disk as disk_helpers
+
+    base_dir = args.work_dir or Path(tempfile.mkdtemp(prefix="smolvm-disk-bench-"))
+    base_dir = base_dir.expanduser()
+    base_dir.mkdir(parents=True, exist_ok=True)
+    records: list[dict[str, Any]] = []
+    try:
+        for iteration in range(args.iterations):
+            for size in sizes:
+                source = base_dir / f"source-{iteration}-{size}.img"
+                compressed = base_dir / f"source-{iteration}-{size}.img.zst"
+                write_sparse_source(source, size=size)
+                source_hash = sha256_file(source)
+                compress_ms = (
+                    compress_zstd(source, compressed) if "decompress" in operations else None
+                )
+
+                for operation in operations:
+                    for variant in args.variants:
+                        record = {
+                            "iter": iteration,
+                            "operation": operation,
+                            "variant": variant,
+                            "size_bytes": size,
+                            "source_allocated_bytes": allocated_bytes(source),
+                            "source_sha256": source_hash,
+                        }
+                        if compress_ms is not None:
+                            record["zstd_prepare_ms"] = compress_ms
+                            record["zstd_bytes"] = compressed.stat().st_size
+                        with disk_variant(variant):
+                            if variant == "native" and not disk_helpers.has_native_disk_io():
+                                record["status"] = "skipped"
+                                record["reason"] = "native disk helpers are unavailable"
+                                records.append(record)
+                                continue
+                            target = base_dir / f"{operation}-{variant}-{iteration}-{size}.img"
+                            started = time.monotonic()
+                            if operation == "copy":
+                                method = disk_helpers.clone_or_sparse_copy(source, target)
+                            else:
+                                method = disk_helpers.decompress_zstd_sparse(
+                                    compressed,
+                                    target,
+                                    chunk_size=args.chunk_size,
+                                )
+                            record.update(
+                                {
+                                    "status": "ok",
+                                    "duration_ms": elapsed_ms(started),
+                                    "method": method,
+                                    "target_bytes": target.stat().st_size,
+                                    "target_allocated_bytes": allocated_bytes(target),
+                                    "target_sha256": sha256_file(target),
+                                    "sha256_match": sha256_file(target) == source_hash,
+                                }
+                            )
+                            records.append(record)
+        return records
+    finally:
+        if not args.keep and args.work_dir is None:
+            shutil.rmtree(base_dir, ignore_errors=True)
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--iterations", type=int, default=1)
+    parser.add_argument("--sizes", default="16M,128M")
+    parser.add_argument("--operations", default="copy,decompress")
+    parser.add_argument("--variants", default="native,forced-off")
+    parser.add_argument("--chunk-size", type=int, default=1024 * 1024)
+    parser.add_argument("--work-dir", type=Path, default=None)
+    parser.add_argument("--keep", action="store_true", help="Keep generated benchmark files.")
+    parser.add_argument("--dry-run", action="store_true", help="Print the benchmark plan only.")
+    parser.add_argument("--json", action="store_true", help="Print JSON.")
+    parser.add_argument("--output", type=Path, help="Optional JSON output path.")
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = build_parser()
+    args = parser.parse_args(argv)
+    if args.iterations < 1:
+        parser.error("--iterations must be >= 1")
+    if args.chunk_size < 1:
+        parser.error("--chunk-size must be >= 1")
+    try:
+        sizes = [parse_size(raw) for raw in args.sizes.split(",") if raw.strip()]
+        operations = parse_csv(args.operations, allowed=OPERATIONS)
+        args.variants = parse_csv(args.variants, allowed=VARIANTS)
+    except argparse.ArgumentTypeError as exc:
+        parser.error(str(exc))
+    if not sizes:
+        parser.error("--sizes must include at least one size")
+
+    config = {
+        "iterations": args.iterations,
+        "sizes_bytes": sizes,
+        "operations": operations,
+        "variants": args.variants,
+        "chunk_size": args.chunk_size,
+        "work_dir": str(args.work_dir.expanduser()) if args.work_dir else None,
+        "keep": args.keep,
+    }
+    report, started = start_report("disk_io", config=config, dry_run=args.dry_run)
+    report["records"] = (
+        dry_run_records(args, sizes, operations)
+        if args.dry_run
+        else run_records(args, sizes, operations)
+    )
+    finish_report(report, started)
+    print_report(
+        report,
+        json_output=args.json,
+        output=args.output,
+        human_lines=_human_lines(report),
+    )
+    ok_statuses = {"ok", "skipped", "dry-run"}
+    return 0 if all(record.get("status") in ok_statuses for record in report["records"]) else 1
+
+
+def _human_lines(report: dict[str, Any]) -> list[str]:
+    lines = ["Disk I/O:"]
+    for record in report["records"]:
+        label = f"{record['operation']} {record['variant']} {record['size_bytes']} bytes"
+        if record["status"] == "ok":
+            lines.append(f"  {label}: {record['duration_ms']} ms ({record['method']})")
+        elif record["status"] == "skipped":
+            lines.append(f"  {label}: skipped - {record['reason']}")
+        else:
+            lines.append(f"  {label}: {record['status']}")
+    return lines
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/benchmarks/disk_io.py
+++ b/scripts/benchmarks/disk_io.py
@@ -19,6 +19,7 @@ from __future__ import annotations
 
 import argparse
 import hashlib
+import math
 import os
 import shutil
 import sys
@@ -83,7 +84,12 @@ def parse_size(raw: str) -> int:
         value = float(number)
     except ValueError as exc:
         raise argparse.ArgumentTypeError(f"invalid size {raw!r}") from exc
-    size = int(value * SIZE_SUFFIXES[suffix])
+    if not math.isfinite(value):
+        raise argparse.ArgumentTypeError(f"invalid size {raw!r}")
+    try:
+        size = int(value * SIZE_SUFFIXES[suffix])
+    except OverflowError as exc:
+        raise argparse.ArgumentTypeError(f"size is too large: {raw!r}") from exc
     if size < 1:
         raise argparse.ArgumentTypeError("size must be at least 1 byte")
     return size
@@ -216,6 +222,7 @@ def run_records(args: argparse.Namespace, sizes: list[int], operations: list[str
                                     target,
                                     chunk_size=args.chunk_size,
                                 )
+                            target_hash = sha256_file(target)
                             record.update(
                                 {
                                     "status": "ok",
@@ -223,8 +230,8 @@ def run_records(args: argparse.Namespace, sizes: list[int], operations: list[str
                                     "method": method,
                                     "target_bytes": target.stat().st_size,
                                     "target_allocated_bytes": allocated_bytes(target),
-                                    "target_sha256": sha256_file(target),
-                                    "sha256_match": sha256_file(target) == source_hash,
+                                    "target_sha256": target_hash,
+                                    "sha256_match": target_hash == source_hash,
                                 }
                             )
                             records.append(record)

--- a/scripts/benchmarks/file_transfer.py
+++ b/scripts/benchmarks/file_transfer.py
@@ -1,0 +1,364 @@
+#!/usr/bin/env python3
+# Copyright 2026 Celesto AI
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Measure file and directory transfer through SmolVM control channels."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import shutil
+import sys
+import tempfile
+import time
+import uuid
+from collections.abc import Callable
+from contextlib import suppress
+from pathlib import Path
+from typing import Any
+
+try:
+    from .disk_io import parse_size
+    from .reporting import finish_report, print_report, start_report
+except ImportError:  # pragma: no cover - script execution path
+    sys.path.insert(0, str(Path(__file__).resolve().parent))
+    from disk_io import parse_size  # type: ignore[no-redef]
+    from reporting import finish_report, print_report, start_report
+
+_REPO_ROOT = Path(__file__).resolve().parent.parent.parent
+sys.path.insert(0, str(_REPO_ROOT / "src"))
+
+
+def elapsed_ms(started: float) -> float:
+    return round((time.monotonic() - started) * 1000, 1)
+
+
+def sha256_file(path: Path) -> str:
+    hasher = hashlib.sha256()
+    with path.open("rb") as handle:
+        for chunk in iter(lambda: handle.read(1024 * 1024), b""):
+            hasher.update(chunk)
+    return hasher.hexdigest()
+
+
+def write_payload(path: Path, *, size: int) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    block = hashlib.sha256(f"smolvm-transfer-benchmark:{size}".encode()).digest()
+    remaining = size
+    with path.open("wb") as handle:
+        while remaining > 0:
+            chunk = (block * 32768)[: min(remaining, 1024 * 1024)]
+            handle.write(chunk)
+            remaining -= len(chunk)
+
+
+def create_directory_payload(path: Path, *, files: int, file_size: int) -> None:
+    path.mkdir(parents=True, exist_ok=True)
+    for index in range(files):
+        write_payload(path / f"file-{index:05d}.bin", size=file_size)
+
+
+def directory_digest(path: Path) -> str:
+    hasher = hashlib.sha256()
+    for child in sorted(item for item in path.rglob("*") if item.is_file()):
+        hasher.update(str(child.relative_to(path)).encode())
+        hasher.update(b"\0")
+        hasher.update(sha256_file(child).encode())
+        hasher.update(b"\0")
+    return hasher.hexdigest()
+
+
+def dry_run_records(args: argparse.Namespace, sizes: list[int]) -> list[dict[str, Any]]:
+    records = []
+    for iteration in range(args.iterations):
+        for size in sizes:
+            records.append(
+                {
+                    "iter": iteration,
+                    "operation": "file_round_trip",
+                    "size_bytes": size,
+                    "status": "dry-run",
+                    "would_start_vm": True,
+                    "backend": args.backend,
+                    "comm_channel": args.comm_channel,
+                }
+            )
+        if not args.skip_directory:
+            records.append(
+                {
+                    "iter": iteration,
+                    "operation": "directory_round_trip",
+                    "files": args.directory_files,
+                    "file_size_bytes": args.directory_file_size,
+                    "status": "dry-run",
+                    "would_start_vm": True,
+                    "backend": args.backend,
+                    "comm_channel": args.comm_channel,
+                }
+            )
+    return records
+
+
+def run_iteration(args: argparse.Namespace, iteration: int, sizes: list[int]) -> dict[str, Any]:
+    from smolvm.facade import SmolVM
+
+    sandbox_hint = f"{args.name_prefix}-{uuid.uuid4().hex[:8]}"
+    workspace = Path(tempfile.mkdtemp(prefix=f"smolvm-transfer-{iteration}-"))
+    record: dict[str, Any] = {
+        "iter": iteration,
+        "sandbox_hint": sandbox_hint,
+        "backend": args.backend,
+        "comm_channel": args.comm_channel,
+        "cleanup_expected": not args.keep,
+        "file_records": [],
+        "directory_record": None,
+    }
+    vm = SmolVM(
+        backend=args.backend,
+        os=args.os,
+        comm_channel=None if args.comm_channel == "auto" else args.comm_channel,
+        memory=args.memory_mib,
+        disk_size=args.disk_size_mib,
+    )
+    try:
+        started = time.monotonic()
+        vm.start(boot_timeout=args.boot_timeout)
+        record["start_ms"] = elapsed_ms(started)
+        record["sandbox"] = vm._vm_id  # noqa: SLF001
+        started = time.monotonic()
+        vm.wait_for_ready(timeout=args.ready_timeout)
+        record["ready_ms"] = elapsed_ms(started)
+
+        for size in sizes:
+            record["file_records"].append(measure_file_round_trip(vm, workspace, size=size))
+        if not args.skip_directory:
+            record["directory_record"] = measure_directory_round_trip(
+                vm,
+                workspace,
+                files=args.directory_files,
+                file_size=args.directory_file_size,
+            )
+        record["status"] = "ok"
+    except Exception as exc:  # noqa: BLE001
+        record["status"] = "error"
+        record["error"] = str(exc)
+        record["error_type"] = type(exc).__name__
+    finally:
+        if not args.keep:
+            started = time.monotonic()
+            with suppress(Exception):
+                vm.stop(timeout=15.0)
+            with suppress(Exception):
+                vm.delete()
+            record["cleanup_ms"] = elapsed_ms(started)
+        shutil.rmtree(workspace, ignore_errors=True)
+    return record
+
+
+def measure_file_round_trip(vm: Any, workspace: Path, *, size: int) -> dict[str, Any]:
+    source = workspace / f"source-{size}.bin"
+    target = workspace / f"download-{size}.bin"
+    remote = f"/tmp/smolvm-transfer-bench/file-{size}.bin"
+    write_payload(source, size=size)
+    source_hash = sha256_file(source)
+
+    started = time.monotonic()
+    vm.upload_file(source, remote)
+    upload_ms = elapsed_ms(started)
+
+    started = time.monotonic()
+    vm.download_file(remote, target)
+    download_ms = elapsed_ms(started)
+
+    return {
+        "operation": "file_round_trip",
+        "size_bytes": size,
+        "upload_ms": upload_ms,
+        "download_ms": download_ms,
+        "sha256_match": sha256_file(target) == source_hash,
+    }
+
+
+def measure_directory_round_trip(
+    vm: Any,
+    workspace: Path,
+    *,
+    files: int,
+    file_size: int,
+) -> dict[str, Any]:
+    source = workspace / "dir-source"
+    target = workspace / "dir-download"
+    remote = "/tmp/smolvm-transfer-bench/directory"
+    create_directory_payload(source, files=files, file_size=file_size)
+    source_digest = directory_digest(source)
+
+    channel = vm._ensure_control_for_file_transfer()  # noqa: SLF001
+    put_directory: Callable[[Path, str], None] | None = getattr(channel, "put_directory", None)
+    get_directory: Callable[[str, Path], Path] | None = getattr(channel, "get_directory", None)
+    supports = getattr(channel, "supports", None)
+    features = {
+        "files.stream": bool(callable(supports) and supports("file_raw", "files.stream")),
+        "files.directory_tar": bool(
+            callable(supports) and supports("dir_tar", "files.directory_tar")
+        ),
+    }
+    if put_directory is None or get_directory is None:
+        return {
+            "operation": "directory_round_trip",
+            "status": "skipped",
+            "reason": "selected control channel does not expose directory transfer",
+            "features": features,
+        }
+
+    started = time.monotonic()
+    put_directory(source, remote)
+    upload_ms = elapsed_ms(started)
+
+    started = time.monotonic()
+    get_directory(remote, target)
+    download_ms = elapsed_ms(started)
+
+    return {
+        "operation": "directory_round_trip",
+        "status": "ok",
+        "files": files,
+        "file_size_bytes": file_size,
+        "total_payload_bytes": files * file_size,
+        "upload_ms": upload_ms,
+        "download_ms": download_ms,
+        "digest_match": directory_digest(target) == source_digest,
+        "features": features,
+    }
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--iterations", type=int, default=1)
+    parser.add_argument("--sizes", default="1K,1M,16M")
+    parser.add_argument(
+        "--backend",
+        choices=("auto", "firecracker", "qemu", "libkrun"),
+        default="auto",
+    )
+    parser.add_argument("--comm-channel", choices=("auto", "vsock", "ssh"), default="auto")
+    parser.add_argument("--os", choices=("alpine", "ubuntu"), default="alpine")
+    parser.add_argument("--name-prefix", default="bench-transfer")
+    parser.add_argument("--memory", dest="memory_mib", type=int, default=None)
+    parser.add_argument("--disk-size", dest="disk_size_mib", type=int, default=None)
+    parser.add_argument("--boot-timeout", type=float, default=90.0)
+    parser.add_argument("--ready-timeout", type=float, default=90.0)
+    parser.add_argument("--directory-files", type=int, default=200)
+    parser.add_argument("--directory-file-size", type=parse_size, default=parse_size("4K"))
+    parser.add_argument("--skip-directory", action="store_true")
+    parser.add_argument("--keep", action="store_true", help="Leave created sandboxes running.")
+    parser.add_argument("--dry-run", action="store_true", help="Print the benchmark plan only.")
+    parser.add_argument("--json", action="store_true", help="Print JSON.")
+    parser.add_argument("--output", type=Path, help="Optional JSON output path.")
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = build_parser()
+    args = parser.parse_args(argv)
+    if args.iterations < 1:
+        parser.error("--iterations must be >= 1")
+    for option in ("boot_timeout", "ready_timeout"):
+        if getattr(args, option) <= 0:
+            parser.error(f"--{option.replace('_', '-')} must be > 0")
+    if args.directory_files < 1:
+        parser.error("--directory-files must be >= 1")
+    sizes = [parse_size(raw) for raw in args.sizes.split(",") if raw.strip()]
+    if not sizes:
+        parser.error("--sizes must include at least one size")
+
+    config = {
+        "iterations": args.iterations,
+        "sizes_bytes": sizes,
+        "backend": args.backend,
+        "comm_channel": args.comm_channel,
+        "os": args.os,
+        "name_prefix": args.name_prefix,
+        "memory_mib": args.memory_mib,
+        "disk_size_mib": args.disk_size_mib,
+        "boot_timeout": args.boot_timeout,
+        "ready_timeout": args.ready_timeout,
+        "directory_files": args.directory_files,
+        "directory_file_size": args.directory_file_size,
+        "skip_directory": args.skip_directory,
+        "keep": args.keep,
+    }
+    report, started = start_report("file_transfer", config=config, dry_run=args.dry_run)
+    report["records"] = (
+        dry_run_records(args, sizes)
+        if args.dry_run
+        else [run_iteration(args, iteration, sizes) for iteration in range(args.iterations)]
+    )
+    finish_report(report, started)
+    print_report(
+        report,
+        json_output=args.json,
+        output=args.output,
+        human_lines=_human_lines(report),
+    )
+    return 0 if all(_record_ok(record) for record in report["records"]) else 1
+
+
+def _record_ok(record: dict[str, Any]) -> bool:
+    if record.get("status") == "dry-run":
+        return True
+    if record.get("status") != "ok":
+        return False
+    files = record.get("file_records", [])
+    if not all(item.get("sha256_match") for item in files):
+        return False
+    directory = record.get("directory_record")
+    if isinstance(directory, dict) and directory.get("status") == "ok":
+        return bool(directory.get("digest_match"))
+    return True
+
+
+def _human_lines(report: dict[str, Any]) -> list[str]:
+    lines = ["File transfer:"]
+    for record in report["records"]:
+        if record.get("status") == "dry-run":
+            lines.append(
+                f"  {record['operation']} {record.get('size_bytes', record.get('files'))}: dry-run"
+            )
+            continue
+        lines.append(
+            f"  {record.get('sandbox', record.get('sandbox_hint'))}: {record['status']} "
+            f"(start={record.get('start_ms')} ms, ready={record.get('ready_ms')} ms)"
+        )
+        for item in record.get("file_records", []):
+            lines.append(
+                f"    file {item['size_bytes']} bytes: upload={item['upload_ms']} ms, "
+                f"download={item['download_ms']} ms"
+            )
+        directory = record.get("directory_record")
+        if isinstance(directory, dict):
+            if directory.get("status") == "ok":
+                lines.append(
+                    f"    directory {directory['files']} file(s): "
+                    f"upload={directory['upload_ms']} ms, download={directory['download_ms']} ms"
+                )
+            else:
+                lines.append(
+                    f"    directory: {directory.get('status')} - {directory.get('reason')}"
+                )
+    return lines
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/benchmarks/file_transfer.py
+++ b/scripts/benchmarks/file_transfer.py
@@ -279,7 +279,10 @@ def main(argv: list[str] | None = None) -> int:
             parser.error(f"--{option.replace('_', '-')} must be > 0")
     if args.directory_files < 1:
         parser.error("--directory-files must be >= 1")
-    sizes = [parse_size(raw) for raw in args.sizes.split(",") if raw.strip()]
+    try:
+        sizes = [parse_size(raw) for raw in args.sizes.split(",") if raw.strip()]
+    except argparse.ArgumentTypeError as exc:
+        parser.error(f"invalid --sizes value {args.sizes!r}: {exc}")
     if not sizes:
         parser.error("--sizes must include at least one size")
 

--- a/src/smolvm/comm/rust_http_vsock_channel.py
+++ b/src/smolvm/comm/rust_http_vsock_channel.py
@@ -137,9 +137,15 @@ def _parse_size_header(value: str, *, header: str, method: str, path: str) -> in
 
 def _directory_to_tar(source: Path) -> bytes:
     buffer = io.BytesIO()
-    with tarfile.open(fileobj=buffer, mode="w", format=tarfile.USTAR_FORMAT) as archive:
-        for child in sorted(source.iterdir()):
-            _add_tar_path(archive, child, PurePosixPath(child.name))
+    try:
+        with tarfile.open(fileobj=buffer, mode="w", format=tarfile.USTAR_FORMAT) as archive:
+            for child in sorted(source.iterdir()):
+                _add_tar_path(archive, child, PurePosixPath(child.name))
+    except (tarfile.TarError, ValueError) as exc:
+        raise SmolVMError(
+            "Directory cannot be uploaded because a file path is too long "
+            "for the portable tar format."
+        ) from exc
     return buffer.getvalue()
 
 

--- a/src/smolvm/comm/rust_http_vsock_channel.py
+++ b/src/smolvm/comm/rust_http_vsock_channel.py
@@ -137,7 +137,7 @@ def _parse_size_header(value: str, *, header: str, method: str, path: str) -> in
 
 def _directory_to_tar(source: Path) -> bytes:
     buffer = io.BytesIO()
-    with tarfile.open(fileobj=buffer, mode="w") as archive:
+    with tarfile.open(fileobj=buffer, mode="w", format=tarfile.USTAR_FORMAT) as archive:
         for child in sorted(source.iterdir()):
             _add_tar_path(archive, child, PurePosixPath(child.name))
     return buffer.getvalue()

--- a/tests/test_benchmark_foundation.py
+++ b/tests/test_benchmark_foundation.py
@@ -18,7 +18,14 @@ import json
 from pathlib import Path
 from typing import Any
 
-from scripts.benchmarks import artifacts, browser_ready, preset_start, runtime_control
+from scripts.benchmarks import (
+    artifacts,
+    browser_ready,
+    disk_io,
+    file_transfer,
+    preset_start,
+    runtime_control,
+)
 
 
 def test_artifacts_dry_run_json_reports_scan_plan(capsys, tmp_path: Path) -> None:
@@ -105,6 +112,67 @@ def test_runtime_control_dry_run_json_plans_noun_verb_lifecycle(capsys) -> None:
         ["sandbox", "start"],
     ]
     assert record["cleanup"]["command"][:3] == ["smolvm", "sandbox", "delete"]
+
+
+def test_disk_io_dry_run_json_reports_variants_and_operations(capsys) -> None:
+    rc = disk_io.main(
+        [
+            "--dry-run",
+            "--json",
+            "--sizes",
+            "1K",
+            "--operations",
+            "copy,decompress",
+            "--variants",
+            "native,forced-off",
+        ]
+    )
+
+    assert rc == 0
+    report = json.loads(capsys.readouterr().out)
+    assert report["script"] == "disk_io"
+    assert report["dry_run"] is True
+    assert [record["operation"] for record in report["records"]] == [
+        "copy",
+        "copy",
+        "decompress",
+        "decompress",
+    ]
+    assert {record["variant"] for record in report["records"]} == {"native", "forced-off"}
+    assert {record["size_bytes"] for record in report["records"]} == {1024}
+
+
+def test_file_transfer_dry_run_json_reports_files_and_directory(capsys) -> None:
+    rc = file_transfer.main(
+        [
+            "--dry-run",
+            "--json",
+            "--sizes",
+            "1K,2K",
+            "--directory-files",
+            "3",
+            "--directory-file-size",
+            "4K",
+            "--backend",
+            "qemu",
+            "--comm-channel",
+            "vsock",
+        ]
+    )
+
+    assert rc == 0
+    report = json.loads(capsys.readouterr().out)
+    assert report["script"] == "file_transfer"
+    assert report["dry_run"] is True
+    assert [record["operation"] for record in report["records"]] == [
+        "file_round_trip",
+        "file_round_trip",
+        "directory_round_trip",
+    ]
+    assert report["records"][0]["backend"] == "qemu"
+    assert report["records"][0]["comm_channel"] == "vsock"
+    assert report["records"][2]["files"] == 3
+    assert report["records"][2]["file_size_bytes"] == 4096
 
 
 def test_preset_start_attempts_cleanup_after_start_failure(monkeypatch, capsys) -> None:

--- a/tests/test_rust_http_vsock_channel.py
+++ b/tests/test_rust_http_vsock_channel.py
@@ -475,6 +475,16 @@ def test_directory_tar_strips_owner_metadata(tmp_path: Path) -> None:
     assert key_member.mode & 0o777 == 0o600
 
 
+def test_directory_tar_wraps_ustar_path_limit_errors(tmp_path: Path) -> None:
+    source = tmp_path / "source"
+    source.mkdir()
+    long_name = "a" * 120
+    (source / long_name).write_text("too long for ustar")
+
+    with pytest.raises(SmolVMError, match="file path is too long"):
+        _directory_to_tar(source)
+
+
 def test_legacy_directory_download_uses_guest_mktemp(tmp_path: Path) -> None:
     archive = io.BytesIO()
     with tarfile.open(fileobj=archive, mode="w") as tar:

--- a/tests/test_rust_http_vsock_channel.py
+++ b/tests/test_rust_http_vsock_channel.py
@@ -464,6 +464,7 @@ def test_directory_tar_strips_owner_metadata(tmp_path: Path) -> None:
 
     data = _directory_to_tar(source)
 
+    assert b"././@PaxHeader" not in data
     with tarfile.open(fileobj=io.BytesIO(data), mode="r:") as archive:
         members = archive.getmembers()
 


### PR DESCRIPTION
## Summary

Bundles the next Rust-migration measurement work into one benchmark PR:

- adds `scripts/benchmarks/disk_io.py` to compare native vs forced-off sparse copy and zstd decompression helpers
- adds `scripts/benchmarks/file_transfer.py` to measure file upload/download sizes and directory tar round trips through the selected control channel
- documents the post-merge benchmark bundle commands in `scripts/benchmarks/README.md`
- fixes a directory transfer issue found by the live benchmark smoke: Python now emits USTAR tar archives so the guest-agent extractor does not reject PAX headers as unsupported entries

## Validation

- `uv run ruff check scripts/benchmarks/disk_io.py scripts/benchmarks/file_transfer.py src/smolvm/comm/rust_http_vsock_channel.py tests/test_benchmark_foundation.py tests/test_rust_http_vsock_channel.py`
- `uv run ruff format --check scripts/benchmarks/disk_io.py scripts/benchmarks/file_transfer.py src/smolvm/comm/rust_http_vsock_channel.py tests/test_benchmark_foundation.py tests/test_rust_http_vsock_channel.py`
- `PYTHONPATH=$PWD uv run pytest tests/test_benchmark_foundation.py tests/test_rust_http_vsock_channel.py -q`
- `uv run python scripts/benchmarks/disk_io.py --dry-run --json --sizes 1K --operations copy,decompress --variants native,forced-off`
- `uv run python scripts/benchmarks/file_transfer.py --dry-run --json --sizes 1K --directory-files 2 --directory-file-size 1K`
- `uv run python scripts/benchmarks/disk_io.py --json --sizes 1M --iterations 1 --output /tmp/smolvm-disk-io-smoke.json`
- `uv run python scripts/benchmarks/file_transfer.py --backend qemu --comm-channel vsock --sizes 1K --directory-files 2 --directory-file-size 1K --json --output /tmp/smolvm-file-transfer-smoke.json`

## Follow-up

The QEMU explicit preset SSH fallback timeout is intentionally not fixed here. That changes runtime fallback behavior and should be a small separate correctness PR.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added disk I/O benchmarking to measure sparse file operations and compression decompression.
  * Added file transfer benchmarking to measure upload/download performance through control channels.

* **Documentation**
  * Updated benchmark documentation with new script examples, dry-run instructions, and command references.

* **Improvements**
  * Standardized tar archive format for improved directory transfer compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->