### PR TITLE
Fix QEMU vsock on Python builds without AF_VSOCK

### DIFF
--- a/src/smolvm/comm/rust_http_vsock_channel.py
+++ b/src/smolvm/comm/rust_http_vsock_channel.py
@@ -16,6 +16,8 @@
 
 from __future__ import annotations
 
+import ctypes
+import errno
 import http.client
 import io
 import ipaddress
@@ -64,6 +66,57 @@ _TERMINAL_FRAME_CLOSE = 3
 _TERMINAL_FRAME_OUTPUT = 101
 _TERMINAL_FRAME_EXIT = 102
 _TERMINAL_FRAME_ERROR = 103
+_LINUX_AF_VSOCK = 40
+
+
+class _SockaddrVm(ctypes.Structure):
+    _fields_ = [
+        ("svm_family", ctypes.c_ushort),
+        ("svm_reserved1", ctypes.c_ushort),
+        ("svm_port", ctypes.c_uint32),
+        ("svm_cid", ctypes.c_uint32),
+        ("svm_zero", ctypes.c_ubyte * 4),
+    ]
+
+
+_SVM_ZERO = ctypes.c_ubyte * 4
+
+
+def _vsock_family() -> int | None:
+    family = getattr(socket, "AF_VSOCK", None)
+    if family is not None:
+        return int(family)
+    if sys.platform.startswith("linux"):
+        # Some Python builds omit socket.AF_VSOCK even though Linux supports
+        # the socket family. The kernel ABI value is stable.
+        return _LINUX_AF_VSOCK
+    return None
+
+
+def _connect_vsock_raw(sock: socket.socket, guest_cid: int, port: int, timeout: float) -> None:
+    libc = ctypes.CDLL(None, use_errno=True)
+    libc.connect.argtypes = [ctypes.c_int, ctypes.c_void_p, ctypes.c_uint32]
+    libc.connect.restype = ctypes.c_int
+    addr = _SockaddrVm(
+        svm_family=_LINUX_AF_VSOCK,
+        svm_reserved1=0,
+        svm_port=port,
+        svm_cid=guest_cid,
+        svm_zero=_SVM_ZERO(0, 0, 0, 0),
+    )
+    sock.setblocking(False)
+    result = libc.connect(sock.fileno(), ctypes.byref(addr), ctypes.sizeof(addr))
+    if result != 0:
+        err = ctypes.get_errno()
+        if err not in {errno.EINPROGRESS, errno.EWOULDBLOCK, errno.EALREADY}:
+            raise OSError(err, os.strerror(err))
+        _, writable, _ = select.select([], [sock], [], timeout)
+        if not writable:
+            raise TimeoutError("timed out")
+        err = sock.getsockopt(socket.SOL_SOCKET, socket.SO_ERROR)
+        if err != 0:
+            raise OSError(err, os.strerror(err))
+    sock.settimeout(timeout)
 
 
 @dataclass(frozen=True)
@@ -450,15 +503,20 @@ class RustHttpVsockChannel:
 
     def _open_vsock(self, port: int | None = None) -> socket.socket:
         port = self.agent_port if port is None else port
-        if not hasattr(socket, "AF_VSOCK"):
+        family = _vsock_family()
+        if family is None:
             raise SmolVMError(
                 "vsock is not available on this host (no AF_VSOCK). "
                 "Use the SSH channel, or run on a Linux host with vhost_vsock loaded."
             )
-        sock = socket.socket(socket.AF_VSOCK, socket.SOCK_STREAM)
+        sock = socket.socket(family, socket.SOCK_STREAM)
         sock.settimeout(float(self.connect_timeout))
         try:
-            sock.connect((self.guest_cid, port))
+            if hasattr(socket, "AF_VSOCK"):
+                sock.connect((self.guest_cid, port))
+            else:
+                assert self.guest_cid is not None
+                _connect_vsock_raw(sock, self.guest_cid, port, float(self.connect_timeout))
         except OSError:
             sock.close()
             raise

--- a/src/smolvm/comm/rust_http_vsock_channel.py
+++ b/src/smolvm/comm/rust_http_vsock_channel.py
@@ -163,6 +163,20 @@ def _feature_required_message(feature: str, sandbox_name: str | None) -> str:
     )
 
 
+def _vsock_unavailable_message(sandbox_name: str | None) -> str:
+    if sandbox_name:
+        sandbox = shlex.quote(sandbox_name)
+        return (
+            f"This computer cannot open fast sandbox connections for {sandbox}; "
+            f"run `smolvm sandbox delete {sandbox}` and then "
+            f"`smolvm sandbox create --name {sandbox} --comm-channel ssh`."
+        )
+    return (
+        "This computer cannot open fast sandbox connections; run "
+        "`smolvm sandbox create --comm-channel ssh` to create a sandbox with the compatible path."
+    )
+
+
 def _parse_mode_header(value: str) -> int:
     value = value.strip().removeprefix("0o")
     return int(value, 8)
@@ -505,10 +519,7 @@ class RustHttpVsockChannel:
         port = self.agent_port if port is None else port
         family = _vsock_family()
         if family is None:
-            raise SmolVMError(
-                "vsock is not available on this host (no AF_VSOCK). "
-                "Use the SSH channel, or run on a Linux host with vhost_vsock loaded."
-            )
+            raise SmolVMError(_vsock_unavailable_message(self.sandbox_name))
         sock = socket.socket(family, socket.SOCK_STREAM)
         sock.settimeout(float(self.connect_timeout))
         try:

--- a/tests/test_rust_http_vsock_channel.py
+++ b/tests/test_rust_http_vsock_channel.py
@@ -41,6 +41,7 @@ from smolvm.comm.rust_http_vsock_channel import (
     _read_terminal_frame,
     _SocketHTTPConnection,
     _vsock_family,
+    _vsock_unavailable_message,
 )
 from smolvm.exceptions import OperationTimeoutError, SmolVMError
 
@@ -240,6 +241,15 @@ def test_open_vsock_uses_raw_connect_when_python_lacks_af_vsock(
     assert calls["raw_port"] == 1029
     assert calls["raw_timeout"] == 4.0
     assert "closed" not in calls
+
+
+def test_vsock_unavailable_message_names_ssh_recovery_command() -> None:
+    message = _vsock_unavailable_message("sbx-pauling")
+
+    assert "AF_VSOCK" not in message
+    assert "vhost_vsock" not in message
+    assert "smolvm sandbox delete sbx-pauling" in message
+    assert "smolvm sandbox create --name sbx-pauling --comm-channel ssh" in message
 
 
 def test_wait_ready_uses_health() -> None:

--- a/tests/test_rust_http_vsock_channel.py
+++ b/tests/test_rust_http_vsock_channel.py
@@ -30,6 +30,7 @@ from typing import Any
 
 import pytest
 
+import smolvm.comm.rust_http_vsock_channel as vsock_channel
 from smolvm.comm.base import CommChannel
 from smolvm.comm.rust_http_vsock_channel import (
     SMOLVM_TERMINAL_PORT,
@@ -39,6 +40,7 @@ from smolvm.comm.rust_http_vsock_channel import (
     _pack_terminal_frame,
     _read_terminal_frame,
     _SocketHTTPConnection,
+    _vsock_family,
 )
 from smolvm.exceptions import OperationTimeoutError, SmolVMError
 
@@ -187,6 +189,57 @@ def test_rust_http_channel_satisfies_comm_channel() -> None:
     channel = RustHttpVsockChannel.from_cid(42)
     assert isinstance(channel, CommChannel)
     assert channel.kind == "vsock"
+
+
+def test_vsock_family_falls_back_to_linux_abi_value(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delattr(socket, "AF_VSOCK", raising=False)
+    monkeypatch.setattr("smolvm.comm.rust_http_vsock_channel.sys.platform", "linux")
+
+    assert _vsock_family() == 40
+
+
+def test_open_vsock_uses_raw_connect_when_python_lacks_af_vsock(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    calls: dict[str, Any] = {}
+
+    class FakeSocket:
+        def settimeout(self, timeout: float) -> None:
+            calls["timeout"] = timeout
+
+        def close(self) -> None:
+            calls["closed"] = True
+
+    fake = FakeSocket()
+    monkeypatch.delattr(socket, "AF_VSOCK", raising=False)
+    monkeypatch.setattr("smolvm.comm.rust_http_vsock_channel.sys.platform", "linux")
+    monkeypatch.setattr(
+        socket,
+        "socket",
+        lambda family, kind: calls.update(family=family, kind=kind) or fake,
+    )
+    monkeypatch.setattr(
+        vsock_channel,
+        "_connect_vsock_raw",
+        lambda sock, cid, port, timeout: calls.update(
+            raw_sock=sock,
+            raw_cid=cid,
+            raw_port=port,
+            raw_timeout=timeout,
+        ),
+    )
+
+    channel = RustHttpVsockChannel.from_cid(123, connect_timeout=4)
+
+    assert channel._open_vsock(1029) is fake
+    assert calls["family"] == 40
+    assert calls["kind"] == socket.SOCK_STREAM
+    assert calls["timeout"] == 4.0
+    assert calls["raw_sock"] is fake
+    assert calls["raw_cid"] == 123
+    assert calls["raw_port"] == 1029
+    assert calls["raw_timeout"] == 4.0
+    assert "closed" not in calls
 
 
 def test_wait_ready_uses_health() -> None:


### PR DESCRIPTION
## Summary
- support Linux Python builds that can create vsock sockets but do not expose socket.AF_VSOCK
- use a small raw connect(2) fallback for QEMU/vsock host connections in that case
- add focused coverage for the missing-AF_VSOCK path

## Why
The uv tool installed SmolVM runs under Python 3.13 on this host. That Python build does not expose socket.AF_VSOCK, so QEMU/vsock sandboxes booted but wait_for_ready timed out. The editable uv run path used Python 3.14, which exposed AF_VSOCK and worked.

## Validation
- uv run --with pytest pytest tests/test_rust_http_vsock_channel.py -q
- uv run ruff check src/smolvm/comm/rust_http_vsock_channel.py tests/test_rust_http_vsock_channel.py
- uv run --python 3.13 smolvm sandbox create --name bench-py313-vsock-fixed-153528 --backend qemu --os ubuntu --json --boot-timeout 20
- uv run --python 3.13 smolvm sandbox delete bench-py313-vsock-fixed-153528 --json

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved vsock connectivity on Linux when native vsock socket support is not available.
  * Added a low-level connection fallback to maintain connection attempts in restricted environments.
  * Strengthened timeout behavior and error reporting for more predictable connection outcomes, including clearer guidance when applicable.

* **Tests**
  * Added tests to verify vsock family detection falls back correctly when native support is missing.
  * Added tests confirming the fallback connection path is used and receives the expected parameters.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->