### PR TITLE
Release SmolVM 0.0.24.post3

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "smolvm"
-version = "0.0.24.post2"
+version = "0.0.24.post3"
 description = "Isolated computers that AI agents can use to browse, run code, and get real work done. Free and open-source from Celesto AI"
 readme = "README.md"
 license = "Apache-2.0"


### PR DESCRIPTION
## Summary
- bump the SmolVM Python package to 0.0.24.post3
- publish the already-merged images-2026.06.30.0 manifest through a new package version

## Validation
- uv run python - <<'PY'
import tomllib
from pathlib import Path
from smolvm.images.published import IMAGES_RELEASE_TAG, BASE_KERNELS
print('pyproject', tomllib.loads(Path('pyproject.toml').read_text())['project']['version'])
print('images', IMAGES_RELEASE_TAG)
print('amd64', BASE_KERNELS['amd64'].image_sha256)
PY
- git diff --check
- uv run pytest tests/test_published_images.py -q -k 'not preserves_sparse_zero_ranges'
- uv run pytest tests/test_kernel_config.py tests/test_version.py -q

Note: the full focused test command failed locally only on tests/test_published_images.py::TestDecompressZstd::test_decompress_zstd_preserves_sparse_zero_ranges because the macOS temp filesystem did not report sparse allocation smaller than file size; the rest of the published-image/version/kernel checks passed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the package version to `0.0.24.post3`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->