### PR TITLE
Start QEMU presets over the control channel

### DIFF
--- a/src/smolvm/api.py
+++ b/src/smolvm/api.py
@@ -54,6 +54,25 @@ def _native_firecracker_available() -> bool:
         return False
 
 
+def _is_instance_start_request(
+    method: str,
+    path: str,
+    body: dict[str, Any] | None,
+) -> bool:
+    """Return whether a request asks Firecracker to start the microVM."""
+    return (
+        method.upper() == "PUT"
+        and path == "/actions"
+        and body is not None
+        and body.get("action_type") == "InstanceStart"
+    )
+
+
+def _instance_start_already_succeeded(error_msg: str) -> bool:
+    """Return whether a replayed start request found the VM already running."""
+    return "not supported after starting the microVM" in error_msg
+
+
 class FirecrackerClient:
     """Client for the Firecracker HTTP API over Unix socket."""
 
@@ -114,6 +133,7 @@ class FirecrackerClient:
         url = self._socket_url(path)
         logger.debug("%s %s", method, path)
 
+        native_transport_error: OSError | None = None
         if self.socket_path.exists() and _native_firecracker_available():
             body_json = json_module.dumps(json, separators=(",", ":")) if json is not None else None
             try:
@@ -125,6 +145,7 @@ class FirecrackerClient:
                     10.0,
                 )
             except OSError as e:
+                native_transport_error = e
                 logger.debug(
                     "Native Firecracker request failed, falling back to requests-unixsocket: %s",
                     e,
@@ -168,6 +189,17 @@ class FirecrackerClient:
                 error_msg = error_data.get("fault_message", error_msg)
             except Exception:
                 pass
+            if (
+                native_transport_error is not None
+                and _is_instance_start_request(method, path, json)
+                and _instance_start_already_succeeded(error_msg)
+            ):
+                logger.debug(
+                    "Treating replayed InstanceStart as successful after native "
+                    "transport error: %s",
+                    native_transport_error,
+                )
+                return None
             raise FirecrackerAPIError(
                 f"API error: {error_msg}",
                 status_code=response.status_code,

--- a/src/smolvm/cli/commands/app.py
+++ b/src/smolvm/cli/commands/app.py
@@ -905,6 +905,7 @@ def _register_preset_commands() -> None:
             @click.option("--writable-mounts", is_flag=True)
             @click.option("--install-timeout", type=positive_float_type(), default=600.0)
             @click.option("--attach/--no-attach", default=None)
+            @comm_channel_option
             @boot_timeout_option
             @json_option
             def start(
@@ -918,6 +919,7 @@ def _register_preset_commands() -> None:
                 writable_mounts: bool,
                 install_timeout: float,
                 attach: bool | None,
+                comm_channel: str | None,
                 boot_timeout: float,
                 json_output: bool,
             ) -> Any:
@@ -936,6 +938,7 @@ def _register_preset_commands() -> None:
                         writable_mounts=writable_mounts,
                         install_timeout=install_timeout,
                         attach=attach,
+                        comm_channel=comm_channel,
                         boot_timeout=boot_timeout,
                         json=json_output,
                     )

--- a/src/smolvm/cli/main.py
+++ b/src/smolvm/cli/main.py
@@ -1289,6 +1289,7 @@ def _run_start_with_published_image(args: SimpleNamespace, preset: object) -> in
                 ssh_key_path=str(private_key),
                 mounts=args.mounts,
                 writable_mounts=args.writable_mounts,
+                comm_channel=getattr(args, "comm_channel", None),
             )
             vm.start(boot_timeout=args.boot_timeout)
             # Wait for the *resolved* control channel, not SSH specifically:

--- a/src/smolvm/cli/main.py
+++ b/src/smolvm/cli/main.py
@@ -1432,6 +1432,8 @@ def _run_start(args: SimpleNamespace) -> int:
                     on_download=on_download,
                 ),
                 boot_timeout=args.boot_timeout,
+                comm_channel=getattr(args, "comm_channel", None),
+                wait_for_control_channel=True,
                 mounts=args.mounts,
                 writable_mounts=args.writable_mounts,
             )
@@ -1457,6 +1459,11 @@ def _run_start(args: SimpleNamespace) -> int:
                 ssh_key_path=ssh_key_path,
                 mounts=args.mounts,
                 writable_mounts=args.writable_mounts,
+                **(
+                    {"comm_channel": args.comm_channel}
+                    if getattr(args, "comm_channel", None) is not None
+                    else {}
+                ),
             )
             vm.start(boot_timeout=args.boot_timeout)
             ssh = _preset_control_channel(vm, timeout=args.boot_timeout)
@@ -1631,24 +1638,7 @@ def _preset_control_channel(vm: object, *, timeout: float = 30.0) -> object:
     from smolvm.facade import SmolVM
 
     _vm: SmolVM = vm  # type: ignore[assignment]
-    try:
-        channel = _vm._ensure_control_for_operation(action="apply preset", timeout=timeout)
-        supports = getattr(channel, "supports", None)
-        if not callable(supports) or supports(
-            "file_raw",
-            "files.stream",
-            "dir_tar",
-            "files.directory_tar",
-            "env_managed",
-            "env.managed",
-        ):
-            return channel
-    except Exception:
-        # Control-channel setup is an optimization; SSH remains the supported fallback.
-        _vm.wait_for_ssh(timeout=timeout)
-        return _vm._ensure_ssh_for_env(timeout=timeout)
-    _vm.wait_for_ssh(timeout=timeout)
-    return _vm._ensure_ssh_for_env(timeout=timeout)
+    return _vm._ensure_control_for_operation(action="apply preset", timeout=timeout)
 
 
 def _render_vm_lifecycle_result(

--- a/src/smolvm/comm/rust_http_vsock_channel.py
+++ b/src/smolvm/comm/rust_http_vsock_channel.py
@@ -236,6 +236,7 @@ class _SocketHTTPConnection(http.client.HTTPConnection):
 
     def connect(self) -> None:
         self.sock = self._open_socket()
+        self.sock.settimeout(self.timeout)
 
 
 class RustHttpVsockChannel:

--- a/src/smolvm/presets/_install.py
+++ b/src/smolvm/presets/_install.py
@@ -139,7 +139,8 @@ def _run_install_phase(
     *phase* tags the SmolVMError context (``"setup"`` or ``"install"``) so
     JSON consumers can tell which step failed without parsing the message.
     """
-    result = ssh.run(script, timeout=install_timeout)
+    command = f"bash -lc {shlex.quote(script)}"
+    result = ssh.run(command, timeout=install_timeout, shell="raw")
     if not result.ok:
         stderr_tail = (result.stderr or "").strip().splitlines()[-20:]
         raise SmolVMError(

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -141,6 +141,32 @@ def test_native_firecracker_transport_error_falls_back_to_requests(tmp_path: Pat
     client.session.request.assert_called_once()
 
 
+def test_native_firecracker_transport_error_treats_replayed_start_as_success(
+    tmp_path: Path,
+) -> None:
+    """A native start may take effect even when its response read fails."""
+    socket_path = tmp_path / "fc.sock"
+    socket_path.touch()
+    native = MagicMock()
+    native.has_native_firecracker_api.return_value = True
+    native._firecracker_request.side_effect = OSError("connection reset")
+    client = _client(tmp_path)
+    client.session.request.return_value = _Response(
+        status_code=400,
+        payload={
+            "fault_message": (
+                "The requested operation is not supported after starting the microVM."
+            )
+        },
+    )
+
+    with patch("smolvm.api._native", native):
+        client.start_instance()
+
+    native._firecracker_request.assert_called_once()
+    client.session.request.assert_called_once()
+
+
 def test_native_firecracker_request_can_be_disabled(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -3979,6 +3979,53 @@ class TestPublishedImageLaunchPath:
     @patch("smolvm.facade.SmolVM")
     @patch("smolvm.utils.ensure_ssh_key")
     @patch("smolvm.images.published.ensure_published_image")
+    @patch("smolvm.cli.main.platform.machine", return_value="x86_64")
+    @patch("smolvm.cli.main.platform.system", return_value="Linux")
+    def test_published_path_threads_explicit_comm_channel(
+        self,
+        _mock_system: MagicMock,
+        _mock_machine: MagicMock,
+        mock_ensure_image: MagicMock,
+        mock_ensure_ssh_key: MagicMock,
+        mock_vm_cls: MagicMock,
+        _mock_subprocess: MagicMock,
+        tmp_path: Path,
+    ) -> None:
+        """Published images must honor an explicit control-channel choice."""
+        from smolvm.images.manager import LocalImage
+
+        kernel = tmp_path / "vmlinux.bin"
+        rootfs = tmp_path / "rootfs.ext4"
+        priv = tmp_path / "id_ed25519"
+        pub = tmp_path / "id_ed25519.pub"
+        for path in (kernel, rootfs, priv):
+            path.touch()
+        pub.write_text("ssh-ed25519 AAAAExampleKey user@host\n")
+
+        mock_ensure_image.return_value = LocalImage(
+            name="openclaw-v0.0.13-amd64-firecracker",
+            kernel_path=kernel,
+            rootfs_path=rootfs,
+        )
+        mock_ensure_ssh_key.return_value = (priv, pub)
+        mock_vm = MagicMock()
+        mock_vm.vm_id = "sbx-published-1"
+        mock_vm.info.status = VMState.RUNNING
+        mock_vm.info.config.backend = "firecracker"
+        mock_vm.info.network = MagicMock(spec=NetworkConfig)
+        mock_vm.info.network.guest_ip = "172.16.0.2"
+        mock_vm.info.network.ssh_host_port = 2200
+        mock_vm_cls.return_value = mock_vm
+
+        ret = main(["openclaw", "start", "--json", "--comm-channel", "ssh"])
+
+        assert ret == 0
+        assert mock_vm_cls.call_args.kwargs["comm_channel"] == "ssh"
+
+    @patch("smolvm.cli.main.subprocess.run")
+    @patch("smolvm.facade.SmolVM")
+    @patch("smolvm.utils.ensure_ssh_key")
+    @patch("smolvm.images.published.ensure_published_image")
     @patch("smolvm.cli.main.platform.machine", return_value="arm64")
     @patch("smolvm.cli.main.platform.system", return_value="Darwin")
     def test_published_path_reaps_vm_on_failure(

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -3283,7 +3283,8 @@ class TestCliStart:
             writable_mounts=False,
         )
         vm.start.assert_called_once_with(boot_timeout=30.0, on_progress=ANY)
-        vm.wait_for_ssh.assert_called_once_with(timeout=30.0, on_progress=ANY)
+        vm.wait_for_ready.assert_called_once_with(timeout=30.0, on_progress=ANY)
+        vm.wait_for_ssh.assert_not_called()
         mock_apply.assert_called_once()
         vm.close.assert_called_once()
 
@@ -3327,6 +3328,54 @@ class TestCliStart:
         assert payload["data"]["preset"]["name"] == "codex"
         assert payload["data"]["preset"]["injected_env_keys"] == ["OPENAI_API_KEY"]
         assert payload["data"]["next"]["ssh_command"] == "smolvm sandbox ssh sbx-1"
+
+    @patch("smolvm.images.published.is_preset_published", return_value=False)
+    @patch("smolvm.presets.apply_preset")
+    @patch("smolvm.facade._build_auto_config")
+    @patch("smolvm.facade.SmolVM")
+    def test_start_codex_json_threads_explicit_comm_channel(
+        self,
+        mock_vm_cls: MagicMock,
+        mock_build_auto_config: MagicMock,
+        mock_apply_fn: MagicMock,
+        _mock_is_published: MagicMock,
+        capsys: pytest.CaptureFixture,
+    ) -> None:
+        config = MagicMock(vm_id="sbx-1")
+        mock_build_auto_config.return_value = (config, "/tmp/id_ed25519")
+        vm = self._make_vm_mock("sbx-1")
+        mock_vm_cls.return_value = vm
+        mock_apply_fn.return_value = {
+            "preset": "codex",
+            "copied_configs": [],
+            "injected_env_keys": [],
+        }
+
+        ret = main(["codex", "start", "--name", "sbx-1", "--json", "--comm-channel", "ssh"])
+
+        assert ret == 0
+        mock_vm_cls.assert_called_once_with(
+            config,
+            ssh_key_path="/tmp/id_ed25519",
+            mounts=None,
+            writable_mounts=False,
+            comm_channel="ssh",
+        )
+        json.loads(capsys.readouterr().out)
+
+    def test_preset_control_channel_uses_resolved_control_without_ssh_fallback(self) -> None:
+        from smolvm.cli.main import _preset_control_channel
+
+        channel = object()
+        vm = MagicMock()
+        vm._ensure_control_for_operation.return_value = channel
+
+        assert _preset_control_channel(vm, timeout=12.0) is channel
+        vm._ensure_control_for_operation.assert_called_once_with(
+            action="apply preset",
+            timeout=12.0,
+        )
+        vm.wait_for_ssh.assert_not_called()
 
     @patch("smolvm.images.published.is_preset_published", return_value=False)
     @patch("smolvm.cli.main._apply_preset_with_progress")

--- a/tests/test_presets.py
+++ b/tests/test_presets.py
@@ -643,8 +643,10 @@ class TestApplyPreset:
         assert summary["injected_env_keys"] == ["MY_KEY"]
         assert summary["copied_configs"] == []
         # install command was run
-        commands_run = [call.args[0] for call in ssh.run.call_args_list]
-        assert any("true" in cmd for cmd in commands_run)
+        assert any(
+            call.args == ("bash -lc true",) and call.kwargs["shell"] == "raw"
+            for call in ssh.run.call_args_list
+        )
 
     def test_skips_missing_optional_config(
         self,

--- a/tests/test_rust_http_vsock_channel.py
+++ b/tests/test_rust_http_vsock_channel.py
@@ -35,6 +35,7 @@ from smolvm.comm.rust_http_vsock_channel import (
     ControlCapabilities,
     RustHttpVsockChannel,
     _directory_to_tar,
+    _SocketHTTPConnection,
 )
 from smolvm.exceptions import OperationTimeoutError, SmolVMError
 from smolvm.types import CommandResult
@@ -192,6 +193,19 @@ def test_from_uds_closes_socket_when_connect_rejected() -> None:
         server.close()
         thread.join(timeout=5)
         sock_dir.cleanup()
+
+
+def test_socket_http_connection_uses_request_timeout_for_reads() -> None:
+    host, guest = socket.socketpair()
+    host.settimeout(1.0)
+    try:
+        conn = _SocketHTTPConnection(lambda: host, timeout=123.0)
+        conn.connect()
+        assert conn.sock is not None
+        assert conn.sock.gettimeout() == 123.0
+    finally:
+        host.close()
+        guest.close()
 
 
 def test_run_maps_command_result() -> None:


### PR DESCRIPTION
## Summary
- route preset startup through the resolved control channel instead of waiting for SSH first
- thread `--comm-channel` through preset start commands so explicit SSH still remains selectable
- run preset setup/install snippets under bash over raw control execution
- fix HTTP-over-vsock request sockets so long `/exec` calls use the full request timeout instead of the short connect timeout

## Validation
- `uv run ruff check src/smolvm/comm/rust_http_vsock_channel.py src/smolvm/cli/main.py src/smolvm/cli/commands/app.py src/smolvm/presets/_install.py tests/test_rust_http_vsock_channel.py tests/test_cli.py tests/test_presets.py`
- `uv run ruff format --check src/smolvm/comm/rust_http_vsock_channel.py src/smolvm/cli/main.py src/smolvm/cli/commands/app.py src/smolvm/presets/_install.py tests/test_rust_http_vsock_channel.py tests/test_cli.py tests/test_presets.py`
- `PYTHONPATH=$PWD uv run pytest tests/test_rust_http_vsock_channel.py tests/test_cli.py tests/test_presets.py -q`
- `git diff --check`
- `uv run python scripts/benchmarks/preset_start.py --preset codex --backend qemu --json --output /tmp/smolvm-preset-codex-qemu-fixed3.json`

Live benchmark result: QEMU Codex preset start succeeded in `33149.7 ms`; cleanup succeeded in `391.8 ms`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `--comm-channel` option to the `start` CLI command, forwarding the choice through VM startup.
* **Bug Fixes**
  * Fixed HTTP request timeout propagation for socket-based connections.
  * Improved install script execution by running it via `bash -lc` for consistent behavior.
  * Fixed handling of certain native Firecracker “replayed start” failures by treating them as success.
* **Refactor**
  * Simplified control-channel resolution to always use a single, deterministic path (no fallback).
* **Tests**
  * Updated and expanded CLI, preset, API, and channel unit/integration coverage for the new startup and timeout behaviors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->