### PR TITLE
Fix guest agent release SHA pins

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,6 +13,21 @@ SmolVM is specifically designed to provide a secure "sandbox" for AI agents to e
 - **Testing:** `pytest` (runs the suite in `tests/`)
 - **Linting & Formatting:** `uv run ruff check .` or `uv run ruff format .`
 
+### Release checklist
+
+- For guest-agent or published-image changes, build and smoke the new image
+  release before tagging the SmolVM package release.
+- Update `src/smolvm/images/published.py` with the new `IMAGES_RELEASE_TAG`
+  and rootfs SHA pins before the PyPI tag is pushed.
+- Also update `src/smolvm/images/builder.py::_GUEST_AGENT_RELEASE_SHA256`
+  from the `smolvm-guest-agent-linux-<arch>.sha256` release assets. This is a
+  separate pin from the rootfs manifest.
+- Verify both paths: `uv run smolvm ...` from a source checkout may build or use
+  the local guest-agent binary, while `smolvm ...` from `uv tool` uses the
+  installed wheel and downloads the standalone guest-agent release binary.
+- Only tag the SmolVM package release after the image manifest, guest-agent
+  binary SHA pins, image smoke, and focused tests are complete.
+
 ### CLI design
 
 - New CLI commands follow a **NOUN-VERB** structure: `smolvm <noun> <verb>`,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "smolvm"
-version = "0.0.24.post1"
+version = "0.0.24.post2"
 description = "Isolated computers that AI agents can use to browse, run code, and get real work done. Free and open-source from Celesto AI"
 readme = "README.md"
 license = "Apache-2.0"

--- a/src/smolvm/images/builder.py
+++ b/src/smolvm/images/builder.py
@@ -66,8 +66,8 @@ _GUEST_AGENT_CRATE_DIR = _REPO_ROOT / "guest-agent"
 _GUEST_AGENT_BUILD_FILE = "smolvm-guest-agent"
 _GUEST_AGENT_GUEST_PATH = "/usr/local/bin/smolvm-guest-agent"
 _GUEST_AGENT_RELEASE_SHA256: dict[str, str] = {
-    "amd64": "08f10561688891b43f64a2e0d83dd365fadf515bb0889603c974e506b2eceed5",
-    "arm64": "8976db4f9a337ad3b7e9b44b4f96913577598373d772fb79d50adca11e3364a7",
+    "amd64": "61ead9a6b13f9a5f63211cd8873ff000e17a98bb40b450d57b5d6332fdb90232",
+    "arm64": "d7a04d2c7502dcbd0ae38dfdae1fbb3a98845be0f48ed1451c3b82de1eccbcbb",
 }
 
 

--- a/tests/test_guest_agent_image.py
+++ b/tests/test_guest_agent_image.py
@@ -199,6 +199,14 @@ def test_guest_agent_source_digest_tracks_release_binary_without_source(
     assert first != second
 
 
+def test_guest_agent_release_sha_pins_match_published_assets() -> None:
+    """Installed wheels must verify the standalone guest-agent release binaries."""
+    assert builder_mod._GUEST_AGENT_RELEASE_SHA256 == {
+        "amd64": "61ead9a6b13f9a5f63211cd8873ff000e17a98bb40b450d57b5d6332fdb90232",
+        "arm64": "d7a04d2c7502dcbd0ae38dfdae1fbb3a98845be0f48ed1451c3b82de1eccbcbb",
+    }
+
+
 def test_guest_agent_source_digest_tracks_env_binary(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,


### PR DESCRIPTION
## Summary
- update standalone guest-agent release SHA pins for images-2026.06.24.0
- bump SmolVM to 0.0.24.post2 for the installed-wheel fix
- add a regression test for the published guest-agent SHA table

## Root Cause
The repo checkout path can build/use the local guest-agent binary, but installed wheels download smolvm-guest-agent-linux-<arch> from the image release and verify it against _GUEST_AGENT_RELEASE_SHA256. The image manifest bump updated rootfs pins but missed this separate binary SHA table.

## Validation
- curl -fsSL https://github.com/CelestoAI/SmolVM/releases/download/images-2026.06.24.0/smolvm-guest-agent-linux-amd64.sha256
- curl -fsSL https://github.com/CelestoAI/SmolVM/releases/download/images-2026.06.24.0/smolvm-guest-agent-linux-arm64.sha256
- uv run pytest tests/test_guest_agent_image.py tests/test_version.py -q
- uv run ruff check src/smolvm/images/builder.py tests/test_guest_agent_image.py pyproject.toml tests/test_version.py
- uv build