### PR TITLE
[codex] Prepare smolvm-core 2026.6.23 release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -936,7 +936,7 @@ checksum = "8ed6a63f02c8539c91a8685a86f4099661ba3da017932f6ebbea6de3f0fa7c90"
 
 [[package]]
 name = "smolvm-core"
-version = "2026.6.22"
+version = "2026.6.23"
 dependencies = [
  "futures-util",
  "libc",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,7 @@ classifiers = [
 ]
 dependencies = [
     "click>=8.0",
-    "smolvm-core~=2026.6.22",
+    "smolvm-core~=2026.6.23",
     "paramiko>=3.0",
     "pycdlib>=1.14.0",
     "pydantic>=2.0",

--- a/smolvm-core/Cargo.toml
+++ b/smolvm-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "smolvm-core"
-version = "2026.6.22"
+version = "2026.6.23"
 description = "Rust-native core package for SmolVM"
 documentation = "https://docs.rs/smolvm-core"
 readme = "README.md"


### PR DESCRIPTION
## Summary
- Bump smolvm-core to 2026.6.23.
- Update the main smolvm dependency to require smolvm-core ~=2026.6.23.
- Refresh Cargo.lock for the new core package version.

## Release steps after merge
1. Wait for the target main commit to be final.
2. Push tag: `git tag core-v2026.6.23 && git push origin core-v2026.6.23`.
3. Watch the `Publish smolvm-core` workflow until wheels and sdist publish to PyPI.
4. Verify PyPI exposes `smolvm-core==2026.6.23` before publishing a dependent smolvm package.

## Validation
- `cargo check -p smolvm-core`
- `uv build --package smolvm-core --wheel --out-dir /tmp/smolvm-core-dist`
- `uv build --package smolvm-core --sdist --out-dir /tmp/smolvm-core-dist`
- `uv run --isolated --with /tmp/smolvm-core-dist/smolvm_core-2026.6.23-cp314-cp314-linux_x86_64.whl python - <import/version smoke>`
- `uv run pytest tests/test_smolvm_core.py -q`

## Note
`cargo test -p smolvm-core` still needs a host Python development library; this local machine is missing `libpython3.14`, while the maturin wheel path succeeds.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated core dependency to version 2026.6.23.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->