### PR TITLE
Fix running sandbox disk size reporting

### DIFF
--- a/src/smolvm/facade.py
+++ b/src/smolvm/facade.py
@@ -177,7 +177,7 @@ def _default_guest_os_for_backend(backend: str) -> GuestOS:
 def _qcow2_virtual_size_mib(qcow2_path: Path) -> int:
     """Return the guest-visible virtual size of a qcow2 image in MiB."""
     result = subprocess.run(
-        ["qemu-img", "info", "--output=json", str(qcow2_path)],
+        ["qemu-img", "info", "-U", "--output=json", str(qcow2_path)],
         check=True,
         capture_output=True,
         text=True,

--- a/tests/test_facade.py
+++ b/tests/test_facade.py
@@ -25,7 +25,7 @@ from smolvm.exceptions import (
     OperationTimeoutError,
     SmolVMError,
 )
-from smolvm.facade import SmolVM, _build_auto_config
+from smolvm.facade import SmolVM, _build_auto_config, _qcow2_virtual_size_mib
 from smolvm.images import BootImage, DirectKernelBoot, FirmwareBoot
 from smolvm.types import (
     GuestFlushPolicy,
@@ -55,6 +55,24 @@ def sample_config(tmp_path: Path) -> VMConfig:
         kernel_path=kernel,
         rootfs_path=rootfs,
     )
+
+
+class TestDiskSizeHelpers:
+    """Tests for guest-visible disk size inspection."""
+
+    @patch("smolvm.facade.subprocess.run")
+    def test_qcow2_virtual_size_allows_concurrent_access(self, mock_run: MagicMock) -> None:
+        """A running QEMU process must not prevent virtual size inspection."""
+        disk = Path("/tmp/running.qcow2")
+        mock_run.return_value.stdout = '{"virtual-size": 4294967296}'
+
+        assert _qcow2_virtual_size_mib(disk) == 4096
+        mock_run.assert_called_once_with(
+            ["qemu-img", "info", "-U", "--output=json", str(disk)],
+            check=True,
+            capture_output=True,
+            text=True,
+        )
 
 
 class TestVMInit:


### PR DESCRIPTION
## Summary

- allow `qemu-img info` to inspect a qcow2 disk while QEMU is using it
- report the guest-visible virtual disk size consistently for running and stopped sandboxes
- add regression coverage for concurrent qcow2 inspection

## Root cause

QEMU holds a lock on a running sandbox's qcow2 disk. The disk size probe did not use shared access, so `qemu-img info` failed and `sandbox info` fell back to the sparse host file size. This produced values such as 2 MiB while running and 4096 MiB while stopped.

## Testing

- `uv run pytest tests/test_facade.py::TestDiskSizeHelpers tests/test_cli.py::TestCliInfo` — 8 passed
- `uv run ruff check src/smolvm/facade.py tests/test_facade.py`
- `uv run ruff format --check src/smolvm/facade.py tests/test_facade.py`
- verified `uv run smolvm sandbox info live-snap-test --json` reports `disk_size: 4096` while the QEMU sandbox is running


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved qcow2 disk size inspection while the virtual machine is running.
  * Ensured virtual disk capacity is accurately reported in MiB.

* **Tests**
  * Added coverage validating disk-size inspection and command behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->