### PR TITLE
Fix Firecracker vsock guest egress

### DIFF
--- a/docs/benchmarks/startup-speedups.md
+++ b/docs/benchmarks/startup-speedups.md
@@ -247,6 +247,8 @@ Notes:
 - Host: Linux with KVM; Firecracker networking used the unprivileged fallback path.
 - Method: one warm-up VM per variant, then three measured warm-cache iterations per variant.
 - Behavior changed: explicit Firecracker-vsock creates/configures the TAP for Firecracker, but defers route/NAT/egress setup until a network-backed operation needs it.
+- Follow-up: route/NAT deferral was later removed because guests need internet
+  immediately after create; vsock still avoids SSH port forwarding.
 
 | Backend | Transport | Before total ready | After total ready | Delta | Improvement |
 |---|---:|---:|---:|---:|---:|

--- a/docs/deep-dive/startup-time-optimization-plan.md
+++ b/docs/deep-dive/startup-time-optimization-plan.md
@@ -103,9 +103,9 @@ Current status:
 
 - Guest-agent startup already happens before network and SSH in the current
   published Ubuntu init script.
-- Firecracker explicit-vsock now creates/configures the TAP needed by
-  Firecracker, but defers route/NAT/egress setup until SSH or port forwarding
-  needs host TCP/IP connectivity.
+- Firecracker explicit-vsock now creates/configures the TAP and route/NAT
+  egress during create so guests have internet immediately. SSH forwarding
+  still stays off unless an SSH-backed path needs it.
 - Published zstd rootfs decompression preserves sparse zero regions, and raw
   isolated-disk copies preserve those holes. This removes the accidental
   4 GiB copy from the Firecracker critical path on non-reflink filesystems.

--- a/src/smolvm/vm.py
+++ b/src/smolvm/vm.py
@@ -1389,35 +1389,6 @@ class SmolVMManager:
         resolution = resolution or self._resolve_control_channel_for_config(config, backend)
         return resolution.kind == "ssh"
 
-    def _should_setup_tap_connectivity_for_create(
-        self,
-        config: VMConfig,
-        backend: str,
-        *,
-        resolution: ChannelResolution,
-        ssh_forward_required: bool,
-    ) -> bool:
-        """Return whether TAP route/NAT rules are needed before first boot."""
-        if not self._uses_host_tap_networking(config, backend):
-            return False
-
-        if backend != BACKEND_FIRECRACKER:
-            return True
-
-        if ssh_forward_required:
-            return True
-
-        if (
-            config.internet_settings is not None
-            and not config.internet_settings.is_allow_all_domains
-        ):
-            return True
-
-        # Firecracker-vsock command paths do not need host TCP/IP
-        # connectivity before boot. The TAP still exists for Firecracker's
-        # network device, and connectivity is installed lazily if SSH/ports need it.
-        return resolution.kind != "vsock"
-
     def ensure_network_connectivity(self, vm_info: VMInfo) -> None:
         """Ensure host-side TAP connectivity exists for network-backed operations."""
         if vm_info.network is None:
@@ -1776,42 +1747,29 @@ class SmolVMManager:
             # Update the lease with the real TAP name
             self.state.update_ip_lease_tap(effective_config.vm_id, tap_name)
 
-            tap_connectivity_required = self._should_setup_tap_connectivity_for_create(
-                effective_config,
-                backend,
-                resolution=channel_resolution,
-                ssh_forward_required=ssh_forward_required,
-            )
-
             # Create and configure TAP device
             user = os.environ.get("USER", "root")
             # Use /32 mask to avoid subnet conflicts between multiple TAPs.
             self.network.prepare_tap_device(tap_name, user=user, netmask="32")
 
-            if tap_connectivity_required:
-                self.network.add_route(guest_ip, tap_name)
-                self.network.setup_nat(tap_name)
+            self.network.add_route(guest_ip, tap_name)
+            self.network.setup_nat(tap_name)
 
-                # Apply domain allowlist if configured
-                if (
-                    effective_config.internet_settings is not None
-                    and not effective_config.internet_settings.is_allow_all_domains
-                ):
-                    allowed_ips = resolve_domains_to_ips(
-                        effective_config.internet_settings.allowed_domains
-                    )
-                    self.network.apply_egress_allowlist(tap_name, allowed_ips)
+            # Apply domain allowlist if configured
+            if (
+                effective_config.internet_settings is not None
+                and not effective_config.internet_settings.is_allow_all_domains
+            ):
+                allowed_ips = resolve_domains_to_ips(
+                    effective_config.internet_settings.allowed_domains
+                )
+                self.network.apply_egress_allowlist(tap_name, allowed_ips)
 
-                if ssh_host_port is not None:
-                    self.network.setup_ssh_port_forward(
-                        vm_id=effective_config.vm_id,
-                        guest_ip=guest_ip,
-                        host_port=ssh_host_port,
-                    )
-            else:
-                logger.info(
-                    "VM %s: deferring Firecracker route/NAT setup until network is needed",
-                    effective_config.vm_id,
+            if ssh_host_port is not None:
+                self.network.setup_ssh_port_forward(
+                    vm_id=effective_config.vm_id,
+                    guest_ip=guest_ip,
+                    host_port=ssh_host_port,
                 )
 
             # Generate MAC address from pool index
@@ -3151,39 +3109,26 @@ class SmolVMManager:
             vm_number = ip_to_pool_index(guest_ip)
             tap_name = f"tap{vm_number}"
             self.state.update_ip_lease_tap(effective_config.vm_id, tap_name)
-            tap_connectivity_required = self._should_setup_tap_connectivity_for_create(
-                effective_config,
-                backend,
-                resolution=channel_resolution,
-                ssh_forward_required=ssh_forward_required,
-            )
-
             user = os.environ.get("USER", "root")
             await self.network.async_prepare_tap_device(tap_name, user=user, netmask="32")
-            if tap_connectivity_required:
-                await self.network.async_add_route(guest_ip, tap_name)
-                await self.network.async_setup_nat(tap_name)
+            await self.network.async_add_route(guest_ip, tap_name)
+            await self.network.async_setup_nat(tap_name)
 
-                # Apply domain allowlist if configured
-                if (
-                    effective_config.internet_settings is not None
-                    and not effective_config.internet_settings.is_allow_all_domains
-                ):
-                    allowed_ips = resolve_domains_to_ips(
-                        effective_config.internet_settings.allowed_domains
-                    )
-                    await self.network.async_apply_egress_allowlist(tap_name, allowed_ips)
+            # Apply domain allowlist if configured
+            if (
+                effective_config.internet_settings is not None
+                and not effective_config.internet_settings.is_allow_all_domains
+            ):
+                allowed_ips = resolve_domains_to_ips(
+                    effective_config.internet_settings.allowed_domains
+                )
+                await self.network.async_apply_egress_allowlist(tap_name, allowed_ips)
 
-                if ssh_host_port is not None:
-                    await self.network.async_setup_ssh_port_forward(
-                        vm_id=effective_config.vm_id,
-                        guest_ip=guest_ip,
-                        host_port=ssh_host_port,
-                    )
-            else:
-                logger.info(
-                    "VM %s: deferring Firecracker route/NAT setup until network is needed",
-                    effective_config.vm_id,
+            if ssh_host_port is not None:
+                await self.network.async_setup_ssh_port_forward(
+                    vm_id=effective_config.vm_id,
+                    guest_ip=guest_ip,
+                    host_port=ssh_host_port,
                 )
 
             guest_mac = self.network.generate_mac(vm_number)

--- a/tests/test_vm.py
+++ b/tests/test_vm.py
@@ -218,13 +218,13 @@ class TestSmolVMCreate:
             assert smol_vm.check_prerequisites() == []
 
     @patch("smolvm.comm.select.platform.system", return_value="Linux")
-    def test_create_firecracker_explicit_vsock_skips_ssh_forward(
+    def test_create_firecracker_explicit_vsock_sets_up_egress_without_ssh_forward(
         self,
         _mock_system: MagicMock,
         smol_vm: SmolVMManager,
         sample_config: VMConfig,
     ) -> None:
-        """Explicit Firecracker vsock without SSH-backed startup should not add DNAT."""
+        """Explicit Firecracker vsock should keep internet egress without SSH DNAT."""
         mock_network = _attach_mock_network(smol_vm)
         config = sample_config.model_copy(
             update={"vm_id": "vm-vsock", "backend": "firecracker", "comm_channel": "vsock"}
@@ -236,29 +236,6 @@ class TestSmolVMCreate:
         assert vm_info.network.ssh_host_port is None
         assert vm_info.config.vsock is not None
         mock_network.prepare_tap_device.assert_called_once()
-        mock_network.add_route.assert_not_called()
-        mock_network.setup_nat.assert_not_called()
-        mock_network.setup_ssh_port_forward.assert_not_called()
-
-    @patch("smolvm.comm.select.platform.system", return_value="Linux")
-    def test_create_firecracker_explicit_vsock_lazy_network_can_be_activated(
-        self,
-        _mock_system: MagicMock,
-        smol_vm: SmolVMManager,
-        sample_config: VMConfig,
-    ) -> None:
-        """Deferred Firecracker network connectivity is installed before network use."""
-        mock_network = _attach_mock_network(smol_vm)
-        config = sample_config.model_copy(
-            update={"vm_id": "vm-vsock-lazy", "backend": "firecracker", "comm_channel": "vsock"}
-        )
-        vm_info = smol_vm.create(config)
-
-        mock_network.add_route.assert_not_called()
-        mock_network.setup_nat.assert_not_called()
-
-        smol_vm.ensure_network_connectivity(vm_info)
-
         mock_network.add_route.assert_called_once_with(
             vm_info.network.guest_ip,
             vm_info.network.tap_device,
@@ -267,13 +244,41 @@ class TestSmolVMCreate:
         mock_network.setup_ssh_port_forward.assert_not_called()
 
     @patch("smolvm.comm.select.platform.system", return_value="Linux")
-    def test_create_firecracker_auto_vsock_defers_ssh_networking(
+    def test_create_firecracker_explicit_vsock_network_connectivity_stays_idempotent(
         self,
         _mock_system: MagicMock,
         smol_vm: SmolVMManager,
         sample_config: VMConfig,
     ) -> None:
-        """Auto-selected Firecracker vsock behaves like explicit vsock in alpha builds."""
+        """Later network-backed operations can still re-apply idempotent egress setup."""
+        mock_network = _attach_mock_network(smol_vm)
+        config = sample_config.model_copy(
+            update={"vm_id": "vm-vsock-lazy", "backend": "firecracker", "comm_channel": "vsock"}
+        )
+        vm_info = smol_vm.create(config)
+
+        mock_network.add_route.assert_called_once()
+        mock_network.setup_nat.assert_called_once()
+
+        smol_vm.ensure_network_connectivity(vm_info)
+
+        assert mock_network.add_route.call_count == 2
+        mock_network.add_route.assert_called_with(
+            vm_info.network.guest_ip,
+            vm_info.network.tap_device,
+        )
+        assert mock_network.setup_nat.call_count == 2
+        mock_network.setup_nat.assert_called_with(vm_info.network.tap_device)
+        mock_network.setup_ssh_port_forward.assert_not_called()
+
+    @patch("smolvm.comm.select.platform.system", return_value="Linux")
+    def test_create_firecracker_auto_vsock_sets_up_egress_without_ssh_forward(
+        self,
+        _mock_system: MagicMock,
+        smol_vm: SmolVMManager,
+        sample_config: VMConfig,
+    ) -> None:
+        """Auto-selected Firecracker vsock should still provision guest internet."""
         mock_network = _attach_mock_network(smol_vm)
         config = sample_config.model_copy(update={"vm_id": "vm-auto", "backend": "firecracker"})
 
@@ -281,8 +286,11 @@ class TestSmolVMCreate:
 
         assert vm_info.network is not None
         assert vm_info.network.ssh_host_port is None
-        mock_network.add_route.assert_not_called()
-        mock_network.setup_nat.assert_not_called()
+        mock_network.add_route.assert_called_once_with(
+            vm_info.network.guest_ip,
+            vm_info.network.tap_device,
+        )
+        mock_network.setup_nat.assert_called_once_with(vm_info.network.tap_device)
         mock_network.setup_ssh_port_forward.assert_not_called()
 
     @patch("smolvm.comm.select.platform.system", return_value="Linux")
@@ -307,13 +315,13 @@ class TestSmolVMCreate:
         mock_network.setup_ssh_port_forward.assert_called_once()
 
     @patch("smolvm.comm.select.platform.system", return_value="Linux")
-    def test_create_firecracker_explicit_vsock_with_env_skips_ssh_forward(
+    def test_create_firecracker_explicit_vsock_with_env_sets_up_egress_without_ssh_forward(
         self,
         _mock_system: MagicMock,
         smol_vm: SmolVMManager,
         sample_config: VMConfig,
     ) -> None:
-        """Env-only startup uses managed vsock env and should not expose SSH."""
+        """Env-only startup uses managed vsock env, but guest egress still needs NAT."""
         mock_network = _attach_mock_network(smol_vm)
         config = sample_config.model_copy(
             update={
@@ -328,8 +336,11 @@ class TestSmolVMCreate:
 
         assert vm_info.network is not None
         assert vm_info.network.ssh_host_port is None
-        mock_network.add_route.assert_not_called()
-        mock_network.setup_nat.assert_not_called()
+        mock_network.add_route.assert_called_once_with(
+            vm_info.network.guest_ip,
+            vm_info.network.tap_device,
+        )
+        mock_network.setup_nat.assert_called_once_with(vm_info.network.tap_device)
         mock_network.setup_ssh_port_forward.assert_not_called()
 
     @patch("smolvm.comm.select.platform.system", return_value="Linux")
@@ -477,13 +488,13 @@ class TestSmolVMCreate:
 
     @pytest.mark.asyncio
     @patch("smolvm.comm.select.platform.system", return_value="Linux")
-    async def test_async_create_firecracker_explicit_vsock_skips_ssh_forward(
+    async def test_async_create_firecracker_explicit_vsock_sets_up_egress_without_ssh_forward(
         self,
         _mock_system: MagicMock,
         tmp_path: Path,
         sample_config: VMConfig,
     ) -> None:
-        """Async create should mirror the Firecracker explicit-vsock no-forward policy."""
+        """Async create should mirror Firecracker vsock egress without SSH forwarding."""
         smol_vm = SmolVMManager(
             data_dir=tmp_path / "data-async-vsock",
             socket_dir=tmp_path / "sockets-async-vsock",
@@ -499,8 +510,11 @@ class TestSmolVMCreate:
         assert vm_info.network is not None
         assert vm_info.network.ssh_host_port is None
         mock_network.async_prepare_tap_device.assert_awaited_once()
-        mock_network.async_add_route.assert_not_awaited()
-        mock_network.async_setup_nat.assert_not_awaited()
+        mock_network.async_add_route.assert_awaited_once_with(
+            vm_info.network.guest_ip,
+            vm_info.network.tap_device,
+        )
+        mock_network.async_setup_nat.assert_awaited_once_with(vm_info.network.tap_device)
         mock_network.async_setup_ssh_port_forward.assert_not_awaited()
 
 


### PR DESCRIPTION
## Summary

Fixes #430.

Firecracker sandboxes that use the vsock control channel were creating and configuring the TAP device but deferring route/NAT setup unless an SSH-backed path or explicit egress policy needed it. That made the guest control channel work while normal guest outbound internet could fail because `smolvm_nat` / `smolvm_filter` were not populated for the sandbox TAP.

This change makes host-TAP create paths always install the guest route and NAT rules during create, while keeping SSH port forwarding conditional. Firecracker/vsock still avoids exposing an SSH host port.

## Impact

- New Firecracker/vsock sandboxes get guest internet immediately after create.
- Existing working sandboxes are unaffected because route/NAT setup is idempotent.
- Already-created broken Firecracker/vsock sandboxes are not migrated automatically; they can be repaired by re-running `SmolVMManager.ensure_network_connectivity()` or by recreating the sandbox.

## Validation

- `uv run --with pytest --with pytest-asyncio pytest tests/test_vm.py -q` — 76 passed
- `uv run --with pytest --with pytest-asyncio pytest tests/test_vm.py tests/test_facade.py tests/test_facade_vsock.py tests/test_async_lifecycle.py tests/test_network.py -q` — 267 passed, 8 skipped
- `uv run ruff check src/smolvm/vm.py tests/test_vm.py` — passed
- `git diff --check` — clean

## Live Smoke

Created `sbx-egress-smoke-20260709083412` from this checkout with `--backend firecracker --comm-channel vsock`.

Observed:

- backend `firecracker`, comm channel `vsock`, vsock CID `4`
- guest IP `172.16.0.5`, TAP `tap5`, no SSH host port
- `tap5` present in `inet smolvm_filter allowed_taps`
- NAT masquerade present in `ip smolvm_nat`
- guest route: `default via 172.16.0.1 dev eth0`
- guest DNS resolved `github.com`
- guest HTTPS fetched `https://github.com/robots.txt`
- forward counter increased during the smoke
- smoke sandbox deleted successfully and `tap5` was removed from `allowed_taps`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Firecracker-based VMs now get internet access immediately during creation, even when using explicit-vsock networking.
  * SSH port forwarding is still only enabled when needed.

* **Bug Fixes**
  * Removed delayed network setup that could leave newly created guests without outbound connectivity.
  * Improved consistency so network setup is applied reliably on startup, including repeated setup attempts.

* **Documentation**
  * Updated startup and optimization docs to reflect the new networking behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->