### PR TITLE
Remove duplicated Python QMP and disk copy code

### DIFF
--- a/src/smolvm/qmp.py
+++ b/src/smolvm/qmp.py
@@ -12,28 +12,23 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Minimal QMP client for QEMU runtime control."""
+"""Thin QMP wrapper around the native smolvm-core client."""
 
 from __future__ import annotations
 
 import importlib
 import json
-import logging
-import socket
-import time
 from contextlib import suppress
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Any, cast
+from typing import Any
 
 from smolvm.exceptions import SmolVMError
-
-logger = logging.getLogger(__name__)
 
 try:
     _smolvm_core = importlib.import_module("smolvm_core._smolvm_core")
     _NativeQMPClient: Any | None = getattr(_smolvm_core, "_QmpClient", None)
-except Exception:  # pragma: no cover - depends on optional native wheel shape
+except Exception:  # pragma: no cover - depends on wheel import failure shape
     _NativeQMPClient = None
 
 
@@ -47,294 +42,6 @@ class QMPJob:
     current_progress: int
     total_progress: int
     error: str | None = None
-
-
-class _PythonQMPClient:
-    """Pure-Python QMP client fallback over a Unix socket."""
-
-    def __init__(self, socket_path: Path) -> None:
-        """Initialize a client for the given QMP control socket."""
-        if socket_path is None:
-            raise ValueError("socket_path cannot be None")
-
-        self.socket_path = socket_path
-        self._socket: socket.socket | None = None
-        self._reader: Any | None = None
-        self._writer: Any | None = None
-
-    def __enter__(self) -> _PythonQMPClient:
-        return self
-
-    def __exit__(self, *args: object) -> None:
-        self.close()
-
-    def connect(self, timeout: float = 5.0, read_timeout: float = 30.0) -> None:
-        """Connect to the QMP socket and negotiate capabilities.
-
-        ``timeout`` bounds how long we keep retrying the initial connect while
-        QEMU is still bringing the monitor socket up; each probe uses a short
-        (≤1s) socket timeout so a not-yet-ready socket fails fast and retries.
-        Once QMP greeting/capabilities negotiation succeeds, the socket timeout
-        is raised to ``read_timeout`` so that replies to slow commands (e.g.
-        ``snapshot-save`` while QEMU is busy
-        dumping guest RAM, which can take far longer than 1s to even
-        acknowledge) are not cut off mid-read with ``TimeoutError``.
-        """
-        if self._socket is not None:
-            return
-
-        deadline = time.time() + timeout
-        while True:
-            qmp_socket: socket.socket | None = None
-            try:
-                qmp_socket = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
-                qmp_socket.settimeout(min(timeout, 1.0))
-                qmp_socket.connect(str(self.socket_path))
-                self._socket = qmp_socket
-                self._reader = qmp_socket.makefile("r", encoding="utf-8")
-                self._writer = qmp_socket.makefile("w", encoding="utf-8")
-                break
-            except (FileNotFoundError, ConnectionRefusedError, OSError):
-                if time.time() >= deadline:
-                    raise SmolVMError(
-                        "Timed out waiting for QMP socket",
-                        {"socket_path": str(self.socket_path)},
-                    ) from None
-                with suppress(Exception):
-                    if qmp_socket is not None:
-                        qmp_socket.close()
-                time.sleep(0.05)
-
-        try:
-            greeting = self._read_message()
-            if "QMP" not in greeting:
-                raise SmolVMError(
-                    "Invalid QMP greeting",
-                    {"socket_path": str(self.socket_path), "greeting": greeting},
-                )
-            self.execute("qmp_capabilities")
-            assert self._socket is not None
-            # Handshake complete: switch from the short probe timeout to a
-            # generous read timeout for command replies.
-            self._socket.settimeout(read_timeout)
-        except Exception:
-            self.close()
-            raise
-
-    def execute(
-        self,
-        command: str,
-        arguments: dict[str, Any] | None = None,
-    ) -> Any:
-        """Execute a QMP command and return the ``return`` payload."""
-        if self._socket is None:
-            self.connect()
-
-        assert self._writer is not None
-        payload: dict[str, Any] = {"execute": command}
-        if arguments:
-            payload["arguments"] = arguments
-
-        self._writer.write(json.dumps(payload))
-        self._writer.write("\n")
-        self._writer.flush()
-
-        while True:
-            message = self._read_message()
-            if "event" in message:
-                logger.debug("Ignoring QMP event: %s", message)
-                continue
-            if "error" in message:
-                error = message["error"]
-                raise SmolVMError(
-                    f"QMP command '{command}' failed",
-                    {
-                        "socket_path": str(self.socket_path),
-                        "command": command,
-                        "class": error.get("class"),
-                        "desc": error.get("desc"),
-                    },
-                )
-            if "return" in message:
-                return message["return"]
-
-    def query_status(self) -> dict[str, Any]:
-        """Query the current VM run state."""
-        result = self.execute("query-status")
-        if not isinstance(result, dict):
-            raise SmolVMError("Unexpected QMP query-status response", {"result": result})
-        return result
-
-    def query_version(self) -> dict[str, Any]:
-        """Query the runtime QEMU version."""
-        result = self.execute("query-version")
-        if not isinstance(result, dict):
-            raise SmolVMError("Unexpected QMP query-version response", {"result": result})
-        return result
-
-    def stop_vm(self) -> None:
-        """Pause guest execution."""
-        self.execute("stop")
-
-    def cont(self) -> None:
-        """Resume guest execution."""
-        self.execute("cont")
-
-    def snapshot_save(self, job_id: str, tag: str, vmstate: str, devices: list[str]) -> None:
-        """Create a QEMU internal snapshot."""
-        self.execute(
-            "snapshot-save",
-            {
-                "job-id": job_id,
-                "tag": tag,
-                "vmstate": vmstate,
-                "devices": devices,
-            },
-        )
-
-    def snapshot_load(self, job_id: str, tag: str, vmstate: str, devices: list[str]) -> None:
-        """Load a QEMU internal snapshot."""
-        self.execute(
-            "snapshot-load",
-            {
-                "job-id": job_id,
-                "tag": tag,
-                "vmstate": vmstate,
-                "devices": devices,
-            },
-        )
-
-    def snapshot_delete(self, job_id: str, tag: str, devices: list[str]) -> None:
-        """Delete a QEMU internal snapshot."""
-        self.execute(
-            "snapshot-delete",
-            {
-                "job-id": job_id,
-                "tag": tag,
-                "devices": devices,
-            },
-        )
-
-    def blockdev_snapshot_internal_sync(self, device: str, name: str) -> None:
-        """Create a **disk-only** internal qcow2 snapshot, synchronously.
-
-        Unlike ``snapshot-save``, this saves only the block device's data (no
-        guest RAM / vmstate), so it is fast, never dumps memory, and does not go
-        through the async job API — it returns once the consistent point is
-        written. ``device`` is the block node-name (or qdev id); ``name`` is the
-        internal snapshot tag.
-        """
-        self.execute(
-            "blockdev-snapshot-internal-sync",
-            {
-                "device": device,
-                "name": name,
-            },
-        )
-
-    def blockdev_snapshot_delete_internal_sync(self, device: str, name: str) -> None:
-        """Delete a disk-only internal qcow2 snapshot, synchronously."""
-        self.execute(
-            "blockdev-snapshot-delete-internal-sync",
-            {
-                "device": device,
-                "name": name,
-            },
-        )
-
-    def query_jobs(self) -> list[QMPJob]:
-        """Return normalized job status rows."""
-        result = self.execute("query-jobs")
-        if not isinstance(result, list):
-            raise SmolVMError("Unexpected QMP query-jobs response", {"result": result})
-        return [
-            QMPJob(
-                job_id=str(job["id"]),
-                job_type=str(job["type"]),
-                status=str(job["status"]),
-                current_progress=int(job.get("current-progress", 0)),
-                total_progress=int(job.get("total-progress", 0)),
-                error=str(job["error"]) if "error" in job else None,
-            )
-            for job in result
-        ]
-
-    def dismiss_job(self, job_id: str) -> None:
-        """Dismiss a concluded QMP job."""
-        self.execute("job-dismiss", {"id": job_id})
-
-    def wait_for_job(
-        self,
-        job_id: str,
-        *,
-        timeout: float = 60.0,
-        poll_interval: float = 0.1,
-    ) -> QMPJob:
-        """Wait until a QMP job reaches the concluded state."""
-        deadline = time.time() + timeout
-        last_job: QMPJob | None = None
-        while time.time() < deadline:
-            for job in self.query_jobs():
-                if job.job_id != job_id:
-                    continue
-                last_job = job
-                if job.status == "concluded":
-                    if job.error is not None:
-                        raise SmolVMError(
-                            "QMP job failed",
-                            {
-                                "socket_path": str(self.socket_path),
-                                "job_id": job.job_id,
-                                "job_type": job.job_type,
-                                "status": job.status,
-                                "error": job.error,
-                            },
-                        )
-                    with suppress(Exception):
-                        self.dismiss_job(job_id)
-                    return job
-                break
-            time.sleep(poll_interval)
-
-        raise SmolVMError(
-            "Timed out waiting for QMP job",
-            {
-                "socket_path": str(self.socket_path),
-                "job_id": job_id,
-                "last_status": last_job.status if last_job else None,
-            },
-        )
-
-    def close(self) -> None:
-        """Close all file and socket handles."""
-        for handle in (self._reader, self._writer):
-            with suppress(Exception):
-                if handle is not None:
-                    handle.close()
-        self._reader = None
-        self._writer = None
-        if self._socket is not None:
-            with suppress(Exception):
-                self._socket.close()
-        self._socket = None
-
-    def _read_message(self) -> dict[str, Any]:
-        """Read a single QMP JSON message."""
-        if self._reader is None:
-            raise SmolVMError("QMP client is not connected", {"socket_path": str(self.socket_path)})
-
-        line = self._reader.readline()
-        if not line:
-            raise SmolVMError(
-                "QMP socket closed unexpectedly", {"socket_path": str(self.socket_path)}
-            )
-        message = json.loads(line)
-        if not isinstance(message, dict):
-            raise SmolVMError(
-                "Invalid QMP message",
-                {"socket_path": str(self.socket_path), "message": message},
-            )
-        return cast(dict[str, Any], message)
 
 
 def _native_error_to_smolvm(exc: Exception, socket_path: Path) -> SmolVMError:
@@ -364,29 +71,15 @@ class QMPClient:
         """Initialize a client for the given QMP control socket."""
         if socket_path is None:
             raise ValueError("socket_path cannot be None")
+        if _NativeQMPClient is None:
+            raise SmolVMError(
+                "QEMU control support is missing; "
+                "run `uv sync --reinstall-package smolvm-core` and try again.",
+                {"socket_path": str(socket_path)},
+            )
 
         self.socket_path = socket_path
-        self._native: Any | None = (
-            _NativeQMPClient(str(socket_path)) if _NativeQMPClient is not None else None
-        )
-        self._fallback: _PythonQMPClient | None = (
-            None if self._native is not None else _PythonQMPClient(socket_path)
-        )
-
-    @property
-    def _socket(self) -> socket.socket | None:
-        """Expose fallback socket for legacy tests/debugging."""
-        return self._fallback._socket if self._fallback is not None else None
-
-    @property
-    def _reader(self) -> Any | None:
-        """Expose fallback reader for legacy tests/debugging."""
-        return self._fallback._reader if self._fallback is not None else None
-
-    @property
-    def _writer(self) -> Any | None:
-        """Expose fallback writer for legacy tests/debugging."""
-        return self._fallback._writer if self._fallback is not None else None
+        self._native: Any = _NativeQMPClient(str(socket_path))
 
     def __enter__(self) -> QMPClient:
         return self
@@ -396,10 +89,6 @@ class QMPClient:
 
     def connect(self, timeout: float = 5.0, read_timeout: float = 30.0) -> None:
         """Connect to the QMP socket and negotiate capabilities."""
-        if self._native is None:
-            assert self._fallback is not None
-            self._fallback.connect(timeout=timeout, read_timeout=read_timeout)
-            return
         try:
             self._native.connect(timeout, read_timeout)
         except Exception as exc:
@@ -411,10 +100,6 @@ class QMPClient:
         arguments: dict[str, Any] | None = None,
     ) -> Any:
         """Execute a QMP command and return the ``return`` payload."""
-        if self._native is None:
-            assert self._fallback is not None
-            return self._fallback.execute(command, arguments)
-
         arguments_json = json.dumps(arguments) if arguments else None
         try:
             result_json = self._native.execute(command, arguments_json)
@@ -438,10 +123,6 @@ class QMPClient:
 
     def stop_vm(self) -> None:
         """Pause guest execution."""
-        if self._native is None:
-            assert self._fallback is not None
-            self._fallback.stop_vm()
-            return
         try:
             self._native.stop_vm()
         except Exception as exc:
@@ -449,10 +130,6 @@ class QMPClient:
 
     def cont(self) -> None:
         """Resume guest execution."""
-        if self._native is None:
-            assert self._fallback is not None
-            self._fallback.cont()
-            return
         try:
             self._native.cont()
         except Exception as exc:
@@ -460,10 +137,6 @@ class QMPClient:
 
     def snapshot_save(self, job_id: str, tag: str, vmstate: str, devices: list[str]) -> None:
         """Create a QEMU internal snapshot."""
-        if self._native is None:
-            assert self._fallback is not None
-            self._fallback.snapshot_save(job_id, tag, vmstate, devices)
-            return
         try:
             self._native.snapshot_save(job_id, tag, vmstate, devices)
         except Exception as exc:
@@ -471,10 +144,6 @@ class QMPClient:
 
     def snapshot_load(self, job_id: str, tag: str, vmstate: str, devices: list[str]) -> None:
         """Load a QEMU internal snapshot."""
-        if self._native is None:
-            assert self._fallback is not None
-            self._fallback.snapshot_load(job_id, tag, vmstate, devices)
-            return
         try:
             self._native.snapshot_load(job_id, tag, vmstate, devices)
         except Exception as exc:
@@ -482,10 +151,6 @@ class QMPClient:
 
     def snapshot_delete(self, job_id: str, tag: str, devices: list[str]) -> None:
         """Delete a QEMU internal snapshot."""
-        if self._native is None:
-            assert self._fallback is not None
-            self._fallback.snapshot_delete(job_id, tag, devices)
-            return
         try:
             self._native.snapshot_delete(job_id, tag, devices)
         except Exception as exc:
@@ -493,10 +158,6 @@ class QMPClient:
 
     def blockdev_snapshot_internal_sync(self, device: str, name: str) -> None:
         """Create a disk-only internal qcow2 snapshot, synchronously."""
-        if self._native is None:
-            assert self._fallback is not None
-            self._fallback.blockdev_snapshot_internal_sync(device, name)
-            return
         try:
             self._native.blockdev_snapshot_internal_sync(device, name)
         except Exception as exc:
@@ -504,10 +165,6 @@ class QMPClient:
 
     def blockdev_snapshot_delete_internal_sync(self, device: str, name: str) -> None:
         """Delete a disk-only internal qcow2 snapshot, synchronously."""
-        if self._native is None:
-            assert self._fallback is not None
-            self._fallback.blockdev_snapshot_delete_internal_sync(device, name)
-            return
         try:
             self._native.blockdev_snapshot_delete_internal_sync(device, name)
         except Exception as exc:
@@ -515,9 +172,6 @@ class QMPClient:
 
     def query_jobs(self) -> list[QMPJob]:
         """Return normalized job status rows."""
-        if self._native is None:
-            assert self._fallback is not None
-            return self._fallback.query_jobs()
         try:
             result = json.loads(self._native.query_jobs())
         except Exception as exc:
@@ -528,10 +182,6 @@ class QMPClient:
 
     def dismiss_job(self, job_id: str) -> None:
         """Dismiss a concluded QMP job."""
-        if self._native is None:
-            assert self._fallback is not None
-            self._fallback.dismiss_job(job_id)
-            return
         try:
             self._native.dismiss_job(job_id)
         except Exception as exc:
@@ -545,9 +195,6 @@ class QMPClient:
         poll_interval: float = 0.1,
     ) -> QMPJob:
         """Wait until a QMP job reaches the concluded state."""
-        if self._native is None:
-            assert self._fallback is not None
-            return self._fallback.wait_for_job(job_id, timeout=timeout, poll_interval=poll_interval)
         try:
             result = json.loads(self._native.wait_for_job(job_id, timeout, poll_interval))
         except Exception as exc:
@@ -555,19 +202,6 @@ class QMPClient:
         return QMPJob(**result)
 
     def close(self) -> None:
-        """Close all file and socket handles."""
-        if self._native is None:
-            assert self._fallback is not None
-            self._fallback.close()
-            return
+        """Close the native client."""
         with suppress(Exception):
             self._native.close()
-
-    def _read_message(self) -> dict[str, Any]:
-        """Read a single QMP JSON message through the fallback client."""
-        if self._fallback is None:
-            raise SmolVMError(
-                "QMP native client does not expose raw message reads",
-                {"socket_path": str(self.socket_path)},
-            )
-        return self._fallback._read_message()

--- a/src/smolvm/runtime/firecracker.py
+++ b/src/smolvm/runtime/firecracker.py
@@ -25,6 +25,7 @@ from typing import Any
 
 from smolvm.api import FirecrackerClient
 from smolvm.exceptions import SmolVMError
+from smolvm.host.disk import clone_or_sparse_copy
 from smolvm.runtime.backends import BACKEND_FIRECRACKER
 from smolvm.runtime.base import (
     RuntimeAdapter,
@@ -35,7 +36,6 @@ from smolvm.runtime.base import (
     SnapshotRestoreRequest,
 )
 from smolvm.types import SnapshotArtifacts, SnapshotType, VMInfo, VMState
-from smolvm.utils import copy_with_reflink
 
 logger = logging.getLogger(__name__)
 
@@ -193,7 +193,7 @@ class FirecrackerRuntimeAdapter(RuntimeAdapter):
 
             client.create_snapshot(state_path, memory_path, snapshot_type="Full")
             if request.snapshot_type == SnapshotType.DIFF:
-                copy_with_reflink(request.managed_disk_path, disk_path)
+                clone_or_sparse_copy(request.managed_disk_path, disk_path)
             else:
                 shutil.copy2(request.managed_disk_path, disk_path)
             return SnapshotCreateResult(

--- a/src/smolvm/utils.py
+++ b/src/smolvm/utils.py
@@ -42,34 +42,6 @@ def _is_sudo_non_interactive_error(stderr: str) -> bool:
     return any(pattern in text for pattern in patterns)
 
 
-def copy_with_reflink(source_path: Path, target_path: Path) -> None:
-    """Copy a file using a copy-on-write reflink when the filesystem allows it.
-
-    On CoW filesystems (btrfs, XFS with reflinks, ZFS, APFS) the new file
-    shares its blocks with the source, so the copy is near-instant and costs
-    almost no extra space regardless of file size. Later writes to either file
-    allocate fresh blocks, so the copy stays an independent, point-in-time
-    image. On filesystems or platforms without reflink support (for example,
-    macOS ``cp`` has no ``--reflink`` flag) this falls back to a regular copy.
-    """
-    result = subprocess.run(
-        ["cp", "--reflink=auto", str(source_path), str(target_path)],
-        capture_output=True,
-        text=True,
-        check=False,
-    )
-    if result.returncode == 0:
-        logger.debug("Copied %s -> %s via cp --reflink=auto", source_path, target_path)
-        return
-    logger.debug(
-        "cp --reflink failed for %s -> %s; falling back to a regular copy: %s",
-        source_path,
-        target_path,
-        (result.stderr or "").strip(),
-    )
-    shutil.copy2(source_path, target_path)
-
-
 def run_command(
     cmd: Sequence[str],
     *,

--- a/tests/test_qmp.py
+++ b/tests/test_qmp.py
@@ -204,14 +204,14 @@ def test_qmp_wait_for_job_raises_on_job_error(qmp_socket_path: Path) -> None:
     ]
 
 
-def test_qmp_connect_raises_read_timeout_above_connect_probe_timeout(
+def test_qmp_connect_accepts_read_timeout_above_connect_probe_timeout(
     qmp_socket_path: Path,
 ) -> None:
-    """After connecting, the socket read timeout must be the generous read_timeout.
+    """Native QMP should accept a generous read_timeout after the connect probe.
 
     Regression guard for the snapshot-save read TimeoutError: the connect probe
     used a ≤1s socket timeout that previously persisted for every command read,
-    cutting off replies to slow commands. Once connected we raise it.
+    cutting off replies to slow commands.
     """
     socket_path = qmp_socket_path
     requests: list[dict[str, object]] = []
@@ -222,10 +222,6 @@ def test_qmp_connect_raises_read_timeout_above_connect_probe_timeout(
 
     with QMPClient(socket_path) as client:
         client.connect(timeout=5.0, read_timeout=30.0)
-        if client._socket is not None:
-            assert client._socket.gettimeout() == 30.0
-        else:
-            assert client._native is not None
 
     thread.join(timeout=2.0)
     if socket_path.exists():
@@ -312,8 +308,7 @@ def test_qmp_connect_can_retry_after_capabilities_handshake_failure(
 
 def test_native_qmp_client_smoke_exercises_socket_protocol(qmp_socket_path: Path) -> None:
     """Native QMP should work on every platform that ships smolvm-core."""
-    if qmp_module._NativeQMPClient is None:
-        pytest.skip("native QMP binding is unavailable")
+    assert qmp_module._NativeQMPClient is not None
 
     socket_path = qmp_socket_path
     requests: list[dict[str, object]] = []
@@ -380,34 +375,18 @@ def test_native_qmp_client_smoke_exercises_socket_protocol(qmp_socket_path: Path
     ]
 
 
-def test_qmp_python_fallback_still_executes(
+def test_qmp_client_requires_native_binding(
     monkeypatch: pytest.MonkeyPatch,
     qmp_socket_path: Path,
 ) -> None:
-    """The public QMPClient should keep working when the Rust binding is absent."""
+    """The public QMPClient should fail clearly when the Rust binding is absent."""
     monkeypatch.setattr(qmp_module, "_NativeQMPClient", None)
     socket_path = qmp_socket_path
-    requests: list[dict[str, object]] = []
-    responses: dict[str, list[dict[str, object] | list[dict[str, object]]]] = {
-        "qmp_capabilities": [{"return": {}}],
-        "query-status": [{"return": {"running": False, "status": "paused"}}],
-    }
-    thread = _start_qmp_server(socket_path, responses, requests)
 
-    with qmp_module.QMPClient(socket_path) as client:
-        client.connect()
-        assert client._socket is not None
-        status = client.query_status()
+    with pytest.raises(SmolVMError, match="QEMU control support is missing") as exc_info:
+        qmp_module.QMPClient(socket_path)
 
-    thread.join(timeout=2.0)
-    if socket_path.exists():
-        socket_path.unlink()
-
-    assert status["status"] == "paused"
-    assert [request["execute"] for request in requests] == [
-        "qmp_capabilities",
-        "query-status",
-    ]
+    assert exc_info.value.details == {"socket_path": str(socket_path)}
 
 
 def test_qmp_native_errors_become_smolvm_errors(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/test_snapshot.py
+++ b/tests/test_snapshot.py
@@ -569,9 +569,9 @@ def test_create_diff_snapshot_records_type_and_copies_disk(
     with (
         patch("smolvm.runtime.firecracker.FirecrackerClient") as mock_client_cls,
         patch(
-            "smolvm.runtime.firecracker.copy_with_reflink",
+            "smolvm.runtime.firecracker.clone_or_sparse_copy",
             side_effect=lambda source, dest: dest.write_text(Path(source).read_text()),
-        ) as mock_reflink,
+        ) as mock_copy,
     ):
         mock_client = MagicMock()
         mock_client.create_snapshot.side_effect = _stub_fc_snapshot
@@ -580,7 +580,7 @@ def test_create_diff_snapshot_records_type_and_copies_disk(
             "vm001", snapshot_id="snap-diff", snapshot_type=SnapshotType.DIFF
         )
 
-    mock_reflink.assert_called_once()
+    mock_copy.assert_called_once()
     persisted = smol_vm.state.get_snapshot("snap-diff")
     assert snapshot.snapshot_type is SnapshotType.DIFF
     assert persisted.snapshot_type is SnapshotType.DIFF


### PR DESCRIPTION
## Summary
- remove the pure-Python QMP socket fallback and keep `smolvm.qmp.QMPClient` as a native smolvm-core wrapper
- fail clearly when the private native QMP binding is unavailable instead of maintaining a second protocol implementation
- route Firecracker diff snapshot disk copies through `smolvm.host.disk.clone_or_sparse_copy` and delete the older utility-level reflink helper

## Validation
- `UV_CACHE_DIR=/tmp/uv-cache uv run pytest -q tests/test_qmp.py tests/test_smolvm_core.py`
- `UV_CACHE_DIR=/tmp/uv-cache uv run pytest -q tests/test_qmp.py tests/test_smolvm_core.py tests/test_runtime_qemu.py tests/test_snapshot_qemu.py tests/test_facade.py::TestVMQemuLocalExpose`
- `UV_CACHE_DIR=/tmp/uv-cache uv run pytest -q tests/test_snapshot.py::test_create_diff_snapshot_records_type_and_copies_disk tests/test_host_disk.py`
- `UV_CACHE_DIR=/tmp/uv-cache uv run pytest -q tests/test_vm.py -k 'copy_with_reflink'`
- `UV_CACHE_DIR=/tmp/uv-cache uv run ruff check src/smolvm/qmp.py tests/test_qmp.py src/smolvm/runtime/firecracker.py src/smolvm/utils.py tests/test_snapshot.py`
- `LIBRARY_PATH=/tmp/smolvm-py314-link cargo test -p smolvm-core qmp`

Note: plain `cargo test -p smolvm-core qmp` could not link in this local shell because only a versioned Python 3.14 shared library is available; the listed command used a temporary `/tmp` symlink via `LIBRARY_PATH`, without touching system files.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * QMP connections now require the native client and surface clearer errors when it isn’t available.
  * Snapshot-related disk copying now uses a more flexible copy method that better handles different storage environments.

* **Bug Fixes**
  * Improved consistency in QMP command handling and error reporting.
  * Fixed timeout behavior so longer read timeouts are respected after connection setup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->