### PR TITLE
Fix dashboard release asset upload

### DIFF
--- a/.github/workflows/publish-dashboard-ui.yml
+++ b/.github/workflows/publish-dashboard-ui.yml
@@ -41,4 +41,11 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
           REF_NAME: ${{ github.ref_name }}
-        run: gh release upload "${REF_NAME}" "smolvm-dashboard-ui-${REF_NAME}.tar.gz"
+        run: |
+          if ! gh release view "${REF_NAME}" >/dev/null 2>&1; then
+            gh release create "${REF_NAME}" \
+              --verify-tag \
+              --title "${REF_NAME}" \
+              --generate-notes
+          fi
+          gh release upload "${REF_NAME}" "smolvm-dashboard-ui-${REF_NAME}.tar.gz" --clobber


### PR DESCRIPTION
## Summary
- create the matching GitHub Release before uploading the dashboard UI dist asset
- upload with clobber so reruns of the tag workflow are idempotent

## Validation
- git diff --check
- python3 inline workflow assertion for release create/upload behavior

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the release publishing process so assets are uploaded reliably even when a release already exists.
  * Prevents duplicate-release failures by checking for an existing release before uploading and replacing the asset if needed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->