### PR TITLE
[codex] Add Rust migration next-phase optimizations

### DIFF
--- a/docs/benchmarks/startup-speedups.md
+++ b/docs/benchmarks/startup-speedups.md
@@ -46,6 +46,44 @@ Snapshot restore metrics are now instrumented separately by
 restore rows only after running that lane; do not mix them with the fresh-boot
 summary timeline above.
 
+## 2026-06-23 - Rust Migration Follow-up Benchmarks
+
+- Commit: `cbd0d52`
+- Image tag: current published Ubuntu image used by the local benchmark run.
+- Commands:
+  - `uv run python scripts/benchmarks/ubuntu_transport.py --variants qemu-ssh,qemu-vsock --iterations 3 --warm-exec-runs 5 --rootfs-source published --output /tmp/smolvm-post-release-benchmarks/ubuntu-transport-qemu-20260623T175406Z.json -v`
+  - `uv run python scripts/benchmarks/ubuntu_transport.py --variants firecracker-ssh,firecracker-vsock --iterations 3 --warm-exec-runs 5 --rootfs-source published --output /tmp/smolvm-post-release-benchmarks/ubuntu-transport-firecracker-20260623T175406Z.json -v`
+  - `uv run python scripts/benchmarks/disk_io.py --iterations 3 --json --output /tmp/smolvm-post-release-benchmarks/disk-io-20260623T175406Z.json`
+  - `uv run python scripts/benchmarks/networking.py --json --output /tmp/smolvm-post-release-benchmarks/networking-20260623T175406Z.json`
+- Host: Linux x86_64, kernel `7.0.0-15-generic`, KVM available.
+- Method: one warm-up VM per transport variant, then three measured warm-cache iterations per variant.
+- Behavior changed: follow-up measurement after protocol-v2 control paths, native disk helpers, native Firecracker API, and `smolvm-core` `2026.6.23`.
+
+Published Ubuntu medians from this run:
+
+| Backend | Transport | Total ready | First command | Warm exec | Notes |
+|---|---:|---:|---:|---:|---|
+| QEMU | SSH | 1152.2 ms | 12.0 ms | 42.7 ms | Published Ubuntu, local warm-cache run. |
+| QEMU | vsock | 413.1 ms | 1.2 ms | 1.0 ms | 64.1% faster ready than SSH in this run. |
+| Firecracker | SSH | 3506.4 ms | 53.9 ms | 42.9 ms | Host used unprivileged sudo-command networking fallback. |
+| Firecracker | vsock | 2939.8 ms | 1.1 ms | 0.9 ms | 16.2% faster ready than SSH in this run; not a direct native-TAP result. |
+
+Disk helper findings from this run:
+
+| Operation | Size | Native Rust | Forced-off | Result |
+|---|---:|---:|---:|---|
+| zstd decompress | 16 MiB | 13.0 ms | 39.3 ms | 66.9% faster |
+| zstd decompress | 128 MiB | 95.4 ms | 350.1 ms | 72.8% faster |
+| sparse copy | 16 MiB | 12.9 ms | 10.3 ms | 25.2% slower |
+| sparse copy | 128 MiB | 95.7 ms | 64.3 ms | 48.8% slower |
+
+Networking note:
+
+- True native TAP mode was skipped because the benchmark process did not have
+  root or `CAP_NET_ADMIN`. Forced-off and unprivileged-fallback measured the
+  existing sudo-command path, with stage sums of `242.1 ms` and `236.4 ms`.
+  These are fallback-path numbers, not native TAP speedup numbers.
+
 ## Required Entry Format
 
 Add a short section for each PR that changes startup behavior or benchmark

--- a/scripts/benchmarks/README.md
+++ b/scripts/benchmarks/README.md
@@ -58,7 +58,7 @@ check the command plan before starting any sandbox:
 uv run python scripts/benchmarks/artifacts.py --dry-run --json
 uv run python scripts/benchmarks/disk_io.py --dry-run --json
 uv run python scripts/benchmarks/file_transfer.py --dry-run --json
-uv run python scripts/benchmarks/preset_start.py --preset codex --dry-run --json
+uv run python scripts/benchmarks/preset_start.py --preset codex --comm-channel vsock --dry-run --json
 uv run python scripts/benchmarks/browser_ready.py --dry-run --json
 uv run python scripts/benchmarks/runtime_control.py --operations info,stop,start --dry-run --json
 ```
@@ -72,8 +72,10 @@ file sizes plus a directory tar round trip, meaning pack a folder into one tar
 archive, send it, and unpack or fetch it again, when the selected control
 channel supports it.
 `preset_start.py` times `smolvm <preset> start` and cleans up the sandbox unless
-`--keep` is set. `browser_ready.py` starts a browser sandbox, then polls the CDP
-endpoint, which is the local browser debugging URL, when it is available.
+`--keep` is set. Use `--comm-channel vsock` or `--comm-channel ssh` when you
+want preset startup numbers for a specific control path. `browser_ready.py`
+starts a browser sandbox, then polls the CDP endpoint, which is the local
+browser debugging URL, when it is available.
 `runtime_control.py` measures public lifecycle commands such as
 `smolvm sandbox pause`, `resume`, `stop`, and `start`.
 
@@ -84,7 +86,7 @@ sandboxes and clean them up unless `--keep` is set:
 ```bash
 uv run python scripts/benchmarks/disk_io.py --json --output /tmp/smolvm-disk-io.json
 uv run python scripts/benchmarks/file_transfer.py --backend qemu --comm-channel vsock --json --output /tmp/smolvm-file-transfer.json
-uv run python scripts/benchmarks/preset_start.py --preset codex --backend qemu --json --output /tmp/smolvm-preset-codex.json
+uv run python scripts/benchmarks/preset_start.py --preset codex --backend qemu --comm-channel vsock --json --output /tmp/smolvm-preset-codex.json
 uv run python scripts/benchmarks/browser_ready.py --backend qemu --json --output /tmp/smolvm-browser-ready.json
 ```
 
@@ -92,7 +94,9 @@ uv run python scripts/benchmarks/browser_ready.py --backend qemu --json --output
 
 Use `networking.py` to decide whether the Rust networking path makes Linux VM
 startup faster on your machine. It records each host networking stage, then
-compares the native path with the subprocess fallback.
+compares the native path with the subprocess fallback. Its JSON output uses the
+same benchmark envelope as the other focused probes, including git, host, and
+package-version metadata.
 
 The measured stages include TAP setup (the virtual network device used by
 Firecracker), routes (the host paths for guest IPs), sysctls (kernel networking

--- a/scripts/benchmarks/networking.py
+++ b/scripts/benchmarks/networking.py
@@ -32,6 +32,11 @@ from typing import Any
 
 _REPO_ROOT = Path(__file__).resolve().parent.parent.parent
 sys.path.insert(0, str(_REPO_ROOT / "src"))
+try:
+    from .reporting import finish_report, print_report, start_report
+except ImportError:  # pragma: no cover - script execution path
+    sys.path.insert(0, str(Path(__file__).resolve().parent))
+    from reporting import finish_report, print_report, start_report  # type: ignore[no-redef]
 
 logger = logging.getLogger("smolvm.bench.networking")
 
@@ -275,7 +280,7 @@ def _benchmark_full_start(boot_timeout: float) -> float:
             vm.delete()
 
 
-def _parse_args() -> argparse.Namespace:
+def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument(
         "--modes",
@@ -290,21 +295,27 @@ def _parse_args() -> argparse.Namespace:
     parser.add_argument("--boot-timeout", type=float, default=180.0)
     parser.add_argument("--json", action="store_true", help="Print machine-readable JSON only.")
     parser.add_argument("--output", type=Path, help="Optional JSON output path.")
-    return parser.parse_args()
+    return parser.parse_args(argv)
 
 
-def main() -> int:
+def main(argv: list[str] | None = None) -> int:
     if sys.platform != "linux":
         raise SystemExit("This benchmark only runs on Linux.")
 
-    args = _parse_args()
+    args = _parse_args(argv)
     logging.basicConfig(level=logging.INFO, format="%(levelname)s %(name)s: %(message)s")
     modes = [mode.strip() for mode in args.modes.split(",") if mode.strip()]
     unknown = sorted(set(modes) - set(MODES))
     if unknown:
         raise SystemExit(f"Unknown mode(s): {', '.join(unknown)}")
 
-    records = [
+    config = {
+        "modes": modes,
+        "include_full_start": args.include_full_start,
+        "boot_timeout": args.boot_timeout,
+    }
+    report, started = start_report("networking", config=config, dry_run=False)
+    report["records"] = [
         _benchmark_network_stages(
             mode,
             include_full_start=args.include_full_start,
@@ -312,24 +323,27 @@ def main() -> int:
         )
         for mode in modes
     ]
-    report = {
-        "created_at": time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime()),
-        "records": records,
-    }
-    if args.output:
-        args.output.write_text(json.dumps(report, indent=2, sort_keys=True) + "\n")
-    if args.json:
-        print(json.dumps(report, indent=2, sort_keys=True))
-    else:
-        for record in records:
-            if "skipped" in record:
-                print(f"{record['mode']}: skipped - {record['skipped']}")
-                continue
-            print(f"{record['mode']}:")
-            for key, value in record.items():
-                if key.endswith("_ms"):
-                    print(f"  {key}: {value}")
+    finish_report(report, started)
+    print_report(
+        report,
+        json_output=args.json,
+        output=args.output,
+        human_lines=_human_lines(report),
+    )
     return 0
+
+
+def _human_lines(report: dict[str, Any]) -> list[str]:
+    lines = ["Networking stages:"]
+    for record in report["records"]:
+        if "skipped" in record:
+            lines.append(f"  {record['mode']}: skipped - {record['skipped']}")
+            continue
+        lines.append(f"  {record['mode']}:")
+        for key, value in record.items():
+            if key.endswith("_ms"):
+                lines.append(f"    {key}: {value}")
+    return lines
 
 
 if __name__ == "__main__":

--- a/scripts/benchmarks/preset_start.py
+++ b/scripts/benchmarks/preset_start.py
@@ -75,6 +75,8 @@ def build_start_command(args: argparse.Namespace, sandbox_name: str) -> list[str
         command.extend(["--os", args.os])
     if args.backend:
         command.extend(["--backend", args.backend])
+    if args.comm_channel:
+        command.extend(["--comm-channel", args.comm_channel])
     if args.memory_mib is not None:
         command.extend(["--memory", str(args.memory_mib)])
     if args.disk_size_mib is not None:
@@ -150,6 +152,7 @@ def build_parser() -> argparse.ArgumentParser:
         choices=("auto", "firecracker", "qemu", "libkrun"),
         default=None,
     )
+    parser.add_argument("--comm-channel", choices=("auto", "vsock", "ssh"), default=None)
     parser.add_argument("--memory", dest="memory_mib", type=int, default=None)
     parser.add_argument("--disk-size", dest="disk_size_mib", type=int, default=None)
     parser.add_argument("--mount", dest="mounts", action="append", default=[])
@@ -182,6 +185,7 @@ def main(argv: list[str] | None = None) -> int:
         "name_prefix": args.name_prefix,
         "os": args.os,
         "backend": args.backend,
+        "comm_channel": args.comm_channel,
         "memory_mib": args.memory_mib,
         "disk_size_mib": args.disk_size_mib,
         "mounts": args.mounts,

--- a/src/smolvm/browser.py
+++ b/src/smolvm/browser.py
@@ -420,7 +420,10 @@ class _BrowserSandbox:
                     raise SmolVMError(
                         f"Browser sandbox '{self.session_id}' did not expose a CDP port in time."
                     )
-                debug_host_port = self._resolve_browser_host_port(_BROWSER_DEBUG_PORT)
+                debug_host_port = self._resolve_browser_host_port(
+                    _BROWSER_DEBUG_PORT,
+                    guest_loopback=False,
+                )
                 cdp_url = f"http://127.0.0.1:{debug_host_port}"
                 if not self._wait_for_cdp_http(cdp_url, timeout=boot_timeout):
                     raise SmolVMError(
@@ -440,9 +443,15 @@ class _BrowserSandbox:
                     raise SmolVMError(
                         f"Browser sandbox '{self.session_id}' did not expose a viewer in time."
                     )
-                live_host_port = self._resolve_browser_host_port(_BROWSER_LIVE_PORT)
+                live_host_port = self._resolve_browser_host_port(
+                    _BROWSER_LIVE_PORT,
+                    guest_loopback=False,
+                )
                 live_url = f"http://127.0.0.1:{live_host_port}/vnc.html?autoconnect=1&resize=scale"
-                vnc_host_port = self._resolve_browser_host_port(_BROWSER_VNC_PORT)
+                vnc_host_port = self._resolve_browser_host_port(
+                    _BROWSER_VNC_PORT,
+                    guest_loopback=True,
+                )
                 vnc_url = f"vnc://127.0.0.1:{vnc_host_port}"
 
             self._info = self._state.update_browser_session(
@@ -652,12 +661,12 @@ class _BrowserSandbox:
                 f"Failed to launch guest browser: {result.stderr.strip() or result.stdout}"
             )
 
-    def _resolve_browser_host_port(self, guest_port: int) -> int:
+    def _resolve_browser_host_port(self, guest_port: int, *, guest_loopback: bool) -> int:
         """Return a localhost port that exposes a browser guest port.
 
-        Browser services such as Chromium's DevTools endpoint can bind guest
-        loopback only. Route them through ``expose_local()`` so SmolVM can
-        fall back to an SSH tunnel when direct guest networking is not enough.
+        Prefer QEMU forwards created with the VM. When no configured forward
+        is available, route through ``expose_local()`` using the caller's
+        loopback policy for that browser endpoint.
         """
         if self._vm is None:
             raise SmolVMError("Browser sandbox VM is unavailable.")
@@ -666,19 +675,22 @@ class _BrowserSandbox:
         if configured is not None and self._probe_local_port(configured):
             return configured
 
-        return self._vm.expose_local(guest_port=guest_port, guest_loopback=True)
+        return self._vm.expose_local(
+            guest_port=guest_port,
+            guest_loopback=guest_loopback,
+        )
 
     def _wait_for_guest_port(self, port: int, *, timeout: float) -> bool:
         if self._vm is None:
             raise SmolVMError("Browser sandbox VM is unavailable.")
 
-        wait_for_ports = getattr(self._vm._control_channel, "wait_for_ports", None)
-        if callable(wait_for_ports):
-            try:
-                wait_for_ports([port], timeout=timeout)
-                return True
-            except Exception:
-                pass
+        control_wait_result = self._vm.wait_for_guest_tcp_ports(
+            [port],
+            timeout=timeout,
+            host="127.0.0.1",
+        )
+        if control_wait_result is not None:
+            return control_wait_result
 
         command = f"/usr/local/bin/smolvm-browser-wait-port {port} {timeout}"
         result = self._vm.run(command, timeout=max(5, int(timeout) + 5))

--- a/src/smolvm/facade.py
+++ b/src/smolvm/facade.py
@@ -1533,7 +1533,7 @@ class SmolVM:
         """Start the VM.
 
         If the VM config contains ``env_vars``, they are injected into
-        the guest via SSH after boot completes.
+        the guest after boot completes.
 
         Args:
             boot_timeout: Maximum seconds to wait for boot.
@@ -1547,7 +1547,8 @@ class SmolVM:
 
         Raises:
             SmolVMError: If ``env_vars`` is set but the image does not
-                support SSH.
+                support guest commands or the selected control channel
+                cannot manage environment variables.
         """
         notify = on_progress or (lambda _msg: None)
 
@@ -1567,9 +1568,8 @@ class SmolVM:
             if not self.can_run_commands():
                 raise SmolVMError(
                     "Cannot inject environment variables: VM image does not "
-                    "support guest SSH. Use an SSH-capable prebuilt image or "
-                    "an image built with ImageBuilder, or bake env vars into "
-                    "the rootfs at build time.",
+                    "support guest commands. Use a command-capable image, or "
+                    "bake env vars into the rootfs at build time.",
                     {"vm_id": self._vm_id},
                 )
             control_env = self._control_env_channel(timeout=boot_timeout)
@@ -2102,6 +2102,52 @@ class SmolVM:
         self._wait_for_ssh_over_network(timeout=timeout)
         return self
 
+    def wait_for_guest_tcp_ports(
+        self,
+        ports: list[int],
+        *,
+        timeout: float = 30.0,
+        host: str = "127.0.0.1",
+    ) -> bool | None:
+        """Wait for guest TCP ports through the control protocol when supported.
+
+        Returns ``True`` when all ports become reachable, ``False`` when the
+        control protocol reports a timeout, and ``None`` when the active
+        control channel does not expose protocol-level port waiting.
+        """
+        if not ports:
+            raise ValueError("ports cannot be empty")
+        invalid_ports = [
+            port for port in ports if isinstance(port, bool) or not isinstance(port, int)
+        ]
+        invalid_ports.extend(port for port in ports if isinstance(port, int) and port < 1)
+        invalid_ports.extend(port for port in ports if isinstance(port, int) and port > 65535)
+        if invalid_ports:
+            raise ValueError("ports must be integers between 1 and 65535")
+        if isinstance(timeout, bool) or not isinstance(timeout, (int, float)) or timeout <= 0:
+            raise ValueError("timeout must be greater than 0")
+
+        channel = self._ensure_control_for_operation(
+            action="wait for guest TCP ports",
+            timeout=timeout,
+        )
+        if getattr(channel, "kind", None) != "vsock":
+            return None
+
+        supports = getattr(channel, "supports", None)
+        if callable(supports) and not supports("ports_wait", "ports.wait"):
+            return None
+
+        wait_for_ports = getattr(channel, "wait_for_ports", None)
+        if not callable(wait_for_ports):
+            return None
+
+        try:
+            ready_ports = wait_for_ports(ports, timeout=timeout, host=host)
+        except OperationTimeoutError:
+            return False
+        return set(ready_ports) >= set(ports)
+
     def ssh_commands(
         self,
         *,
@@ -2510,7 +2556,8 @@ class SmolVM:
         if env_vars:
             if not self.can_run_commands():
                 raise SmolVMError(
-                    "Cannot inject environment variables: VM image does not support SSH.",
+                    "Cannot inject environment variables: VM image does not "
+                    "support guest commands.",
                     {"vm_id": self._vm_id},
                 )
             control_env = await asyncio.to_thread(self._control_env_channel, timeout=boot_timeout)
@@ -2905,10 +2952,24 @@ modprobe 9pnet_virtio""".strip()
         return self._ensure_control_for_operation(action="transfer files")
 
     def _ensure_ssh_for_env(self, *, timeout: float = _DEFAULT_RUN_READY_TIMEOUT) -> SSHClient:
-        """Return a ready SSH client for env operations on a running VM."""
+        """Return a ready SSH client for env operations that use SSH."""
         return self._ensure_ssh_for_operation(
             action="manage environment variables",
             timeout=timeout,
+        )
+
+    def _managed_env_required_error(self) -> SmolVMError:
+        """Return the user-facing error for vsock env without managed support."""
+        recovery_command = f"smolvm sandbox create --name {self._vm_id} --comm-channel ssh"
+        return SmolVMError(
+            f"Managed environment variables are not available for sandbox "
+            f"'{self._vm_id}' over vsock; run 'smolvm sandbox delete {self._vm_id}' "
+            f"and then '{recovery_command}' to use SSH.",
+            {
+                "vm_id": self._vm_id,
+                "comm_channel": "vsock",
+                "recovery_command": recovery_command,
+            },
         )
 
     def _control_env_channel(
@@ -2916,19 +2977,24 @@ modprobe 9pnet_virtio""".strip()
         *,
         timeout: float = _DEFAULT_RUN_READY_TIMEOUT,
     ) -> CommChannel | None:
-        """Return a control channel with managed-env support for Linux guests."""
+        """Return a managed-env control channel, or None when SSH fallback is allowed."""
         if self._is_windows_guest():
             return None
+        resolution = self._resolve_channel()
         try:
             channel = self._ensure_control_for_operation(
                 action="manage environment variables",
                 timeout=timeout,
             )
         except Exception:
+            if resolution.kind == "vsock":
+                raise
             return None
         supports = getattr(channel, "supports", None)
         if callable(supports) and supports("env_managed", "env.managed") is True:
             return channel
+        if resolution.kind == "vsock":
+            raise self._managed_env_required_error()
         return None
 
     def _ensure_control_for_operation(

--- a/src/smolvm/host/disk.py
+++ b/src/smolvm/host/disk.py
@@ -47,7 +47,7 @@ def has_native_disk_io() -> bool:
 
 
 def clone_or_sparse_copy(source_path: Path | str, target_path: Path | str) -> str:
-    """Copy a disk image with native reflink/sparse I/O when available.
+    """Copy a disk image with reflink/sparse I/O when available.
 
     Returns a short method label for logging/tests. Callers that only need the
     copy side effect can ignore the return value.
@@ -57,10 +57,11 @@ def clone_or_sparse_copy(source_path: Path | str, target_path: Path | str) -> st
     target = Path(target_path)
     _ensure_parent_dir(target)
 
+    if method := _cp_clone_or_sparse_copy(source, target):
+        return method
+
     if _native_available():
-        method = str(_native.clone_or_sparse_copy(str(source), str(target)))
-        shutil.copystat(source, target)
-        return f"native:{method}"
+        return _native_clone_or_sparse_copy(source, target)
 
     return _python_clone_or_sparse_copy(source, target)
 
@@ -96,7 +97,7 @@ def _native_available() -> bool:
         return False
 
 
-def _python_clone_or_sparse_copy(source: Path, target: Path) -> str:
+def _cp_clone_or_sparse_copy(source: Path, target: Path) -> str | None:
     try:
         result = subprocess.run(
             ["cp", "--reflink=auto", "--sparse=always", str(source), str(target)],
@@ -105,18 +106,27 @@ def _python_clone_or_sparse_copy(source: Path, target: Path) -> str:
             check=False,
         )
     except OSError as exc:
-        logger.debug("cp --reflink=auto unavailable; using Python sparse copy: %s", exc)
+        logger.debug("cp --reflink=auto unavailable; trying next sparse copy method: %s", exc)
     else:
         if result.returncode == 0:
             shutil.copystat(source, target)
             return "cp"
         logger.debug(
-            "cp --reflink=auto failed for %s -> %s; using Python sparse copy: %s",
+            "cp --reflink=auto failed for %s -> %s; trying next sparse copy method: %s",
             source,
             target,
             (result.stderr or "").strip(),
         )
+    return None
 
+
+def _native_clone_or_sparse_copy(source: Path, target: Path) -> str:
+    method = str(_native.clone_or_sparse_copy(str(source), str(target)))
+    shutil.copystat(source, target)
+    return f"native:{method}"
+
+
+def _python_clone_or_sparse_copy(source: Path, target: Path) -> str:
     _copy_sparse_preserving(source, target)
     return "sparse"
 

--- a/src/smolvm/presets/_install.py
+++ b/src/smolvm/presets/_install.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Apply a preset to a running, SSH-ready SmolVM guest."""
+"""Apply a preset to a running SmolVM guest over its control channel."""
 
 from __future__ import annotations
 
@@ -65,7 +65,7 @@ def apply_preset(
     on_progress: Callable[[str], None] | None = None,
     install_timeout: int = _DEFAULT_INSTALL_TIMEOUT,
 ) -> dict[str, object]:
-    """Apply *preset* to a guest reachable via *ssh*.
+    """Apply *preset* to a guest reachable through a control channel.
 
     Order: copy host configs, inject env vars, then run the install
     script. Configs are placed before install runs so that the freshly

--- a/src/smolvm/vm.py
+++ b/src/smolvm/vm.py
@@ -1383,7 +1383,7 @@ class SmolVMManager:
         resolution: ChannelResolution | None = None,
     ) -> bool:
         """Return whether create-time networking must expose guest SSH."""
-        if config.env_vars or config.workspace_mounts:
+        if config.workspace_mounts:
             return True
 
         resolution = resolution or self._resolve_control_channel_for_config(config, backend)

--- a/tests/test_benchmark_foundation.py
+++ b/tests/test_benchmark_foundation.py
@@ -71,9 +71,10 @@ def test_preset_start_dry_run_json_plans_preset_start_and_cleanup(capsys) -> Non
     record = report["records"][0]
     assert record["start"]["command"][:3] == ["smolvm", "codex", "start"]
     assert "--no-attach" in record["start"]["command"]
-    assert record["start"]["command"][
-        record["start"]["command"].index("--comm-channel") + 1
-    ] == "vsock"
+    assert (
+        record["start"]["command"][record["start"]["command"].index("--comm-channel") + 1]
+        == "vsock"
+    )
     assert report["parameters"]["comm_channel"] == "vsock"
     assert record["cleanup"]["command"][:3] == ["smolvm", "sandbox", "delete"]
 

--- a/tests/test_benchmark_foundation.py
+++ b/tests/test_benchmark_foundation.py
@@ -23,6 +23,7 @@ from scripts.benchmarks import (
     browser_ready,
     disk_io,
     file_transfer,
+    networking,
     preset_start,
     runtime_control,
 )
@@ -56,6 +57,8 @@ def test_preset_start_dry_run_json_plans_preset_start_and_cleanup(capsys) -> Non
             "--json",
             "--preset",
             "codex",
+            "--comm-channel",
+            "vsock",
             "--iterations",
             "1",
             "--name-prefix",
@@ -68,7 +71,33 @@ def test_preset_start_dry_run_json_plans_preset_start_and_cleanup(capsys) -> Non
     record = report["records"][0]
     assert record["start"]["command"][:3] == ["smolvm", "codex", "start"]
     assert "--no-attach" in record["start"]["command"]
+    assert record["start"]["command"][
+        record["start"]["command"].index("--comm-channel") + 1
+    ] == "vsock"
+    assert report["parameters"]["comm_channel"] == "vsock"
     assert record["cleanup"]["command"][:3] == ["smolvm", "sandbox", "delete"]
+
+
+def test_networking_arg_parser_and_human_lines_use_shared_report_shape() -> None:
+    args = networking._parse_args(["--modes", "forced-off", "--boot-timeout", "15"])
+
+    assert args.modes == "forced-off"
+    assert args.boot_timeout == 15
+
+    lines = networking._human_lines(
+        {
+            "records": [
+                {"mode": "native", "skipped": "needs CAP_NET_ADMIN"},
+                {"mode": "forced-off", "create_tap_ms": 1.2},
+            ]
+        }
+    )
+    assert lines == [
+        "Networking stages:",
+        "  native: skipped - needs CAP_NET_ADMIN",
+        "  forced-off:",
+        "    create_tap_ms: 1.2",
+    ]
 
 
 def test_browser_ready_dry_run_json_plans_browser_start_and_stop(capsys) -> None:

--- a/tests/test_browser.py
+++ b/tests/test_browser.py
@@ -441,17 +441,10 @@ def test_browser_session_start_persists_ready_state(
     vm.vm_id = "browser-abc123"
     vm.status = VMState.CREATED
     vm.expose_local.side_effect = [39222, 36080, 35900]
+    vm.wait_for_guest_tcp_ports.side_effect = [False, True, True, True, True, True]
 
     def _run_side_effect(command: str, timeout: int = 30, shell: str = "login") -> CommandResult:
-        if command.startswith("/usr/local/bin/smolvm-browser-wait-port 9222 1.0"):
-            return CommandResult(exit_code=1, stdout="", stderr="")
         if command.startswith("/usr/local/bin/smolvm-browser-session start"):
-            return CommandResult(exit_code=0, stdout="", stderr="")
-        if command.startswith("/usr/local/bin/smolvm-browser-wait-port 9222"):
-            return CommandResult(exit_code=0, stdout="", stderr="")
-        if command.startswith("/usr/local/bin/smolvm-browser-wait-port 6080"):
-            return CommandResult(exit_code=0, stdout="", stderr="")
-        if command.startswith("/usr/local/bin/smolvm-browser-wait-port 5900"):
             return CommandResult(exit_code=0, stdout="", stderr="")
         return CommandResult(exit_code=0, stdout="", stderr="")
 
@@ -481,6 +474,11 @@ def test_browser_session_start_persists_ready_state(
     assert persisted.debug_port == 39222
     assert persisted.vnc_port == 35900
     assert persisted.vnc_url == "vnc://127.0.0.1:35900"
+    assert [call.kwargs for call in vm.expose_local.call_args_list] == [
+        {"guest_port": 9222, "guest_loopback": False},
+        {"guest_port": 6080, "guest_loopback": False},
+        {"guest_port": 5900, "guest_loopback": True},
+    ]
     session.close()
 
 
@@ -512,14 +510,11 @@ def test_browser_sandbox_start_uses_configured_qemu_cdp_forward(
     vm.status = VMState.CREATED
     vm.info.config = qemu_vm_config
     vm.expose_local.return_value = 39222
+    vm.wait_for_guest_tcp_ports.side_effect = [False, True]
 
     def _run_side_effect(command: str, timeout: int = 30, shell: str = "login") -> CommandResult:
         del timeout, shell
-        if command.startswith("/usr/local/bin/smolvm-browser-wait-port 9222 1.0"):
-            return CommandResult(exit_code=1, stdout="", stderr="")
         if command.startswith("/usr/local/bin/smolvm-browser-session start"):
-            return CommandResult(exit_code=0, stdout="", stderr="")
-        if command.startswith("/usr/local/bin/smolvm-browser-wait-port 9222"):
             return CommandResult(exit_code=0, stdout="", stderr="")
         return CommandResult(exit_code=0, stdout="", stderr="")
 
@@ -545,6 +540,51 @@ def test_browser_sandbox_start_uses_configured_qemu_cdp_forward(
     session.close()
 
 
+def test_browser_wait_for_guest_port_uses_facade_control_wait() -> None:
+    """Browser orchestration should use the SmolVM facade for protocol port waits."""
+    vm = MagicMock()
+    vm.wait_for_guest_tcp_ports.return_value = True
+    session = object.__new__(_BrowserSandbox)
+    session._vm = vm
+
+    assert session._wait_for_guest_port(9222, timeout=2.5) is True
+
+    vm.wait_for_guest_tcp_ports.assert_called_once_with(
+        [9222],
+        timeout=2.5,
+        host="127.0.0.1",
+    )
+    vm.run.assert_not_called()
+
+
+def test_browser_wait_for_guest_port_falls_back_when_control_wait_unsupported() -> None:
+    """Legacy channels should still use the browser image's wait-port script."""
+    vm = MagicMock()
+    vm.wait_for_guest_tcp_ports.return_value = None
+    vm.run.return_value = CommandResult(exit_code=0, stdout="", stderr="")
+    session = object.__new__(_BrowserSandbox)
+    session._vm = vm
+
+    assert session._wait_for_guest_port(9222, timeout=2.5) is True
+
+    vm.run.assert_called_once_with(
+        "/usr/local/bin/smolvm-browser-wait-port 9222 2.5",
+        timeout=7,
+    )
+
+
+def test_browser_wait_for_guest_port_does_not_fallback_after_control_timeout() -> None:
+    """A real protocol timeout should not spend the deadline again via shell fallback."""
+    vm = MagicMock()
+    vm.wait_for_guest_tcp_ports.return_value = False
+    session = object.__new__(_BrowserSandbox)
+    session._vm = vm
+
+    assert session._wait_for_guest_port(9222, timeout=2.5) is False
+
+    vm.run.assert_not_called()
+
+
 @patch("smolvm.browser.SmolVM")
 @patch("smolvm.browser._build_browser_vm_config")
 def test_desktop_sandbox_start_exposes_viewer_and_display_only(
@@ -560,6 +600,7 @@ def test_desktop_sandbox_start_exposes_viewer_and_display_only(
     vm.vm_id = "desktop-abc123"
     vm.status = VMState.CREATED
     vm.expose_local.side_effect = [36080, 35900]
+    vm.wait_for_guest_tcp_ports.side_effect = [False, True, True]
 
     def _run_side_effect(command: str, timeout: int = 30, shell: str = "login") -> CommandResult:
         del timeout, shell
@@ -588,7 +629,7 @@ def test_desktop_sandbox_start_exposes_viewer_and_display_only(
     assert session.viewer_url == "http://127.0.0.1:36080/vnc.html?autoconnect=1&resize=scale"
     assert session.display_url == "vnc://127.0.0.1:35900"
     assert [call.kwargs for call in vm.expose_local.call_args_list] == [
-        {"guest_port": 6080, "guest_loopback": True},
+        {"guest_port": 6080, "guest_loopback": False},
         {"guest_port": 5900, "guest_loopback": True},
     ]
     session.close()

--- a/tests/test_facade.py
+++ b/tests/test_facade.py
@@ -2254,6 +2254,96 @@ class TestVMRun:
             vm.run("echo test")
 
 
+class TestVMGuestTcpPortWait:
+    """Tests for facade-level guest TCP port waits."""
+
+    @staticmethod
+    def _running_vsock_vm(sample_config: VMConfig, mock_sdk_cls: MagicMock) -> SmolVM:
+        config = sample_config.model_copy(
+            update={
+                "backend": "qemu",
+                "comm_channel": "vsock",
+                "vsock": VsockConfig(guest_cid=42),
+            }
+        )
+        running_info = MagicMock(vm_id="vm001", status=VMState.RUNNING)
+        running_info.config = config
+        running_info.network = None
+
+        mock_sdk = MagicMock()
+        mock_sdk.create.return_value = running_info
+        mock_sdk.get.return_value = running_info
+        mock_sdk_cls.return_value = mock_sdk
+
+        return SmolVM(config)
+
+    @patch("smolvm.facade.SmolVMManager")
+    def test_wait_for_guest_tcp_ports_uses_vsock_protocol_wait(
+        self,
+        mock_sdk_cls: MagicMock,
+        sample_config: VMConfig,
+    ) -> None:
+        vm = self._running_vsock_vm(sample_config, mock_sdk_cls)
+        channel = MagicMock()
+        channel.kind = "vsock"
+        channel.supports.return_value = True
+        channel.wait_for_ports.return_value = [9222, 6080]
+        vm._control_channel = channel
+        vm._control_ready = True
+
+        assert vm.wait_for_guest_tcp_ports([9222, 6080], timeout=1.5) is True
+
+        channel.supports.assert_called_once_with("ports_wait", "ports.wait")
+        channel.wait_for_ports.assert_called_once_with(
+            [9222, 6080],
+            timeout=1.5,
+            host="127.0.0.1",
+        )
+
+    @patch("smolvm.facade.SmolVMManager")
+    def test_wait_for_guest_tcp_ports_returns_false_after_protocol_timeout(
+        self,
+        mock_sdk_cls: MagicMock,
+        sample_config: VMConfig,
+    ) -> None:
+        vm = self._running_vsock_vm(sample_config, mock_sdk_cls)
+        channel = MagicMock()
+        channel.kind = "vsock"
+        channel.supports.return_value = True
+        channel.wait_for_ports.side_effect = OperationTimeoutError(
+            "waiting for guest ports 9222",
+            1.5,
+        )
+        vm._control_channel = channel
+        vm._control_ready = True
+
+        assert vm.wait_for_guest_tcp_ports([9222], timeout=1.5) is False
+
+        channel.wait_for_ports.assert_called_once_with(
+            [9222],
+            timeout=1.5,
+            host="127.0.0.1",
+        )
+
+    @patch("smolvm.facade.SmolVMManager")
+    def test_wait_for_guest_tcp_ports_returns_none_when_protocol_wait_missing(
+        self,
+        mock_sdk_cls: MagicMock,
+        sample_config: VMConfig,
+    ) -> None:
+        vm = self._running_vsock_vm(sample_config, mock_sdk_cls)
+        channel = MagicMock()
+        channel.kind = "vsock"
+        channel.supports.return_value = False
+        vm._control_channel = channel
+        vm._control_ready = True
+
+        assert vm.wait_for_guest_tcp_ports([9222], timeout=1.5) is None
+
+        channel.supports.assert_called_once_with("ports_wait", "ports.wait")
+        channel.wait_for_ports.assert_not_called()
+
+
 class TestVMQemuLocalExpose:
     """Tests for QEMU slirp localhost exposure."""
 
@@ -3079,13 +3169,13 @@ class TestVMEnvInjection:
 
     @patch("smolvm.facade.inject_env_vars")
     @patch("smolvm.facade.SmolVMManager")
-    def test_start_raises_if_ssh_not_supported(
+    def test_start_raises_if_guest_commands_not_supported(
         self,
         mock_sdk_cls: MagicMock,
         mock_inject: MagicMock,
         sample_config: VMConfig,
     ) -> None:
-        """Test that start() raises if env_vars set but no SSH support."""
+        """Test that start() raises if env_vars set but guest commands are unavailable."""
         mock_sdk = MagicMock()
         mock_info = MagicMock(vm_id="vm001", status=VMState.CREATED)
         # boot_args missing init=/init
@@ -3100,7 +3190,7 @@ class TestVMEnvInjection:
 
         vm = SmolVM(config)
 
-        with pytest.raises(SmolVMError, match="does not support guest SSH"):
+        with pytest.raises(SmolVMError, match="does not support guest commands"):
             vm.start()
 
         mock_inject.assert_not_called()

--- a/tests/test_facade_vsock.py
+++ b/tests/test_facade_vsock.py
@@ -25,7 +25,7 @@ from unittest.mock import MagicMock
 import pytest
 
 from smolvm.comm.rust_http_vsock_channel import RustHttpVsockChannel
-from smolvm.exceptions import OperationTimeoutError
+from smolvm.exceptions import OperationTimeoutError, SmolVMError
 from smolvm.facade import SmolVM
 from smolvm.types import (
     CommandResult,
@@ -209,3 +209,42 @@ def test_resolve_channel_reads_config_and_request(
     # auto on linux+qemu -> vsock, agent required
     res = vm._resolve_channel()
     assert res.kind == "vsock"
+
+
+def test_explicit_vsock_env_uses_managed_env_not_ssh(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setattr("smolvm.comm.select.host_supports_vsock", lambda: True)
+    vm = _vsock_vm(tmp_path, comm_channel="vsock", request="vsock")
+    channel = MagicMock()
+    channel.supports.return_value = True
+    channel.set_managed_env.return_value = {"FOO": "bar"}
+    vm._control_channel = channel
+    vm._control_ready = True
+
+    def _ssh_not_allowed(self, *, timeout: float = 30.0):  # noqa: ANN001
+        raise AssertionError("explicit vsock env must not fall back to SSH")
+
+    monkeypatch.setattr(SmolVM, "_ensure_ssh_for_env", _ssh_not_allowed)
+
+    assert vm.set_env_vars({"FOO": "bar"}) == ["FOO"]
+    channel.set_managed_env.assert_called_once_with({"FOO": "bar"}, merge=True)
+
+
+def test_explicit_vsock_env_requires_managed_env(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setattr("smolvm.comm.select.host_supports_vsock", lambda: True)
+    vm = _vsock_vm(tmp_path, comm_channel="vsock", request="vsock")
+    channel = MagicMock()
+    channel.supports.return_value = False
+    vm._control_channel = channel
+    vm._control_ready = True
+
+    def _ssh_not_allowed(self, *, timeout: float = 30.0):  # noqa: ANN001
+        raise AssertionError("explicit vsock env must not fall back to SSH")
+
+    monkeypatch.setattr(SmolVM, "_ensure_ssh_for_env", _ssh_not_allowed)
+
+    with pytest.raises(SmolVMError, match="Managed environment variables are not available"):
+        vm.set_env_vars({"FOO": "bar"})

--- a/tests/test_host_disk.py
+++ b/tests/test_host_disk.py
@@ -22,17 +22,61 @@ import pytest
 from smolvm.host import disk
 
 
-def test_clone_or_sparse_copy_uses_python_when_native_unavailable(tmp_path: Path) -> None:
-    """Native-disabled disk copies should keep the Python fallback path."""
+def test_clone_or_sparse_copy_prefers_cp_before_native(tmp_path: Path) -> None:
+    """GNU cp should stay the production default for raw disk clones."""
+    source = tmp_path / "source.ext4"
+    target = tmp_path / "target.ext4"
+    native = MagicMock()
+
+    with (
+        patch.object(disk, "_cp_clone_or_sparse_copy", return_value="cp") as mock_cp,
+        patch.object(disk, "_native_available", side_effect=AssertionError("native skipped")),
+        patch.object(disk, "_native", native),
+    ):
+        assert disk.clone_or_sparse_copy(source, target) == "cp"
+
+    mock_cp.assert_called_once_with(source, target)
+    native.clone_or_sparse_copy.assert_not_called()
+
+
+def test_clone_or_sparse_copy_uses_native_after_cp_failure(tmp_path: Path) -> None:
+    """Native copy remains available after cp cannot handle the clone."""
+    source = tmp_path / "source.ext4"
+    target = tmp_path / "target.ext4"
+    native = MagicMock()
+    native.clone_or_sparse_copy.return_value = "sparse"
+
+    with (
+        patch.object(disk, "_cp_clone_or_sparse_copy", return_value=None) as mock_cp,
+        patch.object(disk, "_native_available", return_value=True),
+        patch.object(disk, "_native", native),
+        patch.object(disk.shutil, "copystat") as mock_copystat,
+        patch.object(
+            disk,
+            "_python_clone_or_sparse_copy",
+            side_effect=AssertionError("must not fall back"),
+        ),
+    ):
+        assert disk.clone_or_sparse_copy(source, target) == "native:sparse"
+
+    mock_cp.assert_called_once_with(source, target)
+    native.clone_or_sparse_copy.assert_called_once_with(str(source), str(target))
+    mock_copystat.assert_called_once_with(source, target)
+
+
+def test_clone_or_sparse_copy_uses_python_when_cp_and_native_unavailable(tmp_path: Path) -> None:
+    """Disk copies should keep the Python sparse fallback path."""
     source = tmp_path / "source.ext4"
     target = tmp_path / "target.ext4"
 
     with (
+        patch.object(disk, "_cp_clone_or_sparse_copy", return_value=None) as mock_cp,
         patch.object(disk, "_native_available", return_value=False),
         patch.object(disk, "_python_clone_or_sparse_copy", return_value="sparse") as mock_python,
     ):
         assert disk.clone_or_sparse_copy(source, target) == "sparse"
 
+    mock_cp.assert_called_once_with(source, target)
     mock_python.assert_called_once_with(source, target)
 
 
@@ -42,6 +86,7 @@ def test_clone_or_sparse_copy_propagates_native_oserror(tmp_path: Path) -> None:
     native.clone_or_sparse_copy.side_effect = OSError("No space left on device")
 
     with (
+        patch.object(disk, "_cp_clone_or_sparse_copy", return_value=None),
         patch.object(disk, "_native_available", return_value=True),
         patch.object(disk, "_native", native),
         patch.object(

--- a/tests/test_presets.py
+++ b/tests/test_presets.py
@@ -606,7 +606,7 @@ class TestCollectHostEnv:
 
 
 class TestApplyPreset:
-    """Integration of file copy + env injection + install over a mocked SSH."""
+    """Integration of file copy + env injection + install over a mocked channel."""
 
     def _make_preset(
         self,

--- a/tests/test_vm.py
+++ b/tests/test_vm.py
@@ -307,13 +307,13 @@ class TestSmolVMCreate:
         mock_network.setup_ssh_port_forward.assert_called_once()
 
     @patch("smolvm.comm.select.platform.system", return_value="Linux")
-    def test_create_firecracker_explicit_vsock_with_env_keeps_ssh_forward(
+    def test_create_firecracker_explicit_vsock_with_env_skips_ssh_forward(
         self,
         _mock_system: MagicMock,
         smol_vm: SmolVMManager,
         sample_config: VMConfig,
     ) -> None:
-        """Env injection is still SSH-backed at startup, so keep forwarding."""
+        """Env-only startup uses managed vsock env and should not expose SSH."""
         mock_network = _attach_mock_network(smol_vm)
         config = sample_config.model_copy(
             update={
@@ -327,10 +327,10 @@ class TestSmolVMCreate:
         vm_info = smol_vm.create(config)
 
         assert vm_info.network is not None
-        assert vm_info.network.ssh_host_port is not None
-        mock_network.add_route.assert_called_once()
-        mock_network.setup_nat.assert_called_once()
-        mock_network.setup_ssh_port_forward.assert_called_once()
+        assert vm_info.network.ssh_host_port is None
+        mock_network.add_route.assert_not_called()
+        mock_network.setup_nat.assert_not_called()
+        mock_network.setup_ssh_port_forward.assert_not_called()
 
     @patch("smolvm.comm.select.platform.system", return_value="Linux")
     @patch("smolvm.vm.resolve_domains_to_ips", return_value=["93.184.216.34"])


### PR DESCRIPTION
## Summary
- move Linux vsock env handling away from SSH fallback when managed env is required, while keeping SSH paths for unsupported channels
- route browser port readiness through the facade and protocol v2 port wait where available, with shell fallback only when unsupported
- keep VNC loopback-protected while allowing CDP/viewer ports to use direct guest networking when available
- prefer host cp reflink/sparse copy before native/Python sparse copy, and keep native zstd decompression documented with measured results
- update benchmark scripts/docs with comm-channel selection, shared networking report shape, and post-release Rust migration measurements

## Validation
- UV_CACHE_DIR=/tmp/uv-cache uv run pytest -q -> 1438 passed, 12 skipped, 27 deselected
- uv run ruff check . -> All checks passed
- git diff --check

## Notes
- The latest Firecracker numbers in the docs are marked as unprivileged fallback, not native TAP.
- Sparse copy benchmarks show cp is still faster than the current native helper on this machine, so production copy dispatch keeps cp first.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added `--comm-channel` option to benchmark startup with vsock/SSH/auto selection.
  * New guest TCP port readiness detection capability.

* **Documentation**
  * Updated benchmark documentation with follow-up results and revised preset startup examples.

* **Bug Fixes**
  * Improved disk copy performance with intelligent fallback strategy.
  * Enhanced port exposure configuration for browser sessions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->