### PR TITLE
v0.0.23 chore: release SmolVM

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "smolvm"
-version = "0.0.22"
+version = "0.0.23"
 description = "Isolated computers that AI agents can use to browse, run code, and get real work done. Free and open-source from Celesto AI"
 readme = "README.md"
 license = "Apache-2.0"


### PR DESCRIPTION
## Summary
- bump the `smolvm` Python package version to `0.0.23`
- keep `smolvm-core~=2026.6.23` unchanged because there are no post-release core changes
- ship the newly published image manifest from #408 in an installable `smolvm` package

## Release notes
This release makes the `images-2026.06.23.0` published-image manifest available to normal `smolvm` installs.

## Validation
- `UV_CACHE_DIR=/tmp/uv-cache uv run python - <<'PY' ...` metadata check
- `UV_CACHE_DIR=/tmp/uv-cache uv build --out-dir /tmp/smolvm-0.0.23-dist`
- `UV_CACHE_DIR=/tmp/uv-cache uv run ruff check pyproject.toml`
- `UV_CACHE_DIR=/tmp/uv-cache uv run pytest -q` (`1438 passed, 12 skipped, 27 deselected`)

## Publish plan
After merge, create GitHub Release/tag `v0.0.23` at the merge commit. That triggers `.github/workflows/publish.yml` for PyPI and `.github/workflows/publish-dashboard-ui.yml` for the dashboard release asset.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Version bump to 0.0.23

<!-- end of auto-generated comment: release notes by coderabbit.ai -->