### PR TITLE
Tighten guest agent transfer cleanup and benchmarks

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -135,12 +135,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "base64"
-version = "0.22.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
-
-[[package]]
 name = "bitflags"
 version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -957,7 +951,6 @@ name = "smolvm-guest-agent"
 version = "0.1.0"
 dependencies = [
  "axum",
- "base64",
  "clap",
  "hyper",
  "hyper-util",

--- a/docs/benchmarks/startup-speedups.md
+++ b/docs/benchmarks/startup-speedups.md
@@ -84,6 +84,42 @@ Networking note:
   existing sudo-command path, with stage sums of `242.1 ms` and `236.4 ms`.
   These are fallback-path numbers, not native TAP speedup numbers.
 
+## 2026-06-23 - Current PR: Alpha Cleanup And Transfer Validation
+
+- Commit: current PR branch, based on `0818286`.
+- Image tag: current published Ubuntu image used by the local benchmark run.
+- Commands:
+  - `UV_CACHE_DIR=/tmp/uv-cache uv run python scripts/benchmarks/disk_io.py --iterations 2 --sizes 16M,128M --json --output /tmp/smolvm-alpha-cleanup-disk-io.json`
+  - `UV_CACHE_DIR=/tmp/uv-cache uv run python scripts/benchmarks/file_transfer.py --backend qemu --comm-channel vsock --os ubuntu --sizes 1K,1M --directory-files 10 --directory-file-size 1K --boot-timeout 120 --ready-timeout 120 --json --output /tmp/smolvm-alpha-cleanup-file-transfer.json`
+- Host: Linux x86_64, kernel `7.0.0-15-generic`, KVM available.
+- Method: two local disk iterations; one QEMU/vsock published-Ubuntu file
+  transfer smoke with small payloads.
+- Behavior changed: the new Rust guest-agent build drops the old JSON/base64
+  file endpoints, while the host keeps a warning-backed compatibility path
+  because the active published Ubuntu image still lacks protocol-v2 transfer
+  capabilities.
+
+Disk helper validation:
+
+| Operation | Size | Native path | Forced-off path | Result |
+|---|---:|---:|---:|---|
+| sparse copy | 16 MiB | 10.5 ms (`cp`) | 10.2 ms (`cp`) | unchanged; `cp` remains first |
+| sparse copy | 128 MiB | 64.6 ms (`cp`) | 64.8 ms (`cp`) | unchanged; `cp` remains first |
+| zstd decompress | 16 MiB | 13.5 ms | 40.6 ms | 66.8% faster |
+| zstd decompress | 128 MiB | 96.4 ms | 376.1 ms | 74.4% faster |
+
+File-transfer validation:
+
+| Backend | Transport | Start | Ready | 1 KiB upload/download | 1 MiB upload/download | Directory upload/download | Feature flags |
+|---|---|---:|---:|---:|---:|---:|---|
+| QEMU | vsock | 52.6 ms | 286.4 ms | 2.6 / 0.7 ms | 12.6 / 9.6 ms | 8.6 / 7.5 ms | `files.stream=false`, `files.directory_tar=false` |
+
+Finding: the current published Ubuntu image can boot over vsock but still lacks
+`GET /capabilities`, `files.stream`, and `files.directory_tar`. SmolVM now logs
+a clear compatibility warning instead of silently using the slower path. Rerun
+this file-transfer benchmark after the next published-image release before
+claiming v2 streaming transfer speedups.
+
 ## Required Entry Format
 
 Add a short section for each PR that changes startup behavior or benchmark

--- a/docs/benchmarks/startup-speedups.md
+++ b/docs/benchmarks/startup-speedups.md
@@ -86,18 +86,23 @@ Networking note:
 
 ## 2026-06-23 - Current PR: Alpha Cleanup And Transfer Validation
 
+This benchmark confirms the disk-image speedup and shows that current
+published Ubuntu images must be republished before the new fast file-transfer
+path can be measured.
+
 - Commit: current PR branch, based on `0818286`.
 - Image tag: current published Ubuntu image used by the local benchmark run.
 - Commands:
   - `UV_CACHE_DIR=/tmp/uv-cache uv run python scripts/benchmarks/disk_io.py --iterations 2 --sizes 16M,128M --json --output /tmp/smolvm-alpha-cleanup-disk-io.json`
-  - `UV_CACHE_DIR=/tmp/uv-cache uv run python scripts/benchmarks/file_transfer.py --backend qemu --comm-channel vsock --os ubuntu --sizes 1K,1M --directory-files 10 --directory-file-size 1K --boot-timeout 120 --ready-timeout 120 --json --output /tmp/smolvm-alpha-cleanup-file-transfer.json`
+  - `UV_CACHE_DIR=/tmp/uv-cache uv run python scripts/benchmarks/file_transfer.py --backend qemu --comm-channel vsock --os ubuntu --sizes 1K --skip-directory --boot-timeout 120 --ready-timeout 120 --json --output /tmp/smolvm-alpha-cleanup-file-transfer-current-published.json`
 - Host: Linux x86_64, kernel `7.0.0-15-generic`, KVM available.
 - Method: two local disk iterations; one QEMU/vsock published-Ubuntu file
   transfer smoke with small payloads.
 - Behavior changed: the new Rust guest-agent build drops the old JSON/base64
-  file endpoints, while the host keeps a warning-backed compatibility path
-  because the active published Ubuntu image still lacks protocol-v2 transfer
-  capabilities.
+  file endpoints, and the host no longer falls back to those older endpoints.
+  The active published Ubuntu image still lacks protocol-v2 transfer
+  capabilities, meaning the newer fast file-transfer protocol is not present
+  until the image is republished from this branch.
 
 Disk helper validation:
 
@@ -110,15 +115,13 @@ Disk helper validation:
 
 File-transfer validation:
 
-| Backend | Transport | Start | Ready | 1 KiB upload/download | 1 MiB upload/download | Directory upload/download | Feature flags |
-|---|---|---:|---:|---:|---:|---:|---|
-| QEMU | vsock | 52.6 ms | 286.4 ms | 2.6 / 0.7 ms | 12.6 / 9.6 ms | 8.6 / 7.5 ms | `files.stream=false`, `files.directory_tar=false` |
+| Backend | Transport | Result | Feature flags |
+|---|---|---|---|
+| QEMU | vsock | failed as expected after 52.7 ms start and 282.9 ms ready | current published image lacks `GET /capabilities`, `files.stream`, and `files.directory_tar` |
 
-Finding: the current published Ubuntu image can boot over vsock but still lacks
-`GET /capabilities`, `files.stream`, and `files.directory_tar`. SmolVM now logs
-a clear compatibility warning instead of silently using the slower path. Rerun
-this file-transfer benchmark after the next published-image release before
-claiming v2 streaming transfer speedups.
+Finding: the current published Ubuntu image can boot over vsock but cannot use
+the new fast file-transfer protocol. Rerun this file-transfer benchmark after
+the next published-image release before claiming streaming transfer speedups.
 
 ## Required Entry Format
 

--- a/guest-agent/Cargo.toml
+++ b/guest-agent/Cargo.toml
@@ -18,7 +18,6 @@ tcp = []
 
 [dependencies]
 axum = "0.8"
-base64 = "0.22"
 clap = { version = "4", features = ["derive"] }
 hyper = { version = "1", features = ["server", "http1"] }
 hyper-util = { version = "0.1", features = ["tokio"] }

--- a/guest-agent/src/files.rs
+++ b/guest-agent/src/files.rs
@@ -1,17 +1,8 @@
-use base64::Engine;
 use serde::{Deserialize, Serialize};
 use std::fs::{self, File, OpenOptions};
 use std::io::Write;
 use std::os::unix::fs::PermissionsExt;
 use std::path::{Component, Path, PathBuf};
-
-#[derive(Debug, Deserialize)]
-pub struct FilePutRequest {
-    pub path: String,
-    pub name: Option<String>,
-    pub mode: Option<u32>,
-    pub data_base64: String,
-}
 
 #[derive(Debug, Serialize)]
 pub struct FilePutResponse {
@@ -23,16 +14,6 @@ pub struct FilePutResponse {
 #[derive(Debug, Deserialize)]
 pub struct FileGetQuery {
     pub path: String,
-}
-
-#[derive(Debug, Serialize)]
-pub struct FileGetResponse {
-    pub ok: bool,
-    pub mode: Option<u32>,
-    pub size: Option<u64>,
-    pub data_base64: Option<String>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub error: Option<String>,
 }
 
 #[derive(Debug)]
@@ -57,16 +38,6 @@ pub struct DirectoryTarQuery {
 fn response_error(error: impl Into<String>) -> FilePutResponse {
     FilePutResponse {
         ok: false,
-        error: Some(error.into()),
-    }
-}
-
-fn get_response_error(error: impl Into<String>) -> FileGetResponse {
-    FileGetResponse {
-        ok: false,
-        mode: None,
-        size: None,
-        data_base64: None,
         error: Some(error.into()),
     }
 }
@@ -176,14 +147,6 @@ pub fn put_file_bytes(
     write_file_atomically(&target, mode, data)
 }
 
-pub async fn put_file(req: FilePutRequest) -> FilePutResponse {
-    let data = match base64::engine::general_purpose::STANDARD.decode(req.data_base64.as_bytes()) {
-        Ok(data) => data,
-        Err(error) => return response_error(format!("invalid base64 data: {error}")),
-    };
-    put_file_bytes(&req.path, req.name.as_deref(), req.mode, &data)
-}
-
 pub fn read_file_bytes(path: &str) -> Result<RawFile, String> {
     if path.is_empty() {
         return Err("missing path".to_string());
@@ -205,20 +168,6 @@ pub fn read_file_bytes(path: &str) -> Result<RawFile, String> {
         size: data.len() as u64,
         data,
     })
-}
-
-pub async fn get_file(query: FileGetQuery) -> FileGetResponse {
-    let file = match read_file_bytes(&query.path) {
-        Ok(file) => file,
-        Err(error) => return get_response_error(error),
-    };
-    FileGetResponse {
-        ok: true,
-        mode: Some(file.mode),
-        size: Some(file.size),
-        data_base64: Some(base64::engine::general_purpose::STANDARD.encode(file.data)),
-        error: None,
-    }
 }
 
 pub fn create_directory_tar(path: &str) -> Result<Vec<u8>, String> {
@@ -532,74 +481,27 @@ mod tests {
 
     static TEMPFILE_COUNTER: AtomicUsize = AtomicUsize::new(0);
 
-    #[tokio::test]
-    async fn put_and_get_file_preserves_mode() {
+    #[test]
+    fn put_into_directory_strips_traversal() {
         let dir = tempfile_dir();
-        let path = dir.join("payload.bin");
-        let data = b"hello world";
-
-        let put = put_file(FilePutRequest {
-            path: path.to_string_lossy().to_string(),
-            name: None,
-            mode: Some(0o640),
-            data_base64: base64::engine::general_purpose::STANDARD.encode(data),
-        })
-        .await;
-        assert!(put.ok, "{:?}", put.error);
-
-        let get = get_file(FileGetQuery {
-            path: path.to_string_lossy().to_string(),
-        })
-        .await;
-        assert!(get.ok, "{:?}", get.error);
-        assert_eq!(get.mode, Some(0o640));
-        assert_eq!(
-            base64::engine::general_purpose::STANDARD
-                .decode(get.data_base64.unwrap())
-                .unwrap(),
-            data
-        );
-    }
-
-    #[tokio::test]
-    async fn put_into_directory_strips_traversal() {
-        let dir = tempfile_dir();
-        let put = put_file(FilePutRequest {
-            path: dir.to_string_lossy().to_string(),
-            name: Some("../escape.txt".to_string()),
-            mode: None,
-            data_base64: base64::engine::general_purpose::STANDARD.encode(b"safe"),
-        })
-        .await;
+        let put = put_file_bytes(dir.to_str().unwrap(), Some("../escape.txt"), None, b"safe");
         assert!(put.ok, "{:?}", put.error);
         assert_eq!(fs::read(dir.join("escape.txt")).unwrap(), b"safe");
         assert!(!dir.parent().unwrap().join("escape.txt").exists());
     }
 
-    #[tokio::test]
-    async fn put_into_directory_rejects_missing_name() {
+    #[test]
+    fn put_into_directory_rejects_missing_name() {
         let dir = tempfile_dir();
-        let put = put_file(FilePutRequest {
-            path: dir.to_string_lossy().to_string(),
-            name: None,
-            mode: None,
-            data_base64: base64::engine::general_purpose::STANDARD.encode(b"data"),
-        })
-        .await;
+        let put = put_file_bytes(dir.to_str().unwrap(), None, None, b"data");
         assert!(!put.ok);
         assert!(put.error.unwrap().contains("directory"));
     }
 
-    #[tokio::test]
-    async fn put_rejects_invalid_directory_filename() {
+    #[test]
+    fn put_rejects_invalid_directory_filename() {
         let dir = tempfile_dir();
-        let put = put_file(FilePutRequest {
-            path: dir.to_string_lossy().to_string(),
-            name: Some("..".to_string()),
-            mode: None,
-            data_base64: base64::engine::general_purpose::STANDARD.encode(b"data"),
-        })
-        .await;
+        let put = put_file_bytes(dir.to_str().unwrap(), Some(".."), None, b"data");
         assert!(!put.ok);
         assert!(
             put.error
@@ -608,36 +510,14 @@ mod tests {
         );
     }
 
-    #[tokio::test]
-    async fn put_rejects_invalid_base64() {
+    #[test]
+    fn read_file_bytes_rejects_missing_and_non_regular_paths() {
         let dir = tempfile_dir();
-        let put = put_file(FilePutRequest {
-            path: dir.join("bad.bin").to_string_lossy().to_string(),
-            name: None,
-            mode: None,
-            data_base64: "%%%".to_string(),
-        })
-        .await;
-        assert!(!put.ok);
-        assert!(put.error.unwrap().contains("invalid base64 data"));
-    }
+        let missing = read_file_bytes(dir.join("missing.bin").to_str().unwrap());
+        assert!(missing.unwrap_err().contains("No such file"));
 
-    #[tokio::test]
-    async fn get_rejects_missing_and_non_regular_paths() {
-        let dir = tempfile_dir();
-        let missing = get_file(FileGetQuery {
-            path: dir.join("missing.bin").to_string_lossy().to_string(),
-        })
-        .await;
-        assert!(!missing.ok);
-        assert!(missing.error.unwrap().contains("No such file"));
-
-        let directory = get_file(FileGetQuery {
-            path: dir.to_string_lossy().to_string(),
-        })
-        .await;
-        assert!(!directory.ok);
-        assert_eq!(directory.error.as_deref(), Some("not a regular file"));
+        let directory = read_file_bytes(dir.to_str().unwrap());
+        assert_eq!(directory.unwrap_err(), "not a regular file");
     }
 
     #[test]

--- a/guest-agent/src/handler.rs
+++ b/guest-agent/src/handler.rs
@@ -13,14 +13,10 @@ use std::time::Instant;
 use crate::boot::{self, BootMilestonesResponse};
 use crate::env::{self, EnvDeleteRequest, EnvPutRequest, EnvResponse};
 use crate::exec::{self, ExecRequest, ExecResponse};
-use crate::files::{
-    self, DirectoryTarQuery, FileGetQuery, FileGetResponse, FilePutRequest, FilePutResponse,
-    FileRawPutQuery,
-};
+use crate::files::{self, DirectoryTarQuery, FileGetQuery, FilePutResponse, FileRawPutQuery};
 use crate::ports::{self, PortsWaitRequest, PortsWaitResponse};
 
 pub const PROTOCOL_VERSION: u32 = 2;
-const FILE_PUT_BODY_LIMIT_BYTES: usize = 50 * 1024 * 1024;
 const FILE_RAW_BODY_LIMIT_BYTES: usize = 256 * 1024 * 1024;
 const DIRECTORY_TAR_BODY_LIMIT_BYTES: usize = 512 * 1024 * 1024;
 static START_TIME: Lazy<Instant> = Lazy::new(Instant::now);
@@ -33,11 +29,6 @@ pub fn router() -> Router {
         .route("/capabilities", get(handle_capabilities))
         .route("/exec", post(handle_exec))
         .route("/sync", post(handle_sync))
-        .route(
-            "/files/put",
-            post(handle_file_put).layer(DefaultBodyLimit::max(FILE_PUT_BODY_LIMIT_BYTES)),
-        )
-        .route("/files/get", get(handle_file_get))
         .route(
             "/files/raw",
             get(handle_file_raw_get)
@@ -84,11 +75,6 @@ pub fn extension_router() -> Router {
         .route("/version", get(handle_version))
         .route("/capabilities", get(handle_capabilities))
         .route("/sync", post(handle_sync))
-        .route(
-            "/files/put",
-            post(handle_file_put).layer(DefaultBodyLimit::max(FILE_PUT_BODY_LIMIT_BYTES)),
-        )
-        .route("/files/get", get(handle_file_get))
         .route(
             "/files/raw",
             get(handle_file_raw_get)
@@ -180,7 +166,6 @@ pub struct CapabilitiesResponse {
 pub struct CapabilityFeatures {
     pub exec: bool,
     pub sync: bool,
-    pub file_base64: bool,
     pub file_raw: bool,
     #[serde(rename = "files.stream")]
     pub files_stream: bool,
@@ -205,7 +190,6 @@ pub struct CapabilityFeatures {
 
 #[derive(Serialize)]
 pub struct CapabilityLimits {
-    pub file_put_json_bytes: usize,
     pub file_raw_put_bytes: usize,
     pub max_stream_size_bytes: usize,
     pub directory_tar_put_bytes: usize,
@@ -223,8 +207,6 @@ pub async fn handle_capabilities() -> Json<CapabilitiesResponse> {
             "GET /capabilities",
             "POST /exec",
             "POST /sync",
-            "POST /files/put",
-            "GET /files/get",
             "PUT /files/content",
             "GET /files/content",
             "PUT /directories/tar",
@@ -245,7 +227,6 @@ pub async fn handle_capabilities() -> Json<CapabilitiesResponse> {
         features: CapabilityFeatures {
             exec: true,
             sync: true,
-            file_base64: true,
             file_raw: true,
             files_stream: true,
             dir_tar: true,
@@ -262,7 +243,6 @@ pub async fn handle_capabilities() -> Json<CapabilitiesResponse> {
             prod_metrics: false,
         },
         limits: CapabilityLimits {
-            file_put_json_bytes: FILE_PUT_BODY_LIMIT_BYTES,
             file_raw_put_bytes: FILE_RAW_BODY_LIMIT_BYTES,
             max_stream_size_bytes: FILE_RAW_BODY_LIMIT_BYTES,
             directory_tar_put_bytes: DIRECTORY_TAR_BODY_LIMIT_BYTES,
@@ -299,14 +279,6 @@ pub async fn handle_sync() -> Json<SyncResponse> {
             error: Some(format!("sync task failed: {error}")),
         }),
     }
-}
-
-pub async fn handle_file_put(Json(req): Json<FilePutRequest>) -> Json<FilePutResponse> {
-    Json(files::put_file(req).await)
-}
-
-pub async fn handle_file_get(Query(query): Query<FileGetQuery>) -> Json<FileGetResponse> {
-    Json(files::get_file(query).await)
 }
 
 pub async fn handle_file_raw_put(
@@ -429,7 +401,7 @@ mod tests {
         assert_eq!(capabilities.body["tcp_enabled"], cfg!(feature = "tcp"));
         assert_eq!(capabilities.body["terminal_enabled"], false);
         assert_eq!(capabilities.body["prod_metrics_enabled"], false);
-        assert_eq!(capabilities.body["features"]["file_base64"], true);
+        assert!(capabilities.body["features"].get("file_base64").is_none());
         assert_eq!(capabilities.body["features"]["file_raw"], true);
         assert_eq!(capabilities.body["features"]["files.stream"], true);
         assert_eq!(capabilities.body["features"]["dir_tar"], true);
@@ -441,9 +413,10 @@ mod tests {
         assert_eq!(capabilities.body["features"]["ports_wait"], true);
         assert_eq!(capabilities.body["features"]["ports.wait"], true);
         assert_eq!(capabilities.body["features"]["browser.status"], false);
-        assert_eq!(
-            capabilities.body["limits"]["file_put_json_bytes"],
-            FILE_PUT_BODY_LIMIT_BYTES
+        assert!(
+            capabilities.body["limits"]
+                .get("file_put_json_bytes")
+                .is_none()
         );
         assert_eq!(
             capabilities.body["limits"]["max_stream_size_bytes"],
@@ -456,8 +429,8 @@ mod tests {
         let endpoints = capabilities.body["endpoints"].as_array().unwrap();
         assert!(endpoints.contains(&json!("POST /exec")));
         assert!(endpoints.contains(&json!("POST /sync")));
-        assert!(endpoints.contains(&json!("POST /files/put")));
-        assert!(endpoints.contains(&json!("GET /files/get")));
+        assert!(!endpoints.contains(&json!("POST /files/put")));
+        assert!(!endpoints.contains(&json!("GET /files/get")));
         assert!(endpoints.contains(&json!("PUT /files/content")));
         assert!(endpoints.contains(&json!("GET /files/content")));
         assert!(endpoints.contains(&json!("PUT /directories/tar")));

--- a/scripts/benchmarks/README.md
+++ b/scripts/benchmarks/README.md
@@ -90,6 +90,12 @@ uv run python scripts/benchmarks/preset_start.py --preset codex --backend qemu -
 uv run python scripts/benchmarks/browser_ready.py --backend qemu --json --output /tmp/smolvm-browser-ready.json
 ```
 
+If `file_transfer.py` prints a compatibility warning about the current control
+protocol, fast file transfer, or directory transfer, the sandbox image is using
+the older guest-agent path. Treat those numbers as compatibility-path timings,
+then rebuild or republish the image with the current Rust guest agent and rerun
+before claiming protocol-v2 streaming speedups.
+
 ## Linux Networking Stages
 
 Use `networking.py` to decide whether the Rust networking path makes Linux VM

--- a/scripts/benchmarks/README.md
+++ b/scripts/benchmarks/README.md
@@ -90,11 +90,10 @@ uv run python scripts/benchmarks/preset_start.py --preset codex --backend qemu -
 uv run python scripts/benchmarks/browser_ready.py --backend qemu --json --output /tmp/smolvm-browser-ready.json
 ```
 
-If `file_transfer.py` prints a compatibility warning about the current control
-protocol, fast file transfer, or directory transfer, the sandbox image is using
-the older guest-agent path. Treat those numbers as compatibility-path timings,
-then rebuild or republish the image with the current Rust guest agent and rerun
-before claiming protocol-v2 streaming speedups.
+If `file_transfer.py` fails because the sandbox image does not support fast file
+or directory transfer, rebuild or republish the image with the current control
+service and rerun before claiming streaming speedups from the newer fast
+file-transfer protocol.
 
 ## Linux Networking Stages
 

--- a/src/smolvm/comm/rust_http_vsock_channel.py
+++ b/src/smolvm/comm/rust_http_vsock_channel.py
@@ -69,6 +69,7 @@ _LEGACY_CAPABILITIES: dict[str, Any] = {
     "limits": {},
     "endpoints": ["POST /exec", "POST /files/put", "GET /files/get"],
 }
+_LEGACY_FALLBACK_WARNED: set[str] = set()
 
 
 @dataclass(frozen=True)
@@ -100,6 +101,14 @@ class ControlCapabilities:
         return False
 
 
+def _endpoint_missing(exc: BaseException, method: str, path: str) -> bool:
+    text = str(exc)
+    return (
+        f"guest agent HTTP 404 for {method} {path}" in text
+        or f"guest agent HTTP 405 for {method} {path}" in text
+    )
+
+
 def _legacy_control_capabilities() -> ControlCapabilities:
     features = _LEGACY_CAPABILITIES["features"]
     limits = _LEGACY_CAPABILITIES["limits"]
@@ -110,11 +119,15 @@ def _legacy_control_capabilities() -> ControlCapabilities:
     )
 
 
-def _endpoint_missing(exc: BaseException, method: str, path: str) -> bool:
-    text = str(exc)
-    return (
-        f"guest agent HTTP 404 for {method} {path}" in text
-        or f"guest agent HTTP 405 for {method} {path}" in text
+def _warn_legacy_fallback(feature: str) -> None:
+    if feature in _LEGACY_FALLBACK_WARNED:
+        return
+    _LEGACY_FALLBACK_WARNED.add(feature)
+    logger.warning(
+        "This sandbox image does not support %s; SmolVM is using a slower "
+        "compatibility path. Rebuild or republish the image with the current "
+        "Rust guest agent, or create the sandbox with `--comm-channel ssh`.",
+        feature,
     )
 
 
@@ -133,6 +146,14 @@ def _parse_size_header(value: str, *, header: str, method: str, path: str) -> in
     if size < 0:
         raise SmolVMError(f"guest agent returned negative {header} for {method} {path}")
     return size
+
+
+def _feature_required_error(feature: str) -> SmolVMError:
+    return SmolVMError(
+        f"This sandbox image does not support {feature}; recreate it with "
+        "an image that includes the current Rust guest agent, or create it "
+        "with `--comm-channel ssh`."
+    )
 
 
 def _directory_to_tar(source: Path) -> bytes:
@@ -443,6 +464,7 @@ class RustHttpVsockChannel:
                 limits = resp.get("limits") if isinstance(resp.get("limits"), dict) else {}
                 protocol_version = int(resp.get("protocol_version", 1))
                 if protocol_version < 2 and not features:
+                    _warn_legacy_fallback("the current control protocol")
                     features = _LEGACY_CAPABILITIES["features"]
                 self._capabilities = ControlCapabilities(
                     protocol_version=protocol_version,
@@ -450,11 +472,16 @@ class RustHttpVsockChannel:
                     limits=dict(limits),
                 )
             except (OSError, SmolVMError, ValueError, OperationTimeoutError):
+                _warn_legacy_fallback("the current control protocol")
                 self._capabilities = _legacy_control_capabilities()
         return self._capabilities
 
     def supports(self, *features: str) -> bool:
         return self.capabilities.enabled(*features)
+
+    def _require_feature(self, feature: str, *capability_names: str) -> None:
+        if not self.supports(*capability_names):
+            raise _feature_required_error(feature)
 
     def _limit_bytes(self, name: str, default: int) -> int:
         value = self.capabilities.limits.get(name)
@@ -503,6 +530,7 @@ class RustHttpVsockChannel:
         except SmolVMError as exc:
             if "guest agent HTTP 404 for POST /sync" not in str(exc):
                 raise
+            _warn_legacy_fallback("guest filesystem sync")
             result = self.run("sync", timeout=timeout, shell="raw")
             if result.exit_code != 0:
                 raise SmolVMError(
@@ -523,10 +551,8 @@ class RustHttpVsockChannel:
             raise ValueError(f"local_path is not a file: {source}")
         mode = stat.S_IMODE(source.stat().st_mode)
         if self.supports("file_raw", "files.stream"):
+            query = urllib.parse.urlencode({"path": remote_path, "name": source.name, "mode": mode})
             try:
-                query = urllib.parse.urlencode(
-                    {"path": remote_path, "name": source.name, "mode": mode}
-                )
                 resp, data = self._request_bytes(
                     "PUT",
                     f"/files/content?{query}",
@@ -542,7 +568,10 @@ class RustHttpVsockChannel:
             except SmolVMError as exc:
                 if not _endpoint_missing(exc, "PUT", "/files/content"):
                     raise
+                _warn_legacy_fallback("fast file transfer")
                 self._capabilities = _legacy_control_capabilities()
+        else:
+            _warn_legacy_fallback("fast file transfer")
         payload = {
             "path": remote_path,
             "name": source.name,
@@ -585,7 +614,10 @@ class RustHttpVsockChannel:
             except SmolVMError as exc:
                 if not _endpoint_missing(exc, "GET", "/files/content"):
                     raise
+                _warn_legacy_fallback("fast file transfer")
                 self._capabilities = _legacy_control_capabilities()
+        else:
+            _warn_legacy_fallback("fast file transfer")
         resp = self._request_json("GET", f"/files/get?{query}")
         if not resp.get("ok"):
             raise SmolVMError(f"Failed to download guest file '{remote_path}': {resp.get('error')}")
@@ -612,6 +644,7 @@ class RustHttpVsockChannel:
         if not source.is_dir():
             raise ValueError(f"local_path is not a directory: {source}")
         if not self.supports("dir_tar", "files.directory_tar"):
+            _warn_legacy_fallback("directory transfer")
             self._put_directory_legacy(source, remote_path)
             return
         data = _directory_to_tar(source)
@@ -626,6 +659,7 @@ class RustHttpVsockChannel:
         except SmolVMError as exc:
             if not _endpoint_missing(exc, "PUT", "/directories/tar"):
                 raise
+            _warn_legacy_fallback("directory transfer")
             self._put_directory_legacy(source, remote_path)
             return
         decoded = json.loads(response_data.decode("utf-8")) if response_data else {}
@@ -639,6 +673,7 @@ class RustHttpVsockChannel:
         if not remote_path:
             raise ValueError("remote_path cannot be empty")
         if not self.supports("dir_tar", "files.directory_tar"):
+            _warn_legacy_fallback("directory transfer")
             return self._get_directory_legacy(remote_path, Path(local_path))
         destination = Path(local_path)
         destination.mkdir(parents=True, exist_ok=True)
@@ -652,6 +687,7 @@ class RustHttpVsockChannel:
         except SmolVMError as exc:
             if not _endpoint_missing(exc, "GET", "/directories/tar"):
                 raise
+            _warn_legacy_fallback("directory transfer")
             return self._get_directory_legacy(remote_path, destination)
         _safe_extract_tar(data, destination)
         return destination
@@ -716,6 +752,7 @@ class RustHttpVsockChannel:
                 self.run(f"rm -f -- {shlex.quote(remote_tmp)}", timeout=10, shell="raw")
 
     def set_managed_env(self, env_vars: dict[str, str], *, merge: bool = True) -> dict[str, str]:
+        self._require_feature("managed environment variables", "env_managed", "env.managed")
         resp = self._request_json("PUT", "/env", {"vars": env_vars, "merge": merge})
         if not resp.get("ok"):
             raise SmolVMError(f"guest agent error during env update: {resp.get('error', resp)}")
@@ -723,6 +760,7 @@ class RustHttpVsockChannel:
         return dict(vars_value) if isinstance(vars_value, dict) else {}
 
     def unset_managed_env(self, keys: list[str]) -> dict[str, str]:
+        self._require_feature("managed environment variables", "env_managed", "env.managed")
         resp = self._request_json("DELETE", "/env", {"keys": keys})
         if not resp.get("ok"):
             raise SmolVMError(f"guest agent error during env update: {resp.get('error', resp)}")
@@ -730,6 +768,7 @@ class RustHttpVsockChannel:
         return dict(vars_value) if isinstance(vars_value, dict) else {}
 
     def list_managed_env(self) -> dict[str, str]:
+        self._require_feature("managed environment variables", "env_managed", "env.managed")
         resp = self._request_json("GET", "/env")
         if not resp.get("ok"):
             raise SmolVMError(f"guest agent error during env read: {resp.get('error', resp)}")
@@ -746,6 +785,7 @@ class RustHttpVsockChannel:
                 exc, "PUT", "/env"
             ):
                 raise
+            _warn_legacy_fallback("managed environment variables")
             from smolvm.env import inject_env_vars
 
             return inject_env_vars(self, env_vars, merge=merge)
@@ -762,6 +802,7 @@ class RustHttpVsockChannel:
                 exc, "DELETE", "/env"
             ):
                 raise
+            _warn_legacy_fallback("managed environment variables")
             from smolvm.env import remove_env_vars
 
             return remove_env_vars(self, keys)
@@ -774,6 +815,7 @@ class RustHttpVsockChannel:
                 exc, "GET", "/env"
             ):
                 raise
+            _warn_legacy_fallback("managed environment variables")
             from smolvm.env import read_env_vars
 
             return read_env_vars(self)

--- a/src/smolvm/comm/rust_http_vsock_channel.py
+++ b/src/smolvm/comm/rust_http_vsock_channel.py
@@ -499,8 +499,18 @@ class RustHttpVsockChannel:
             raise ValueError(f"local_path does not exist: {source}")
         if not source.is_file():
             raise ValueError(f"local_path is not a file: {source}")
-        mode = stat.S_IMODE(source.stat().st_mode)
+        source_stat = source.stat()
+        mode = stat.S_IMODE(source_stat.st_mode)
         self._require_feature("fast file transfer", "file_raw", "files.stream")
+        max_stream_size = self._limit_bytes(
+            "max_stream_size_bytes",
+            _DEFAULT_MAX_STREAM_SIZE_BYTES,
+        )
+        if source_stat.st_size > max_stream_size:
+            raise SmolVMError(
+                f"File '{source}' is {source_stat.st_size} bytes, "
+                f"but this sandbox accepts files up to {max_stream_size} bytes in one upload."
+            )
         query = urllib.parse.urlencode({"path": remote_path, "name": source.name, "mode": mode})
         _resp, data = self._request_bytes(
             "PUT",

--- a/src/smolvm/comm/rust_http_vsock_channel.py
+++ b/src/smolvm/comm/rust_http_vsock_channel.py
@@ -16,7 +16,6 @@
 
 from __future__ import annotations
 
-import base64
 import http.client
 import io
 import ipaddress
@@ -28,7 +27,6 @@ import shlex
 import socket
 import stat
 import tarfile
-import tempfile
 import time
 import urllib.parse
 from collections.abc import Callable
@@ -53,23 +51,6 @@ _DEFAULT_MAX_STREAM_SIZE_BYTES = 256 * 1024 * 1024
 _DEFAULT_MAX_TAR_SIZE_BYTES = 512 * 1024 * 1024
 _MAX_PORTS_WAIT = 256
 _MAX_PORT_WAIT_TIMEOUT_SECONDS = 300.0
-
-_LEGACY_CAPABILITIES: dict[str, Any] = {
-    "protocol_version": 1,
-    "features": {
-        "exec": True,
-        "sync": False,
-        "file_base64": True,
-        "file_raw": False,
-        "dir_tar": False,
-        "env_managed": False,
-        "boot_milestones": False,
-        "ports_wait": False,
-    },
-    "limits": {},
-    "endpoints": ["POST /exec", "POST /files/put", "GET /files/get"],
-}
-_LEGACY_FALLBACK_WARNED: set[str] = set()
 
 
 @dataclass(frozen=True)
@@ -101,33 +82,17 @@ class ControlCapabilities:
         return False
 
 
-def _endpoint_missing(exc: BaseException, method: str, path: str) -> bool:
-    text = str(exc)
+def _feature_required_message(feature: str, sandbox_name: str | None) -> str:
+    if sandbox_name:
+        sandbox = shlex.quote(sandbox_name)
+        return (
+            f"Sandbox {sandbox} is using an older image that does not support {feature}; "
+            f"run `smolvm sandbox delete {sandbox}` and create it again after updating the image."
+        )
     return (
-        f"guest agent HTTP 404 for {method} {path}" in text
-        or f"guest agent HTTP 405 for {method} {path}" in text
-    )
-
-
-def _legacy_control_capabilities() -> ControlCapabilities:
-    features = _LEGACY_CAPABILITIES["features"]
-    limits = _LEGACY_CAPABILITIES["limits"]
-    return ControlCapabilities(
-        protocol_version=1,
-        features=dict(features) if isinstance(features, dict) else {},
-        limits=dict(limits) if isinstance(limits, dict) else {},
-    )
-
-
-def _warn_legacy_fallback(feature: str) -> None:
-    if feature in _LEGACY_FALLBACK_WARNED:
-        return
-    _LEGACY_FALLBACK_WARNED.add(feature)
-    logger.warning(
-        "This sandbox image does not support %s; SmolVM is using a slower "
-        "compatibility path. Rebuild or republish the image with the current "
-        "Rust guest agent, or create the sandbox with `--comm-channel ssh`.",
-        feature,
+        f"This sandbox is using an older image that does not support {feature}; "
+        "run `smolvm sandbox list` to find its name, then delete it and create it again "
+        "after updating the image."
     )
 
 
@@ -148,12 +113,8 @@ def _parse_size_header(value: str, *, header: str, method: str, path: str) -> in
     return size
 
 
-def _feature_required_error(feature: str) -> SmolVMError:
-    return SmolVMError(
-        f"This sandbox image does not support {feature}; recreate it with "
-        "an image that includes the current Rust guest agent, or create it "
-        "with `--comm-channel ssh`."
-    )
+def _feature_required_error(feature: str, *, sandbox_name: str | None = None) -> SmolVMError:
+    return SmolVMError(_feature_required_message(feature, sandbox_name))
 
 
 def _directory_to_tar(source: Path) -> bytes:
@@ -176,13 +137,6 @@ def _strip_tar_owner(info: tarfile.TarInfo) -> tarfile.TarInfo:
     info.uname = ""
     info.gname = ""
     return info
-
-
-def _write_temp_tar(data: bytes) -> Path:
-    fd, path = tempfile.mkstemp(prefix="smolvm-dir-", suffix=".tar")
-    with os.fdopen(fd, "wb") as handle:
-        handle.write(data)
-    return Path(path)
 
 
 def _add_tar_path(archive: tarfile.TarFile, path: Path, arcname: PurePosixPath) -> None:
@@ -284,6 +238,7 @@ class RustHttpVsockChannel:
         uds_path: str | Path | None = None,
         agent_port: int = SMOLVM_AGENT_PORT,
         connect_timeout: int = 10,
+        sandbox_name: str | None = None,
     ) -> None:
         if (guest_cid is None) == (uds_path is None):
             raise ValueError("provide exactly one of guest_cid or uds_path")
@@ -293,6 +248,7 @@ class RustHttpVsockChannel:
         self.uds_path = str(uds_path) if uds_path is not None else None
         self.agent_port = agent_port
         self.connect_timeout = connect_timeout
+        self.sandbox_name = sandbox_name
         self._ready = False
         self._capabilities: ControlCapabilities | None = None
 
@@ -303,8 +259,14 @@ class RustHttpVsockChannel:
         *,
         agent_port: int = SMOLVM_AGENT_PORT,
         connect_timeout: int = 10,
+        sandbox_name: str | None = None,
     ) -> RustHttpVsockChannel:
-        return cls(guest_cid=guest_cid, agent_port=agent_port, connect_timeout=connect_timeout)
+        return cls(
+            guest_cid=guest_cid,
+            agent_port=agent_port,
+            connect_timeout=connect_timeout,
+            sandbox_name=sandbox_name,
+        )
 
     @classmethod
     def from_uds(
@@ -313,8 +275,14 @@ class RustHttpVsockChannel:
         *,
         agent_port: int = SMOLVM_AGENT_PORT,
         connect_timeout: int = 10,
+        sandbox_name: str | None = None,
     ) -> RustHttpVsockChannel:
-        return cls(uds_path=uds_path, agent_port=agent_port, connect_timeout=connect_timeout)
+        return cls(
+            uds_path=uds_path,
+            agent_port=agent_port,
+            connect_timeout=connect_timeout,
+            sandbox_name=sandbox_name,
+        )
 
     def _open(self) -> socket.socket:
         if self.uds_path is not None:
@@ -458,22 +426,15 @@ class RustHttpVsockChannel:
     @property
     def capabilities(self) -> ControlCapabilities:
         if self._capabilities is None:
-            try:
-                resp = self._request_json("GET", "/capabilities")
-                features = resp.get("features") if isinstance(resp.get("features"), dict) else {}
-                limits = resp.get("limits") if isinstance(resp.get("limits"), dict) else {}
-                protocol_version = int(resp.get("protocol_version", 1))
-                if protocol_version < 2 and not features:
-                    _warn_legacy_fallback("the current control protocol")
-                    features = _LEGACY_CAPABILITIES["features"]
-                self._capabilities = ControlCapabilities(
-                    protocol_version=protocol_version,
-                    features=dict(features),
-                    limits=dict(limits),
-                )
-            except (OSError, SmolVMError, ValueError, OperationTimeoutError):
-                _warn_legacy_fallback("the current control protocol")
-                self._capabilities = _legacy_control_capabilities()
+            resp = self._request_json("GET", "/capabilities")
+            features = resp.get("features") if isinstance(resp.get("features"), dict) else {}
+            limits = resp.get("limits") if isinstance(resp.get("limits"), dict) else {}
+            protocol_version = int(resp.get("protocol_version", 1))
+            self._capabilities = ControlCapabilities(
+                protocol_version=protocol_version,
+                features=dict(features),
+                limits=dict(limits),
+            )
         return self._capabilities
 
     def supports(self, *features: str) -> bool:
@@ -481,7 +442,7 @@ class RustHttpVsockChannel:
 
     def _require_feature(self, feature: str, *capability_names: str) -> None:
         if not self.supports(*capability_names):
-            raise _feature_required_error(feature)
+            raise _feature_required_error(feature, sandbox_name=self.sandbox_name)
 
     def _limit_bytes(self, name: str, default: int) -> int:
         value = self.capabilities.limits.get(name)
@@ -521,23 +482,12 @@ class RustHttpVsockChannel:
     def sync(self, timeout: float = 10) -> None:
         if timeout <= 0:
             raise ValueError("timeout must be > 0")
-        try:
-            resp = self._request_json(
-                "POST",
-                "/sync",
-                timeout=float(timeout + self.connect_timeout),
-            )
-        except SmolVMError as exc:
-            if "guest agent HTTP 404 for POST /sync" not in str(exc):
-                raise
-            _warn_legacy_fallback("guest filesystem sync")
-            result = self.run("sync", timeout=timeout, shell="raw")
-            if result.exit_code != 0:
-                raise SmolVMError(
-                    "guest agent error during legacy sync fallback: "
-                    f"exit_code={result.exit_code} stderr={result.stderr!r}"
-                ) from exc
-            return
+        self._require_feature("saving files before shutdown", "sync")
+        resp = self._request_json(
+            "POST",
+            "/sync",
+            timeout=float(timeout + self.connect_timeout),
+        )
         if not resp.get("ok"):
             raise SmolVMError(f"guest agent error during sync: {resp.get('error', resp)}")
 
@@ -550,38 +500,18 @@ class RustHttpVsockChannel:
         if not source.is_file():
             raise ValueError(f"local_path is not a file: {source}")
         mode = stat.S_IMODE(source.stat().st_mode)
-        if self.supports("file_raw", "files.stream"):
-            query = urllib.parse.urlencode({"path": remote_path, "name": source.name, "mode": mode})
-            try:
-                resp, data = self._request_bytes(
-                    "PUT",
-                    f"/files/content?{query}",
-                    source.read_bytes(),
-                    content_type="application/octet-stream",
-                )
-                decoded = json.loads(data.decode("utf-8")) if data else {}
-                if resp.status >= 400 or not decoded.get("ok"):
-                    raise SmolVMError(
-                        f"Failed to upload file to guest '{remote_path}': {decoded.get('error')}"
-                    )
-                return
-            except SmolVMError as exc:
-                if not _endpoint_missing(exc, "PUT", "/files/content"):
-                    raise
-                _warn_legacy_fallback("fast file transfer")
-                self._capabilities = _legacy_control_capabilities()
-        else:
-            _warn_legacy_fallback("fast file transfer")
-        payload = {
-            "path": remote_path,
-            "name": source.name,
-            "mode": mode,
-            "data_base64": base64.b64encode(source.read_bytes()).decode("ascii"),
-        }
-        resp = self._request_json("POST", "/files/put", payload)
-        if not resp.get("ok"):
+        self._require_feature("fast file transfer", "file_raw", "files.stream")
+        query = urllib.parse.urlencode({"path": remote_path, "name": source.name, "mode": mode})
+        _resp, data = self._request_bytes(
+            "PUT",
+            f"/files/content?{query}",
+            source.read_bytes(),
+            content_type="application/octet-stream",
+        )
+        decoded = json.loads(data.decode("utf-8")) if data else {}
+        if not decoded.get("ok"):
             raise SmolVMError(
-                f"Failed to upload file to guest '{remote_path}': {resp.get('error')}"
+                f"Failed to upload file to guest '{remote_path}': {decoded.get('error')}"
             )
 
     def get_file(self, remote_path: str, local_path: str | Path) -> Path:
@@ -589,51 +519,26 @@ class RustHttpVsockChannel:
             raise ValueError("remote_path cannot be empty")
         destination = Path(local_path)
         destination.parent.mkdir(parents=True, exist_ok=True)
+        self._require_feature("fast file transfer", "file_raw", "files.stream")
         query = urllib.parse.urlencode({"path": remote_path})
-        if self.supports("file_raw", "files.stream"):
-            try:
-                resp, data = self._request_bytes(
-                    "GET",
-                    f"/files/content?{query}",
-                    max_bytes=self._limit_bytes(
-                        "max_stream_size_bytes",
-                        _DEFAULT_MAX_STREAM_SIZE_BYTES,
-                    ),
-                )
-                expected_size = resp.getheader("x-smolvm-file-size")
-                if expected_size is not None and int(expected_size) != len(data):
-                    raise SmolVMError(
-                        f"Guest file response for '{remote_path}' had size {expected_size}, "
-                        f"got {len(data)} bytes"
-                    )
-                destination.write_bytes(data)
-                mode = resp.getheader("x-smolvm-file-mode")
-                if mode is not None:
-                    os.chmod(destination, _parse_mode_header(mode))
-                return destination
-            except SmolVMError as exc:
-                if not _endpoint_missing(exc, "GET", "/files/content"):
-                    raise
-                _warn_legacy_fallback("fast file transfer")
-                self._capabilities = _legacy_control_capabilities()
-        else:
-            _warn_legacy_fallback("fast file transfer")
-        resp = self._request_json("GET", f"/files/get?{query}")
-        if not resp.get("ok"):
-            raise SmolVMError(f"Failed to download guest file '{remote_path}': {resp.get('error')}")
-        data_b64 = resp.get("data_base64")
-        if not isinstance(data_b64, str):
-            raise SmolVMError(f"Guest file response for '{remote_path}' did not include data")
-        data = base64.b64decode(data_b64.encode("ascii"))
-        destination.write_bytes(data)
-        size = resp.get("size")
-        if size is not None and int(size) != len(data):
+        resp, data = self._request_bytes(
+            "GET",
+            f"/files/content?{query}",
+            max_bytes=self._limit_bytes(
+                "max_stream_size_bytes",
+                _DEFAULT_MAX_STREAM_SIZE_BYTES,
+            ),
+        )
+        expected_size = resp.getheader("x-smolvm-file-size")
+        if expected_size is not None and int(expected_size) != len(data):
             raise SmolVMError(
-                f"Guest file response for '{remote_path}' had size {size}, got {len(data)} bytes"
+                f"Guest file response for '{remote_path}' had size {expected_size}, "
+                f"got {len(data)} bytes"
             )
-        mode = resp.get("mode")
+        destination.write_bytes(data)
+        mode = resp.getheader("x-smolvm-file-mode")
         if mode is not None:
-            os.chmod(destination, int(mode))
+            os.chmod(destination, _parse_mode_header(mode))
         return destination
 
     def put_directory(self, local_path: str | Path, remote_path: str) -> None:
@@ -643,25 +548,15 @@ class RustHttpVsockChannel:
         source = Path(local_path)
         if not source.is_dir():
             raise ValueError(f"local_path is not a directory: {source}")
-        if not self.supports("dir_tar", "files.directory_tar"):
-            _warn_legacy_fallback("directory transfer")
-            self._put_directory_legacy(source, remote_path)
-            return
+        self._require_feature("directory transfer", "dir_tar", "files.directory_tar")
         data = _directory_to_tar(source)
         query = urllib.parse.urlencode({"path": remote_path})
-        try:
-            _resp, response_data = self._request_bytes(
-                "PUT",
-                f"/directories/tar?{query}",
-                data,
-                content_type="application/x-tar",
-            )
-        except SmolVMError as exc:
-            if not _endpoint_missing(exc, "PUT", "/directories/tar"):
-                raise
-            _warn_legacy_fallback("directory transfer")
-            self._put_directory_legacy(source, remote_path)
-            return
+        _resp, response_data = self._request_bytes(
+            "PUT",
+            f"/directories/tar?{query}",
+            data,
+            content_type="application/x-tar",
+        )
         decoded = json.loads(response_data.decode("utf-8")) if response_data else {}
         if not decoded.get("ok"):
             raise SmolVMError(
@@ -672,84 +567,17 @@ class RustHttpVsockChannel:
         """Download a directory tar stream when the guest supports it."""
         if not remote_path:
             raise ValueError("remote_path cannot be empty")
-        if not self.supports("dir_tar", "files.directory_tar"):
-            _warn_legacy_fallback("directory transfer")
-            return self._get_directory_legacy(remote_path, Path(local_path))
+        self._require_feature("directory transfer", "dir_tar", "files.directory_tar")
         destination = Path(local_path)
         destination.mkdir(parents=True, exist_ok=True)
         query = urllib.parse.urlencode({"path": remote_path})
-        try:
-            _resp, data = self._request_bytes(
-                "GET",
-                f"/directories/tar?{query}",
-                max_bytes=self._limit_bytes("max_tar_size_bytes", _DEFAULT_MAX_TAR_SIZE_BYTES),
-            )
-        except SmolVMError as exc:
-            if not _endpoint_missing(exc, "GET", "/directories/tar"):
-                raise
-            _warn_legacy_fallback("directory transfer")
-            return self._get_directory_legacy(remote_path, destination)
+        _resp, data = self._request_bytes(
+            "GET",
+            f"/directories/tar?{query}",
+            max_bytes=self._limit_bytes("max_tar_size_bytes", _DEFAULT_MAX_TAR_SIZE_BYTES),
+        )
         _safe_extract_tar(data, destination)
         return destination
-
-    def _remote_temp_archive(self) -> str:
-        result = self.run("mktemp /tmp/smolvm-dir.XXXXXX.tar", timeout=10, shell="raw")
-        remote_tmp = result.stdout.strip()
-        if not result.ok or not remote_tmp:
-            raise SmolVMError(
-                "Failed to create temporary archive path in guest: "
-                f"{result.stderr.strip() or result.stdout}"
-            )
-        return remote_tmp
-
-    def _put_directory_legacy(self, source: Path, remote_path: str) -> None:
-        data = _directory_to_tar(source)
-        local_tmp = _write_temp_tar(data)
-        remote_tmp = self._remote_temp_archive()
-        try:
-            self.put_file(local_tmp, remote_tmp)
-            result = self.run(
-                "set -e; "
-                f"remote_tmp={shlex.quote(remote_tmp)}; "
-                "trap 'rm -f -- \"$remote_tmp\"' EXIT; "
-                f"mkdir -p -- {shlex.quote(remote_path)}; "
-                f'tar -xf "$remote_tmp" -C {shlex.quote(remote_path)}',
-                timeout=120,
-                shell="raw",
-            )
-            if not result.ok:
-                raise SmolVMError(
-                    "Failed to extract directory in guest: "
-                    f"{result.stderr.strip() or result.stdout}"
-                )
-        finally:
-            local_tmp.unlink(missing_ok=True)
-            with suppress(SmolVMError):
-                self.run(f"rm -f -- {shlex.quote(remote_tmp)}", timeout=10, shell="raw")
-
-    def _get_directory_legacy(self, remote_path: str, destination: Path) -> Path:
-        destination.mkdir(parents=True, exist_ok=True)
-        remote_tmp = self._remote_temp_archive()
-        local_fd, local_name = tempfile.mkstemp(prefix="smolvm-dir-", suffix=".tar")
-        os.close(local_fd)
-        local_tmp = Path(local_name)
-        try:
-            result = self.run(
-                f"set -e; tar -cf {shlex.quote(remote_tmp)} -C {shlex.quote(remote_path)} .",
-                timeout=120,
-                shell="raw",
-            )
-            if not result.ok:
-                raise SmolVMError(
-                    f"Failed to archive guest directory: {result.stderr.strip() or result.stdout}"
-                )
-            self.get_file(remote_tmp, local_tmp)
-            _safe_extract_tar(local_tmp.read_bytes(), destination)
-            return destination
-        finally:
-            local_tmp.unlink(missing_ok=True)
-            with suppress(SmolVMError):
-                self.run(f"rm -f -- {shlex.quote(remote_tmp)}", timeout=10, shell="raw")
 
     def set_managed_env(self, env_vars: dict[str, str], *, merge: bool = True) -> dict[str, str]:
         self._require_feature("managed environment variables", "env_managed", "env.managed")
@@ -778,47 +606,17 @@ class RustHttpVsockChannel:
     def set_env_vars(self, env_vars: dict[str, str], *, merge: bool = True) -> list[str]:
         if not env_vars:
             return []
-        try:
-            return sorted(self.set_managed_env(env_vars, merge=merge))
-        except SmolVMError as exc:
-            if self.supports("env_managed", "env.managed") and not _endpoint_missing(
-                exc, "PUT", "/env"
-            ):
-                raise
-            _warn_legacy_fallback("managed environment variables")
-            from smolvm.env import inject_env_vars
-
-            return inject_env_vars(self, env_vars, merge=merge)
+        return sorted(self.set_managed_env(env_vars, merge=merge))
 
     def unset_env_vars(self, keys: list[str]) -> dict[str, str]:
         if not keys:
             return {}
-        try:
-            before = self.list_managed_env()
-            after = self.unset_managed_env(keys)
-            return {key: before[key] for key in keys if key in before and key not in after}
-        except SmolVMError as exc:
-            if self.supports("env_managed", "env.managed") and not _endpoint_missing(
-                exc, "DELETE", "/env"
-            ):
-                raise
-            _warn_legacy_fallback("managed environment variables")
-            from smolvm.env import remove_env_vars
-
-            return remove_env_vars(self, keys)
+        before = self.list_managed_env()
+        after = self.unset_managed_env(keys)
+        return {key: before[key] for key in keys if key in before and key not in after}
 
     def list_env_vars(self) -> dict[str, str]:
-        try:
-            return self.list_managed_env()
-        except SmolVMError as exc:
-            if self.supports("env_managed", "env.managed") and not _endpoint_missing(
-                exc, "GET", "/env"
-            ):
-                raise
-            _warn_legacy_fallback("managed environment variables")
-            from smolvm.env import read_env_vars
-
-            return read_env_vars(self)
+        return self.list_managed_env()
 
     def wait_for_ports(
         self,

--- a/src/smolvm/facade.py
+++ b/src/smolvm/facade.py
@@ -3231,9 +3231,12 @@ modprobe 9pnet_virtio""".strip()
             uds_path = vsock.uds_path or getattr(self._info, "vsock_uds_path", None)
             if not uds_path:
                 return False
-            channel: CommChannel = RustHttpVsockChannel.from_uds(uds_path)
+            channel: CommChannel = RustHttpVsockChannel.from_uds(
+                uds_path,
+                sandbox_name=self._vm_id,
+            )
         else:
-            channel = RustHttpVsockChannel.from_cid(vsock.guest_cid)
+            channel = RustHttpVsockChannel.from_cid(vsock.guest_cid, sandbox_name=self._vm_id)
 
         try:
             channel.wait_ready(timeout=timeout)

--- a/tests/test_facade_vsock.py
+++ b/tests/test_facade_vsock.py
@@ -85,6 +85,7 @@ def test_wait_for_ready_uses_rust_vsock_when_agent_answers(
     assert vm._control_ready is True
     assert isinstance(vm._control_channel, RustHttpVsockChannel)
     assert vm._control_channel.guest_cid == 5
+    assert vm._control_channel.sandbox_name == "vm1"
     assert vm._ssh is None
 
 

--- a/tests/test_rust_http_vsock_channel.py
+++ b/tests/test_rust_http_vsock_channel.py
@@ -340,6 +340,28 @@ def test_put_file_does_not_fallback_when_raw_endpoint_missing(tmp_path: Path) ->
         channel.put_file(source, "/tmp/source.txt")
 
 
+def test_put_file_rejects_local_size_over_cap_before_upload(tmp_path: Path) -> None:
+    source = tmp_path / "source.txt"
+    source.write_text("payload")
+
+    def _unexpected_put(method: str, path: str, body: bytes) -> dict:
+        raise AssertionError(f"unexpected request: {method} {path} {len(body)} bytes")
+
+    channel = FakeRustChannel(
+        [
+            _capabilities(
+                {"file_raw": True},
+                limits={"max_stream_size_bytes": 4},
+            ),
+            _unexpected_put,
+        ]
+    )
+
+    with pytest.raises(SmolVMError, match="up to 4 bytes"):
+        channel.put_file(source, "/tmp/source.txt")
+    assert [request[:2] for request in channel.requests] == [("GET", "/capabilities")]
+
+
 def test_get_directory_rejects_unsafe_tar_entries(tmp_path: Path) -> None:
     archive = io.BytesIO()
     with tarfile.open(fileobj=archive, mode="w") as tar:

--- a/tests/test_rust_http_vsock_channel.py
+++ b/tests/test_rust_http_vsock_channel.py
@@ -307,7 +307,7 @@ def test_sync_fallback_exec_failure_maps_to_smolvm_error() -> None:
         channel.sync(timeout=10)
 
 
-def test_put_and_get_file(tmp_path: Path) -> None:
+def test_put_and_get_file_use_base64_fallback_when_streaming_missing(tmp_path: Path) -> None:
     source = tmp_path / "source.txt"
     source.write_text("payload")
     source.chmod(0o644)
@@ -338,7 +338,7 @@ def test_put_and_get_file(tmp_path: Path) -> None:
     assert destination.stat().st_mode & 0o777 == 0o640
 
 
-def test_put_and_get_file_prefer_raw_streaming_and_cache_capabilities(tmp_path: Path) -> None:
+def test_put_and_get_file_use_raw_streaming_and_cache_capabilities(tmp_path: Path) -> None:
     source = tmp_path / "source.txt"
     source.write_text("payload")
     source.chmod(0o644)
@@ -360,9 +360,7 @@ def test_put_and_get_file_prefer_raw_streaming_and_cache_capabilities(tmp_path: 
             {"x-smolvm-file-mode": "640", "x-smolvm-file-size": "7"},
         )
 
-    channel = FakeRustChannel(
-        [_capabilities({"file_base64": True, "file_raw": True}), _raw_put, _raw_get]
-    )
+    channel = FakeRustChannel([_capabilities({"file_raw": True}), _raw_put, _raw_get])
     channel.put_file(source, "/tmp/source.txt")
     channel.get_file("/tmp/source.txt", destination)
 
@@ -391,9 +389,7 @@ def test_put_file_falls_back_to_base64_when_raw_endpoint_missing(tmp_path: Path)
         assert base64.b64decode(request["data_base64"]) == b"payload"
         return {"ok": True}
 
-    channel = FakeRustChannel(
-        [_capabilities({"file_base64": True, "file_raw": True}), _missing_raw, _base64_put]
-    )
+    channel = FakeRustChannel([_capabilities({"file_raw": True}), _missing_raw, _base64_put])
     channel.put_file(source, "/tmp/source.txt")
 
 
@@ -554,10 +550,17 @@ def test_env_helpers_use_v2_env_endpoint() -> None:
         assert json.loads(body) == {"keys": ["FOO"]}
         return {"ok": True, "vars": {}}
 
-    channel = FakeRustChannel([_set, _get, _get, _delete])
+    channel = FakeRustChannel([_capabilities({"env_managed": True}), _set, _get, _get, _delete])
     assert channel.set_env_vars({"FOO": "bar"}) == ["FOO"]
     assert channel.list_env_vars() == {"FOO": "bar"}
     assert channel.unset_env_vars(["FOO"]) == {"FOO": "bar"}
+
+
+def test_env_helpers_require_managed_env_capability() -> None:
+    channel = FakeRustChannel([_capabilities({})])
+
+    with pytest.raises(SmolVMError, match="managed environment variables"):
+        channel.set_managed_env({"FOO": "bar"})
 
 
 def test_wait_for_ports_and_boot_milestones_use_v2_endpoints() -> None:

--- a/tests/test_rust_http_vsock_channel.py
+++ b/tests/test_rust_http_vsock_channel.py
@@ -16,7 +16,6 @@
 
 from __future__ import annotations
 
-import base64
 import io
 import json
 import queue
@@ -38,7 +37,6 @@ from smolvm.comm.rust_http_vsock_channel import (
     _SocketHTTPConnection,
 )
 from smolvm.exceptions import OperationTimeoutError, SmolVMError
-from smolvm.types import CommandResult
 
 Handler = Callable[[str, str, bytes], Any]
 
@@ -265,77 +263,32 @@ def test_sync_posts_dedicated_endpoint() -> None:
         assert body == b""
         return {"ok": True}
 
-    FakeRustChannel([_handler]).sync(timeout=10)
+    FakeRustChannel([_capabilities({"sync": True}), _handler]).sync(timeout=10)
 
 
 def test_sync_error_maps_to_smolvm_error() -> None:
-    channel = FakeRustChannel([lambda method, path, body: {"ok": False, "error": "busy"}])
+    channel = FakeRustChannel(
+        [_capabilities({"sync": True}), lambda method, path, body: {"ok": False, "error": "busy"}]
+    )
 
     with pytest.raises(SmolVMError, match="busy"):
         channel.sync()
 
 
-def test_sync_falls_back_to_raw_exec_when_endpoint_missing() -> None:
-    def _missing_sync(method: str, path: str, body: bytes) -> tuple[int, str]:
-        assert method == "POST"
-        assert path == "/sync"
-        assert body == b""
-        return (404, "")
+def test_sync_requires_sync_capability() -> None:
+    channel = FakeRustChannel([_capabilities({})])
 
-    def _legacy_exec(method: str, path: str, body: bytes) -> dict:
-        assert method == "POST"
-        assert path == "/exec"
-        request = json.loads(body)
-        assert request["command"] == "sync"
-        assert request["shell"] == "raw"
-        assert request["timeout_seconds"] == 10
-        return {"ok": True, "exit_code": 0, "stdout": "", "stderr": "", "timed_out": False}
-
-    channel = FakeRustChannel([_missing_sync, _legacy_exec])
-    channel.sync(timeout=10)
-
-
-def test_sync_fallback_exec_failure_maps_to_smolvm_error() -> None:
-    def _missing_sync(method: str, path: str, body: bytes) -> tuple[int, str]:
-        return (404, "")
-
-    def _legacy_exec(method: str, path: str, body: bytes) -> dict:
-        return {"ok": True, "exit_code": 1, "stdout": "", "stderr": "nope", "timed_out": False}
-
-    channel = FakeRustChannel([_missing_sync, _legacy_exec])
-    with pytest.raises(SmolVMError, match="legacy sync fallback"):
+    with pytest.raises(SmolVMError, match="saving files before shutdown"):
         channel.sync(timeout=10)
 
 
-def test_put_and_get_file_use_base64_fallback_when_streaming_missing(tmp_path: Path) -> None:
+def test_put_file_requires_streaming_capability(tmp_path: Path) -> None:
     source = tmp_path / "source.txt"
     source.write_text("payload")
-    source.chmod(0o644)
-    destination = tmp_path / "download.txt"
 
-    def _put(method: str, path: str, body: bytes) -> dict:
-        request = json.loads(body)
-        assert method == "POST"
-        assert path == "/files/put"
-        assert request["path"] == "/tmp/source.txt"
-        assert base64.b64decode(request["data_base64"]) == b"payload"
-        return {"ok": True}
-
-    def _get(method: str, path: str, body: bytes) -> dict:
-        assert method == "GET"
-        assert path == "/files/get?path=%2Ftmp%2Fsource.txt"
-        return {
-            "ok": True,
-            "mode": 0o640,
-            "size": 7,
-            "data_base64": base64.b64encode(b"payload").decode(),
-        }
-
-    channel = FakeRustChannel([_capabilities({"file_base64": True}), _put, _get])
-    channel.put_file(source, "/tmp/source.txt")
-    channel.get_file("/tmp/source.txt", destination)
-    assert destination.read_text() == "payload"
-    assert destination.stat().st_mode & 0o777 == 0o640
+    channel = FakeRustChannel([_capabilities({})])
+    with pytest.raises(SmolVMError, match="fast file transfer"):
+        channel.put_file(source, "/tmp/source.txt")
 
 
 def test_put_and_get_file_use_raw_streaming_and_cache_capabilities(tmp_path: Path) -> None:
@@ -373,7 +326,7 @@ def test_put_and_get_file_use_raw_streaming_and_cache_capabilities(tmp_path: Pat
     ]
 
 
-def test_put_file_falls_back_to_base64_when_raw_endpoint_missing(tmp_path: Path) -> None:
+def test_put_file_does_not_fallback_when_raw_endpoint_missing(tmp_path: Path) -> None:
     source = tmp_path / "source.txt"
     source.write_text("payload")
 
@@ -382,15 +335,9 @@ def test_put_file_falls_back_to_base64_when_raw_endpoint_missing(tmp_path: Path)
         assert path.startswith("/files/content?")
         return (404, "")
 
-    def _base64_put(method: str, path: str, body: bytes) -> dict:
-        request = json.loads(body)
-        assert method == "POST"
-        assert path == "/files/put"
-        assert base64.b64decode(request["data_base64"]) == b"payload"
-        return {"ok": True}
-
-    channel = FakeRustChannel([_capabilities({"file_raw": True}), _missing_raw, _base64_put])
-    channel.put_file(source, "/tmp/source.txt")
+    channel = FakeRustChannel([_capabilities({"file_raw": True}), _missing_raw])
+    with pytest.raises(SmolVMError, match="guest agent HTTP 404"):
+        channel.put_file(source, "/tmp/source.txt")
 
 
 def test_get_directory_rejects_unsafe_tar_entries(tmp_path: Path) -> None:
@@ -435,34 +382,14 @@ def test_raw_file_download_rejects_declared_size_over_cap(tmp_path: Path) -> Non
         channel.get_file("/tmp/source.txt", destination)
 
 
-def test_legacy_directory_fallback_uses_guest_mktemp(tmp_path: Path) -> None:
+def test_directory_transfer_requires_tar_capability(tmp_path: Path) -> None:
     source = tmp_path / "source"
     source.mkdir()
     (source / "note.txt").write_text("hello")
-    commands: list[str] = []
-    uploads: list[str] = []
+    channel = FakeRustChannel([_capabilities({})])
 
-    channel = RustHttpVsockChannel(guest_cid=42)
-
-    def fake_run(command: str, timeout: float = 30, shell: str = "login") -> CommandResult:
-        commands.append(command)
-        if command.startswith("mktemp "):
-            return CommandResult(exit_code=0, stdout="/tmp/smolvm-dir.ABC123.tar\n", stderr="")
-        return CommandResult(exit_code=0, stdout="", stderr="")
-
-    def fake_put_file(local_path: str | Path, remote_path: str) -> None:
-        uploads.append(remote_path)
-
-    channel.run = fake_run  # type: ignore[method-assign]
-    channel.put_file = fake_put_file  # type: ignore[method-assign]
-
-    channel._put_directory_legacy(source, "/tmp/target")
-
-    assert uploads == ["/tmp/smolvm-dir.ABC123.tar"]
-    assert commands[0].startswith("mktemp /tmp/smolvm-dir.")
-    assert "trap" in commands[1]
-    assert 'tar -xf "$remote_tmp"' in commands[1]
-    assert commands[-1] == "rm -f -- /tmp/smolvm-dir.ABC123.tar"
+    with pytest.raises(SmolVMError, match="directory transfer"):
+        channel.put_directory(source, "/tmp/target")
 
 
 def test_directory_tar_strips_owner_metadata(tmp_path: Path) -> None:
@@ -493,42 +420,6 @@ def test_directory_tar_wraps_ustar_path_limit_errors(tmp_path: Path) -> None:
 
     with pytest.raises(SmolVMError, match="file path is too long"):
         _directory_to_tar(source)
-
-
-def test_legacy_directory_download_uses_guest_mktemp(tmp_path: Path) -> None:
-    archive = io.BytesIO()
-    with tarfile.open(fileobj=archive, mode="w") as tar:
-        info = tarfile.TarInfo("note.txt")
-        payload = b"hello"
-        info.size = len(payload)
-        tar.addfile(info, io.BytesIO(payload))
-
-    commands: list[str] = []
-    downloads: list[str] = []
-    channel = RustHttpVsockChannel(guest_cid=42)
-
-    def fake_run(command: str, timeout: float = 30, shell: str = "login") -> CommandResult:
-        commands.append(command)
-        if command.startswith("mktemp "):
-            return CommandResult(exit_code=0, stdout="/tmp/smolvm-dir.DEF456.tar\n", stderr="")
-        return CommandResult(exit_code=0, stdout="", stderr="")
-
-    def fake_get_file(remote_path: str, local_path: str | Path) -> Path:
-        downloads.append(remote_path)
-        destination = Path(local_path)
-        destination.write_bytes(archive.getvalue())
-        return destination
-
-    channel.run = fake_run  # type: ignore[method-assign]
-    channel.get_file = fake_get_file  # type: ignore[method-assign]
-
-    destination = channel._get_directory_legacy("/tmp/source", tmp_path / "download")
-
-    assert downloads == ["/tmp/smolvm-dir.DEF456.tar"]
-    assert (destination / "note.txt").read_text() == "hello"
-    assert commands[0].startswith("mktemp /tmp/smolvm-dir.")
-    assert commands[1] == "set -e; tar -cf /tmp/smolvm-dir.DEF456.tar -C /tmp/source ."
-    assert commands[-1] == "rm -f -- /tmp/smolvm-dir.DEF456.tar"
 
 
 def test_env_helpers_use_v2_env_endpoint() -> None:


### PR DESCRIPTION
## Summary

- remove the legacy JSON/base64 file upload/download endpoints from new Rust guest-agent builds and drop the guest-agent `base64` dependency
- remove Python host fallbacks to old vsock file, directory, sync, and environment paths; current images must advertise the protocol-v2 capabilities or the operation fails with a sandbox-specific recovery message
- pass the sandbox name into the vsock channel so feature-gate failures can name the exact `smolvm sandbox delete <name>` recovery command
- update benchmark docs with final disk results and mark current published Ubuntu file-transfer numbers as blocked until the image is republished from this branch

## Benchmark Evidence

- `disk_io.py`: native zstd decompression was 66.8% faster at 16 MiB and 74.4% faster at 128 MiB; sparse copy still routes through `cp` and remains unchanged
- `file_transfer.py`: QEMU/vsock current published Ubuntu now fails as intended because it lacks the new fast transfer capabilities; rerun after publishing a branch image before claiming streaming speedups

## Validation

- `UV_CACHE_DIR=/tmp/uv-cache uv run ruff check .`
- `UV_CACHE_DIR=/tmp/uv-cache uv run ruff format --check .`
- `UV_CACHE_DIR=/tmp/uv-cache uv run pytest -q`
- `cargo test -p smolvm-guest-agent`
- `UV_CACHE_DIR=/tmp/uv-cache uv run python scripts/benchmarks/disk_io.py --iterations 2 --sizes 16M,128M --json --output /tmp/smolvm-alpha-cleanup-disk-io.json`
- `UV_CACHE_DIR=/tmp/uv-cache uv run python scripts/benchmarks/file_transfer.py --backend qemu --comm-channel vsock --os ubuntu --sizes 1K --skip-directory --boot-timeout 120 --ready-timeout 120 --json --output /tmp/smolvm-alpha-cleanup-file-transfer-current-published.json` failed as expected with: `Sandbox sbx-hubble is using an older image that does not support fast file transfer; run `smolvm sandbox delete sbx-hubble` and create it again after updating the image.`

Blocked locally:

- `cargo test -p smolvm-core` still fails in this environment because the linker cannot find `-lpython3.14`; this is the same local Python dev-library blocker as before, not introduced by this PR.
