### PR TITLE
Fix silent first-run sandbox create

### DIFF
--- a/src/smolvm/cli/main.py
+++ b/src/smolvm/cli/main.py
@@ -770,6 +770,7 @@ def _build_and_boot_with_progress(
     console: object,
     build_fn: object,
     boot_timeout: int,
+    prepare_message: str = "Preparing sandbox image...",
     comm_channel: str | None = None,
     wait_for_control_channel: bool = False,
     mounts: list[str] | None = None,
@@ -807,7 +808,9 @@ def _build_and_boot_with_progress(
                 download_tasks[label] = progress.add_task(f"Downloading {label}", total=total)
             progress.update(download_tasks[label], advance=chunk)
 
+        prepare_task = progress.add_task(prepare_message, total=None)
         config, ssh_key_path = _build_fn(on_download)
+        progress.remove_task(prepare_task)
 
         # One task that re-labels as the boot pipeline progresses
         # (boot → ready → workspace mount when --mount is set).
@@ -945,6 +948,7 @@ def _run_create(args: SimpleNamespace) -> int:
                         vm_name=args.name,
                     ),
                     boot_timeout=args.boot_timeout,
+                    prepare_message=_create_progress_message(resolved_backend, resolved_guest_os),
                     comm_channel=args.comm_channel,
                     wait_for_control_channel=True,
                     mounts=args.mounts,
@@ -990,6 +994,7 @@ def _run_create(args: SimpleNamespace) -> int:
                         on_download=on_download,
                     ),
                     boot_timeout=args.boot_timeout,
+                    prepare_message=_create_progress_message(resolved_backend, resolved_guest_os),
                     comm_channel=args.comm_channel,
                     wait_for_control_channel=True,
                     mounts=args.mounts,
@@ -1035,6 +1040,7 @@ def _run_create(args: SimpleNamespace) -> int:
                         on_download=on_download,
                     ),
                     boot_timeout=args.boot_timeout,
+                    prepare_message=_create_progress_message(resolved_backend, resolved_guest_os),
                     comm_channel=args.comm_channel,
                     wait_for_control_channel=True,
                     mounts=args.mounts,

--- a/src/smolvm/facade.py
+++ b/src/smolvm/facade.py
@@ -593,7 +593,13 @@ def _build_auto_config(
         vmm = vmm_by_backend[resolved_backend]
         arch = to_published_arch(platform.machine())
         resolved_vm_name = _resolve_vm_name(vm_name, prefix=name_prefix)
-        local_image = ensure_published_image("ubuntu", arch, vmm, "ubuntu")
+        local_image = ensure_published_image(
+            "ubuntu",
+            arch,
+            vmm,
+            "ubuntu",
+            on_download=on_download,
+        )
         base_rootfs_size_mib = _path_size_mib(local_image.rootfs_path)
         required_disk_size_mib = max(default_disk_size_mib, base_rootfs_size_mib)
         if disk_size_mib is None:

--- a/src/smolvm/images/published.py
+++ b/src/smolvm/images/published.py
@@ -37,6 +37,7 @@ is policy-free.
 from __future__ import annotations
 
 import os
+from collections.abc import Callable
 from pathlib import Path
 from typing import Literal
 
@@ -439,6 +440,7 @@ def ensure_published_image(
     cache_dir: Path | None = None,
     manifest: dict[ManifestKey, PublishedImage] | None = None,
     version: str = __version__,
+    on_download: Callable[[str, int, int | None], None] | None = None,
 ) -> LocalImage:
     """Download (if needed) and return paths to a published preset image.
 
@@ -453,6 +455,8 @@ def ensure_published_image(
         cache_dir: Override the default cache directory (mainly for tests).
         manifest: Override the bundled manifest (mainly for tests).
         version: Override the CLI version used to compute the cache name.
+        on_download: Optional callback invoked as published image assets
+            are downloaded.
 
     Returns:
         :class:`LocalImage` with paths to the kernel and (decompressed)
@@ -468,7 +472,7 @@ def ensure_published_image(
     entry = lookup(preset, arch, vmm, os, manifest=manifest)
     source = to_image_source(entry, version=version)
     manager = ImageManager(cache_dir=cache_dir, registry={source.name: source})
-    local = manager.ensure_image(source.name)
+    local = manager.ensure_image(source.name, on_download=on_download)
 
     # Wire-format short-circuit: nothing to decompress.
     if not source.rootfs_filename.endswith(".zst"):

--- a/tests/test_facade.py
+++ b/tests/test_facade.py
@@ -335,10 +335,18 @@ class TestVMInit:
             name=f"ubuntu-{expected_vmm}", kernel_path=kernel, rootfs_path=rootfs
         )
 
-        config, _ = _build_auto_config(os="ubuntu", backend=backend)
+        def on_download(label: str, chunk: int, total: int | None) -> None:
+            pass
+
+        config, _ = _build_auto_config(
+            os="ubuntu",
+            backend=backend,
+            on_download=on_download,
+        )
 
         preset, _arch, vmm, os_ = mock_ensure_published.call_args.args
         assert (preset, vmm, os_) == ("ubuntu", expected_vmm, "ubuntu")
+        assert mock_ensure_published.call_args.kwargs["on_download"] is on_download
 
         assert config.backend == backend
         assert config.guest_os is GuestOS.UBUNTU

--- a/tests/test_published_images.py
+++ b/tests/test_published_images.py
@@ -391,6 +391,45 @@ class TestEnsurePublishedImage:
         assert local.rootfs_path.read_bytes() == b"fake-rootfs"
         assert mock_get.call_count == 2
 
+    @patch("smolvm.images.manager.requests.get")
+    def test_download_progress_callback_receives_asset_labels(
+        self,
+        mock_get: MagicMock,
+        tmp_path: Path,
+        sample_manifest: dict[ManifestKey, PublishedImage],
+    ) -> None:
+        """First-run published downloads should report visible asset progress."""
+        version = "0.0.13"
+        bodies = [b"fake-kernel", b"fake-rootfs"]
+        call = {"i": 0}
+
+        def factory(*_args: object, **_kwargs: object) -> MagicMock:
+            body = bodies[call["i"]]
+            call["i"] += 1
+            resp = MagicMock()
+            resp.raise_for_status = MagicMock()
+            resp.headers.get.return_value = str(len(body))
+            resp.iter_content = lambda chunk_size, body=body: iter([body])
+            return resp
+
+        events: list[tuple[str, int, int | None]] = []
+        mock_get.side_effect = factory
+
+        ensure_published_image(
+            "codex",
+            "amd64",
+            "firecracker",
+            cache_dir=tmp_path,
+            manifest=sample_manifest,
+            version=version,
+            on_download=lambda label, chunk, total: events.append((label, chunk, total)),
+        )
+
+        assert events == [
+            ("kernel", len(b"fake-kernel"), len(b"fake-kernel")),
+            ("rootfs", len(b"fake-rootfs"), len(b"fake-rootfs")),
+        ]
+
     def test_unknown_tuple_raises_before_touching_filesystem(
         self,
         tmp_path: Path,


### PR DESCRIPTION
## Summary
- show an immediate create progress task before image config/download work starts
- pass published Ubuntu image download progress through auto-config so first-run kernel/rootfs downloads render progress
- add tests for published-image progress callbacks and auto-config callback forwarding

## Validation
- UV_CACHE_DIR=/tmp/uv-cache uv run ruff check .
- UV_CACHE_DIR=/tmp/uv-cache uv run pytest -q

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Customizable progress messages for sandbox VM build and preparation phases with configurable status feedback.
  * Download progress callbacks for published image assets with per-asset tracking labels and detailed byte count metrics.

* **Tests**
  * Added test verification for download progress callbacks to ensure correct asset labeling and byte count reporting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->