### PR TITLE
Add vsock interactive shell

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -62,6 +62,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "anyhow"
+version = "1.0.102"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
+
+[[package]]
 name = "arc-swap"
 version = "1.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -136,6 +142,12 @@ dependencies = [
 
 [[package]]
 name = "bitflags"
+version = "1.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
+
+[[package]]
+name = "bitflags"
 version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "843867be96c8daad0d758b57df9392b6d8d271134fce549de6ce169ff98a92af"
@@ -163,6 +175,12 @@ name = "cfg-if"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
+
+[[package]]
+name = "cfg_aliases"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fd16c4719339c4530435d38e511904438d07cce7950afa3718a84ac36c10e89e"
 
 [[package]]
 name = "cfg_aliases"
@@ -217,6 +235,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
 
 [[package]]
+name = "downcast-rs"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75b325c5dbd37f80359721ad39aca5a29fb04c89279657cffdda8736d0c0b9d2"
+
+[[package]]
 name = "errno"
 version = "0.3.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -224,6 +248,17 @@ checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
  "windows-sys",
+]
+
+[[package]]
+name = "filedescriptor"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e40758ed24c9b2eeb76c35fb0aebc66c626084edd827e07e1552279814c6682d"
+dependencies = [
+ "libc",
+ "thiserror 1.0.69",
+ "winapi",
 ]
 
 [[package]]
@@ -538,7 +573,7 @@ version = "0.30.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "be8919612f6028ab4eacbbfe1234a9a43e3722c6e0915e7ff519066991905092"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.0",
  "libc",
  "log",
  "netlink-packet-core",
@@ -573,13 +608,25 @@ dependencies = [
 
 [[package]]
 name = "nix"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab2156c4fce2f8df6c499cc1c763e4394b7482525bf2a9701c9d79d215f519e4"
+dependencies = [
+ "bitflags 2.11.0",
+ "cfg-if",
+ "cfg_aliases 0.1.1",
+ "libc",
+]
+
+[[package]]
+name = "nix"
 version = "0.30.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "74523f3a35e05aba87a1d978330aef40f67b0304ac79c1c00b294c9830543db6"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.0",
  "cfg-if",
- "cfg_aliases",
+ "cfg_aliases 0.2.1",
  "libc",
 ]
 
@@ -589,9 +636,9 @@ version = "0.31.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf20d2fde8ff38632c426f1165ed7436270b44f199fc55284c38276f9db47c3d"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.0",
  "cfg-if",
- "cfg_aliases",
+ "cfg_aliases 0.2.1",
  "libc",
  "memoffset",
 ]
@@ -669,6 +716,27 @@ name = "portable-atomic"
 version = "1.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
+
+[[package]]
+name = "portable-pty"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4a596a2b3d2752d94f51fac2d4a96737b8705dddd311a32b9af47211f08671e"
+dependencies = [
+ "anyhow",
+ "bitflags 1.3.2",
+ "downcast-rs",
+ "filedescriptor",
+ "lazy_static",
+ "libc",
+ "log",
+ "nix 0.28.0",
+ "serial2",
+ "shared_library",
+ "shell-words",
+ "winapi",
+ "winreg",
+]
 
 [[package]]
 name = "proc-macro2"
@@ -769,7 +837,7 @@ version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.0",
 ]
 
 [[package]]
@@ -892,6 +960,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "serial2"
+version = "0.2.37"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9eb6ea5562eeaed6936b8b54e086aa0f88b9e5b1bef45beb038e2519fa1185b1"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "windows-sys",
+]
+
+[[package]]
 name = "sharded-slab"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -899,6 +978,22 @@ checksum = "f40ca3c46823713e0d4209592e8d6e826aa57e928f09752619fc696c499637f6"
 dependencies = [
  "lazy_static",
 ]
+
+[[package]]
+name = "shared_library"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a9e7e0f2bfae24d8a5b5a66c5b257a83c7412304311512a0c054cd5e619da11"
+dependencies = [
+ "lazy_static",
+ "libc",
+]
+
+[[package]]
+name = "shell-words"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc6fe69c597f9c37bfeeeeeb33da3530379845f10be461a66d16d03eca2ded77"
 
 [[package]]
 name = "shlex"
@@ -956,6 +1051,7 @@ dependencies = [
  "hyper-util",
  "libc",
  "once_cell",
+ "portable-pty",
  "serde",
  "serde_json",
  "tokio",
@@ -1228,6 +1324,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "winapi"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
+dependencies = [
+ "winapi-i686-pc-windows-gnu",
+ "winapi-x86_64-pc-windows-gnu",
+]
+
+[[package]]
+name = "winapi-i686-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
+name = "winapi-x86_64-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
+
+[[package]]
 name = "windows-link"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1240,6 +1358,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
 dependencies = [
  "windows-link",
+]
+
+[[package]]
+name = "winreg"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "80d0f4e272c85def139476380b12f9ac60926689dd2e01d4923222f40580869d"
+dependencies = [
+ "winapi",
 ]
 
 [[package]]

--- a/README.md
+++ b/README.md
@@ -139,8 +139,10 @@ smolvm sandbox stop my-sandbox
 Open a shell inside a running sandbox:
 
 ```bash
-smolvm sandbox ssh my-sandbox
+smolvm sandbox shell my-sandbox
 ```
+
+Use `smolvm sandbox ssh my-sandbox` when you specifically need an SSH session.
 
 ## Windows sandbox
 
@@ -257,7 +259,7 @@ You can give a sandbox access to a folder on your machine. This is useful when a
 
 ```bash
 smolvm sandbox create --name my-sandbox --mount ~/Projects/my-app
-smolvm sandbox ssh my-sandbox
+smolvm sandbox shell my-sandbox
 ls /workspace   # your host files appear here
 ```
 
@@ -296,7 +298,7 @@ This is useful when an agent needs a config file, script, or small input file.
 smolvm sandbox file upload my-sandbox ./prompt.txt /tmp/prompt.txt
 
 # Open a shell in the sandbox to confirm the file is there.
-smolvm sandbox ssh my-sandbox
+smolvm sandbox shell my-sandbox
 # Then, inside the sandbox shell:
 cat /tmp/prompt.txt
 ```

--- a/docs/deep-dive/microvm-from-first-principles.md
+++ b/docs/deep-dive/microvm-from-first-principles.md
@@ -545,7 +545,6 @@ Back on the host, `cli/main.py` polls TCP port 2200 with a 30-second timeout. As
 │ with codex preinstalled │
 ╰─────────────────────────╯
 Next: smolvm sandbox shell codex-davinci
-SSH:  smolvm sandbox ssh codex-davinci
 ```
 
 End-to-end, on a warm cache, this takes 5–10 seconds. On a cold cache (first download), add ~30s for the rootfs zstd download.

--- a/docs/deep-dive/microvm-from-first-principles.md
+++ b/docs/deep-dive/microvm-from-first-principles.md
@@ -544,7 +544,8 @@ Back on the host, `cli/main.py` polls TCP port 2200 with a 30-second timeout. As
 │ Started 'codex-davinci' │
 │ with codex preinstalled │
 ╰─────────────────────────╯
-Next: smolvm sandbox ssh codex-davinci
+Next: smolvm sandbox shell codex-davinci
+SSH:  smolvm sandbox ssh codex-davinci
 ```
 
 End-to-end, on a warm cache, this takes 5–10 seconds. On a cold cache (first download), add ~30s for the rootfs zstd download.

--- a/docs/deep-dive/microvm-from-first-principles.md
+++ b/docs/deep-dive/microvm-from-first-principles.md
@@ -535,9 +535,9 @@ The kernel loads from `-kernel`, mounts the rootfs from the virtio drive at `/`,
 
 `/init` does its six steps from Chapter 3, ending with `/usr/sbin/sshd -e` running and authorized_keys populated.
 
-### Step 6 — Wait for sshd, return
+### Step 6 — Wait until the sandbox can answer
 
-Back on the host, `cli/main.py` polls TCP port 2200 with a 30-second timeout. As soon as the connection succeeds, the CLI prints:
+Back on the host, `cli/main.py` waits until the sandbox control channel answers. On current Linux images this uses the guest agent over vsock, which is a private VM socket; on SSH-only sandboxes it waits for SSH instead. As soon as the sandbox is ready, the CLI prints:
 
 ```
 ╭───── Sandbox Ready ─────╮

--- a/guest-agent/Cargo.toml
+++ b/guest-agent/Cargo.toml
@@ -23,6 +23,7 @@ hyper = { version = "1", features = ["server", "http1"] }
 hyper-util = { version = "0.1", features = ["tokio"] }
 libc = "0.2"
 once_cell = "1"
+portable-pty = "0.9.0"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 tokio = { version = "1", features = ["full"] }

--- a/guest-agent/src/handler.rs
+++ b/guest-agent/src/handler.rs
@@ -15,6 +15,7 @@ use crate::env::{self, EnvDeleteRequest, EnvPutRequest, EnvResponse};
 use crate::exec::{self, ExecRequest, ExecResponse};
 use crate::files::{self, DirectoryTarQuery, FileGetQuery, FilePutResponse, FileRawPutQuery};
 use crate::ports::{self, PortsWaitRequest, PortsWaitResponse};
+use crate::terminal;
 
 pub const PROTOCOL_VERSION: u32 = 2;
 const FILE_RAW_BODY_LIMIT_BYTES: usize = 256 * 1024 * 1024;
@@ -159,6 +160,7 @@ pub struct CapabilitiesResponse {
     pub limits: CapabilityLimits,
     pub tcp_enabled: bool,
     pub terminal_enabled: bool,
+    pub terminal_port: u32,
     pub prod_metrics_enabled: bool,
 }
 
@@ -194,6 +196,8 @@ pub struct CapabilityLimits {
     pub max_stream_size_bytes: usize,
     pub directory_tar_put_bytes: usize,
     pub max_tar_size_bytes: usize,
+    pub terminal_frame_bytes: usize,
+    pub terminal_sessions: usize,
     pub default_operation_timeout_ms: u64,
     pub port_wait_timeout_seconds: u64,
 }
@@ -223,6 +227,7 @@ pub async fn handle_capabilities() -> Json<CapabilitiesResponse> {
             "DELETE /env/managed",
             "GET /boot/milestones",
             "POST /ports/wait",
+            "VSOCK 1025 terminal",
         ],
         features: CapabilityFeatures {
             exec: true,
@@ -239,7 +244,7 @@ pub async fn handle_capabilities() -> Json<CapabilitiesResponse> {
             ports_wait_v2: true,
             browser_status: false,
             tcp_listener: cfg!(feature = "tcp"),
-            terminal: false,
+            terminal: true,
             prod_metrics: false,
         },
         limits: CapabilityLimits {
@@ -247,11 +252,14 @@ pub async fn handle_capabilities() -> Json<CapabilitiesResponse> {
             max_stream_size_bytes: FILE_RAW_BODY_LIMIT_BYTES,
             directory_tar_put_bytes: DIRECTORY_TAR_BODY_LIMIT_BYTES,
             max_tar_size_bytes: DIRECTORY_TAR_BODY_LIMIT_BYTES,
+            terminal_frame_bytes: terminal::MAX_FRAME_PAYLOAD_BYTES,
+            terminal_sessions: terminal::MAX_CONCURRENT_TERMINALS,
             default_operation_timeout_ms: 120_000,
             port_wait_timeout_seconds: 300,
         },
         tcp_enabled: cfg!(feature = "tcp"),
-        terminal_enabled: false,
+        terminal_enabled: true,
+        terminal_port: terminal::DEFAULT_TERMINAL_PORT,
         prod_metrics_enabled: false,
     })
 }
@@ -399,7 +407,11 @@ mod tests {
         assert_eq!(capabilities.status, StatusCode::OK);
         assert_eq!(capabilities.body["protocol_version"], PROTOCOL_VERSION);
         assert_eq!(capabilities.body["tcp_enabled"], cfg!(feature = "tcp"));
-        assert_eq!(capabilities.body["terminal_enabled"], false);
+        assert_eq!(capabilities.body["terminal_enabled"], true);
+        assert_eq!(
+            capabilities.body["terminal_port"],
+            terminal::DEFAULT_TERMINAL_PORT
+        );
         assert_eq!(capabilities.body["prod_metrics_enabled"], false);
         assert!(capabilities.body["features"].get("file_base64").is_none());
         assert_eq!(capabilities.body["features"]["file_raw"], true);
@@ -413,6 +425,7 @@ mod tests {
         assert_eq!(capabilities.body["features"]["ports_wait"], true);
         assert_eq!(capabilities.body["features"]["ports.wait"], true);
         assert_eq!(capabilities.body["features"]["browser.status"], false);
+        assert_eq!(capabilities.body["features"]["terminal"], true);
         assert!(
             capabilities.body["limits"]
                 .get("file_put_json_bytes")
@@ -426,8 +439,17 @@ mod tests {
             capabilities.body["limits"]["max_tar_size_bytes"],
             DIRECTORY_TAR_BODY_LIMIT_BYTES
         );
+        assert_eq!(
+            capabilities.body["limits"]["terminal_frame_bytes"],
+            terminal::MAX_FRAME_PAYLOAD_BYTES
+        );
+        assert_eq!(
+            capabilities.body["limits"]["terminal_sessions"],
+            terminal::MAX_CONCURRENT_TERMINALS
+        );
         let endpoints = capabilities.body["endpoints"].as_array().unwrap();
         assert!(endpoints.contains(&json!("POST /exec")));
+        assert!(endpoints.contains(&json!("VSOCK 1025 terminal")));
         assert!(endpoints.contains(&json!("POST /sync")));
         assert!(!endpoints.contains(&json!("POST /files/put")));
         assert!(!endpoints.contains(&json!("GET /files/get")));

--- a/guest-agent/src/lib.rs
+++ b/guest-agent/src/lib.rs
@@ -5,6 +5,7 @@ pub mod files;
 pub mod handler;
 pub mod ports;
 pub mod server;
+pub mod terminal;
 
 pub use handler::router;
 pub use server::{DEFAULT_LISTEN, serve_listen_addr, serve_tcp, serve_vsock};

--- a/guest-agent/src/main.rs
+++ b/guest-agent/src/main.rs
@@ -1,5 +1,5 @@
 use clap::Parser;
-use smolvm_guest_agent::{handler, server};
+use smolvm_guest_agent::{handler, server, terminal};
 
 #[derive(Parser)]
 #[command(name = "smolvm-guest-agent", about = "SmolVM guest control agent")]
@@ -20,5 +20,12 @@ async fn main() {
 
     let args = Args::parse();
     let app = handler::router();
-    server::serve_listen_addr(app, &args.listen).await;
+    if args.listen.starts_with("vsock://") {
+        tokio::select! {
+            _ = server::serve_listen_addr(app, &args.listen) => {},
+            _ = terminal::serve_vsock_terminal(terminal::DEFAULT_TERMINAL_PORT) => {},
+        }
+    } else {
+        server::serve_listen_addr(app, &args.listen).await;
+    }
 }

--- a/guest-agent/src/terminal.rs
+++ b/guest-agent/src/terminal.rs
@@ -1,0 +1,551 @@
+use once_cell::sync::Lazy;
+use portable_pty::{CommandBuilder, NativePtySystem, PtySize, PtySystem};
+use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
+use std::io::{self, Read, Write};
+use std::path::Path;
+use std::sync::mpsc as std_mpsc;
+use tokio::io::{AsyncRead, AsyncReadExt, AsyncWrite, AsyncWriteExt};
+use tokio::sync::{Semaphore, mpsc, oneshot};
+
+pub const DEFAULT_TERMINAL_PORT: u32 = 1025;
+pub const MAX_FRAME_PAYLOAD_BYTES: usize = 1024 * 1024;
+pub const MAX_CONCURRENT_TERMINALS: usize = 8;
+const MAX_HANDSHAKE_BYTES: usize = 16 * 1024;
+const MAX_ROWS: u16 = 1000;
+const MAX_COLS: u16 = 1000;
+
+pub const FRAME_STDIN: u8 = 1;
+pub const FRAME_RESIZE: u8 = 2;
+pub const FRAME_CLOSE: u8 = 3;
+pub const FRAME_OUTPUT: u8 = 101;
+pub const FRAME_EXIT: u8 = 102;
+pub const FRAME_ERROR: u8 = 103;
+
+static TERMINAL_SEMAPHORE: Lazy<Semaphore> = Lazy::new(|| Semaphore::new(MAX_CONCURRENT_TERMINALS));
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Frame {
+    pub frame_type: u8,
+    pub payload: Vec<u8>,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct TerminalOpenRequest {
+    pub version: u32,
+    pub rows: u16,
+    pub cols: u16,
+    #[serde(default)]
+    pub term: Option<String>,
+    #[serde(default)]
+    pub cwd: Option<String>,
+    #[serde(default)]
+    pub env: HashMap<String, String>,
+}
+
+#[derive(Debug, Serialize)]
+pub struct TerminalOpenResponse {
+    pub ok: bool,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub pid: Option<u32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub error: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct TerminalResizeRequest {
+    pub rows: u16,
+    pub cols: u16,
+}
+
+#[derive(Debug, Serialize)]
+pub struct TerminalExit {
+    pub exit_code: u32,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub signal: Option<String>,
+}
+
+pub fn encode_frame(frame_type: u8, payload: &[u8]) -> Result<Vec<u8>, String> {
+    if payload.len() > MAX_FRAME_PAYLOAD_BYTES {
+        return Err(format!(
+            "frame payload exceeds {MAX_FRAME_PAYLOAD_BYTES} bytes"
+        ));
+    }
+    let mut frame = Vec::with_capacity(5 + payload.len());
+    frame.push(frame_type);
+    frame.extend_from_slice(&(payload.len() as u32).to_be_bytes());
+    frame.extend_from_slice(payload);
+    Ok(frame)
+}
+
+pub fn decode_frame_header(header: &[u8; 5]) -> Result<(u8, usize), String> {
+    let len = u32::from_be_bytes([header[1], header[2], header[3], header[4]]) as usize;
+    if len > MAX_FRAME_PAYLOAD_BYTES {
+        return Err(format!(
+            "frame payload exceeds {MAX_FRAME_PAYLOAD_BYTES} bytes"
+        ));
+    }
+    Ok((header[0], len))
+}
+
+pub fn terminal_size(rows: u16, cols: u16) -> Result<PtySize, String> {
+    if rows == 0 || cols == 0 {
+        return Err("terminal size must be greater than zero".to_string());
+    }
+    if rows > MAX_ROWS || cols > MAX_COLS {
+        return Err(format!(
+            "terminal size must be at most {MAX_ROWS} rows and {MAX_COLS} columns"
+        ));
+    }
+    Ok(PtySize {
+        rows,
+        cols,
+        pixel_width: 0,
+        pixel_height: 0,
+    })
+}
+
+async fn read_json_line<S>(stream: &mut S) -> io::Result<Vec<u8>>
+where
+    S: AsyncRead + Unpin,
+{
+    let mut line = Vec::new();
+    loop {
+        if line.len() >= MAX_HANDSHAKE_BYTES {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidData,
+                "terminal handshake is too large",
+            ));
+        }
+        let byte = match stream.read_u8().await {
+            Ok(byte) => byte,
+            Err(error) if error.kind() == io::ErrorKind::UnexpectedEof => {
+                return Err(io::Error::new(
+                    io::ErrorKind::UnexpectedEof,
+                    "terminal handshake ended early",
+                ));
+            }
+            Err(error) => return Err(error),
+        };
+        if byte == b'\n' {
+            return Ok(line);
+        }
+        line.push(byte);
+    }
+}
+
+async fn write_json_line<S>(stream: &mut S, response: &TerminalOpenResponse) -> io::Result<()>
+where
+    S: AsyncWrite + Unpin,
+{
+    let mut line = serde_json::to_vec(response).map_err(io::Error::other)?;
+    line.push(b'\n');
+    stream.write_all(&line).await
+}
+
+async fn read_frame<R>(reader: &mut R) -> io::Result<Option<Frame>>
+where
+    R: AsyncRead + Unpin,
+{
+    let mut header = [0u8; 5];
+    match reader.read_exact(&mut header).await {
+        Ok(_) => {}
+        Err(error) if error.kind() == io::ErrorKind::UnexpectedEof => return Ok(None),
+        Err(error) => return Err(error),
+    }
+    let (frame_type, len) = decode_frame_header(&header)
+        .map_err(|error| io::Error::new(io::ErrorKind::InvalidData, error))?;
+    let mut payload = vec![0u8; len];
+    reader.read_exact(&mut payload).await?;
+    Ok(Some(Frame {
+        frame_type,
+        payload,
+    }))
+}
+
+async fn write_frame<W>(writer: &mut W, frame_type: u8, payload: &[u8]) -> io::Result<()>
+where
+    W: AsyncWrite + Unpin,
+{
+    let frame = encode_frame(frame_type, payload)
+        .map_err(|error| io::Error::new(io::ErrorKind::InvalidInput, error))?;
+    writer.write_all(&frame).await
+}
+
+fn default_shell() -> &'static str {
+    if Path::new("/bin/bash").exists() {
+        "/bin/bash"
+    } else {
+        "/bin/sh"
+    }
+}
+
+fn command_for_request(req: &TerminalOpenRequest) -> CommandBuilder {
+    let mut cmd = CommandBuilder::new(default_shell());
+    cmd.arg("-l");
+    let term = req.term.as_deref().unwrap_or("xterm-256color");
+    cmd.env("TERM", term);
+    for (key, value) in &req.env {
+        cmd.env(key, value);
+    }
+    if let Some(cwd) = req.cwd.as_deref().filter(|value| !value.is_empty()) {
+        cmd.cwd(cwd);
+    }
+    cmd
+}
+
+fn parse_open_request(line: &[u8]) -> Result<TerminalOpenRequest, String> {
+    let req: TerminalOpenRequest = serde_json::from_slice(line)
+        .map_err(|error| format!("invalid terminal handshake: {error}"))?;
+    if req.version != 1 {
+        return Err("unsupported terminal protocol version".to_string());
+    }
+    terminal_size(req.rows, req.cols)?;
+    Ok(req)
+}
+
+fn outbound_error(tx: &mpsc::UnboundedSender<Frame>, error: impl Into<String>) {
+    let _ = tx.send(Frame {
+        frame_type: FRAME_ERROR,
+        payload: error.into().into_bytes(),
+    });
+}
+
+pub async fn handle_terminal_stream<S>(mut stream: S) -> io::Result<()>
+where
+    S: AsyncRead + AsyncWrite + Unpin + Send + 'static,
+{
+    let permit = match TERMINAL_SEMAPHORE.try_acquire() {
+        Ok(permit) => permit,
+        Err(_) => {
+            write_json_line(
+                &mut stream,
+                &TerminalOpenResponse {
+                    ok: false,
+                    pid: None,
+                    error: Some("too many terminal sessions are already open".to_string()),
+                },
+            )
+            .await?;
+            return Ok(());
+        }
+    };
+
+    let line = read_json_line(&mut stream).await?;
+    let req = match parse_open_request(&line) {
+        Ok(req) => req,
+        Err(error) => {
+            write_json_line(
+                &mut stream,
+                &TerminalOpenResponse {
+                    ok: false,
+                    pid: None,
+                    error: Some(error),
+                },
+            )
+            .await?;
+            return Ok(());
+        }
+    };
+
+    let pty_system = NativePtySystem::default();
+    let pair = match pty_system.openpty(terminal_size(req.rows, req.cols).unwrap()) {
+        Ok(pair) => pair,
+        Err(error) => {
+            write_json_line(
+                &mut stream,
+                &TerminalOpenResponse {
+                    ok: false,
+                    pid: None,
+                    error: Some(format!("could not open terminal: {error}")),
+                },
+            )
+            .await?;
+            return Ok(());
+        }
+    };
+
+    let mut child = match pair.slave.spawn_command(command_for_request(&req)) {
+        Ok(child) => child,
+        Err(error) => {
+            write_json_line(
+                &mut stream,
+                &TerminalOpenResponse {
+                    ok: false,
+                    pid: None,
+                    error: Some(format!("could not start shell: {error}")),
+                },
+            )
+            .await?;
+            return Ok(());
+        }
+    };
+    drop(pair.slave);
+
+    let pid = child.process_id();
+    write_json_line(
+        &mut stream,
+        &TerminalOpenResponse {
+            ok: true,
+            pid,
+            error: None,
+        },
+    )
+    .await?;
+
+    let mut pty_reader = pair.master.try_clone_reader().map_err(io::Error::other)?;
+    let pty_writer = pair.master.take_writer().map_err(io::Error::other)?;
+    let mut child_killer = child.clone_killer();
+
+    let (outbound_tx, mut outbound_rx) = mpsc::unbounded_channel::<Frame>();
+    let (done_tx, mut done_rx) = oneshot::channel::<()>();
+    let (pty_write_tx, pty_write_rx) = std_mpsc::channel::<Vec<u8>>();
+
+    std::thread::spawn(move || write_pty_input(pty_writer, pty_write_rx));
+
+    let output_tx = outbound_tx.clone();
+    let output_handle = std::thread::spawn(move || read_pty_output(&mut pty_reader, output_tx));
+
+    let wait_tx = outbound_tx.clone();
+    std::thread::spawn(move || {
+        let frame = match child.wait() {
+            Ok(status) => TerminalExit {
+                exit_code: status.exit_code(),
+                signal: status.signal().map(ToOwned::to_owned),
+            },
+            Err(error) => {
+                let _ = wait_tx.send(Frame {
+                    frame_type: FRAME_ERROR,
+                    payload: format!("shell wait failed: {error}").into_bytes(),
+                });
+                let _ = done_tx.send(());
+                return;
+            }
+        };
+        let _ = output_handle.join();
+        match serde_json::to_vec(&frame) {
+            Ok(payload) => {
+                let _ = wait_tx.send(Frame {
+                    frame_type: FRAME_EXIT,
+                    payload,
+                });
+            }
+            Err(error) => {
+                let _ = wait_tx.send(Frame {
+                    frame_type: FRAME_ERROR,
+                    payload: format!("could not encode shell exit: {error}").into_bytes(),
+                });
+            }
+        }
+        let _ = done_tx.send(());
+    });
+
+    let (mut socket_reader, mut socket_writer) = tokio::io::split(stream);
+    let socket_writer_task = tokio::spawn(async move {
+        while let Some(frame) = outbound_rx.recv().await {
+            if write_frame(&mut socket_writer, frame.frame_type, &frame.payload)
+                .await
+                .is_err()
+            {
+                break;
+            }
+        }
+    });
+
+    loop {
+        tokio::select! {
+            frame = read_frame(&mut socket_reader) => {
+                match frame? {
+                    Some(frame) => match frame.frame_type {
+                        FRAME_STDIN => {
+                            if pty_write_tx.send(frame.payload).is_err() {
+                                break;
+                            }
+                        }
+                        FRAME_RESIZE => {
+                            let resize: TerminalResizeRequest = match serde_json::from_slice(&frame.payload) {
+                                Ok(resize) => resize,
+                                Err(error) => {
+                                    outbound_error(&outbound_tx, format!("invalid resize frame: {error}"));
+                                    let _ = child_killer.kill();
+                                    break;
+                                }
+                            };
+                            match terminal_size(resize.rows, resize.cols) {
+                                Ok(size) => {
+                                    if let Err(error) = pair.master.resize(size) {
+                                        outbound_error(&outbound_tx, format!("could not resize terminal: {error}"));
+                                    }
+                                }
+                                Err(error) => {
+                                    outbound_error(&outbound_tx, error);
+                                    let _ = child_killer.kill();
+                                    break;
+                                }
+                            }
+                        }
+                        FRAME_CLOSE => {
+                            let _ = child_killer.kill();
+                            break;
+                        }
+                        other => {
+                            outbound_error(&outbound_tx, format!("invalid terminal frame type: {other}"));
+                            let _ = child_killer.kill();
+                            break;
+                        }
+                    },
+                    None => {
+                        let _ = child_killer.kill();
+                        break;
+                    }
+                }
+            }
+            _ = &mut done_rx => {
+                break;
+            }
+        }
+    }
+
+    drop(permit);
+    drop(pty_write_tx);
+    drop(outbound_tx);
+    let _ = socket_writer_task.await;
+    Ok(())
+}
+
+fn read_pty_output(reader: &mut Box<dyn Read + Send>, tx: mpsc::UnboundedSender<Frame>) {
+    let mut buf = [0u8; 8192];
+    loop {
+        match reader.read(&mut buf) {
+            Ok(0) => break,
+            Ok(n) => {
+                if tx
+                    .send(Frame {
+                        frame_type: FRAME_OUTPUT,
+                        payload: buf[..n].to_vec(),
+                    })
+                    .is_err()
+                {
+                    break;
+                }
+            }
+            Err(error) if error.kind() == io::ErrorKind::Interrupted => continue,
+            Err(error) => {
+                let _ = tx.send(Frame {
+                    frame_type: FRAME_ERROR,
+                    payload: format!("terminal read failed: {error}").into_bytes(),
+                });
+                break;
+            }
+        }
+    }
+}
+
+fn write_pty_input(mut writer: Box<dyn Write + Send>, rx: std_mpsc::Receiver<Vec<u8>>) {
+    for payload in rx {
+        if writer.write_all(&payload).is_err() {
+            break;
+        }
+        let _ = writer.flush();
+    }
+}
+
+#[cfg(all(feature = "vsock", target_os = "linux"))]
+pub async fn serve_vsock_terminal(port: u32) {
+    use tokio_vsock::{VsockAddr, VsockListener};
+
+    let addr = VsockAddr::new(u32::MAX, port);
+    let mut listener = VsockListener::bind(addr).expect("failed to bind terminal vsock");
+    tracing::info!("Listening for terminals on vsock://{port}");
+    loop {
+        match listener.accept().await {
+            Ok((stream, addr)) => {
+                tokio::spawn(async move {
+                    if let Err(error) = handle_terminal_stream(stream).await {
+                        tracing::error!("terminal connection error from {addr:?}: {error}");
+                    }
+                });
+            }
+            Err(error) => tracing::error!("terminal vsock accept error: {error}"),
+        }
+    }
+}
+
+#[cfg(not(all(feature = "vsock", target_os = "linux")))]
+pub async fn serve_vsock_terminal(_port: u32) {
+    eprintln!(
+        "terminal vsock support is only available in Linux builds with the vsock feature enabled."
+    );
+    std::process::exit(1);
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn frame_round_trips_header_and_payload() {
+        let frame = encode_frame(FRAME_STDIN, b"abc").unwrap();
+        assert_eq!(frame[0], FRAME_STDIN);
+        let (frame_type, len) = decode_frame_header(&frame[..5].try_into().unwrap()).unwrap();
+        assert_eq!(frame_type, FRAME_STDIN);
+        assert_eq!(len, 3);
+        assert_eq!(&frame[5..], b"abc");
+    }
+
+    #[test]
+    fn frame_rejects_oversized_payload() {
+        let payload = vec![0u8; MAX_FRAME_PAYLOAD_BYTES + 1];
+        assert!(encode_frame(FRAME_STDIN, &payload).is_err());
+
+        let mut header = [0u8; 5];
+        header[1..].copy_from_slice(&((MAX_FRAME_PAYLOAD_BYTES as u32) + 1).to_be_bytes());
+        assert!(decode_frame_header(&header).is_err());
+    }
+
+    #[test]
+    fn terminal_size_rejects_invalid_values() {
+        assert!(terminal_size(24, 80).is_ok());
+        assert!(terminal_size(0, 80).is_err());
+        assert!(terminal_size(24, 0).is_err());
+        assert!(terminal_size(MAX_ROWS + 1, 80).is_err());
+        assert!(terminal_size(24, MAX_COLS + 1).is_err());
+    }
+
+    #[test]
+    fn open_request_validates_version_and_size() {
+        let valid = br#"{"version":1,"rows":24,"cols":80,"term":"xterm","cwd":null,"env":{}}"#;
+        assert!(parse_open_request(valid).is_ok());
+
+        let bad_version = br#"{"version":2,"rows":24,"cols":80,"env":{}}"#;
+        assert!(parse_open_request(bad_version).is_err());
+
+        let bad_size = br#"{"version":1,"rows":0,"cols":80,"env":{}}"#;
+        assert!(parse_open_request(bad_size).is_err());
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn pty_spawn_echo_and_exit() {
+        let pty_system = NativePtySystem::default();
+        let pair = pty_system
+            .openpty(PtySize {
+                rows: 24,
+                cols: 80,
+                pixel_width: 0,
+                pixel_height: 0,
+            })
+            .unwrap();
+        let mut cmd = CommandBuilder::new("/bin/sh");
+        cmd.arg("-c");
+        cmd.arg("printf hello; exit 7");
+        let mut child = pair.slave.spawn_command(cmd).unwrap();
+        drop(pair.slave);
+        let mut reader = pair.master.try_clone_reader().unwrap();
+        let mut output = Vec::new();
+        reader.read_to_end(&mut output).unwrap();
+        let status = child.wait().unwrap();
+        assert_eq!(String::from_utf8_lossy(&output), "hello");
+        assert_eq!(status.exit_code(), 7);
+    }
+}

--- a/src/smolvm/cli/commands/app.py
+++ b/src/smolvm/cli/commands/app.py
@@ -208,12 +208,27 @@ def sandbox_resume(vm_id: str, json_output: bool) -> Any:
     )
 
 
+@sandbox.command("shell")
+@click.argument("vm_id", metavar="sandbox")
+@boot_timeout_option
+def sandbox_shell(vm_id: str, boot_timeout: float) -> Any:
+    """Open a fast shell in a sandbox."""
+    _before_command()
+    return _handlers()._run_shell(
+        _ns(
+            command_name="sandbox.shell",
+            vm_id=vm_id,
+            boot_timeout=boot_timeout,
+        )
+    )
+
+
 @sandbox.command("ssh")
 @click.argument("vm_id", metavar="sandbox")
 @ssh_auth_options
 @boot_timeout_option
 def sandbox_ssh(vm_id: str, ssh_key: str | None, ssh_user: str, boot_timeout: float) -> Any:
-    """Open a shell in a sandbox."""
+    """Open an SSH shell in a sandbox."""
     _before_command()
     return _handlers()._run_ssh(
         _ns(

--- a/src/smolvm/cli/main.py
+++ b/src/smolvm/cli/main.py
@@ -105,6 +105,7 @@ class CreateVmPayload(TypedDict):
 class CreateNextPayload(TypedDict):
     """Suggested follow-up actions for ``smolvm sandbox create``."""
 
+    shell_command: str
     ssh_command: str
     info_command: str
 
@@ -761,8 +762,9 @@ def _render_create_result(data: CreatePayload) -> None:
     details.add_row("OS", str(vm_data["os"]))
     details.add_row("Started", _format_started_at(vm_data["started_at"]))
     console.print(details)
-    console.print(f"Next: [bold]{next_step['ssh_command']}[/bold]")
-    console.print(f"      [bold]{next_step['info_command']}[/bold]")
+    console.print(f"Next: [bold]{next_step['shell_command']}[/bold]")
+    console.print(f"SSH:  [bold]{next_step['ssh_command']}[/bold]")
+    console.print(f"Info: [bold]{next_step['info_command']}[/bold]")
 
 
 def _build_and_boot_with_progress(
@@ -1084,6 +1086,7 @@ def _run_create(args: SimpleNamespace) -> int:
                 "started_at": datetime.now(timezone.utc).isoformat(),
             },
             "next": {
+                "shell_command": f"smolvm sandbox shell {vm.vm_id}",
                 "ssh_command": f"smolvm sandbox ssh {vm.vm_id}",
                 "info_command": f"smolvm sandbox info {vm.vm_id}",
             },
@@ -1142,7 +1145,8 @@ def _render_start_result(data: StartPayload) -> None:
     console.print(details)
     if not preset["injected_env_keys"] and preset.get("no_env_hint"):
         console.print(f"\n[yellow]{preset['no_env_hint']}[/yellow]")
-    console.print(f"Next: [bold]{next_step['ssh_command']}[/bold]")
+    console.print(f"Next: [bold]{next_step['shell_command']}[/bold]")
+    console.print(f"SSH:  [bold]{next_step['ssh_command']}[/bold]")
 
 
 # Boot args for the published-image launch path, keyed by (preset, vmm).
@@ -1343,7 +1347,11 @@ def _run_start_with_published_image(args: SimpleNamespace, preset: object) -> in
                     "injected_env_keys": [],
                     "no_env_hint": _preset.no_env_hint,
                 },
-                "next": {"ssh_command": f"smolvm sandbox ssh {vm.vm_id}"},
+                "next": {
+                    "shell_command": f"smolvm sandbox shell {vm.vm_id}",
+                    "ssh_command": f"smolvm sandbox ssh {vm.vm_id}",
+                    "info_command": f"smolvm sandbox info {vm.vm_id}",
+                },
             }
             if args.json:
                 emit_json(command_name, 0, data=data)
@@ -1501,7 +1509,9 @@ def _run_start(args: SimpleNamespace) -> int:
                 "no_env_hint": preset.no_env_hint,
             },
             "next": {
+                "shell_command": f"smolvm sandbox shell {vm.vm_id}",
                 "ssh_command": f"smolvm sandbox ssh {vm.vm_id}",
+                "info_command": f"smolvm sandbox info {vm.vm_id}",
             },
         }
 
@@ -2319,6 +2329,44 @@ def _run_ssh(args: SimpleNamespace) -> int:
             FileNotFoundError("ssh binary not found. Install openssh-client."),
             json_output=False,
         )
+    except Exception as exc:
+        return _emit_cli_error(command_name, 1, exc, json_output=False)
+    finally:
+        if vm is not None:
+            vm.close()
+
+
+def _run_shell(args: SimpleNamespace) -> int:
+    """Handle ``smolvm sandbox shell``."""
+    from smolvm.facade import SmolVM
+
+    vm: SmolVM | None = None
+    command_name = getattr(args, "command_name", "sandbox.shell")
+    try:
+        vm = SmolVM.from_id(args.vm_id)
+
+        console = console_stdout()
+        if vm.status in {VMState.CREATED, VMState.STOPPED}:
+            with console.status(f"Starting sandbox '{args.vm_id}'...", spinner="dots") as status:
+                vm.start(boot_timeout=args.boot_timeout)
+                status.update("Opening shell...")
+                vm.wait_for_shell(timeout=args.boot_timeout)
+            return vm.attach_shell(timeout=args.boot_timeout)
+        if vm.status == VMState.PAUSED:
+            with console.status(f"Resuming sandbox '{args.vm_id}'...", spinner="dots") as status:
+                vm.resume()
+                status.update("Opening shell...")
+                vm.wait_for_shell(timeout=args.boot_timeout)
+            return vm.attach_shell(timeout=args.boot_timeout)
+        if vm.status == VMState.ERROR:
+            raise RuntimeError(
+                f"VM '{args.vm_id}' is in error state. Recreate it or inspect the VM logs "
+                "before attaching."
+            )
+
+        with console.status("Opening shell...", spinner="dots"):
+            vm.wait_for_shell(timeout=args.boot_timeout)
+        return vm.attach_shell(timeout=args.boot_timeout)
     except Exception as exc:
         return _emit_cli_error(command_name, 1, exc, json_output=False)
     finally:

--- a/src/smolvm/cli/main.py
+++ b/src/smolvm/cli/main.py
@@ -2344,6 +2344,7 @@ def _run_shell(args: SimpleNamespace) -> int:
     command_name = getattr(args, "command_name", "sandbox.shell")
     try:
         vm = SmolVM.from_id(args.vm_id)
+        vm.ensure_shell_supported()
 
         console = console_stdout()
         if vm.status in {VMState.CREATED, VMState.STOPPED}:

--- a/src/smolvm/comm/rust_http_vsock_channel.py
+++ b/src/smolvm/comm/rust_http_vsock_channel.py
@@ -23,9 +23,12 @@ import json
 import logging
 import math
 import os
+import select
 import shlex
+import signal
 import socket
 import stat
+import sys
 import tarfile
 import time
 import urllib.parse
@@ -44,13 +47,23 @@ logger = logging.getLogger(__name__)
 SMOLVM_AGENT_PORT = 1024
 """Guest vsock port where the Rust guest agent listens."""
 
+SMOLVM_TERMINAL_PORT = 1025
+"""Guest vsock port where the Rust guest agent accepts terminal streams."""
+
 _READY_FAST_POLL_WINDOW = 1.0
 _READY_FAST_POLL_INTERVAL = 0.02
 _DEFAULT_MAX_AGENT_RESPONSE_BYTES = 1024 * 1024
 _DEFAULT_MAX_STREAM_SIZE_BYTES = 256 * 1024 * 1024
 _DEFAULT_MAX_TAR_SIZE_BYTES = 512 * 1024 * 1024
+_DEFAULT_MAX_TERMINAL_FRAME_BYTES = 1024 * 1024
 _MAX_PORTS_WAIT = 256
 _MAX_PORT_WAIT_TIMEOUT_SECONDS = 300.0
+_TERMINAL_FRAME_STDIN = 1
+_TERMINAL_FRAME_RESIZE = 2
+_TERMINAL_FRAME_CLOSE = 3
+_TERMINAL_FRAME_OUTPUT = 101
+_TERMINAL_FRAME_EXIT = 102
+_TERMINAL_FRAME_ERROR = 103
 
 
 @dataclass(frozen=True)
@@ -60,6 +73,7 @@ class ControlCapabilities:
     protocol_version: int
     features: dict[str, Any]
     limits: dict[str, Any]
+    terminal_port: int = SMOLVM_TERMINAL_PORT
 
     def enabled(self, *names: str) -> bool:
         for name in names:
@@ -115,6 +129,148 @@ def _parse_size_header(value: str, *, header: str, method: str, path: str) -> in
 
 def _feature_required_error(feature: str, *, sandbox_name: str | None = None) -> SmolVMError:
     return SmolVMError(_feature_required_message(feature, sandbox_name))
+
+
+def _pack_terminal_frame(frame_type: int, payload: bytes) -> bytes:
+    if not 0 <= frame_type <= 255:
+        raise ValueError("frame_type must fit in one byte")
+    if len(payload) > _DEFAULT_MAX_TERMINAL_FRAME_BYTES:
+        raise ValueError(
+            f"terminal frame payload exceeds {_DEFAULT_MAX_TERMINAL_FRAME_BYTES} bytes"
+        )
+    return bytes([frame_type]) + len(payload).to_bytes(4, "big") + payload
+
+
+def _recv_exact(sock: socket.socket, size: int) -> bytes:
+    chunks = bytearray()
+    while len(chunks) < size:
+        chunk = sock.recv(size - len(chunks))
+        if not chunk:
+            raise EOFError("terminal stream closed")
+        chunks.extend(chunk)
+    return bytes(chunks)
+
+
+def _read_terminal_frame(
+    sock: socket.socket,
+    *,
+    max_payload: int = _DEFAULT_MAX_TERMINAL_FRAME_BYTES,
+) -> tuple[int, bytes]:
+    header = _recv_exact(sock, 5)
+    frame_type = header[0]
+    size = int.from_bytes(header[1:], "big")
+    if size > max_payload:
+        raise SmolVMError(f"Terminal response exceeded {max_payload} bytes.")
+    return frame_type, _recv_exact(sock, size)
+
+
+def _send_terminal_frame(sock: socket.socket, frame_type: int, payload: bytes = b"") -> None:
+    sock.sendall(_pack_terminal_frame(frame_type, payload))
+
+
+def _read_socket_line(sock: socket.socket, *, max_bytes: int = 16 * 1024) -> str:
+    buf = bytearray()
+    while not buf.endswith(b"\n"):
+        if len(buf) >= max_bytes:
+            raise SmolVMError("Terminal handshake response was too large.")
+        chunk = sock.recv(1)
+        if not chunk:
+            raise EOFError("terminal stream closed during handshake")
+        buf.extend(chunk)
+    return buf.decode("utf-8", errors="replace").strip()
+
+
+def _terminal_size(fd: int) -> tuple[int, int]:
+    try:
+        size = os.get_terminal_size(fd)
+    except OSError:
+        return 24, 80
+    return max(1, size.lines), max(1, size.columns)
+
+
+def _write_terminal_output(stdout: Any, payload: bytes) -> None:
+    try:
+        stdout.write(payload)
+    except TypeError:
+        stdout.write(payload.decode("utf-8", errors="replace"))
+    stdout.flush()
+
+
+def _run_terminal_io(
+    sock: socket.socket,
+    *,
+    stdin_fd: int,
+    stdout: Any,
+    max_frame_bytes: int,
+) -> int:
+    old_attrs: Any = None
+    old_winch: Any = None
+    resize_pending = False
+    stdin_open = True
+
+    def _mark_resize(_signum: int, _frame: object) -> None:
+        nonlocal resize_pending
+        resize_pending = True
+
+    def _send_resize() -> None:
+        rows, cols = _terminal_size(stdin_fd)
+        payload = json.dumps({"rows": rows, "cols": cols}).encode("utf-8")
+        _send_terminal_frame(sock, _TERMINAL_FRAME_RESIZE, payload)
+
+    try:
+        if os.isatty(stdin_fd):
+            import termios
+            import tty
+
+            old_attrs = termios.tcgetattr(stdin_fd)
+            tty.setraw(stdin_fd)
+        try:
+            old_winch = signal.getsignal(signal.SIGWINCH)
+            signal.signal(signal.SIGWINCH, _mark_resize)
+        except ValueError:
+            old_winch = None
+
+        while True:
+            if resize_pending:
+                resize_pending = False
+                _send_resize()
+
+            readers: list[Any] = [sock]
+            if stdin_open:
+                readers.append(stdin_fd)
+            readable, _, _ = select.select(readers, [], [], 0.25)
+
+            if sock in readable:
+                frame_type, payload = _read_terminal_frame(sock, max_payload=max_frame_bytes)
+                if frame_type == _TERMINAL_FRAME_OUTPUT:
+                    _write_terminal_output(stdout, payload)
+                elif frame_type == _TERMINAL_FRAME_EXIT:
+                    response = json.loads(payload.decode("utf-8"))
+                    return int(response.get("exit_code", 0))
+                elif frame_type == _TERMINAL_FRAME_ERROR:
+                    raise SmolVMError(payload.decode("utf-8", errors="replace"))
+                else:
+                    raise SmolVMError(f"Unknown terminal response frame: {frame_type}")
+
+            if stdin_open and stdin_fd in readable:
+                data = os.read(stdin_fd, 65536)
+                if data:
+                    _send_terminal_frame(sock, _TERMINAL_FRAME_STDIN, data)
+                else:
+                    stdin_open = False
+    except EOFError as exc:
+        raise SmolVMError("Shell connection closed before the shell exited.") from exc
+    except KeyboardInterrupt:
+        with suppress(Exception):
+            _send_terminal_frame(sock, _TERMINAL_FRAME_CLOSE)
+        return 130
+    finally:
+        if old_attrs is not None:
+            with suppress(Exception):
+                termios.tcsetattr(stdin_fd, termios.TCSADRAIN, old_attrs)  # type: ignore[name-defined]
+        if old_winch is not None:
+            with suppress(Exception):
+                signal.signal(signal.SIGWINCH, old_winch)
 
 
 def _directory_to_tar(source: Path) -> bytes:
@@ -285,11 +441,15 @@ class RustHttpVsockChannel:
         )
 
     def _open(self) -> socket.socket:
-        if self.uds_path is not None:
-            return self._open_uds()
-        return self._open_vsock()
+        return self._open_port(self.agent_port)
 
-    def _open_vsock(self) -> socket.socket:
+    def _open_port(self, port: int) -> socket.socket:
+        if self.uds_path is not None:
+            return self._open_uds(port)
+        return self._open_vsock(port)
+
+    def _open_vsock(self, port: int | None = None) -> socket.socket:
+        port = self.agent_port if port is None else port
         if not hasattr(socket, "AF_VSOCK"):
             raise SmolVMError(
                 "vsock is not available on this host (no AF_VSOCK). "
@@ -298,18 +458,19 @@ class RustHttpVsockChannel:
         sock = socket.socket(socket.AF_VSOCK, socket.SOCK_STREAM)
         sock.settimeout(float(self.connect_timeout))
         try:
-            sock.connect((self.guest_cid, self.agent_port))
+            sock.connect((self.guest_cid, port))
         except OSError:
             sock.close()
             raise
         return sock
 
-    def _open_uds(self) -> socket.socket:
+    def _open_uds(self, port: int | None = None) -> socket.socket:
+        port = self.agent_port if port is None else port
         sock = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
         sock.settimeout(float(self.connect_timeout))
         try:
             sock.connect(self.uds_path)
-            sock.sendall(f"CONNECT {self.agent_port}\n".encode())
+            sock.sendall(f"CONNECT {port}\n".encode())
             ack = self._read_line(sock)
             if not ack.startswith("OK"):
                 raise SmolVMError(f"vsock CONNECT handshake failed: {ack!r}")
@@ -434,6 +595,7 @@ class RustHttpVsockChannel:
                 protocol_version=protocol_version,
                 features=dict(features),
                 limits=dict(limits),
+                terminal_port=int(resp.get("terminal_port", SMOLVM_TERMINAL_PORT)),
             )
         return self._capabilities
 
@@ -478,6 +640,45 @@ class RustHttpVsockChannel:
             stdout=str(resp.get("stdout", "")),
             stderr=str(resp.get("stderr", "")),
         )
+
+    def attach_terminal(self) -> int:
+        self._require_feature("fast shell access", "terminal")
+        max_frame_bytes = self._limit_bytes(
+            "terminal_frame_bytes",
+            _DEFAULT_MAX_TERMINAL_FRAME_BYTES,
+        )
+        sock = self._open_port(self.capabilities.terminal_port)
+        try:
+            stdin = getattr(sys.stdin, "buffer", sys.stdin)
+            stdout = getattr(sys.stdout, "buffer", sys.stdout)
+            try:
+                stdin_fd = stdin.fileno()
+            except (AttributeError, io.UnsupportedOperation) as exc:
+                raise SmolVMError("Shell needs a real terminal or pipe for input.") from exc
+
+            rows, cols = _terminal_size(stdin_fd)
+            request = {
+                "version": 1,
+                "rows": rows,
+                "cols": cols,
+                "term": os.environ.get("TERM") or "xterm-256color",
+                "cwd": None,
+                "env": {},
+            }
+            sock.sendall(json.dumps(request).encode("utf-8") + b"\n")
+            response = json.loads(_read_socket_line(sock))
+            if not response.get("ok"):
+                raise SmolVMError(str(response.get("error") or "Shell could not start."))
+
+            sock.settimeout(None)
+            return _run_terminal_io(
+                sock,
+                stdin_fd=stdin_fd,
+                stdout=stdout,
+                max_frame_bytes=max_frame_bytes,
+            )
+        finally:
+            sock.close()
 
     def sync(self, timeout: float = 10) -> None:
         if timeout <= 0:

--- a/src/smolvm/comm/rust_http_vsock_channel.py
+++ b/src/smolvm/comm/rust_http_vsock_channel.py
@@ -100,13 +100,13 @@ def _feature_required_message(feature: str, sandbox_name: str | None) -> str:
     if sandbox_name:
         sandbox = shlex.quote(sandbox_name)
         return (
-            f"Sandbox {sandbox} is using an older image that does not support {feature}; "
-            f"run `smolvm sandbox delete {sandbox}` and create it again after updating the image."
+            f"Sandbox {sandbox} was created from an older image and cannot use {feature}; "
+            f"run `smolvm sandbox delete {sandbox}`, then run "
+            f"`smolvm sandbox create --name {sandbox}` after updating SmolVM."
         )
     return (
-        f"This sandbox is using an older image that does not support {feature}; "
-        "run `smolvm sandbox list` to find its name, then delete it and create it again "
-        "after updating the image."
+        f"This sandbox was created from an older image and cannot use {feature}; "
+        "run `smolvm sandbox list`, then delete and recreate the sandbox after updating SmolVM."
     )
 
 

--- a/src/smolvm/facade.py
+++ b/src/smolvm/facade.py
@@ -2169,6 +2169,34 @@ class SmolVM:
             public_host=public_host,
         )
 
+    def _ensure_shell_control(self, *, timeout: float) -> CommChannel:
+        self._refresh_info()
+        if self._resolve_channel().kind != "vsock":
+            raise SmolVMError(
+                f"Fast shell is not available for sandbox '{self._vm_id}'; "
+                f"run 'smolvm sandbox ssh {self._vm_id}' to use SSH.",
+                {"vm_id": self._vm_id},
+            )
+        channel = self._ensure_control_for_operation(action="open a shell", timeout=timeout)
+        attach_terminal = getattr(channel, "attach_terminal", None)
+        if not callable(attach_terminal):
+            raise SmolVMError(
+                f"Sandbox '{self._vm_id}' does not support fast shell access; "
+                f"run 'smolvm sandbox ssh {self._vm_id}' to use SSH.",
+                {"vm_id": self._vm_id},
+            )
+        return channel
+
+    def wait_for_shell(self, *, timeout: float = _DEFAULT_RUN_READY_TIMEOUT) -> SmolVM:
+        """Wait until the fast interactive shell transport is ready."""
+        self._ensure_shell_control(timeout=timeout)
+        return self
+
+    def attach_shell(self, *, timeout: float = _DEFAULT_RUN_READY_TIMEOUT) -> int:
+        """Open an interactive shell over the resolved control channel."""
+        channel = self._ensure_shell_control(timeout=timeout)
+        return int(channel.attach_terminal())  # type: ignore[attr-defined]
+
     def _ssh_attach_command(self) -> list[str]:
         """Return an interactive SSH command using the resolved ready endpoint."""
         if not self._ssh_ready or self._ssh is None:

--- a/src/smolvm/facade.py
+++ b/src/smolvm/facade.py
@@ -2169,14 +2169,22 @@ class SmolVM:
             public_host=public_host,
         )
 
-    def _ensure_shell_control(self, *, timeout: float) -> CommChannel:
+    def _ensure_shell_supported(self) -> None:
         self._refresh_info()
         if self._resolve_channel().kind != "vsock":
             raise SmolVMError(
-                f"Fast shell is not available for sandbox '{self._vm_id}'; "
-                f"run 'smolvm sandbox ssh {self._vm_id}' to use SSH.",
+                f"Sandbox '{self._vm_id}' cannot use 'smolvm sandbox shell'; "
+                f"run 'smolvm sandbox ssh {self._vm_id}' to open an SSH shell.",
                 {"vm_id": self._vm_id},
             )
+
+    def ensure_shell_supported(self) -> SmolVM:
+        """Verify that this sandbox can use ``smolvm sandbox shell``."""
+        self._ensure_shell_supported()
+        return self
+
+    def _ensure_shell_control(self, *, timeout: float) -> CommChannel:
+        self._ensure_shell_supported()
         channel = self._ensure_control_for_operation(action="open a shell", timeout=timeout)
         attach_terminal = getattr(channel, "attach_terminal", None)
         if not callable(attach_terminal):

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1872,6 +1872,35 @@ class TestCliShell:
         vm.close.assert_called_once()
 
     @patch("smolvm.facade.SmolVM")
+    def test_shell_rejects_unsupported_vm_before_starting(
+        self,
+        mock_vm_cls: MagicMock,
+        capsys: pytest.CaptureFixture,
+    ) -> None:
+        from smolvm.exceptions import SmolVMError
+
+        vm = MagicMock()
+        vm.status = VMState.STOPPED
+        vm.ensure_shell_supported.side_effect = SmolVMError(
+            "Sandbox 'vm001' cannot use 'smolvm sandbox shell'; "
+            "run 'smolvm sandbox ssh vm001' to open an SSH shell."
+        )
+        mock_vm_cls.from_id.return_value = vm
+
+        ret = main(["sandbox", "shell", "vm001"])
+
+        assert ret == 1
+        vm.start.assert_not_called()
+        vm.resume.assert_not_called()
+        vm.wait_for_shell.assert_not_called()
+        vm.wait_for_ssh.assert_not_called()
+        vm.attach_shell.assert_not_called()
+        vm.close.assert_called_once()
+        err = capsys.readouterr().err
+        assert "sandbox ssh vm001" in err
+        assert "vm001" in err
+
+    @patch("smolvm.facade.SmolVM")
     def test_shell_resumes_paused_vm(self, mock_vm_cls: MagicMock) -> None:
         vm = MagicMock()
         vm.status = VMState.PAUSED

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -151,7 +151,8 @@ def test_sandbox_help_describes_all_commands(capsys: pytest.CaptureFixture) -> N
         "Manage port forwarding for a sandbox.",
         "Resume a paused sandbox.",
         "Save and restore sandbox state.",
-        "Open a shell in a sandbox.",
+        "Open a fast shell in a sandbox.",
+        "Open an SSH shell in a sandbox.",
         "Start a stopped sandbox.",
         "Stop a running sandbox.",
     ]:
@@ -770,6 +771,7 @@ class TestCliCreate:
         assert "OS" in out
         assert "ubuntu" in out
         assert "Started" in out
+        assert "smolvm sandbox shell vm-a1b2c3d4" in out
         assert "smolvm sandbox ssh vm-a1b2c3d4" in out
         assert "smolvm sandbox info vm-a1b2c3d4" in out
         assert "Backend" not in out
@@ -847,6 +849,7 @@ class TestCliCreate:
         assert "OS" in out
         assert "ubuntu" in out
         assert "Started" in out
+        assert "smolvm sandbox shell project-spacex" in out
         assert "smolvm sandbox ssh project-spacex" in out
         assert "smolvm sandbox info project-spacex" in out
         assert "Backend" not in out
@@ -971,6 +974,7 @@ class TestCliCreate:
         assert payload["data"]["vm"]["name"] == "project-spacex"
         assert payload["data"]["vm"]["os"] == "ubuntu"
         assert payload["data"]["vm"]["started_at"]
+        assert payload["data"]["next"]["shell_command"] == "smolvm sandbox shell project-spacex"
         assert payload["data"]["next"]["ssh_command"] == "smolvm sandbox ssh project-spacex"
         assert payload["data"]["next"]["info_command"] == "smolvm sandbox info project-spacex"
 
@@ -1824,6 +1828,84 @@ class TestCliPort:
         assert args.vm_id == "vm001"
         assert args.command_name == "sandbox.port.list"
         assert args.json is True
+
+
+class TestCliShell:
+    """Tests for `smolvm sandbox shell`."""
+
+    @patch("smolvm.facade.SmolVM")
+    def test_shell_running_vm_uses_control_channel(self, mock_vm_cls: MagicMock) -> None:
+        vm = MagicMock()
+        vm.status = VMState.RUNNING
+        vm.attach_shell.return_value = 7
+        mock_vm_cls.from_id.return_value = vm
+
+        ret = main(["sandbox", "shell", "vm001", "--boot-timeout", "15"])
+
+        assert ret == 7
+        mock_vm_cls.from_id.assert_called_once_with("vm001")
+        vm.start.assert_not_called()
+        vm.wait_for_shell.assert_called_once_with(timeout=15.0)
+        vm.wait_for_ssh.assert_not_called()
+        vm.attach_shell.assert_called_once_with(timeout=15.0)
+        vm.close.assert_called_once()
+
+    @pytest.mark.parametrize("status", [VMState.CREATED, VMState.STOPPED])
+    @patch("smolvm.facade.SmolVM")
+    def test_shell_auto_starts_created_or_stopped_vm(
+        self,
+        mock_vm_cls: MagicMock,
+        status: VMState,
+    ) -> None:
+        vm = MagicMock()
+        vm.status = status
+        vm.attach_shell.return_value = 0
+        mock_vm_cls.from_id.return_value = vm
+
+        ret = main(["sandbox", "shell", "vm001"])
+
+        assert ret == 0
+        vm.start.assert_called_once_with(boot_timeout=30.0)
+        vm.wait_for_shell.assert_called_once_with(timeout=30.0)
+        vm.wait_for_ssh.assert_not_called()
+        vm.attach_shell.assert_called_once_with(timeout=30.0)
+        vm.close.assert_called_once()
+
+    @patch("smolvm.facade.SmolVM")
+    def test_shell_resumes_paused_vm(self, mock_vm_cls: MagicMock) -> None:
+        vm = MagicMock()
+        vm.status = VMState.PAUSED
+        vm.attach_shell.return_value = 0
+        mock_vm_cls.from_id.return_value = vm
+
+        ret = main(["sandbox", "shell", "vm001"])
+
+        assert ret == 0
+        vm.resume.assert_called_once_with()
+        vm.start.assert_not_called()
+        vm.wait_for_shell.assert_called_once_with(timeout=30.0)
+        vm.wait_for_ssh.assert_not_called()
+        vm.attach_shell.assert_called_once_with(timeout=30.0)
+        vm.close.assert_called_once()
+
+    @patch("smolvm.facade.SmolVM")
+    def test_shell_error_state_fails_fast(
+        self,
+        mock_vm_cls: MagicMock,
+        capsys: pytest.CaptureFixture,
+    ) -> None:
+        vm = MagicMock()
+        vm.status = VMState.ERROR
+        mock_vm_cls.from_id.return_value = vm
+
+        ret = main(["sandbox", "shell", "vm001"])
+
+        assert ret == 1
+        vm.start.assert_not_called()
+        vm.wait_for_ssh.assert_not_called()
+        vm.attach_shell.assert_not_called()
+        vm.close.assert_called_once()
+        assert "error state" in capsys.readouterr().err
 
 
 class TestCliSSH:
@@ -3292,6 +3374,7 @@ class TestCliStart:
         assert "sbx-codex" in out
         assert "codex" in out
         assert "OPENAI_API_KEY" in out
+        assert "smolvm sandbox shell sbx-codex" in out
         assert "smolvm sandbox ssh sbx-codex" in out
 
     @patch("smolvm.images.published.is_preset_published", return_value=False)
@@ -3327,6 +3410,7 @@ class TestCliStart:
         assert payload["data"]["vm"]["os"] == "ubuntu"
         assert payload["data"]["preset"]["name"] == "codex"
         assert payload["data"]["preset"]["injected_env_keys"] == ["OPENAI_API_KEY"]
+        assert payload["data"]["next"]["shell_command"] == "smolvm sandbox shell sbx-1"
         assert payload["data"]["next"]["ssh_command"] == "smolvm sandbox ssh sbx-1"
 
     @patch("smolvm.images.published.is_preset_published", return_value=False)

--- a/tests/test_facade_vsock.py
+++ b/tests/test_facade_vsock.py
@@ -116,6 +116,45 @@ def test_public_vsock_ready_and_run_do_not_require_network(
     assert vm._info.network is None
 
 
+def test_attach_shell_uses_vsock_terminal_not_ssh(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setattr("smolvm.comm.select.host_supports_vsock", lambda: True)
+    monkeypatch.setattr(
+        RustHttpVsockChannel,
+        "wait_ready",
+        lambda self, timeout=60.0, interval=0.1: None,
+    )
+    monkeypatch.setattr(RustHttpVsockChannel, "attach_terminal", lambda self: 7)
+
+    def _fail_ssh(self, timeout: float, *, as_control: bool = False) -> None:
+        raise AssertionError("attach_shell must not wait for SSH")
+
+    monkeypatch.setattr(SmolVM, "_wait_for_ssh_over_network", _fail_ssh)
+    vm = _vsock_vm(tmp_path, comm_channel="vsock", request="vsock")
+
+    assert vm.attach_shell(timeout=5) == 7
+    assert vm._control_ready is True
+    assert vm._ssh_ready is False
+
+
+def test_attach_shell_rejects_ssh_channel_without_waiting_for_ssh(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    vm = _vsock_vm(tmp_path, comm_channel="ssh", request="ssh")
+
+    def _fail_ssh(self, timeout: float, *, as_control: bool = False) -> None:
+        raise AssertionError("attach_shell must not fall back to SSH")
+
+    monkeypatch.setattr(SmolVM, "_wait_for_ssh_over_network", _fail_ssh)
+
+    with pytest.raises(SmolVMError, match="smolvm sandbox ssh vm1"):
+        vm.attach_shell(timeout=5)
+
+    assert vm._control_ready is False
+    assert vm._ssh_ready is False
+
+
 def test_wait_for_ssh_waits_for_ssh_not_vsock(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:

--- a/tests/test_rust_http_vsock_channel.py
+++ b/tests/test_rust_http_vsock_channel.py
@@ -67,6 +67,23 @@ def test_terminal_frame_helpers_round_trip_payload() -> None:
         guest.close()
 
 
+def test_feature_required_error_names_recreate_commands() -> None:
+    channel = RustHttpVsockChannel.from_cid(42, sandbox_name="sbx-riemann")
+    channel._capabilities = ControlCapabilities(
+        protocol_version=2,
+        features={},
+        limits={},
+    )
+
+    with pytest.raises(SmolVMError) as exc_info:
+        channel.attach_terminal()
+
+    message = str(exc_info.value)
+    assert "Sandbox sbx-riemann was created from an older image" in message
+    assert "smolvm sandbox delete sbx-riemann" in message
+    assert "smolvm sandbox create --name sbx-riemann" in message
+
+
 class FakeRustChannel(RustHttpVsockChannel):
     def __init__(self, handlers: list[Handler]) -> None:
         super().__init__(guest_cid=42)

--- a/tests/test_rust_http_vsock_channel.py
+++ b/tests/test_rust_http_vsock_channel.py
@@ -18,6 +18,7 @@ from __future__ import annotations
 
 import io
 import json
+import os
 import queue
 import socket
 import tarfile
@@ -31,9 +32,12 @@ import pytest
 
 from smolvm.comm.base import CommChannel
 from smolvm.comm.rust_http_vsock_channel import (
+    SMOLVM_TERMINAL_PORT,
     ControlCapabilities,
     RustHttpVsockChannel,
     _directory_to_tar,
+    _pack_terminal_frame,
+    _read_terminal_frame,
     _SocketHTTPConnection,
 )
 from smolvm.exceptions import OperationTimeoutError, SmolVMError
@@ -51,6 +55,16 @@ def test_control_capabilities_accept_flat_dotted_features() -> None:
     assert capabilities.enabled("file_raw", "files.stream")
     assert capabilities.enabled("ports.wait")
     assert not capabilities.enabled("env.managed")
+
+
+def test_terminal_frame_helpers_round_trip_payload() -> None:
+    host, guest = socket.socketpair()
+    try:
+        host.sendall(_pack_terminal_frame(101, b"hello"))
+        assert _read_terminal_frame(guest) == (101, b"hello")
+    finally:
+        host.close()
+        guest.close()
 
 
 class FakeRustChannel(RustHttpVsockChannel):
@@ -95,6 +109,35 @@ class FakeRustChannel(RustHttpVsockChannel):
                     + b"Connection: close\r\n\r\n"
                     + payload
                 )
+
+        threading.Thread(target=_serve, daemon=True).start()
+        return host
+
+
+class FakeTerminalChannel(FakeRustChannel):
+    def __init__(self, handlers: list[Handler]) -> None:
+        super().__init__(handlers)
+        self.terminal_requests: list[dict[str, Any]] = []
+        self.terminal_stdin: list[bytes] = []
+
+    def _open_port(self, port: int) -> socket.socket:
+        if port != SMOLVM_TERMINAL_PORT:
+            return self._open()
+
+        host, guest = socket.socketpair()
+
+        def _serve() -> None:
+            with guest:
+                line = b""
+                while not line.endswith(b"\n"):
+                    line += guest.recv(1)
+                self.terminal_requests.append(json.loads(line))
+                guest.sendall(json.dumps({"ok": True, "pid": 1234}).encode() + b"\n")
+                frame_type, payload = _read_terminal_frame(guest)
+                assert frame_type == 1
+                self.terminal_stdin.append(payload)
+                guest.sendall(_pack_terminal_frame(101, b"ok\r\n"))
+                guest.sendall(_pack_terminal_frame(102, json.dumps({"exit_code": 7}).encode()))
 
         threading.Thread(target=_serve, daemon=True).start()
         return host
@@ -237,6 +280,48 @@ def test_run_serializes_float_timeout_as_integer_seconds() -> None:
 
     result = FakeRustChannel([_handler(11)]).run("true", timeout=10.1, shell="raw")
     assert result.exit_code == 0
+
+
+def test_attach_terminal_streams_stdin_stdout_and_exit(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    read_fd, write_fd = os.pipe()
+    os.write(write_fd, b"exit\n")
+    os.close(write_fd)
+
+    class _PipeInput:
+        buffer: _PipeInput
+
+        def __init__(self, fd: int) -> None:
+            self.fd = fd
+            self.buffer = self
+
+        def fileno(self) -> int:
+            return self.fd
+
+    output = io.BytesIO()
+    monkeypatch.setattr("smolvm.comm.rust_http_vsock_channel.sys.stdin", _PipeInput(read_fd))
+    monkeypatch.setattr("smolvm.comm.rust_http_vsock_channel.sys.stdout", output)
+    monkeypatch.setenv("TERM", "xterm-test")
+
+    channel = FakeTerminalChannel([_capabilities({"terminal": True})])
+    try:
+        exit_code = channel.attach_terminal()
+    finally:
+        os.close(read_fd)
+
+    assert exit_code == 7
+    assert output.getvalue() == b"ok\r\n"
+    assert channel.terminal_stdin == [b"exit\n"]
+    assert channel.terminal_requests[0]["version"] == 1
+    assert channel.terminal_requests[0]["term"] == "xterm-test"
+
+
+def test_attach_terminal_requires_terminal_capability() -> None:
+    channel = FakeRustChannel([_capabilities({})])
+
+    with pytest.raises(SmolVMError, match="fast shell access"):
+        channel.attach_terminal()
 
 
 def test_run_timeout_maps_to_operation_timeout() -> None:


### PR DESCRIPTION
## Summary
- add a Rust guest-agent terminal stream on vsock port 1025 with PTY-backed shell support
- add host-side terminal framing and `smolvm sandbox shell` for fast interactive attach
- keep `smolvm sandbox ssh` as literal OpenSSH and update create/start output/docs to prefer the fast shell

## Validation
- `cargo test -p smolvm-guest-agent`
- `uv run ruff check src tests`
- `uv run pytest -q` (1449 passed, 12 skipped, 27 deselected)
- `uv run smolvm sandbox --help`
- `uv run smolvm sandbox shell --help`
- `uv run smolvm sandbox ssh --help`
- `git diff --check`

## Notes
- `cargo test --workspace` still cannot complete locally because `smolvm-core` links against missing `-lpython3.14` on this host; the guest-agent Rust tests pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added `smolvm sandbox shell` for fast interactive shells using the guest vsock terminal (with terminal streaming and resize support).
  * Extended guest agent capabilities and limits to advertise and enable terminal sessions.
  * Updated the CLI “next” output/JSON to include shell startup alongside existing flows.

* **Documentation**
  * Updated README and deep-dive guides to use `smolvm sandbox shell` for interactive access, and reserve `smolvm sandbox ssh` for SSH-specific needs.

* **Tests**
  * Added/updated coverage for shell attachment and terminal feature negotiation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->