### PR TITLE
Remove sandbox shell SSH fallback

### DIFF
--- a/src/smolvm/cli/main.py
+++ b/src/smolvm/cli/main.py
@@ -2344,41 +2344,6 @@ def _run_ssh(args: SimpleNamespace) -> int:
             vm.close()
 
 
-def _fast_shell_unavailable(exc: Exception) -> bool:
-    """Return whether ``sandbox shell`` should use SSH for this sandbox."""
-    message = str(exc).lower()
-    return "fast shell access" in message or "cannot use 'smolvm sandbox shell'" in message
-
-
-def _stop_status(status: Any | None) -> None:
-    """Stop a Rich status before handing the terminal to an interactive child."""
-    stop = getattr(status, "stop", None)
-    if callable(stop):
-        stop()
-
-
-def _attach_shell_or_ssh(vm: Any, args: SimpleNamespace, *, status: Any | None = None) -> int:
-    """Prefer the fast shell transport, with SSH as the stable shell fallback."""
-    try:
-        if status is not None:
-            status.update("Opening shell...")
-        vm.wait_for_shell(timeout=args.boot_timeout)
-        _stop_status(status)
-        return int(vm.attach_shell(timeout=args.boot_timeout))
-    except Exception as exc:
-        if not _fast_shell_unavailable(exc):
-            raise
-
-    if status is not None:
-        status.update("Opening SSH shell...")
-    vm.wait_for_ssh(timeout=args.boot_timeout)
-    _stop_status(status)
-    completed = subprocess.run(vm._ssh_attach_command(), check=False)
-    if completed.returncode != 0:
-        _hint_if_vm_crashed(vm)
-    return completed.returncode
-
-
 def _run_shell(args: SimpleNamespace) -> int:
     """Handle ``smolvm sandbox shell``."""
     from smolvm.facade import SmolVM
@@ -2387,24 +2352,30 @@ def _run_shell(args: SimpleNamespace) -> int:
     command_name = getattr(args, "command_name", "sandbox.shell")
     try:
         vm = SmolVM.from_id(args.vm_id)
+        vm.ensure_shell_supported()
 
         console = console_stdout()
         if vm.status in {VMState.CREATED, VMState.STOPPED}:
             with console.status(f"Starting sandbox '{args.vm_id}'...", spinner="dots") as status:
                 vm.start(boot_timeout=args.boot_timeout)
-                return _attach_shell_or_ssh(vm, args, status=status)
+                status.update("Opening shell...")
+                vm.wait_for_shell(timeout=args.boot_timeout)
+            return vm.attach_shell(timeout=args.boot_timeout)
         if vm.status == VMState.PAUSED:
             with console.status(f"Resuming sandbox '{args.vm_id}'...", spinner="dots") as status:
                 vm.resume()
-                return _attach_shell_or_ssh(vm, args, status=status)
+                status.update("Opening shell...")
+                vm.wait_for_shell(timeout=args.boot_timeout)
+            return vm.attach_shell(timeout=args.boot_timeout)
         if vm.status == VMState.ERROR:
             raise RuntimeError(
                 f"VM '{args.vm_id}' is in error state. Recreate it or inspect the VM logs "
                 "before attaching."
             )
 
-        with console.status("Opening shell...", spinner="dots") as status:
-            return _attach_shell_or_ssh(vm, args, status=status)
+        with console.status("Opening shell...", spinner="dots"):
+            vm.wait_for_shell(timeout=args.boot_timeout)
+        return vm.attach_shell(timeout=args.boot_timeout)
     except Exception as exc:
         return _emit_cli_error(command_name, 1, exc, json_output=False)
     finally:

--- a/src/smolvm/cli/main.py
+++ b/src/smolvm/cli/main.py
@@ -2369,8 +2369,9 @@ def _run_shell(args: SimpleNamespace) -> int:
             return vm.attach_shell(timeout=args.boot_timeout)
         if vm.status == VMState.ERROR:
             raise RuntimeError(
-                f"VM '{args.vm_id}' is in error state. Recreate it or inspect the VM logs "
-                "before attaching."
+                f"Sandbox '{args.vm_id}' is in error state; inspect the sandbox logs, or run "
+                f"'smolvm sandbox delete {args.vm_id}' then "
+                f"'smolvm sandbox create --name {args.vm_id}' to recreate it."
             )
 
         with console.status("Opening shell...", spinner="dots"):

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -18,7 +18,6 @@ import json
 import os
 from datetime import datetime, timezone
 from pathlib import Path
-from types import SimpleNamespace
 from unittest.mock import ANY, MagicMock, patch
 
 import click
@@ -26,7 +25,6 @@ import pytest
 
 from smolvm.cli.main import (
     DASHBOARD_ALLOW_BETA_ENV,
-    _attach_shell_or_ssh,
     _current_version_is_prerelease,
     build_cli,
     main,
@@ -1920,85 +1918,72 @@ class TestCliShell:
 
     @patch("smolvm.cli.main.subprocess.run")
     @patch("smolvm.facade.SmolVM")
-    def test_shell_falls_back_to_ssh_when_fast_shell_unsupported_after_starting(
+    def test_shell_rejects_unsupported_vm_without_ssh_fallback(
         self,
         mock_vm_cls: MagicMock,
         mock_run: MagicMock,
+        capsys: pytest.CaptureFixture,
     ) -> None:
         from smolvm.exceptions import SmolVMError
 
         vm = MagicMock()
         vm.status = VMState.STOPPED
-        vm.wait_for_shell.side_effect = SmolVMError(
+        vm.ensure_shell_supported.side_effect = SmolVMError(
             "Sandbox 'vm001' cannot use 'smolvm sandbox shell'; "
             "run 'smolvm sandbox ssh vm001' to open an SSH shell."
         )
-        vm._ssh_attach_command.return_value = ["ssh", "vm001"]
-        mock_run.return_value.returncode = 0
         mock_vm_cls.from_id.return_value = vm
 
         ret = main(["sandbox", "shell", "vm001"])
 
-        assert ret == 0
-        vm.start.assert_called_once_with(boot_timeout=30.0)
+        assert ret == 1
+        vm.start.assert_not_called()
         vm.resume.assert_not_called()
-        vm.wait_for_shell.assert_called_once_with(timeout=30.0)
-        vm.wait_for_ssh.assert_called_once_with(timeout=30.0)
+        vm.wait_for_shell.assert_not_called()
+        vm.wait_for_ssh.assert_not_called()
         vm.attach_shell.assert_not_called()
-        mock_run.assert_called_once_with(["ssh", "vm001"], check=False)
+        mock_run.assert_not_called()
         vm.close.assert_called_once()
+        err = capsys.readouterr().err
+        assert "sandbox ssh vm001" in err
+        assert "vm001" in err
 
+    @pytest.mark.parametrize("status", [VMState.RUNNING, VMState.STOPPED])
     @patch("smolvm.cli.main.subprocess.run")
     @patch("smolvm.facade.SmolVM")
-    def test_shell_falls_back_to_ssh_when_terminal_feature_missing(
+    def test_shell_old_image_fails_with_recreate_commands(
         self,
         mock_vm_cls: MagicMock,
         mock_run: MagicMock,
+        status: VMState,
+        capsys: pytest.CaptureFixture,
     ) -> None:
         from smolvm.exceptions import SmolVMError
 
         vm = MagicMock()
-        vm.status = VMState.RUNNING
+        vm.status = status
         vm.attach_shell.side_effect = SmolVMError(
-            "Sandbox vm001 was created from an older image and cannot use fast shell access."
+            "Sandbox vm001 was created from an older image and cannot use fast shell access; "
+            "run `smolvm sandbox delete vm001`, then run "
+            "`smolvm sandbox create --name vm001` after updating SmolVM."
         )
-        vm._ssh_attach_command.return_value = ["ssh", "vm001"]
-        mock_run.return_value.returncode = 0
         mock_vm_cls.from_id.return_value = vm
 
         ret = main(["sandbox", "shell", "vm001"])
 
-        assert ret == 0
-        vm.start.assert_not_called()
+        assert ret == 1
+        if status == VMState.STOPPED:
+            vm.start.assert_called_once_with(boot_timeout=30.0)
+        else:
+            vm.start.assert_not_called()
         vm.wait_for_shell.assert_called_once_with(timeout=30.0)
-        vm.wait_for_ssh.assert_called_once_with(timeout=30.0)
+        vm.wait_for_ssh.assert_not_called()
         vm.attach_shell.assert_called_once_with(timeout=30.0)
-        mock_run.assert_called_once_with(["ssh", "vm001"], check=False)
+        mock_run.assert_not_called()
         vm.close.assert_called_once()
-
-    @patch("smolvm.cli.main.subprocess.run")
-    def test_shell_stops_status_before_ssh_subprocess(self, mock_run: MagicMock) -> None:
-        from smolvm.exceptions import SmolVMError
-
-        events: list[str] = []
-        status = MagicMock()
-        status.stop.side_effect = lambda: events.append("stop")
-        vm = MagicMock()
-        vm.wait_for_shell.side_effect = SmolVMError("fast shell access is unavailable")
-        vm._ssh_attach_command.return_value = ["ssh", "vm001"]
-        mock_run.side_effect = lambda *_args, **_kwargs: (
-            events.append("run") or SimpleNamespace(returncode=0)
-        )
-
-        ret = _attach_shell_or_ssh(
-            vm,
-            SimpleNamespace(boot_timeout=30.0),
-            status=status,
-        )
-
-        assert ret == 0
-        assert events == ["stop", "run"]
-        vm.wait_for_ssh.assert_called_once_with(timeout=30.0)
+        err = " ".join(capsys.readouterr().err.replace("│", "").split())
+        assert "smolvm sandbox delete vm001" in err
+        assert "smolvm sandbox create --name vm001" in err
 
     @patch("smolvm.facade.SmolVM")
     def test_shell_resumes_paused_vm(self, mock_vm_cls: MagicMock) -> None:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -2019,7 +2019,11 @@ class TestCliShell:
         vm.wait_for_ssh.assert_not_called()
         vm.attach_shell.assert_not_called()
         vm.close.assert_called_once()
-        assert "error state" in capsys.readouterr().err
+        err = " ".join(capsys.readouterr().err.replace("│", "").split())
+        assert "error state" in err
+        assert "inspect the sandbox logs" in err
+        assert "smolvm sandbox delete vm001" in err
+        assert "smolvm sandbox create --name vm001" in err
 
 
 class TestCliSSH:


### PR DESCRIPTION
## Summary

- remove the temporary SSH fallback from `smolvm sandbox shell`
- preflight shell support and use the vsock terminal path exclusively
- return the existing recreate guidance when an older image lacks terminal support
- keep `smolvm sandbox ssh` and its QEMU/slirp host forwarding unchanged for explicit SSH access

## Related Issues

- Closes #414

## Testing

- `pytest tests/test_cli.py::TestCliShell tests/test_cli.py::TestCliSSH tests/test_facade_vsock.py tests/test_rust_http_vsock_channel.py tests/test_facade.py::TestVMQemuLocalExpose::test_wait_for_ssh_prepares_qemu_hostfwd_before_port_is_ready` — 61 passed
- `ruff check .`
- `ruff format --check .`
- Full `pytest` — 1480 passed; 3 host-vsock failures reproduced on `origin/main` because this environment has no `/dev/vhost-vsock`

QEMU Ubuntu, QEMU Alpine, and Firecracker image smoke tests were not run because this environment has no `/dev/kvm` or `/dev/vhost-vsock`.

## Checklist

- [x] Scope is focused and limited to this change
- [x] Tests added/updated for behavior changes
- [x] Existing docs already describe `sandbox shell` and explicit `sandbox ssh` separately
- [x] No secrets or sensitive data included


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Updated `smolvm sandbox shell` to always validate shell support up front and use a shell-only connection flow.
  * Removed the previous fallback behavior; shell connection failures now stop early.
  * Improved error messaging with clearer recovery steps, including inspecting logs and using delete/recreate commands for outdated sandboxes.
* **Tests**
  * Added/updated CLI tests to verify fast failure when shell is unsupported or the guest image is older, including correct recovery command output and no unnecessary subprocess calls.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->