### PR TITLE
Enable FUSE in the microVM kernel

### DIFF
--- a/kernel/microvm/README.md
+++ b/kernel/microvm/README.md
@@ -62,6 +62,7 @@ the runtimes SmolVM uses today:
 | **Vsock (host↔guest)** | `CONFIG_VSOCKETS`, `CONFIG_VIRTIO_VSOCKETS` | – | – | – | required (libkrun init protocol) |
 | **Filesystems** (no-initrd boot of guest rootfs) | `CONFIG_EXT4_FS` | required (rootfs) | required | required | required |
 |                        | `CONFIG_ISO9660_FS`             | – | required (cloud-init NoCloud seed disk on `/dev/vdb`) | required | – |
+|                        | `CONFIG_FUSE_FS`                | required (guest FUSE filesystems such as JuiceFS) | required | required | required |
 | **Workspace mounts**   | `CONFIG_NET_9P`, `CONFIG_NET_9P_VIRTIO`, `CONFIG_9P_FS` | – | required (`smolvm <preset> start --mount …`) | required | – |
 |                        | `CONFIG_OVERLAY_FS`             | – | required (read-only mount = 9p+overlay) | required | – |
 | **No modules**         | `# CONFIG_MODULES is not set`   | required (no initrd to load modules from) | required | required | required |
@@ -225,6 +226,9 @@ task.
   initrd, which keeps the image set simple. Cost: any future preset that
   needs a kernel module (zfs, btrfs, NFS, etc.) requires adding the symbol
   to `config.fragment` (or the per-arch fragment) as `=y`.
+- **FUSE is built in.** Guest filesystems such as JuiceFS still need userspace
+  packages in the rootfs, but the kernel must provide `/dev/fuse` because
+  there is no initrd or module tree to load it later.
 - **Maintenance burden.** Bumping Linux means re-running `build.sh` once
   to verify the fragment still applies, then committing. CI cache by input
   hash means the rebuild is free until inputs change.

--- a/kernel/microvm/config.fragment
+++ b/kernel/microvm/config.fragment
@@ -32,6 +32,7 @@ CONFIG_ISO9660_FS=y             # why: cloud-init NoCloud seed disk is an iso966
 CONFIG_TMPFS=y                  # why: tmpfs-backed /run during /init bootstrap
 CONFIG_DEVTMPFS=y               # why: /dev populated by kernel at mount
 CONFIG_DEVTMPFS_MOUNT=y         # why: auto-mount /dev at boot
+CONFIG_FUSE_FS=y                # why: guest-mounted FUSE filesystems such as JuiceFS need /dev/fuse
 
 # ── Networking baseline ──────────────────────────────────────────────
 CONFIG_NET=y                    # why: required for virtio-net + sshd


### PR DESCRIPTION
## Summary
- build FUSE into the microVM kernel so guest-mounted JuiceFS can expose `/dev/fuse`
- document why FUSE must be built in for no-initrd/no-modules guests

## Validation
- On `turing-machine`: `SMOLVM_VERIFY_ONLY=1 OUT_DIR=/tmp/smolvm-fuse-verify-out2 WORK_DIR=/tmp/smolvm-fuse-verify-work2 bash kernel/microvm/build.sh`
- On `turing-machine`: full amd64 kernel build with `OUT_DIR=/home/celesto/builds/smolvm-fuse-kernel-out3 WORK_DIR=/home/celesto/builds/smolvm-fuse-kernel-work3 bash kernel/microvm/build.sh`
- Verified generated config contains `CONFIG_FUSE_FS=y`
- Hot-patched active prod host QEMU kernel cache and launched disposable OpenClaw VM: `/dev/fuse` exists, `/proc/filesystems` lists `fuse`, `juicefs version` works
- Prod OpenClaw canary `ocl_9898710828f8`: provisioned, runtime reached `running`, LLM reached `configured`, `sudo -n -u ohm env HOME=/home/ohm openclaw doctor` exited 0

## Notes
- The prod host patch is a temporary cache replacement; this PR is the durable source change for future kernel artifacts.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added built-in FUSE filesystem support for microvm guests, enabling FUSE-based guest filesystems in supported runtimes.
* **Documentation**
  * Updated microvm kernel documentation to reflect the required FUSE capability and related runtime support notes.
  * Clarified that `/dev/fuse` is available even without an initrd or module tree.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->