### PR TITLE
Add bridged networking support for Linux VMs

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -3,8 +3,8 @@
 # Unlike the unit suite (which mocks the hypervisor) and smoke-published-images
 # (which shells out to raw qemu), this boots actual micro-VMs *through the
 # SmolVM Python API* and walks their lifecycle — start, exec, file
-# upload/download, pause/resume, snapshot/restore, stop/cleanup. QEMU and
-# Firecracker are both exercised over SSH and vsock.
+# upload/download, pause/resume, snapshot/restore, stop/cleanup, and direct
+# bridge connectivity. QEMU and Firecracker are both exercised over SSH and vsock.
 #
 # GH-hosted ubuntu-latest (x86) exposes /dev/kvm, so this runs with hardware
 # acceleration. The suite gates review-ready PRs and pushes to main; the
@@ -124,6 +124,11 @@ jobs:
           sudo bash scripts/system-setup.sh \
             --configure-runtime \
             --runtime-user "$USER"
+
+      - name: Install bridge test tooling
+        run: |
+          sudo apt-get update -qq
+          sudo apt-get install -y --no-install-recommends iproute2 iputils-ping
 
       - name: Enable KVM and optional vsock
         run: |

--- a/docs/README.md
+++ b/docs/README.md
@@ -13,7 +13,7 @@ SmolVM gives an AI agent a disposable computer for running code, using a browser
 - [Agent presets](guides/agent-presets.md) — start Codex, Claude Code, Pi, Hermes, or OpenClaw in a sandbox.
 - [Browser sandboxes](guides/browser.md) — run Chromium and connect with a browser or Playwright.
 - [Snapshots](guides/snapshots.md) — save and restore supported sandbox state.
-- [Networking](guides/networking.md) — share a local port and limit outbound domains.
+- [Networking](guides/networking.md) — share a local port, limit outbound domains, or connect a sandbox to an existing bridge.
 - [Windows guests](guides/windows.md) — build and use a Windows image.
 
 ## Contributors

--- a/docs/guides/networking.md
+++ b/docs/guides/networking.md
@@ -12,6 +12,31 @@ smolvm sandbox port expose demo 3000
 
 Use the returned host port in your browser or tool. `smolvm sandbox port list demo` shows active mappings. In `smolvm sandbox port close demo HOST_PORT:3000`, replace `HOST_PORT` with the returned host port—for example, `smolvm sandbox port close demo 49152:3000`.
 
+## Connect a sandbox directly to an existing network
+
+On Linux, a sandbox can appear as a separate computer on a network you already configured. This advanced mode gives the sandbox its own network identity instead of placing it behind SmolVM's private network.
+
+The host must already have a Linux bridge connected to the target network. The bridge and its member interfaces must have no host addresses, including automatic IPv6 addresses. SmolVM checks this setup but never creates, reconfigures, or deletes the bridge.
+
+Check bridge `br10` before creating a sandbox:
+
+```bash
+smolvm bridge check br10
+# Bridge 'br10' is ready for bridged networking.
+```
+
+Create a bridged sandbox only after that check passes:
+
+```bash
+smolvm sandbox create --name demo --network bridge --bridge br10
+```
+
+SmolVM-provided images request an address with DHCP from inside the guest. To use a static address instead, add an executable `/etc/smolvm/network.sh` script inside the guest disk. SmolVM passes `eth0` as the script's first argument each time the guest boots. You can open the guest before it has an address because `smolvm sandbox shell demo` uses a direct host-to-guest control channel rather than the network.
+
+Bridge mode deliberately does not provide SmolVM NAT, port exposure, SSH from the host, workspace mounts, or outbound-domain controls. Connect to guest services from the bridged network, and use `smolvm sandbox shell demo` for host administration.
+
+A bridged sandbox can send traffic directly to the selected network. Configuration mistakes or untrusted guest software can affect other devices through duplicate addresses, address spoofing, or unwanted services. Use this mode only on a network where that access is acceptable.
+
 ## Limit outbound domains in Python
 
 Pass an allow-list when creating a sandbox:
@@ -27,6 +52,6 @@ Use `"*"` to allow all domains, which is the default. Entries may be hostnames o
 
 ## Current limits
 
-Outbound-domain controls require host TAP networking: Firecracker uses it by default, and custom QEMU configurations can opt in with `VMConfig.qemu_network="tap"`. They do not apply to QEMU user-mode networking, libkrun, or Windows guests. Treat an allow-list as a network control, not as a complete security boundary for untrusted code.
+Outbound-domain controls require SmolVM's private TAP networking: Firecracker uses it by default, and custom QEMU configurations can opt in with `VMConfig.qemu_network="tap"`. They do not apply to bridged networking, QEMU user-mode networking, libkrun, or Windows guests. Treat an allow-list as a network control, not as a complete security boundary for untrusted code.
 
 **Implementation notes:** the public settings and validation are in [`src/smolvm/types.py`](../../src/smolvm/types.py), backend networking selection is in [`src/smolvm/vm.py`](../../src/smolvm/vm.py), and host rules are applied in [`src/smolvm/host/network.py`](../../src/smolvm/host/network.py). Behavior is covered by [`tests/test_internet_settings.py`](../../tests/test_internet_settings.py) and [`tests/test_network.py`](../../tests/test_network.py).

--- a/docs/guides/networking.md
+++ b/docs/guides/networking.md
@@ -16,7 +16,7 @@ Use the returned host port in your browser or tool. `smolvm sandbox port list de
 
 On Linux, a sandbox can appear as a separate computer on a network you already configured. This advanced mode gives the sandbox its own network identity instead of placing it behind SmolVM's private network.
 
-The host must already have a Linux bridge connected to the target network. The bridge and its member interfaces must have no host addresses, including automatic IPv6 addresses. SmolVM checks this setup but never creates, reconfigures, or deletes the bridge.
+The host must already have a Linux bridge, a host network interface that joins several connections into one network. It must be connected to the target network, and neither the bridge nor its member interfaces may have host addresses, including automatic IPv6 addresses. SmolVM checks this setup but never creates, reconfigures, or deletes the bridge.
 
 Check bridge `br10` before creating a sandbox:
 
@@ -28,10 +28,12 @@ smolvm bridge check br10
 Create a bridged sandbox only after that check passes:
 
 ```bash
-smolvm sandbox create --name demo --network bridge --bridge br10
+smolvm sandbox create --name demo --os alpine --network bridge --bridge br10
 ```
 
-SmolVM-provided images request an address with DHCP from inside the guest. To use a static address instead, add an executable `/etc/smolvm/network.sh` script inside the guest disk. SmolVM passes `eth0` as the script's first argument each time the guest boots. You can open the guest before it has an address because `smolvm sandbox shell demo` uses a direct host-to-guest control channel rather than the network.
+The current SmolVM Alpine image automatically asks the network for an address using DHCP (Dynamic Host Configuration Protocol). To use a static address instead, add an executable `/etc/smolvm/network.sh` script inside the guest disk. SmolVM passes `eth0` as the script's first argument each time the guest boots. You can open the guest before it has an address because `smolvm sandbox shell demo` uses a direct host-to-guest control channel rather than the network.
+
+Custom images must understand the `smolvm.network=guest` boot setting and configure `eth0`. When creating `VMConfig` directly for a compatible image, set `guest_managed_networking=True`. SmolVM rejects older published or custom images instead of starting them without working bridge configuration.
 
 Bridge mode deliberately does not provide SmolVM NAT, port exposure, SSH from the host, workspace mounts, or outbound-domain controls. Connect to guest services from the bridged network, and use `smolvm sandbox shell demo` for host administration.
 

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -8,6 +8,7 @@ The CLI creates and manages disposable sandboxes. Run `smolvm COMMAND --help` fo
 | --- | --- |
 | `smolvm setup` | Install or check local runtime dependencies. |
 | `smolvm doctor` | Check whether this machine can run sandboxes. |
+| `smolvm bridge check BRIDGE` | Check an existing Linux bridge before connecting a sandbox to it. |
 | `smolvm update` | Upgrade to the latest stable release. |
 | `smolvm prune` | Remove stale cached images. |
 
@@ -17,7 +18,7 @@ Run these in the order you need them:
 
 | Command | Use it to |
 | --- | --- |
-| `smolvm sandbox create` | Create a sandbox. |
+| `smolvm sandbox create` | Create a sandbox. Add `--network bridge --bridge BRIDGE` only when the sandbox should appear as a separate computer on that network. |
 | `smolvm sandbox list` / `info` | Find or inspect sandboxes. |
 | `smolvm sandbox shell` / `ssh` | Open a shell. `shell` uses SmolVM's fast control channel when available; `ssh` explicitly uses SSH. |
 | `smolvm sandbox start` / `stop` | Start or stop a sandbox. |

--- a/scripts/ci/preset-init.sh
+++ b/scripts/ci/preset-init.sh
@@ -128,35 +128,45 @@ netmask_to_prefix() {
 }
 
 IP_CONFIG=$(cat /proc/cmdline | tr ' ' '\n' | grep '^ip=' | head -1)
-if [ -n "$IP_CONFIG" ]; then
-    IP_FIELDS=$(echo "$IP_CONFIG" | cut -d= -f2-)
-    GUEST_IP=$(echo "$IP_FIELDS" | cut -d: -f1)
-    GATEWAY=$(echo "$IP_FIELDS" | cut -d: -f3)
-    NETMASK=$(echo "$IP_FIELDS" | cut -d: -f4)
+GUEST_MANAGED=$(cat /proc/cmdline | tr ' ' '\n' | grep '^smolvm.network=guest' | head -1)
+if [ -n "$GUEST_MANAGED" ]; then
+    # Bridge mode: bring the link up but let the guest configure its own address.
+    ip link set lo up
+    ip link set eth0 up 2>/dev/null || true
+    hostname smolvm
+    log_ts "net-config-done"
+    log_ts "net-ready"
 else
-    GUEST_IP="172.16.0.2"
-    GATEWAY="172.16.0.1"
-    NETMASK="255.255.255.0"
+    if [ -n "$IP_CONFIG" ]; then
+        IP_FIELDS=$(echo "$IP_CONFIG" | cut -d= -f2-)
+        GUEST_IP=$(echo "$IP_FIELDS" | cut -d: -f1)
+        GATEWAY=$(echo "$IP_FIELDS" | cut -d: -f3)
+        NETMASK=$(echo "$IP_FIELDS" | cut -d: -f4)
+    else
+        GUEST_IP="172.16.0.2"
+        GATEWAY="172.16.0.1"
+        NETMASK="255.255.255.0"
+    fi
+
+    PREFIX=$(netmask_to_prefix "$NETMASK") || PREFIX=24
+    ip link set lo up
+    ip link set eth0 up 2>/dev/null || true
+    ip addr add "${GUEST_IP}/${PREFIX}" dev eth0 2>/dev/null || true
+    ip route add default via "${GATEWAY}" dev eth0 2>/dev/null || true
+
+    if [ -n "$GATEWAY" ]; then
+        echo "nameserver ${GATEWAY}" > /etc/resolv.conf
+        echo "nameserver 8.8.8.8" >> /etc/resolv.conf
+        echo "nameserver 8.8.4.4" >> /etc/resolv.conf
+    else
+        echo "nameserver 8.8.8.8" > /etc/resolv.conf
+        echo "nameserver 8.8.4.4" >> /etc/resolv.conf
+    fi
+
+    hostname smolvm
+    log_ts "net-config-done"
+    log_ts "net-ready"
 fi
-
-PREFIX=$(netmask_to_prefix "$NETMASK") || PREFIX=24
-
-ip link set lo up
-ip link set eth0 up 2>/dev/null || true
-ip addr add "${GUEST_IP}/${PREFIX}" dev eth0 2>/dev/null || true
-ip route add default via "${GATEWAY}" dev eth0 2>/dev/null || true
-
-if [ -n "$GATEWAY" ]; then
-    echo "nameserver ${GATEWAY}" > /etc/resolv.conf
-    echo "nameserver 8.8.8.8" >> /etc/resolv.conf
-    echo "nameserver 8.8.4.4" >> /etc/resolv.conf
-else
-    echo "nameserver 8.8.8.8" > /etc/resolv.conf
-    echo "nameserver 8.8.4.4" >> /etc/resolv.conf
-fi
-
-hostname smolvm
-log_ts "net-ready"
 
 # ── SSH host keys ────────────────────────────────────────────
 log_ts "ssh-hostkey-check-start"

--- a/scripts/ci/preset-init.sh
+++ b/scripts/ci/preset-init.sh
@@ -129,10 +129,38 @@ netmask_to_prefix() {
 
 IP_CONFIG=$(cat /proc/cmdline | tr ' ' '\n' | grep '^ip=' | head -1)
 GUEST_MANAGED=$(cat /proc/cmdline | tr ' ' '\n' | grep '^smolvm.network=guest' | head -1)
-if [ -n "$GUEST_MANAGED" ]; then
-    # Bridge mode: bring the link up but let the guest configure its own address.
+
+configure_guest_managed_network() {
     ip link set lo up
+
+    # A custom hook is the authoritative static/DHCP configuration supplied
+    # inside the image. The interface name is passed as its first argument.
+    if [ -x /etc/smolvm/network.sh ]; then
+        /etc/smolvm/network.sh eth0
+        return
+    fi
+
+    # Respect a conventional interfaces file when this image ships ifup.
+    if command -v ifup >/dev/null 2>&1 \
+        && grep -Eq '^[[:space:]]*iface[[:space:]]+eth0' /etc/network/interfaces 2>/dev/null \
+        && ifup eth0; then
+        return
+    fi
+
+    # SmolVM-provided images use guest-side DHCP when no static hook exists.
     ip link set eth0 up 2>/dev/null || true
+    if command -v udhcpc >/dev/null 2>&1 && udhcpc -q -n -t 5 -i eth0; then
+        return
+    fi
+    if command -v dhclient >/dev/null 2>&1 && dhclient -1 eth0; then
+        return
+    fi
+
+    echo "SmolVM init: eth0 has no guest network configuration; add /etc/smolvm/network.sh" >&2
+}
+
+if [ -n "$GUEST_MANAGED" ]; then
+    configure_guest_managed_network
     hostname smolvm
     log_ts "net-config-done"
     log_ts "net-ready"

--- a/scripts/ci/preset-init.sh
+++ b/scripts/ci/preset-init.sh
@@ -137,7 +137,7 @@ configure_guest_managed_network() {
     # inside the image. The interface name is passed as its first argument.
     if [ -x /etc/smolvm/network.sh ]; then
         /etc/smolvm/network.sh eth0
-        return
+        return $?
     fi
 
     # Respect a conventional interfaces file when this image ships ifup.
@@ -157,13 +157,17 @@ configure_guest_managed_network() {
     fi
 
     echo "SmolVM init: eth0 has no guest network configuration; add /etc/smolvm/network.sh" >&2
+    return 1
 }
 
 if [ -n "$GUEST_MANAGED" ]; then
-    configure_guest_managed_network
+    if configure_guest_managed_network; then
+        log_ts "net-ready"
+    else
+        log_ts "net-config-failed"
+    fi
     hostname smolvm
     log_ts "net-config-done"
-    log_ts "net-ready"
 else
     if [ -n "$IP_CONFIG" ]; then
         IP_FIELDS=$(echo "$IP_CONFIG" | cut -d= -f2-)

--- a/src/smolvm/__init__.py
+++ b/src/smolvm/__init__.py
@@ -49,6 +49,7 @@ from smolvm.types import (
     GuestFlushPolicy,
     GuestOS,
     InternetSettings,
+    NetworkAttachmentConfig,
     NetworkConfig,
     QemuMachine,
     SnapshotArtifacts,
@@ -91,6 +92,7 @@ __all__ = [
     "SSHClient",
     # Data models
     "InternetSettings",
+    "NetworkAttachmentConfig",
     "VMConfig",
     "VMInfo",
     "VMState",

--- a/src/smolvm/cli/commands/app.py
+++ b/src/smolvm/cli/commands/app.py
@@ -83,6 +83,20 @@ def sandbox() -> None:
 @comm_channel_option
 @click.option("--mount", "mounts", multiple=True, metavar="HOST_PATH[:GUEST_PATH]")
 @click.option("--writable-mounts", is_flag=True, help="Allow writes to mounted host folders.")
+@click.option(
+    "--network",
+    "network_mode",
+    type=click.Choice(["nat", "bridge"]),
+    default="nat",
+    help="Network mode: 'nat' (default, private network) or 'bridge' (connect to a host bridge).",
+)
+@click.option(
+    "--bridge",
+    "bridge_name",
+    default=None,
+    metavar="BRIDGE",
+    help="Linux bridge to attach to (required with --network bridge).",
+)
 @boot_timeout_option
 @json_option
 def sandbox_create(
@@ -96,6 +110,8 @@ def sandbox_create(
     comm_channel: str | None,
     mounts: tuple[str, ...],
     writable_mounts: bool,
+    network_mode: str,
+    bridge_name: str | None,
     boot_timeout: float,
     json_output: bool,
 ) -> Any:
@@ -114,6 +130,8 @@ def sandbox_create(
             comm_channel=comm_channel,
             mounts=_mounts(mounts),
             writable_mounts=writable_mounts,
+            network_mode=network_mode,
+            bridge_name=bridge_name,
             boot_timeout=boot_timeout,
             json=json_output,
         )
@@ -754,6 +772,26 @@ def port_list(
             ssh_user=ssh_user,
             comm_channel=comm_channel,
             command_name="sandbox.port.list",
+            json=json_output,
+        )
+    )
+
+
+@cli.group(context_settings=CONTEXT_SETTINGS)
+def bridge() -> None:
+    """Check host bridges for bridged networking."""
+
+
+@bridge.command("check")
+@click.argument("bridge_name", metavar="BRIDGE")
+@json_option
+def bridge_check(bridge_name: str, json_output: bool) -> Any:
+    """Check whether a bridge is ready for bridged networking."""
+    _before_command(json_output=json_output)
+    return _handlers()._run_bridge_check(
+        _ns(
+            command_name="bridge.check",
+            bridge_name=bridge_name,
             json=json_output,
         )
     )

--- a/src/smolvm/cli/main.py
+++ b/src/smolvm/cli/main.py
@@ -144,6 +144,7 @@ class CreatePayload(TypedDict):
 
     vm: CreateVmPayload
     next: CreateNextPayload
+    warnings: list[str]
 
 
 class StartPresetPayload(TypedDict):
@@ -785,6 +786,8 @@ def _render_create_result(data: CreatePayload) -> None:
     if next_step["ssh_command"] is not None:
         console.print(f"SSH:  [bold]{next_step['ssh_command']}[/bold]")
     console.print(f"Info: [bold]{next_step['info_command']}[/bold]")
+    for warning in data["warnings"]:
+        console.print(f"Warning: {warning}", style="yellow")
 
 
 def _build_and_boot_with_progress(
@@ -1200,6 +1203,14 @@ def _run_create(args: SimpleNamespace) -> int:
                 "ssh_command": (None if is_bridge else f"smolvm sandbox ssh {vm.vm_id}"),
                 "info_command": f"smolvm sandbox info {vm.vm_id}",
             },
+            "warnings": (
+                [
+                    f"The guest manages its own network address; if it did not receive one, "
+                    f"run 'smolvm sandbox shell {vm.vm_id}' to configure it."
+                ]
+                if is_bridge
+                else []
+            ),
         }
 
         if args.json:

--- a/src/smolvm/cli/main.py
+++ b/src/smolvm/cli/main.py
@@ -107,7 +107,7 @@ class CreateNextPayload(TypedDict):
     """Suggested follow-up actions for ``smolvm sandbox create``."""
 
     shell_command: str
-    ssh_command: str
+    ssh_command: str | None
     info_command: str
 
 
@@ -391,8 +391,6 @@ def _vm_rows(vms: Sequence[VMInfo]) -> list[VmRow]:
     for vm in vms:
         network = vm.network
         ip_address = network.guest_ip if network else None
-        if network is not None and network.mode == "bridge":
-            ip_address = "guest-managed"
         rows.append(
             {
                 "name": vm.vm_id,
@@ -665,8 +663,6 @@ def _info_payload(vm: VMInfo, *, live_data: dict[str, object] | None = None) -> 
     memory_used = live.get("memory_used")
 
     ip_address = network.guest_ip if network else None
-    if network is not None and network.mode == "bridge":
-        ip_address = "guest-managed"
 
     return {
         "vm": {
@@ -709,7 +705,15 @@ def _render_info_result(data: InfoPayload) -> None:
     )
     details.add_row("OS", str(vm_data["os"] or "-"))
     details.add_row("Backend", str(vm_data["backend"]))
-    details.add_row("IP Address", str(vm_data["ip_address"] or "-"))
+    details.add_row("Network Mode", str(vm_data["network_mode"]))
+    if vm_data["bridge"]:
+        details.add_row("Bridge", str(vm_data["bridge"]))
+    ip_value = (
+        "Managed inside guest"
+        if vm_data["network_mode"] == "bridge"
+        else str(vm_data["ip_address"] or "-")
+    )
+    details.add_row("IP Address", ip_value)
     details.add_row(
         "SSH Port",
         str(vm_data["ssh_port"]) if vm_data["ssh_port"] is not None else "-",
@@ -778,7 +782,8 @@ def _render_create_result(data: CreatePayload) -> None:
     details.add_row("Started", _format_started_at(vm_data["started_at"]))
     console.print(details)
     console.print(f"Next: [bold]{next_step['shell_command']}[/bold]")
-    console.print(f"SSH:  [bold]{next_step['ssh_command']}[/bold]")
+    if next_step["ssh_command"] is not None:
+        console.print(f"SSH:  [bold]{next_step['ssh_command']}[/bold]")
     console.print(f"Info: [bold]{next_step['info_command']}[/bold]")
 
 
@@ -924,17 +929,14 @@ def _run_bridge_check(args: SimpleNamespace) -> int:
         nm = NetworkManager()
         inspection = nm.inspect_bridge(bridge_name)
         if json_output:
-            import json
-
-            click.echo(
-                json.dumps(
-                    {
-                        "bridge": bridge_name,
-                        "ok": inspection.ok,
-                        "reason": inspection.reason or None,
-                    },
-                    indent=2,
-                )
+            emit_json(
+                "bridge.check",
+                0 if inspection.ok else 1,
+                data={
+                    "bridge": bridge_name,
+                    "ok": inspection.ok,
+                    "reason": inspection.reason or None,
+                },
             )
         else:
             if inspection.ok:
@@ -1093,6 +1095,8 @@ def _run_create(args: SimpleNamespace) -> int:
                     wait_for_control_channel=True,
                     mounts=args.mounts,
                     writable_mounts=args.writable_mounts,
+                    network_mode=getattr(args, "network_mode", None),
+                    bridge_name=getattr(args, "bridge_name", None),
                 )
             else:
                 config, ssh_key_path = _build_s3_image_config(
@@ -1178,6 +1182,8 @@ def _run_create(args: SimpleNamespace) -> int:
                 )
 
         os_label = "s3-image" if use_s3_image else resolved_guest_os.value
+        network = vm.info.network
+        is_bridge = network is not None and getattr(network, "mode", "nat") == "bridge"
         data: CreatePayload = {
             "vm": {
                 "name": vm.vm_id,
@@ -1191,7 +1197,7 @@ def _run_create(args: SimpleNamespace) -> int:
             },
             "next": {
                 "shell_command": f"smolvm sandbox shell {vm.vm_id}",
-                "ssh_command": f"smolvm sandbox ssh {vm.vm_id}",
+                "ssh_command": (None if is_bridge else f"smolvm sandbox ssh {vm.vm_id}"),
                 "info_command": f"smolvm sandbox info {vm.vm_id}",
             },
         }

--- a/src/smolvm/cli/main.py
+++ b/src/smolvm/cli/main.py
@@ -129,6 +129,8 @@ class InfoVmPayload(TypedDict):
     memory: int
     memory_used: int | None
     disk_size: int | None
+    network_mode: str
+    bridge: str | None
 
 
 class InfoPayload(TypedDict):
@@ -388,12 +390,15 @@ def _vm_rows(vms: Sequence[VMInfo]) -> list[VmRow]:
     rows: list[VmRow] = []
     for vm in vms:
         network = vm.network
+        ip_address = network.guest_ip if network else None
+        if network is not None and network.mode == "bridge":
+            ip_address = "guest-managed"
         rows.append(
             {
                 "name": vm.vm_id,
                 "status": vm.status.value,
                 "pid": vm.pid,
-                "ip_address": network.guest_ip if network else None,
+                "ip_address": ip_address,
                 "ssh_port": network.ssh_host_port if network else None,
                 "warnings": _vm_warnings(vm),
             }
@@ -584,6 +589,9 @@ def _query_live_vm_info(vm: VMInfo) -> dict[str, object]:
     if network is None:
         return {}
 
+    if network.mode == "bridge":
+        return {}
+
     if network.ssh_host_port is not None:
         host, port = "127.0.0.1", network.ssh_host_port
     else:
@@ -656,19 +664,25 @@ def _info_payload(vm: VMInfo, *, live_data: dict[str, object] | None = None) -> 
     os_value = live.get("os") or _guess_os_from_paths(vm)
     memory_used = live.get("memory_used")
 
+    ip_address = network.guest_ip if network else None
+    if network is not None and network.mode == "bridge":
+        ip_address = "guest-managed"
+
     return {
         "vm": {
             "name": vm.vm_id,
             "status": vm.status.value,
             "os": str(os_value) if os_value else None,
             "backend": config.backend or "auto",
-            "ip_address": network.guest_ip if network else None,
+            "ip_address": ip_address,
             "ssh_port": network.ssh_host_port if network else None,
             "pid": vm.pid,
             "vcpus": config.vcpu_count,
             "memory": config.memory,
             "memory_used": memory_used if isinstance(memory_used, int) else None,
             "disk_size": disk_size,
+            "network_mode": network.mode if network else "nat",
+            "bridge": network.bridge if network else None,
         }
     }
 
@@ -778,6 +792,8 @@ def _build_and_boot_with_progress(
     wait_for_control_channel: bool = False,
     mounts: list[str] | None = None,
     writable_mounts: bool = False,
+    network_mode: str | None = None,
+    bridge_name: str | None = None,
 ) -> object:
     """Build a VM config and boot it, showing a Rich progress bar.
 
@@ -813,6 +829,9 @@ def _build_and_boot_with_progress(
 
         prepare_task = progress.add_task(prepare_message, total=None)
         config, ssh_key_path = _build_fn(on_download)
+        config = _apply_network_attachment(
+            config, network_mode=network_mode, bridge_name=bridge_name
+        )
         progress.remove_task(prepare_task)
 
         # One task that re-labels as the boot pipeline progresses
@@ -860,6 +879,71 @@ def _wait_after_create(
         vm.wait_for_ssh(timeout=boot_timeout, on_progress=on_progress)
         return
     vm.wait_for_ready(timeout=boot_timeout, on_progress=on_progress)
+
+
+def _apply_network_attachment(
+    config: Any,
+    *,
+    network_mode: str | None,
+    bridge_name: str | None,
+) -> Any:
+    """Apply --network/--bridge options to a VMConfig."""
+    if network_mode is None or network_mode == "nat":
+        if bridge_name is not None:
+            raise ValueError(
+                "--bridge requires --network bridge; drop --bridge or pass --network bridge."
+            )
+        return config
+    if network_mode == "bridge":
+        if not bridge_name:
+            raise ValueError(
+                "--network bridge requires --bridge <bridge_name>; "
+                "e.g. --network bridge --bridge br10."
+            )
+        from smolvm.types import NetworkAttachmentConfig
+
+        return config.model_copy(
+            update={
+                "network_attachment": NetworkAttachmentConfig(
+                    mode="bridge",
+                    bridge=bridge_name,
+                )
+            }
+        )
+    return config
+
+
+def _run_bridge_check(args: SimpleNamespace) -> int:
+    """Handle ``smolvm bridge check``."""
+    from smolvm.host.network import NetworkManager
+
+    bridge_name = args.bridge_name
+    json_output = getattr(args, "json", False)
+
+    try:
+        nm = NetworkManager()
+        inspection = nm.inspect_bridge(bridge_name)
+        if json_output:
+            import json
+
+            click.echo(
+                json.dumps(
+                    {
+                        "bridge": bridge_name,
+                        "ok": inspection.ok,
+                        "reason": inspection.reason or None,
+                    },
+                    indent=2,
+                )
+            )
+        else:
+            if inspection.ok:
+                click.echo(f"Bridge '{bridge_name}' is ready for bridged networking.")
+            else:
+                click.echo(f"Bridge '{bridge_name}' is not ready: {inspection.reason}")
+        return 0 if inspection.ok else 1
+    except Exception as exc:
+        return _emit_cli_error("bridge.check", 1, exc, json_output=json_output)
 
 
 def _run_create(args: SimpleNamespace) -> int:
@@ -956,6 +1040,8 @@ def _run_create(args: SimpleNamespace) -> int:
                     wait_for_control_channel=True,
                     mounts=args.mounts,
                     writable_mounts=args.writable_mounts,
+                    network_mode=getattr(args, "network_mode", None),
+                    bridge_name=getattr(args, "bridge_name", None),
                 )
             else:
                 config, ssh_key_path = _build_local_image_config(
@@ -966,6 +1052,11 @@ def _run_create(args: SimpleNamespace) -> int:
                     memory=args.memory_mib,
                     ssh_key_path=None,
                     vm_name=args.name,
+                )
+                config = _apply_network_attachment(
+                    config,
+                    network_mode=getattr(args, "network_mode", None),
+                    bridge_name=getattr(args, "bridge_name", None),
                 )
                 vm_kwargs: dict[str, Any] = {
                     "ssh_key_path": ssh_key_path,
@@ -1012,6 +1103,11 @@ def _run_create(args: SimpleNamespace) -> int:
                     memory=args.memory_mib,
                     ssh_key_path=None,
                 )
+                config = _apply_network_attachment(
+                    config,
+                    network_mode=getattr(args, "network_mode", None),
+                    bridge_name=getattr(args, "bridge_name", None),
+                )
                 vm_kwargs = {
                     "ssh_key_path": ssh_key_path,
                     "mounts": args.mounts,
@@ -1048,6 +1144,8 @@ def _run_create(args: SimpleNamespace) -> int:
                     wait_for_control_channel=True,
                     mounts=args.mounts,
                     writable_mounts=args.writable_mounts,
+                    network_mode=getattr(args, "network_mode", None),
+                    bridge_name=getattr(args, "bridge_name", None),
                 )
             else:
                 config, ssh_key_path = _build_auto_config(
@@ -1058,6 +1156,11 @@ def _run_create(args: SimpleNamespace) -> int:
                     memory=args.memory_mib,
                     disk_size_mib=args.disk_size_mib,
                     ssh_key_path=None,
+                )
+                config = _apply_network_attachment(
+                    config,
+                    network_mode=getattr(args, "network_mode", None),
+                    bridge_name=getattr(args, "bridge_name", None),
                 )
                 vm_kwargs = {
                     "ssh_key_path": ssh_key_path,
@@ -1452,6 +1555,8 @@ def _run_start(args: SimpleNamespace) -> int:
                 wait_for_control_channel=True,
                 mounts=args.mounts,
                 writable_mounts=args.writable_mounts,
+                network_mode=getattr(args, "network_mode", None),
+                bridge_name=getattr(args, "bridge_name", None),
             )
             apply_summary = _apply_preset_with_progress(
                 console=console,
@@ -1469,6 +1574,11 @@ def _run_start(args: SimpleNamespace) -> int:
                 memory=memory_mib,
                 disk_size_mib=disk_size_mib,
                 ssh_key_path=None,
+            )
+            config = _apply_network_attachment(
+                config,
+                network_mode=getattr(args, "network_mode", None),
+                bridge_name=getattr(args, "bridge_name", None),
             )
             vm = SmolVM(
                 config,

--- a/src/smolvm/exceptions.py
+++ b/src/smolvm/exceptions.py
@@ -96,6 +96,12 @@ class NetworkError(SmolVMError):
     pass
 
 
+class BridgeTapOwnershipError(NetworkError):
+    """Raised when an existing interface is not owned by the expected sandbox."""
+
+    pass
+
+
 class HostError(SmolVMError):
     """Raised when host environment checks fail (KVM, dependencies, Firecracker)."""
 

--- a/src/smolvm/facade.py
+++ b/src/smolvm/facade.py
@@ -2594,13 +2594,21 @@ class SmolVM:
         """Return the guest IP address.
 
         Raises:
-            SmolVMError: If the VM has no network configuration.
+            SmolVMError: If the VM has no network configuration, or if the
+                VM uses bridge mode where the address is managed inside the VM.
         """
         self._refresh_info()
         if self._info.network is None:
             raise SmolVMError(
                 "VM has no network configuration",
                 {"vm_id": self._vm_id},
+            )
+        if self._info.network.mode == "bridge":
+            raise SmolVMError(
+                f"Bridged sandbox '{self._vm_id}' has a guest-managed address; "
+                f"use 'smolvm sandbox shell {self._vm_id}', or connect to its "
+                f"address from the bridged network.",
+                {"vm_id": self._vm_id, "network_mode": "bridge"},
             )
         return self._info.network.guest_ip
 

--- a/src/smolvm/facade.py
+++ b/src/smolvm/facade.py
@@ -689,6 +689,7 @@ def _build_auto_config(
         backend=resolved_backend,
         qemu_machine=qemu_machine,
         ssh_public_key=public_key_value,
+        guest_managed_networking=True,
     )
     logger.info(
         "Auto-configured VM: %s (os=%s, backend=%s)",
@@ -2385,8 +2386,9 @@ class SmolVM:
         if self._info.network.mode == "bridge":
             raise SmolVMError(
                 f"Bridged sandbox '{self._vm_id}' is already connected directly to its "
-                "network; connect to the guest's address there, or recreate it with "
-                "'--network nat' to use 'smolvm sandbox port expose'.",
+                f"network; run 'smolvm sandbox delete {self._vm_id}', then "
+                f"'smolvm sandbox create --name {self._vm_id} --network nat' to use port "
+                "exposure.",
                 {"vm_id": self._vm_id, "network_mode": "bridge"},
             )
         if guest_port < 1 or guest_port > 65535:

--- a/src/smolvm/facade.py
+++ b/src/smolvm/facade.py
@@ -334,7 +334,9 @@ def _build_auto_config_image_name(
     disk_size_mib: int,
 ) -> str:
     """Build an OS-aware cache key for auto-configured images."""
-    image_name = f"{guest_os.value}-ssh-key"
+    # Bump when /init behavior changes so an older cached rootfs cannot ignore
+    # a new host-side boot contract such as smolvm.network=guest.
+    image_name = f"{guest_os.value}-ssh-key-guestnet-v1"
     if backend == BACKEND_QEMU:
         arch = platform.machine().lower()
         image_arch = "aarch64" if arch in {"arm64", "aarch64"} else "x86_64"
@@ -2380,6 +2382,13 @@ class SmolVM:
                 "Cannot expose port: VM has no network configuration",
                 {"vm_id": self._vm_id},
             )
+        if self._info.network.mode == "bridge":
+            raise SmolVMError(
+                f"Bridged sandbox '{self._vm_id}' is already connected directly to its "
+                "network; connect to the guest's address there, or recreate it with "
+                "'--network nat' to use 'smolvm sandbox port expose'.",
+                {"vm_id": self._vm_id, "network_mode": "bridge"},
+            )
         if guest_port < 1 or guest_port > 65535:
             raise ValueError("guest_port must be 1-65535")
 
@@ -3246,6 +3255,12 @@ modprobe 9pnet_virtio""".strip()
                 "VM has no network configuration",
                 {"vm_id": self._vm_id},
             )
+        if self._info.network.mode == "bridge":
+            raise SmolVMError(
+                f"The host has no SSH path to bridged sandbox '{self._vm_id}'; use "
+                f"'smolvm sandbox shell {self._vm_id}', or connect from its bridged network.",
+                {"vm_id": self._vm_id, "network_mode": "bridge"},
+            )
 
         endpoints: list[tuple[str, int]] = []
         ssh_host_port = self._info.network.ssh_host_port
@@ -3511,12 +3526,18 @@ modprobe 9pnet_virtio""".strip()
 
     def _should_try_nftables_local_forward(self) -> bool:
         """Return whether localhost exposure should attempt host nftables first."""
+        network = getattr(self._info, "network", None)
+        if getattr(network, "mode", None) == "bridge":
+            return False
         config = getattr(self._info, "config", None)
         backend = getattr(config, "backend", None)
         return backend not in {BACKEND_QEMU, BACKEND_LIBKRUN}
 
     def _should_try_qemu_hostfwd_local_forward(self) -> bool:
         """Return whether localhost exposure should use QEMU's slirp hostfwd."""
+        network = getattr(self._info, "network", None)
+        if getattr(network, "mode", None) == "bridge":
+            return False
         config = getattr(self._info, "config", None)
         backend = getattr(config, "backend", None)
         qemu_network = getattr(config, "qemu_network", None)

--- a/src/smolvm/host/network.py
+++ b/src/smolvm/host/network.py
@@ -33,7 +33,7 @@ from pathlib import Path
 from typing import TypeVar
 from urllib.parse import urlparse
 
-from smolvm.exceptions import NetworkError, SmolVMError
+from smolvm.exceptions import BridgeTapOwnershipError, NetworkError, SmolVMError
 from smolvm.host._accel import HAS_NETLINK, network_native
 from smolvm.utils import async_run_command, run_command
 
@@ -2078,8 +2078,21 @@ class NetworkManager:
     # Bridge inspection and bridged TAP attachment
     # ------------------------------------------------------------------
 
+    @staticmethod
+    def _is_missing_interface_error(error: Exception) -> bool:
+        """Return whether iproute2 explicitly reported a missing interface."""
+        message = str(error).lower()
+        return any(
+            marker in message
+            for marker in (
+                "cannot find device",
+                "does not exist",
+                "no such device",
+            )
+        )
+
     def _get_link_info(self, link_name: str) -> dict[str, object] | None:
-        """Return detailed JSON metadata for one Linux network interface."""
+        """Return detailed JSON metadata, or None only for a missing interface."""
         import json
 
         try:
@@ -2087,8 +2100,10 @@ class NetworkManager:
                 ["ip", "-json", "-d", "link", "show", "dev", link_name],
                 use_sudo=False,
             )
-        except SmolVMError:
-            return None
+        except SmolVMError as exc:
+            if self._is_missing_interface_error(exc):
+                return None
+            raise
         links = json.loads(result.stdout)
         return links[0] if links else None
 
@@ -2109,7 +2124,10 @@ class NetworkManager:
             return BridgeInspection(
                 bridge_name=bridge_name,
                 ok=False,
-                reason="Bridged networking is only supported on Linux.",
+                reason=(
+                    "Bridged networking is only supported on Linux; run "
+                    "'smolvm sandbox create --network nat' instead."
+                ),
             )
 
         link_info = self._get_link_info(bridge_name)
@@ -2184,13 +2202,10 @@ class NetworkManager:
         """Return every interface currently attached to a bridge."""
         import json
 
-        try:
-            result = run_command(
-                ["ip", "-json", "link", "show", "master", bridge_name],
-                use_sudo=False,
-            )
-        except SmolVMError:
-            return []
+        result = run_command(
+            ["ip", "-json", "link", "show", "master", bridge_name],
+            use_sudo=False,
+        )
 
         links = json.loads(result.stdout)
         return [str(link["ifname"]) for link in links if link.get("ifname")]
@@ -2212,13 +2227,10 @@ class NetworkManager:
         """Return every IPv4 and IPv6 address, including link-local addresses."""
         import json
 
-        try:
-            result = run_command(
-                ["ip", "-json", "addr", "show", "dev", iface_name],
-                use_sudo=False,
-            )
-        except SmolVMError:
-            return []
+        result = run_command(
+            ["ip", "-json", "addr", "show", "dev", iface_name],
+            use_sudo=False,
+        )
 
         info = json.loads(result.stdout)
         if not info:
@@ -2244,14 +2256,14 @@ class NetworkManager:
         kind = self._link_kind(link_info)
         tap_type = info_data.get("type") if isinstance(info_data, dict) else None
         if kind != "tun" or tap_type != "tap":
-            raise NetworkError(
+            raise BridgeTapOwnershipError(
                 f"Network interface '{tap_name}' already exists and is not a SmolVM TAP; "
                 f"remove the conflicting interface, then retry sandbox '{vm_id}'."
             )
 
         expected_alias = self._bridge_tap_alias(vm_id)
         if link_info.get("ifalias") != expected_alias:
-            raise NetworkError(
+            raise BridgeTapOwnershipError(
                 f"Network interface '{tap_name}' already exists but does not belong to sandbox "
                 f"'{vm_id}'; remove the conflicting interface, then retry."
             )

--- a/src/smolvm/host/network.py
+++ b/src/smolvm/host/network.py
@@ -23,10 +23,13 @@ from __future__ import annotations
 import asyncio
 import logging
 import os
+import random
 import re
 import socket
 import time
 from collections.abc import Callable
+from contextlib import suppress
+from dataclasses import dataclass
 from pathlib import Path
 from typing import TypeVar
 from urllib.parse import urlparse
@@ -123,6 +126,21 @@ _NFT_SET_ALLOWED_TAPS = "allowed_taps"  # TAP interface names
 _NFT_CHAIN_RE = re.compile(r"^chain\s+(?P<chain>[^\s{]+)\s*\{")
 _NFT_RULE_COMMENT_RE = re.compile(r'comment "(?P<comment>[^"]+)"')
 _NFT_RULE_HANDLE_RE = re.compile(r'comment "(?P<comment>[^"]+)".*# handle (?P<handle>\d+)')
+
+
+@dataclass(frozen=True)
+class BridgeInspection:
+    """Result of read-only bridge validation.
+
+    Attributes:
+        bridge_name: The bridge interface name that was checked.
+        ok: Whether the bridge is valid for SmolVM attachment.
+        reason: Human-readable explanation when ok is False.
+    """
+
+    bridge_name: str
+    ok: bool
+    reason: str = ""
 
 
 class NetworkManager:
@@ -2045,6 +2063,281 @@ class NetworkManager:
         if vm_number < 0 or vm_number > 65534:
             raise ValueError("vm_number must be between 0 and 65534")
         return f"AA:FC:00:00:{(vm_number >> 8) & 0xFF:02X}:{vm_number & 0xFF:02X}"
+
+    def generate_bridge_mac(self) -> str:
+        """Generate a random locally-administered unicast MAC for bridge mode.
+
+        Uses the locally-administered bit (second-least-significant of the
+        first octet) and clears the multicast bit. The AA:FC OUI prefix
+        matches :meth:`generate_mac` so all SmolVM MACs share a recognisable
+        family.
+        """
+        suffix = random.randbytes(3)  # noqa: S311
+        return f"AA:FC:00:{suffix[0]:02X}:{suffix[1]:02X}:{suffix[2]:02X}"
+
+    # ------------------------------------------------------------------
+    # Bridge inspection and bridged TAP attachment
+    # ------------------------------------------------------------------
+
+    def inspect_bridge(self, bridge_name: str) -> BridgeInspection:
+        """Read-only validation of a Linux bridge for SmolVM attachment.
+
+        Checks:
+        1. The host is Linux.
+        2. The named interface exists.
+        3. It is a Linux bridge (not a VLAN or physical interface).
+        4. The bridge is up.
+        5. It has at least one non-SmolVM member (the external uplink).
+        6. Neither the bridge nor any existing member has an IPv4 or IPv6 address.
+
+        Never mutates the bridge or any of its members.
+        """
+        import platform
+
+        if platform.system() != "Linux":
+            return BridgeInspection(
+                bridge_name=bridge_name,
+                ok=False,
+                reason="Bridged networking is only supported on Linux.",
+            )
+
+        try:
+            result = run_command(
+                ["ip", "-json", "-d", "link", "show", bridge_name],
+                use_sudo=False,
+            )
+        except SmolVMError:
+            return BridgeInspection(
+                bridge_name=bridge_name,
+                ok=False,
+                reason=f"Interface '{bridge_name}' does not exist. "
+                f"Create a bridge such as 'br10', then rerun "
+                f"'smolvm sandbox create --network bridge --bridge {bridge_name}'.",
+            )
+
+        import json
+
+        links = json.loads(result.stdout)
+        if not links:
+            return BridgeInspection(
+                bridge_name=bridge_name,
+                ok=False,
+                reason=f"Interface '{bridge_name}' does not exist. "
+                f"Create a bridge such as 'br10', then rerun "
+                f"'smolvm sandbox create --network bridge --bridge {bridge_name}'.",
+            )
+
+        link_info = links[0]
+
+        # Check it's a bridge, not a VLAN or physical interface.
+        link_type = link_info.get("link_type", "")
+        if link_type != "bridge":
+            return BridgeInspection(
+                bridge_name=bridge_name,
+                ok=False,
+                reason=f"'{bridge_name}' is a {link_type or 'network interface'}, not a "
+                f"bridge. Create a bridge such as 'br10', then rerun with "
+                f"'--bridge br10'.",
+            )
+
+        # Check the bridge is up.
+        flags = link_info.get("flags", [])
+        if "UP" not in flags and "LOWER_UP" not in flags:
+            return BridgeInspection(
+                bridge_name=bridge_name,
+                ok=False,
+                reason=f"Bridge '{bridge_name}' is not up. Bring it up with "
+                f"'sudo ip link set {bridge_name} up', then rerun "
+                f"'smolvm sandbox create --network bridge --bridge {bridge_name}'.",
+            )
+
+        # Get bridge members.
+        members = self._get_bridge_members(bridge_name)
+        if not members:
+            return BridgeInspection(
+                bridge_name=bridge_name,
+                ok=False,
+                reason=f"Bridge '{bridge_name}' has no member interfaces. "
+                f"Add an upstream interface (e.g. 'sudo ip link set eno1.10 "
+                f"master {bridge_name}'), then rerun "
+                f"'smolvm sandbox create --network bridge --bridge {bridge_name}'.",
+            )
+
+        # Check for host addresses on the bridge and all members.
+        address_errors = self._check_bridge_addresses(bridge_name, members)
+        if address_errors:
+            return BridgeInspection(
+                bridge_name=bridge_name,
+                ok=False,
+                reason=address_errors,
+            )
+
+        return BridgeInspection(bridge_name=bridge_name, ok=True)
+
+    async def async_inspect_bridge(self, bridge_name: str) -> BridgeInspection:
+        """Read-only validation of a Linux bridge (async)."""
+        return await asyncio.to_thread(self.inspect_bridge, bridge_name)
+
+    def _get_bridge_members(self, bridge_name: str) -> list[str]:
+        """Return non-SmolVM member interface names of a bridge."""
+        try:
+            result = run_command(
+                ["ip", "-json", "link", "show", "master", bridge_name],
+                use_sudo=False,
+            )
+        except SmolVMError:
+            return []
+
+        import json
+
+        links = json.loads(result.stdout)
+        members: list[str] = []
+        for link in links:
+            name = link.get("ifname", "")
+            if name and not name.startswith("svmb"):
+                members.append(name)
+        return members
+
+    def _check_bridge_addresses(self, bridge_name: str, members: list[str]) -> str:
+        """Check bridge and members for host IP addresses. Returns error message or empty."""
+        interfaces_to_check = [bridge_name] + members
+        for iface in interfaces_to_check:
+            addrs = self._get_interface_addresses(iface)
+            if addrs:
+                addr_list = ", ".join(addrs)
+                return (
+                    f"Interface '{iface}' gives this machine the address "
+                    f"'{addr_list}'. Remove that address "
+                    f"(e.g. 'sudo ip addr flush dev {iface}'), then rerun "
+                    f"'smolvm sandbox create --network bridge --bridge {bridge_name}'."
+                )
+        return ""
+
+    def _get_interface_addresses(self, iface_name: str) -> list[str]:
+        """Return IPv4 and IPv6 addresses on an interface (excluding link-local)."""
+        addresses: list[str] = []
+        for _family in ["inet", "inet6"]:
+            try:
+                result = run_command(
+                    ["ip", "-json", "addr", "show", "dev", iface_name],
+                    use_sudo=False,
+                )
+            except SmolVMError:
+                continue
+
+            import json
+
+            info = json.loads(result.stdout)
+            if not info:
+                continue
+            for addr_info in info[0].get("addr_info", []):
+                scope = addr_info.get("scope", "")
+                if scope == "link":
+                    continue
+                addr = addr_info.get("local", "")
+                if addr:
+                    addresses.append(addr)
+        return addresses
+
+    def prepare_bridged_tap(
+        self,
+        tap_name: str,
+        bridge_name: str,
+        user: str | None = None,
+    ) -> None:
+        """Create a TAP device and attach it to an existing bridge.
+
+        Steps:
+        1. Re-validate the bridge.
+        2. Create the TAP (idempotent for existing SmolVM-owned TAPs).
+        3. Attach the TAP to the bridge.
+        4. Bring the TAP up without assigning any address.
+        5. Verify the TAP's master is the requested bridge.
+        6. Delete the TAP if attachment fails.
+        """
+        inspection = self.inspect_bridge(bridge_name)
+        if not inspection.ok:
+            raise NetworkError(inspection.reason or "Bridge validation failed")
+
+        if user is None:
+            user = os.environ.get("USER", "root")
+
+        logger.info("Preparing bridged TAP %s on bridge %s (user: %s)", tap_name, bridge_name, user)
+
+        # Create TAP (idempotent — create_tap handles EEXIST).
+        self.create_tap(tap_name, user)
+
+        # Attach TAP to bridge.
+        try:
+            self._set_tap_master(tap_name, bridge_name)
+        except Exception:
+            # Rollback: delete the TAP we just created.
+            with suppress(Exception):
+                self.cleanup_tap(tap_name)
+            raise
+
+        # Bring the TAP up (no address assignment).
+        try:
+            run_command(["ip", "link", "set", tap_name, "up"], use_sudo=True)
+        except SmolVMError as e:
+            logger.error("Failed to bring up bridged TAP %s: %s", tap_name, e)
+            with suppress(Exception):
+                self.cleanup_tap(tap_name)
+            raise SmolVMError(
+                f"Failed to bring up TAP '{tap_name}' on bridge '{bridge_name}': {e}"
+            ) from e
+
+        # Verify the TAP's master is the requested bridge.
+        master = self._get_tap_master(tap_name)
+        if master != bridge_name:
+            with suppress(Exception):
+                self.cleanup_tap(tap_name)
+            raise NetworkError(
+                f"TAP '{tap_name}' is attached to '{master}', not '{bridge_name}'. "
+                f"Run 'smolvm sandbox delete' for any stale sandbox using this TAP, "
+                f"then retry."
+            )
+
+        logger.info("Bridged TAP %s ready on bridge %s", tap_name, bridge_name)
+
+    async def async_prepare_bridged_tap(
+        self,
+        tap_name: str,
+        bridge_name: str,
+        user: str | None = None,
+    ) -> None:
+        """Create a TAP device and attach it to an existing bridge (async)."""
+        await asyncio.to_thread(self.prepare_bridged_tap, tap_name, bridge_name, user)
+
+    def _set_tap_master(self, tap_name: str, bridge_name: str) -> None:
+        """Set the bridge master for a TAP device."""
+        logger.info("Attaching TAP %s to bridge %s", tap_name, bridge_name)
+        try:
+            run_command(
+                ["ip", "link", "set", "dev", tap_name, "master", bridge_name],
+                use_sudo=True,
+            )
+        except SmolVMError as e:
+            raise SmolVMError(
+                f"Failed to attach TAP '{tap_name}' to bridge '{bridge_name}': {e}"
+            ) from e
+
+    def _get_tap_master(self, tap_name: str) -> str | None:
+        """Return the bridge name a TAP is attached to, or None."""
+        try:
+            result = run_command(
+                ["ip", "-json", "-d", "link", "show", tap_name],
+                use_sudo=False,
+            )
+        except SmolVMError:
+            return None
+
+        import json
+
+        links = json.loads(result.stdout)
+        if not links:
+            return None
+        return links[0].get("master")
 
 
 def _extract_hostname(entry: str) -> str:

--- a/src/smolvm/host/network.py
+++ b/src/smolvm/host/network.py
@@ -2352,10 +2352,23 @@ class NetworkManager:
 
     def cleanup_bridged_tap(self, tap_name: str, vm_id: str) -> None:
         """Delete a bridge TAP only after proving this sandbox owns it."""
-        if self._get_link_info(tap_name) is None:
-            return
-        self._require_owned_bridge_tap(tap_name, vm_id)
-        self.cleanup_tap(tap_name)
+        max_attempts = 4
+        for attempt in range(max_attempts):
+            if self._get_link_info(tap_name) is None:
+                return
+            # Recheck ownership before every retry so a same-named foreign
+            # replacement can never be deleted.
+            self._require_owned_bridge_tap(tap_name, vm_id)
+            self.cleanup_tap(tap_name)
+            if self._get_link_info(tap_name) is None:
+                return
+            if attempt < max_attempts - 1:
+                time.sleep(0.1 * (attempt + 1))
+
+        raise NetworkError(
+            f"Could not remove the network interface for sandbox '{vm_id}'; run "
+            f"'smolvm sandbox delete {vm_id}' again."
+        )
 
     async def async_cleanup_bridged_tap(self, tap_name: str, vm_id: str) -> None:
         """Delete an owned bridge TAP asynchronously."""

--- a/src/smolvm/host/network.py
+++ b/src/smolvm/host/network.py
@@ -23,7 +23,6 @@ from __future__ import annotations
 import asyncio
 import logging
 import os
-import random
 import re
 import socket
 import time
@@ -246,8 +245,8 @@ class NetworkManager:
         """Create and configure a TAP device (async)."""
         await self.async_prepare_tap(tap_name, user=user, host_ip=host_ip, netmask=netmask)
 
-    def create_tap(self, tap_name: str, user: str | None = None) -> None:
-        """Create TAP device if missing."""
+    def create_tap(self, tap_name: str, user: str | None = None) -> bool:
+        """Create a TAP device and return whether this call created it."""
         if not tap_name:
             raise ValueError("tap_name cannot be empty")
 
@@ -262,12 +261,12 @@ class NetworkManager:
             for attempt in range(max_busy_retries + 1):
                 try:
                     _call_native("create_tap", network_native.create_tap, tap_name, uid)
-                    return
+                    return True
                 except OSError as e:
                     err = str(e)
                     if "File exists" in err:
                         logger.debug("TAP device %s already exists", tap_name)
-                        return
+                        return False
                     if "Device or resource busy" in err and attempt < max_busy_retries:
                         delay = 0.1 * (attempt + 1)
                         logger.warning(
@@ -283,19 +282,17 @@ class NetworkManager:
                         _mark_native_unprivileged()
                         break
                     raise SmolVMError(err) from e
-            else:
-                return
 
         max_busy_retries = 3
         for attempt in range(max_busy_retries + 1):
             try:
                 run_command(["ip", "tuntap", "add", tap_name, "mode", "tap", "user", user])
-                return
+                return True
             except SmolVMError as e:
                 err = str(e)
                 if "File exists" in err or "EEXIST" in err:
                     logger.debug("TAP device %s already exists", tap_name)
-                    return
+                    return False
 
                 is_busy = "Device or resource busy" in err or "EBUSY" in err
                 if is_busy and attempt < max_busy_retries:
@@ -311,9 +308,10 @@ class NetworkManager:
                     time.sleep(delay)
                     continue
                 raise
+        raise SmolVMError(f"Failed to create TAP device '{tap_name}'")
 
-    async def async_create_tap(self, tap_name: str, user: str | None = None) -> None:
-        """Create TAP device if missing (async)."""
+    async def async_create_tap(self, tap_name: str, user: str | None = None) -> bool:
+        """Create a TAP asynchronously and return whether this call created it."""
         if not tap_name:
             raise ValueError("tap_name cannot be empty")
 
@@ -328,12 +326,12 @@ class NetworkManager:
             for attempt in range(max_busy_retries + 1):
                 try:
                     await _async_call_native("create_tap", network_native.create_tap, tap_name, uid)
-                    return
+                    return True
                 except OSError as e:
                     err = str(e)
                     if "File exists" in err:
                         logger.debug("TAP device %s already exists", tap_name)
-                        return
+                        return False
                     if "Device or resource busy" in err and attempt < max_busy_retries:
                         delay = 0.1 * (attempt + 1)
                         logger.warning(
@@ -349,8 +347,6 @@ class NetworkManager:
                         _mark_native_unprivileged()
                         break
                     raise SmolVMError(err) from e
-            else:
-                return
 
         max_busy_retries = 3
         for attempt in range(max_busy_retries + 1):
@@ -358,12 +354,12 @@ class NetworkManager:
                 await async_run_command(
                     ["ip", "tuntap", "add", tap_name, "mode", "tap", "user", user]
                 )
-                return
+                return True
             except SmolVMError as e:
                 err = str(e)
                 if "File exists" in err or "EEXIST" in err:
                     logger.debug("TAP device %s already exists", tap_name)
-                    return
+                    return False
 
                 is_busy = "Device or resource busy" in err or "EBUSY" in err
                 if is_busy and attempt < max_busy_retries:
@@ -378,6 +374,7 @@ class NetworkManager:
                     await asyncio.sleep(delay)
                     continue
                 raise
+        raise SmolVMError(f"Failed to create TAP device '{tap_name}'")
 
     def prepare_tap(
         self,
@@ -2064,34 +2061,48 @@ class NetworkManager:
             raise ValueError("vm_number must be between 0 and 65534")
         return f"AA:FC:00:00:{(vm_number >> 8) & 0xFF:02X}:{vm_number & 0xFF:02X}"
 
-    def generate_bridge_mac(self) -> str:
-        """Generate a random locally-administered unicast MAC for bridge mode.
+    def generate_bridge_mac(self, tap_name: str | None = None) -> str:
+        """Generate a locally administered unicast MAC for bridge mode.
 
-        Uses the locally-administered bit (second-least-significant of the
-        first octet) and clears the multicast bit. The AA:FC OUI prefix
-        matches :meth:`generate_mac` so all SmolVM MACs share a recognisable
-        family.
+        Newly allocated bridge TAP names carry a unique 32-bit suffix. Encoding
+        that suffix directly makes MAC allocation unique under the same atomic
+        state reservation. The random fallback supports callers without a TAP.
         """
-        suffix = random.randbytes(3)  # noqa: S311
-        return f"AA:FC:00:{suffix[0]:02X}:{suffix[1]:02X}:{suffix[2]:02X}"
+        if tap_name is not None and re.fullmatch(r"svmb[0-9a-fA-F]{8}", tap_name):
+            suffix = bytes.fromhex(tap_name[4:])
+            return "02:53:" + ":".join(f"{octet:02X}" for octet in suffix)
+        suffix = os.urandom(5)
+        return "02:" + ":".join(f"{octet:02X}" for octet in suffix)
 
     # ------------------------------------------------------------------
     # Bridge inspection and bridged TAP attachment
     # ------------------------------------------------------------------
 
+    def _get_link_info(self, link_name: str) -> dict[str, object] | None:
+        """Return detailed JSON metadata for one Linux network interface."""
+        import json
+
+        try:
+            result = run_command(
+                ["ip", "-json", "-d", "link", "show", "dev", link_name],
+                use_sudo=False,
+            )
+        except SmolVMError:
+            return None
+        links = json.loads(result.stdout)
+        return links[0] if links else None
+
+    @staticmethod
+    def _link_kind(link_info: dict[str, object]) -> str:
+        """Return iproute2's detailed interface kind."""
+        linkinfo = link_info.get("linkinfo")
+        if not isinstance(linkinfo, dict):
+            return ""
+        kind = linkinfo.get("info_kind")
+        return str(kind) if kind is not None else ""
+
     def inspect_bridge(self, bridge_name: str) -> BridgeInspection:
-        """Read-only validation of a Linux bridge for SmolVM attachment.
-
-        Checks:
-        1. The host is Linux.
-        2. The named interface exists.
-        3. It is a Linux bridge (not a VLAN or physical interface).
-        4. The bridge is up.
-        5. It has at least one non-SmolVM member (the external uplink).
-        6. Neither the bridge nor any existing member has an IPv4 or IPv6 address.
-
-        Never mutates the bridge or any of its members.
-        """
+        """Read-only validation of a Linux bridge for SmolVM attachment."""
         import platform
 
         if platform.system() != "Linux":
@@ -2101,75 +2112,51 @@ class NetworkManager:
                 reason="Bridged networking is only supported on Linux.",
             )
 
-        try:
-            result = run_command(
-                ["ip", "-json", "-d", "link", "show", bridge_name],
-                use_sudo=False,
-            )
-        except SmolVMError:
+        link_info = self._get_link_info(bridge_name)
+        if link_info is None:
             return BridgeInspection(
                 bridge_name=bridge_name,
                 ok=False,
-                reason=f"Interface '{bridge_name}' does not exist. "
-                f"Create a bridge such as 'br10', then rerun "
-                f"'smolvm sandbox create --network bridge --bridge {bridge_name}'.",
+                reason=f"Interface '{bridge_name}' does not exist; create it, then run "
+                f"'smolvm bridge check {bridge_name}'.",
             )
 
-        import json
-
-        links = json.loads(result.stdout)
-        if not links:
+        kind = self._link_kind(link_info)
+        if kind != "bridge":
+            display_kind = kind or str(link_info.get("link_type") or "network interface")
             return BridgeInspection(
                 bridge_name=bridge_name,
                 ok=False,
-                reason=f"Interface '{bridge_name}' does not exist. "
-                f"Create a bridge such as 'br10', then rerun "
-                f"'smolvm sandbox create --network bridge --bridge {bridge_name}'.",
+                reason=f"'{bridge_name}' is a {display_kind}, not a bridge; create a Linux "
+                f"bridge, then run 'smolvm bridge check {bridge_name}'.",
             )
 
-        link_info = links[0]
-
-        # Check it's a bridge, not a VLAN or physical interface.
-        link_type = link_info.get("link_type", "")
-        if link_type != "bridge":
+        flags = link_info.get("flags")
+        if not isinstance(flags, list) or "UP" not in flags:
             return BridgeInspection(
                 bridge_name=bridge_name,
                 ok=False,
-                reason=f"'{bridge_name}' is a {link_type or 'network interface'}, not a "
-                f"bridge. Create a bridge such as 'br10', then rerun with "
-                f"'--bridge br10'.",
+                reason=f"Bridge '{bridge_name}' is not active; run "
+                f"'sudo ip link set {bridge_name} up', then run "
+                f"'smolvm bridge check {bridge_name}'.",
             )
 
-        # Check the bridge is up.
-        flags = link_info.get("flags", [])
-        if "UP" not in flags and "LOWER_UP" not in flags:
-            return BridgeInspection(
-                bridge_name=bridge_name,
-                ok=False,
-                reason=f"Bridge '{bridge_name}' is not up. Bring it up with "
-                f"'sudo ip link set {bridge_name} up', then rerun "
-                f"'smolvm sandbox create --network bridge --bridge {bridge_name}'.",
-            )
-
-        # Get bridge members.
         members = self._get_bridge_members(bridge_name)
-        if not members:
+        external_members = [name for name in members if not self._is_smolvm_bridge_tap_member(name)]
+        if not external_members:
             return BridgeInspection(
                 bridge_name=bridge_name,
                 ok=False,
-                reason=f"Bridge '{bridge_name}' has no member interfaces. "
-                f"Add an upstream interface (e.g. 'sudo ip link set eno1.10 "
-                f"master {bridge_name}'), then rerun "
-                f"'smolvm sandbox create --network bridge --bridge {bridge_name}'.",
+                reason=f"Bridge '{bridge_name}' is not connected to another interface; connect "
+                f"its VLAN or physical interface, then run 'smolvm bridge check {bridge_name}'.",
             )
 
-        # Check for host addresses on the bridge and all members.
-        address_errors = self._check_bridge_addresses(bridge_name, members)
-        if address_errors:
+        address_error = self._check_bridge_addresses(bridge_name, members)
+        if address_error:
             return BridgeInspection(
                 bridge_name=bridge_name,
                 ok=False,
-                reason=address_errors,
+                reason=address_error,
             )
 
         return BridgeInspection(bridge_name=bridge_name, ok=True)
@@ -2178,8 +2165,25 @@ class NetworkManager:
         """Read-only validation of a Linux bridge (async)."""
         return await asyncio.to_thread(self.inspect_bridge, bridge_name)
 
+    def _is_smolvm_bridge_tap_member(self, interface_name: str) -> bool:
+        """Return whether a bridge member carries SmolVM's TAP ownership marker."""
+        if not interface_name.startswith("svmb"):
+            return False
+        link_info = self._get_link_info(interface_name)
+        if link_info is None or self._link_kind(link_info) != "tun":
+            return False
+        linkinfo = link_info.get("linkinfo")
+        info_data = linkinfo.get("info_data") if isinstance(linkinfo, dict) else None
+        return (
+            isinstance(info_data, dict)
+            and info_data.get("type") == "tap"
+            and str(link_info.get("ifalias") or "").startswith("smolvm-bridge:")
+        )
+
     def _get_bridge_members(self, bridge_name: str) -> list[str]:
-        """Return non-SmolVM member interface names of a bridge."""
+        """Return every interface currently attached to a bridge."""
+        import json
+
         try:
             result = run_command(
                 ["ip", "-json", "link", "show", "master", bridge_name],
@@ -2188,73 +2192,79 @@ class NetworkManager:
         except SmolVMError:
             return []
 
-        import json
-
         links = json.loads(result.stdout)
-        members: list[str] = []
-        for link in links:
-            name = link.get("ifname", "")
-            if name and not name.startswith("svmb"):
-                members.append(name)
-        return members
+        return [str(link["ifname"]) for link in links if link.get("ifname")]
 
     def _check_bridge_addresses(self, bridge_name: str, members: list[str]) -> str:
-        """Check bridge and members for host IP addresses. Returns error message or empty."""
-        interfaces_to_check = [bridge_name] + members
-        for iface in interfaces_to_check:
-            addrs = self._get_interface_addresses(iface)
-            if addrs:
-                addr_list = ", ".join(addrs)
+        """Return an actionable error when the host has an address on this network."""
+        for iface in [bridge_name, *members]:
+            addresses = self._get_interface_addresses(iface)
+            if addresses:
+                address_list = ", ".join(addresses)
                 return (
-                    f"Interface '{iface}' gives this machine the address "
-                    f"'{addr_list}'. Remove that address "
-                    f"(e.g. 'sudo ip addr flush dev {iface}'), then rerun "
-                    f"'smolvm sandbox create --network bridge --bridge {bridge_name}'."
+                    f"Interface '{iface}' gives this machine the address '{address_list}'; "
+                    f"remove it with your host network manager, then run "
+                    f"'smolvm bridge check {bridge_name}'."
                 )
         return ""
 
     def _get_interface_addresses(self, iface_name: str) -> list[str]:
-        """Return IPv4 and IPv6 addresses on an interface (excluding link-local)."""
-        addresses: list[str] = []
-        for _family in ["inet", "inet6"]:
-            try:
-                result = run_command(
-                    ["ip", "-json", "addr", "show", "dev", iface_name],
-                    use_sudo=False,
-                )
-            except SmolVMError:
-                continue
+        """Return every IPv4 and IPv6 address, including link-local addresses."""
+        import json
 
-            import json
+        try:
+            result = run_command(
+                ["ip", "-json", "addr", "show", "dev", iface_name],
+                use_sudo=False,
+            )
+        except SmolVMError:
+            return []
 
-            info = json.loads(result.stdout)
-            if not info:
-                continue
-            for addr_info in info[0].get("addr_info", []):
-                scope = addr_info.get("scope", "")
-                if scope == "link":
-                    continue
-                addr = addr_info.get("local", "")
-                if addr:
-                    addresses.append(addr)
-        return addresses
+        info = json.loads(result.stdout)
+        if not info:
+            return []
+        return [
+            str(address["local"])
+            for address in info[0].get("addr_info", [])
+            if address.get("local")
+        ]
+
+    @staticmethod
+    def _bridge_tap_alias(vm_id: str) -> str:
+        return f"smolvm-bridge:{vm_id}"
+
+    def _require_owned_bridge_tap(self, tap_name: str, vm_id: str) -> dict[str, object]:
+        """Return link metadata only when a TAP is demonstrably owned by this VM."""
+        link_info = self._get_link_info(tap_name)
+        if link_info is None:
+            raise NetworkError(f"TAP '{tap_name}' does not exist")
+
+        linkinfo = link_info.get("linkinfo")
+        info_data = linkinfo.get("info_data") if isinstance(linkinfo, dict) else None
+        kind = self._link_kind(link_info)
+        tap_type = info_data.get("type") if isinstance(info_data, dict) else None
+        if kind != "tun" or tap_type != "tap":
+            raise NetworkError(
+                f"Network interface '{tap_name}' already exists and is not a SmolVM TAP; "
+                f"remove the conflicting interface, then retry sandbox '{vm_id}'."
+            )
+
+        expected_alias = self._bridge_tap_alias(vm_id)
+        if link_info.get("ifalias") != expected_alias:
+            raise NetworkError(
+                f"Network interface '{tap_name}' already exists but does not belong to sandbox "
+                f"'{vm_id}'; remove the conflicting interface, then retry."
+            )
+        return link_info
 
     def prepare_bridged_tap(
         self,
         tap_name: str,
         bridge_name: str,
+        vm_id: str,
         user: str | None = None,
     ) -> None:
-        """Create a TAP device and attach it to an existing bridge.
-
-        Steps:
-        1. Re-validate the bridge.
-        2. Create the TAP (idempotent for existing SmolVM-owned TAPs).
-        3. Attach the TAP to the bridge.
-        4. Bring the TAP up without assigning any address.
-        5. Verify the TAP's master is the requested bridge.
-        6. Delete the TAP if attachment fails.
-        """
+        """Create an owned TAP and attach it to an existing host bridge."""
         inspection = self.inspect_bridge(bridge_name)
         if not inspection.ok:
             raise NetworkError(inspection.reason or "Bridge validation failed")
@@ -2262,41 +2272,54 @@ class NetworkManager:
         if user is None:
             user = os.environ.get("USER", "root")
 
-        logger.info("Preparing bridged TAP %s on bridge %s (user: %s)", tap_name, bridge_name, user)
-
-        # Create TAP (idempotent — create_tap handles EEXIST).
-        self.create_tap(tap_name, user)
-
-        # Attach TAP to bridge.
+        logger.info(
+            "Preparing bridged TAP %s on bridge %s for %s (user: %s)",
+            tap_name,
+            bridge_name,
+            vm_id,
+            user,
+        )
+        created = self.create_tap(tap_name, user)
         try:
+            if created:
+                link_info = self._get_link_info(tap_name)
+                linkinfo = link_info.get("linkinfo") if link_info is not None else None
+                info_data = linkinfo.get("info_data") if isinstance(linkinfo, dict) else None
+                if (
+                    link_info is None
+                    or self._link_kind(link_info) != "tun"
+                    or not isinstance(info_data, dict)
+                    or info_data.get("type") != "tap"
+                ):
+                    raise NetworkError(f"Created interface '{tap_name}' is not a TAP device")
+                run_command(
+                    [
+                        "ip",
+                        "link",
+                        "set",
+                        "dev",
+                        tap_name,
+                        "alias",
+                        self._bridge_tap_alias(vm_id),
+                    ],
+                    use_sudo=True,
+                )
+            else:
+                self._require_owned_bridge_tap(tap_name, vm_id)
+
             self._set_tap_master(tap_name, bridge_name)
+            run_command(["ip", "link", "set", "dev", tap_name, "up"], use_sudo=True)
+            master = self._get_tap_master(tap_name)
+            if master != bridge_name:
+                raise NetworkError(
+                    f"TAP '{tap_name}' is attached to '{master}', not '{bridge_name}'; "
+                    f"run 'smolvm sandbox delete {vm_id}', then retry."
+                )
         except Exception:
-            # Rollback: delete the TAP we just created.
-            with suppress(Exception):
-                self.cleanup_tap(tap_name)
+            if created:
+                with suppress(Exception):
+                    self.cleanup_tap(tap_name)
             raise
-
-        # Bring the TAP up (no address assignment).
-        try:
-            run_command(["ip", "link", "set", tap_name, "up"], use_sudo=True)
-        except SmolVMError as e:
-            logger.error("Failed to bring up bridged TAP %s: %s", tap_name, e)
-            with suppress(Exception):
-                self.cleanup_tap(tap_name)
-            raise SmolVMError(
-                f"Failed to bring up TAP '{tap_name}' on bridge '{bridge_name}': {e}"
-            ) from e
-
-        # Verify the TAP's master is the requested bridge.
-        master = self._get_tap_master(tap_name)
-        if master != bridge_name:
-            with suppress(Exception):
-                self.cleanup_tap(tap_name)
-            raise NetworkError(
-                f"TAP '{tap_name}' is attached to '{master}', not '{bridge_name}'. "
-                f"Run 'smolvm sandbox delete' for any stale sandbox using this TAP, "
-                f"then retry."
-            )
 
         logger.info("Bridged TAP %s ready on bridge %s", tap_name, bridge_name)
 
@@ -2304,10 +2327,22 @@ class NetworkManager:
         self,
         tap_name: str,
         bridge_name: str,
+        vm_id: str,
         user: str | None = None,
     ) -> None:
-        """Create a TAP device and attach it to an existing bridge (async)."""
-        await asyncio.to_thread(self.prepare_bridged_tap, tap_name, bridge_name, user)
+        """Create and attach an owned bridged TAP asynchronously."""
+        await asyncio.to_thread(self.prepare_bridged_tap, tap_name, bridge_name, vm_id, user)
+
+    def cleanup_bridged_tap(self, tap_name: str, vm_id: str) -> None:
+        """Delete a bridge TAP only after proving this sandbox owns it."""
+        if self._get_link_info(tap_name) is None:
+            return
+        self._require_owned_bridge_tap(tap_name, vm_id)
+        self.cleanup_tap(tap_name)
+
+    async def async_cleanup_bridged_tap(self, tap_name: str, vm_id: str) -> None:
+        """Delete an owned bridge TAP asynchronously."""
+        await asyncio.to_thread(self.cleanup_bridged_tap, tap_name, vm_id)
 
     def _set_tap_master(self, tap_name: str, bridge_name: str) -> None:
         """Set the bridge master for a TAP device."""
@@ -2324,20 +2359,10 @@ class NetworkManager:
 
     def _get_tap_master(self, tap_name: str) -> str | None:
         """Return the bridge name a TAP is attached to, or None."""
-        try:
-            result = run_command(
-                ["ip", "-json", "-d", "link", "show", tap_name],
-                use_sudo=False,
-            )
-        except SmolVMError:
+        link_info = self._get_link_info(tap_name)
+        if link_info is None or not link_info.get("master"):
             return None
-
-        import json
-
-        links = json.loads(result.stdout)
-        if not links:
-            return None
-        return links[0].get("master")
+        return str(link_info["master"])
 
 
 def _extract_hostname(entry: str) -> str:

--- a/src/smolvm/host/network.py
+++ b/src/smolvm/host/network.py
@@ -2279,7 +2279,24 @@ class NetworkManager:
             vm_id,
             user,
         )
-        created = self.create_tap(tap_name, user)
+        created = False
+        validated_existing = False
+        existing_link = self._get_link_info(tap_name)
+        if existing_link is not None:
+            self._require_owned_bridge_tap(tap_name, vm_id)
+            validated_existing = True
+        else:
+            try:
+                created = self.create_tap(tap_name, user)
+            except SmolVMError:
+                # Another lifecycle call may have created the reserved TAP
+                # after our read. Reuse it only if the ownership marker proves
+                # it belongs to this sandbox; otherwise preserve the failure.
+                if self._get_link_info(tap_name) is None:
+                    raise
+                self._require_owned_bridge_tap(tap_name, vm_id)
+                validated_existing = True
+
         try:
             if created:
                 link_info = self._get_link_info(tap_name)
@@ -2304,7 +2321,7 @@ class NetworkManager:
                     ],
                     use_sudo=True,
                 )
-            else:
+            elif not validated_existing:
                 self._require_owned_bridge_tap(tap_name, vm_id)
 
             self._set_tap_master(tap_name, bridge_name)

--- a/src/smolvm/images/builder.py
+++ b/src/smolvm/images/builder.py
@@ -1666,7 +1666,7 @@ configure_guest_managed_network() {{
     # inside the image. The interface name is passed as its first argument.
     if [ -x /etc/smolvm/network.sh ]; then
         /etc/smolvm/network.sh eth0
-        return
+        return $?
     fi
 
     # Respect a conventional interfaces file when this image ships ifup.
@@ -1686,13 +1686,17 @@ configure_guest_managed_network() {{
     fi
 
     echo "SmolVM init: eth0 has no guest network configuration; add /etc/smolvm/network.sh" >&2
+    return 1
 }}
 
 if [ -n "$GUEST_MANAGED" ]; then
-    configure_guest_managed_network
+    if configure_guest_managed_network; then
+        log_ts "net-ready"
+    else
+        log_ts "net-config-failed"
+    fi
     hostname {custom_hostname}
     log_ts "net-config-done"
-    log_ts "net-ready"
 else
     if [ -n "$IP_CONFIG" ]; then
         IP_FIELDS=$(echo "$IP_CONFIG" | cut -d= -f2-)

--- a/src/smolvm/images/builder.py
+++ b/src/smolvm/images/builder.py
@@ -1658,10 +1658,38 @@ netmask_to_prefix() {{
 
 IP_CONFIG=$(cat /proc/cmdline | tr ' ' '\n' | grep '^ip=' | head -1)
 GUEST_MANAGED=$(cat /proc/cmdline | tr ' ' '\n' | grep '^smolvm.network=guest' | head -1)
-if [ -n "$GUEST_MANAGED" ]; then
-    # Bridge mode: bring the link up but let the guest configure its own address.
+
+configure_guest_managed_network() {{
     ip link set lo up
+
+    # A custom hook is the authoritative static/DHCP configuration supplied
+    # inside the image. The interface name is passed as its first argument.
+    if [ -x /etc/smolvm/network.sh ]; then
+        /etc/smolvm/network.sh eth0
+        return
+    fi
+
+    # Respect a conventional interfaces file when this image ships ifup.
+    if command -v ifup >/dev/null 2>&1 \
+        && grep -Eq '^[[:space:]]*iface[[:space:]]+eth0' /etc/network/interfaces 2>/dev/null \
+        && ifup eth0; then
+        return
+    fi
+
+    # SmolVM-provided images use guest-side DHCP when no static hook exists.
     ip link set eth0 up 2>/dev/null || true
+    if command -v udhcpc >/dev/null 2>&1 && udhcpc -q -n -t 5 -i eth0; then
+        return
+    fi
+    if command -v dhclient >/dev/null 2>&1 && dhclient -1 eth0; then
+        return
+    fi
+
+    echo "SmolVM init: eth0 has no guest network configuration; add /etc/smolvm/network.sh" >&2
+}}
+
+if [ -n "$GUEST_MANAGED" ]; then
+    configure_guest_managed_network
     hostname {custom_hostname}
     log_ts "net-config-done"
     log_ts "net-ready"
@@ -1680,7 +1708,7 @@ else
     PREFIX=$(netmask_to_prefix "$NETMASK") || PREFIX=24
 
     ip link set lo up
-    ip link set eth0 up
+    ip link set eth0 up 2>/dev/null || true
     ip addr add "${{GUEST_IP}}/${{PREFIX}}" dev eth0 2>/dev/null || true
     ip route add default via "${{GATEWAY}}" dev eth0 2>/dev/null || true
 

--- a/src/smolvm/images/builder.py
+++ b/src/smolvm/images/builder.py
@@ -1657,36 +1657,47 @@ netmask_to_prefix() {{
 }}
 
 IP_CONFIG=$(cat /proc/cmdline | tr ' ' '\n' | grep '^ip=' | head -1)
-if [ -n "$IP_CONFIG" ]; then
-    IP_FIELDS=$(echo "$IP_CONFIG" | cut -d= -f2-)
-    GUEST_IP=$(echo "$IP_FIELDS" | cut -d: -f1)
-    GATEWAY=$(echo "$IP_FIELDS" | cut -d: -f3)
-    NETMASK=$(echo "$IP_FIELDS" | cut -d: -f4)
+GUEST_MANAGED=$(cat /proc/cmdline | tr ' ' '\n' | grep '^smolvm.network=guest' | head -1)
+if [ -n "$GUEST_MANAGED" ]; then
+    # Bridge mode: bring the link up but let the guest configure its own address.
+    ip link set lo up
+    ip link set eth0 up 2>/dev/null || true
+    hostname {custom_hostname}
+    log_ts "net-config-done"
+    log_ts "net-ready"
 else
-    GUEST_IP="172.16.0.2"
-    GATEWAY="172.16.0.1"
-    NETMASK="255.255.255.0"
+    if [ -n "$IP_CONFIG" ]; then
+        IP_FIELDS=$(echo "$IP_CONFIG" | cut -d= -f2-)
+        GUEST_IP=$(echo "$IP_FIELDS" | cut -d: -f1)
+        GATEWAY=$(echo "$IP_FIELDS" | cut -d: -f3)
+        NETMASK=$(echo "$IP_FIELDS" | cut -d: -f4)
+    else
+        GUEST_IP="172.16.0.2"
+        GATEWAY="172.16.0.1"
+        NETMASK="255.255.255.0"
+    fi
+
+    PREFIX=$(netmask_to_prefix "$NETMASK") || PREFIX=24
+
+    ip link set lo up
+    ip link set eth0 up
+    ip addr add "${{GUEST_IP}}/${{PREFIX}}" dev eth0 2>/dev/null || true
+    ip route add default via "${{GATEWAY}}" dev eth0 2>/dev/null || true
+
+    # DNS
+    if [ -n "$GATEWAY" ]; then
+        echo "nameserver ${{GATEWAY}}" > /etc/resolv.conf
+        echo "nameserver 8.8.8.8" >> /etc/resolv.conf
+        echo "nameserver 8.8.4.4" >> /etc/resolv.conf
+    else
+        echo "nameserver 8.8.8.8" > /etc/resolv.conf
+        echo "nameserver 8.8.4.4" >> /etc/resolv.conf
+    fi
+
+    hostname {custom_hostname}
+    log_ts "net-config-done"
+    log_ts "net-ready"
 fi
-
-PREFIX=$(netmask_to_prefix "$NETMASK") || PREFIX=24
-
-ip link set lo up
-ip link set eth0 up
-ip addr add "${{GUEST_IP}}/${{PREFIX}}" dev eth0 2>/dev/null || true
-ip route add default via "${{GATEWAY}}" dev eth0 2>/dev/null || true
-
-# DNS
-if [ -n "$GATEWAY" ]; then
-    echo "nameserver ${{GATEWAY}}" > /etc/resolv.conf
-    echo "nameserver 8.8.8.8" >> /etc/resolv.conf
-    echo "nameserver 8.8.4.4" >> /etc/resolv.conf
-else
-    echo "nameserver 8.8.8.8" > /etc/resolv.conf
-    echo "nameserver 8.8.4.4" >> /etc/resolv.conf
-fi
-
-hostname {custom_hostname}
-log_ts "net-ready"
 
 # ── Clock sync (host-sleep drift) ────────────────────────────
 # The guest tracks time with its own clocksource (the TSC under

--- a/src/smolvm/runtime/qemu_args.py
+++ b/src/smolvm/runtime/qemu_args.py
@@ -177,7 +177,9 @@ def build_qemu_argv(
     # device managed by NetworkManager, giving the guest a real routable IP
     # and bringing it under the same nftables NAT/isolation rules as the
     # Firecracker backend (egress masquerade, cross-sandbox drop, IMDS block).
-    tap_mode = vm_info.config.qemu_network == "tap"
+    tap_mode = vm_info.config.qemu_network == "tap" or (
+        vm_info.network is not None and vm_info.network.mode == "bridge"
+    )
 
     if vm_info.network is None:
         raise SmolVMError("QEMU backend requires a VM network config")

--- a/src/smolvm/storage/_postgres.py
+++ b/src/smolvm/storage/_postgres.py
@@ -65,6 +65,7 @@ logger = logging.getLogger(__name__)
 _ADVISORY_LOCK_IP = 1
 _ADVISORY_LOCK_SSH = 2
 _ADVISORY_LOCK_VSOCK = 3
+_ADVISORY_LOCK_TAP = 4
 
 
 def _require_psycopg() -> None:
@@ -607,13 +608,31 @@ class PostgresStateManager:
         now = now_iso()
 
         with self._pool.connection() as conn:
-            conn.execute("SELECT pg_advisory_xact_lock(%s)", (_ADVISORY_LOCK_VSOCK + 10,))
+            conn.execute("SELECT pg_advisory_xact_lock(%s)", (_ADVISORY_LOCK_TAP,))
 
             existing = conn.execute(
-                "SELECT tap_device FROM tap_allocations WHERE vm_id = %s", (vm_id,)
+                """
+                SELECT tap_device, mode, bridge_name
+                FROM tap_allocations
+                WHERE vm_id = %s
+                """,
+                (vm_id,),
             ).fetchone()
             if existing:
-                return str(existing["tap_device"])
+                existing_tap = str(existing["tap_device"])
+                existing_mode = str(existing["mode"])
+                existing_bridge = existing["bridge_name"]
+                if (
+                    existing_mode != mode
+                    or existing_bridge != bridge_name
+                    or (requested_tap is not None and requested_tap != existing_tap)
+                ):
+                    raise NetworkError(
+                        f"Sandbox '{vm_id}' already reserves TAP '{existing_tap}' for "
+                        f"{existing_mode} networking; delete the sandbox before changing "
+                        "its network attachment."
+                    )
+                return existing_tap
 
             if requested_tap:
                 clash = conn.execute(
@@ -621,9 +640,7 @@ class PostgresStateManager:
                     (requested_tap,),
                 ).fetchone()
                 if clash:
-                    raise NetworkError(
-                        f"TAP device name '{requested_tap}' is already reserved"
-                    )
+                    raise NetworkError(f"TAP device name '{requested_tap}' is already reserved")
                 tap_name = requested_tap
             else:
                 import secrets

--- a/src/smolvm/storage/_postgres.py
+++ b/src/smolvm/storage/_postgres.py
@@ -152,6 +152,18 @@ class PostgresStateManager:
 
                 CREATE INDEX IF NOT EXISTS idx_vsock_cids_vm_id ON vsock_cids(vm_id);
 
+                CREATE TABLE IF NOT EXISTS tap_allocations (
+                    vm_id TEXT PRIMARY KEY,
+                    tap_device TEXT NOT NULL UNIQUE,
+                    mode TEXT NOT NULL,
+                    bridge_name TEXT,
+                    created_at TEXT NOT NULL,
+                    FOREIGN KEY (vm_id) REFERENCES vms(id) ON DELETE CASCADE
+                );
+
+                CREATE INDEX IF NOT EXISTS idx_tap_allocations_tap_device
+                    ON tap_allocations(tap_device);
+
                 CREATE TABLE IF NOT EXISTS browser_sessions (
                     session_id TEXT PRIMARY KEY,
                     vm_id TEXT NOT NULL UNIQUE,
@@ -574,6 +586,89 @@ class PostgresStateManager:
         with self._pool.connection() as conn:
             conn.execute("DELETE FROM vsock_cids WHERE vm_id = %s", (vm_id,))
             logger.info("Released vsock CID for VM: %s", vm_id)
+
+    # ------------------------------------------------------------------
+    # TAP allocation (bridge mode)
+    # ------------------------------------------------------------------
+
+    def reserve_tap_name(
+        self,
+        vm_id: str,
+        mode: str,
+        bridge_name: str | None = None,
+        requested_tap: str | None = None,
+    ) -> str:
+        """Reserve a unique TAP device name for a VM (idempotent)."""
+        if not vm_id:
+            raise ValueError("vm_id cannot be empty")
+        if mode not in ("nat", "bridge"):
+            raise ValueError(f"mode must be 'nat' or 'bridge', got {mode!r}")
+
+        now = now_iso()
+
+        with self._pool.connection() as conn:
+            conn.execute("SELECT pg_advisory_xact_lock(%s)", (_ADVISORY_LOCK_VSOCK + 10,))
+
+            existing = conn.execute(
+                "SELECT tap_device FROM tap_allocations WHERE vm_id = %s", (vm_id,)
+            ).fetchone()
+            if existing:
+                return str(existing["tap_device"])
+
+            if requested_tap:
+                clash = conn.execute(
+                    "SELECT 1 FROM tap_allocations WHERE tap_device = %s",
+                    (requested_tap,),
+                ).fetchone()
+                if clash:
+                    raise NetworkError(
+                        f"TAP device name '{requested_tap}' is already reserved"
+                    )
+                tap_name = requested_tap
+            else:
+                import secrets
+
+                for _ in range(100):
+                    suffix = secrets.token_hex(4)
+                    tap_name = f"svmb{suffix}"
+                    clash = conn.execute(
+                        "SELECT 1 FROM tap_allocations WHERE tap_device = %s",
+                        (tap_name,),
+                    ).fetchone()
+                    if not clash:
+                        break
+                else:
+                    raise NetworkError("Could not find a free TAP device name")
+
+            conn.execute(
+                """
+                INSERT INTO tap_allocations (vm_id, tap_device, mode, bridge_name, created_at)
+                VALUES (%s, %s, %s, %s, %s)
+                """,
+                (vm_id, tap_name, mode, bridge_name, now),
+            )
+            logger.info("Reserved TAP %s for VM %s (mode=%s)", tap_name, vm_id, mode)
+            return tap_name
+
+    def get_tap_allocation(self, vm_id: str) -> tuple[str, str, str | None] | None:
+        """Return (tap_device, mode, bridge_name) or None."""
+        if not vm_id:
+            raise ValueError("vm_id cannot be empty")
+        with self._pool.connection() as conn:
+            row = conn.execute(
+                "SELECT tap_device, mode, bridge_name FROM tap_allocations WHERE vm_id = %s",
+                (vm_id,),
+            ).fetchone()
+        if row:
+            return (str(row["tap_device"]), str(row["mode"]), row["bridge_name"])
+        return None
+
+    def release_tap_name(self, vm_id: str) -> None:
+        if not vm_id:
+            raise ValueError("vm_id cannot be empty")
+        with self._pool.connection() as conn:
+            conn.execute("DELETE FROM tap_allocations WHERE vm_id = %s", (vm_id,))
+            logger.info("Released TAP allocation for VM: %s", vm_id)
 
     # ------------------------------------------------------------------
     # Snapshots

--- a/src/smolvm/storage/_protocol.py
+++ b/src/smolvm/storage/_protocol.py
@@ -131,6 +131,25 @@ class StateManagerProtocol(Protocol):
         pass
 
     # ------------------------------------------------------------------
+    # TAP allocation (bridge mode)
+    # ------------------------------------------------------------------
+
+    def reserve_tap_name(
+        self,
+        vm_id: str,
+        mode: str,
+        bridge_name: str | None = None,
+        requested_tap: str | None = None,
+    ) -> str:
+        pass
+
+    def get_tap_allocation(self, vm_id: str) -> tuple[str, str, str | None] | None:
+        pass
+
+    def release_tap_name(self, vm_id: str) -> None:
+        pass
+
+    # ------------------------------------------------------------------
     # Snapshots
     # ------------------------------------------------------------------
 

--- a/src/smolvm/storage/_sqlite.py
+++ b/src/smolvm/storage/_sqlite.py
@@ -146,6 +146,18 @@ class SQLiteStateManager:
 
                 CREATE INDEX IF NOT EXISTS idx_vsock_cids_vm_id ON vsock_cids(vm_id);
 
+                CREATE TABLE IF NOT EXISTS tap_allocations (
+                    vm_id TEXT PRIMARY KEY,
+                    tap_device TEXT NOT NULL UNIQUE,
+                    mode TEXT NOT NULL,
+                    bridge_name TEXT,
+                    created_at TEXT NOT NULL,
+                    FOREIGN KEY (vm_id) REFERENCES vms(id) ON DELETE CASCADE
+                );
+
+                CREATE INDEX IF NOT EXISTS idx_tap_allocations_tap_device
+                    ON tap_allocations(tap_device);
+
                 CREATE TABLE IF NOT EXISTS browser_sessions (
                     session_id TEXT PRIMARY KEY,
                     vm_id TEXT NOT NULL UNIQUE,
@@ -581,6 +593,99 @@ class SQLiteStateManager:
             result = conn.execute("DELETE FROM vsock_cids WHERE vm_id = ?", (vm_id,))
             if result.rowcount > 0:
                 logger.info("Released vsock CID for VM: %s", vm_id)
+
+    # ------------------------------------------------------------------
+    # TAP allocation (bridge mode)
+    # ------------------------------------------------------------------
+
+    def reserve_tap_name(
+        self,
+        vm_id: str,
+        mode: str,
+        bridge_name: str | None = None,
+        requested_tap: str | None = None,
+    ) -> str:
+        """Reserve a unique TAP device name for a VM (idempotent).
+
+        Returns the existing reservation if the VM already has one.
+        Otherwise allocates a Linux-safe name (<=15 bytes) prefixed with
+        ``svmb`` followed by a random hex suffix, or the requested name if
+        provided and available.
+        """
+        if not vm_id:
+            raise ValueError("vm_id cannot be empty")
+        if mode not in ("nat", "bridge"):
+            raise ValueError(f"mode must be 'nat' or 'bridge', got {mode!r}")
+
+        now = now_iso()
+
+        with self._get_connection(exclusive=True) as conn:
+            existing = conn.execute(
+                "SELECT tap_device FROM tap_allocations WHERE vm_id = ?", (vm_id,)
+            ).fetchone()
+            if existing:
+                return str(existing["tap_device"])
+
+            if requested_tap:
+                clash = conn.execute(
+                    "SELECT 1 FROM tap_allocations WHERE tap_device = ?",
+                    (requested_tap,),
+                ).fetchone()
+                if clash:
+                    raise NetworkError(
+                        f"TAP device name '{requested_tap}' is already reserved"
+                    )
+                tap_name = requested_tap
+            else:
+                import secrets
+
+                for _ in range(100):
+                    suffix = secrets.token_hex(4)
+                    tap_name = f"svmb{suffix}"
+                    clash = conn.execute(
+                        "SELECT 1 FROM tap_allocations WHERE tap_device = ?",
+                        (tap_name,),
+                    ).fetchone()
+                    if not clash:
+                        break
+                else:
+                    raise NetworkError("Could not find a free TAP device name")
+
+            conn.execute(
+                """
+                INSERT INTO tap_allocations (vm_id, tap_device, mode, bridge_name, created_at)
+                VALUES (?, ?, ?, ?, ?)
+                """,
+                (vm_id, tap_name, mode, bridge_name, now),
+            )
+            logger.info("Reserved TAP %s for VM %s (mode=%s)", tap_name, vm_id, mode)
+            return tap_name
+
+    def get_tap_allocation(self, vm_id: str) -> tuple[str, str, str | None] | None:
+        """Return (tap_device, mode, bridge_name) or None."""
+        if not vm_id:
+            raise ValueError("vm_id cannot be empty")
+
+        with self._get_connection() as conn:
+            row = conn.execute(
+                "SELECT tap_device, mode, bridge_name FROM tap_allocations WHERE vm_id = ?",
+                (vm_id,),
+            ).fetchone()
+
+        if row:
+            return (str(row["tap_device"]), str(row["mode"]), row["bridge_name"])
+        return None
+
+    def release_tap_name(self, vm_id: str) -> None:
+        if not vm_id:
+            raise ValueError("vm_id cannot be empty")
+
+        with self._get_connection(exclusive=True) as conn:
+            result = conn.execute(
+                "DELETE FROM tap_allocations WHERE vm_id = ?", (vm_id,)
+            )
+            if result.rowcount > 0:
+                logger.info("Released TAP allocation for VM: %s", vm_id)
 
     # ------------------------------------------------------------------
     # Snapshots

--- a/src/smolvm/storage/_sqlite.py
+++ b/src/smolvm/storage/_sqlite.py
@@ -621,10 +621,28 @@ class SQLiteStateManager:
 
         with self._get_connection(exclusive=True) as conn:
             existing = conn.execute(
-                "SELECT tap_device FROM tap_allocations WHERE vm_id = ?", (vm_id,)
+                """
+                SELECT tap_device, mode, bridge_name
+                FROM tap_allocations
+                WHERE vm_id = ?
+                """,
+                (vm_id,),
             ).fetchone()
             if existing:
-                return str(existing["tap_device"])
+                existing_tap = str(existing["tap_device"])
+                existing_mode = str(existing["mode"])
+                existing_bridge = existing["bridge_name"]
+                if (
+                    existing_mode != mode
+                    or existing_bridge != bridge_name
+                    or (requested_tap is not None and requested_tap != existing_tap)
+                ):
+                    raise NetworkError(
+                        f"Sandbox '{vm_id}' already reserves TAP '{existing_tap}' for "
+                        f"{existing_mode} networking; delete the sandbox before changing "
+                        "its network attachment."
+                    )
+                return existing_tap
 
             if requested_tap:
                 clash = conn.execute(
@@ -632,9 +650,7 @@ class SQLiteStateManager:
                     (requested_tap,),
                 ).fetchone()
                 if clash:
-                    raise NetworkError(
-                        f"TAP device name '{requested_tap}' is already reserved"
-                    )
+                    raise NetworkError(f"TAP device name '{requested_tap}' is already reserved")
                 tap_name = requested_tap
             else:
                 import secrets
@@ -681,9 +697,7 @@ class SQLiteStateManager:
             raise ValueError("vm_id cannot be empty")
 
         with self._get_connection(exclusive=True) as conn:
-            result = conn.execute(
-                "DELETE FROM tap_allocations WHERE vm_id = ?", (vm_id,)
-            )
+            result = conn.execute("DELETE FROM tap_allocations WHERE vm_id = ?", (vm_id,))
             if result.rowcount > 0:
                 logger.info("Released TAP allocation for VM: %s", vm_id)
 

--- a/src/smolvm/types.py
+++ b/src/smolvm/types.py
@@ -342,9 +342,7 @@ class NetworkAttachmentConfig(BaseModel):
         if not v:
             raise ValueError("bridge name cannot be empty or whitespace")
         if len(v) > 15:
-            raise ValueError(
-                f"bridge name must be 15 bytes or fewer (got {len(v)} bytes: {v!r})"
-            )
+            raise ValueError(f"bridge name must be 15 bytes or fewer (got {len(v)} bytes: {v!r})")
         if not re.match(r"^[a-zA-Z0-9_.-]+$", v):
             raise ValueError(
                 f"bridge name contains characters that are not valid in a Linux "
@@ -549,9 +547,7 @@ class VMConfig(BaseModel):
                 "comm_channel='ssh' is not supported with bridge mode."
             )
         if self.workspace_mounts:
-            raise ValueError(
-                "Workspace mounts are not supported with bridge mode in this release."
-            )
+            raise ValueError("Workspace mounts are not supported with bridge mode in this release.")
         if self.port_forwards:
             raise ValueError(
                 "Port forwards are not supported with bridge mode; "
@@ -776,9 +772,9 @@ class NetworkConfig(BaseModel):
         mode = data.get("mode", "nat")
         if mode == "nat":
             if data.get("gateway_ip") is None:
-                data.setdefault("gateway_ip", "172.16.0.1")
+                data["gateway_ip"] = "172.16.0.1"
             if data.get("netmask") is None:
-                data.setdefault("netmask", "255.255.255.0")
+                data["netmask"] = "255.255.255.0"
         return data
 
     @model_validator(mode="after")

--- a/src/smolvm/types.py
+++ b/src/smolvm/types.py
@@ -428,6 +428,10 @@ class VMConfig(BaseModel):
             ``smolvm.authorized_key_b64=<base64>`` and read by ``/init``. Use
             this for published pre-built images that don't bake keys at build
             time, so each VM gets the launching user's key without rebuilding.
+        guest_managed_networking: Whether the guest image understands
+            ``smolvm.network=guest`` and can configure its own interface.
+            Required for bridge mode so older cached or custom images cannot
+            silently boot without usable networking.
     """
 
     vm_id: Annotated[
@@ -463,6 +467,7 @@ class VMConfig(BaseModel):
     internet_settings: InternetSettings | None = None
     workspace_mounts: list[WorkspaceMount] = []
     ssh_public_key: str | None = None
+    guest_managed_networking: bool = False
     network_attachment: NetworkAttachmentConfig = Field(default_factory=NetworkAttachmentConfig)
 
     @property
@@ -541,6 +546,12 @@ class VMConfig(BaseModel):
         """Reject feature combinations not supported by bridge mode in v1."""
         if self.network_attachment.mode != "bridge":
             return self
+        if not self.guest_managed_networking:
+            raise ValueError(
+                "Bridge mode requires an image that supports guest-managed networking; "
+                "use a current SmolVM Alpine image or set guest_managed_networking=True "
+                "for a compatible custom image."
+            )
         if self.comm_channel == "ssh":
             raise ValueError(
                 "Bridge mode requires vsock for host-guest communication; "

--- a/src/smolvm/types.py
+++ b/src/smolvm/types.py
@@ -14,6 +14,7 @@
 
 """Core types and Pydantic models for SmolVM SDK."""
 
+import re
 from datetime import datetime
 from enum import Enum
 from pathlib import Path
@@ -317,6 +318,54 @@ class InternetSettings(BaseModel):
     model_config = {"frozen": True}
 
 
+class NetworkAttachmentConfig(BaseModel):
+    """Product-level network attachment mode for a VM.
+
+    Attributes:
+        mode: ``"nat"`` (default) keeps the current SmolVM private network
+            with NAT, port forwarding, and domain controls. ``"bridge"``
+            connects the VM directly to an existing host bridge so it
+            appears as a regular machine on that network.
+        bridge: Name of the Linux bridge to attach to. Required when
+            ``mode="bridge"``; rejected when ``mode="nat"``.
+    """
+
+    mode: Literal["nat", "bridge"] = "nat"
+    bridge: str | None = None
+
+    @field_validator("bridge")
+    @classmethod
+    def validate_bridge_name(cls, v: str | None) -> str | None:
+        if v is None:
+            return None
+        v = v.strip()
+        if not v:
+            raise ValueError("bridge name cannot be empty or whitespace")
+        if len(v) > 15:
+            raise ValueError(
+                f"bridge name must be 15 bytes or fewer (got {len(v)} bytes: {v!r})"
+            )
+        if not re.match(r"^[a-zA-Z0-9_.-]+$", v):
+            raise ValueError(
+                f"bridge name contains characters that are not valid in a Linux "
+                f"interface name: {v!r}"
+            )
+        return v
+
+    @model_validator(mode="after")
+    def _check_mode_bridge_consistency(self) -> "NetworkAttachmentConfig":
+        if self.mode == "bridge" and self.bridge is None:
+            raise ValueError("mode='bridge' requires a bridge name")
+        if self.mode == "nat" and self.bridge is not None:
+            raise ValueError(
+                "mode='nat' does not accept a bridge name; "
+                "use mode='bridge' with --bridge to connect to a host bridge"
+            )
+        return self
+
+    model_config = {"frozen": True}
+
+
 class VMConfig(BaseModel):
     """Configuration for creating a microVM.
 
@@ -416,6 +465,7 @@ class VMConfig(BaseModel):
     internet_settings: InternetSettings | None = None
     workspace_mounts: list[WorkspaceMount] = []
     ssh_public_key: str | None = None
+    network_attachment: NetworkAttachmentConfig = Field(default_factory=NetworkAttachmentConfig)
 
     @property
     def effective_rootfs_format(self) -> RootfsFormat:
@@ -487,6 +537,32 @@ class VMConfig(BaseModel):
         if not _should_validate_paths(info):
             return v
         return cls._validate_file_path(v)
+
+    @model_validator(mode="after")
+    def _check_bridge_mode_constraints(self) -> "VMConfig":
+        """Reject feature combinations not supported by bridge mode in v1."""
+        if self.network_attachment.mode != "bridge":
+            return self
+        if self.comm_channel == "ssh":
+            raise ValueError(
+                "Bridge mode requires vsock for host-guest communication; "
+                "comm_channel='ssh' is not supported with bridge mode."
+            )
+        if self.workspace_mounts:
+            raise ValueError(
+                "Workspace mounts are not supported with bridge mode in this release."
+            )
+        if self.port_forwards:
+            raise ValueError(
+                "Port forwards are not supported with bridge mode; "
+                "the VM is directly reachable on the bridged network."
+            )
+        if self.internet_settings is not None and not self.internet_settings.is_allow_all_domains:
+            raise ValueError(
+                "Domain allow-lists are not enforced in bridge mode; "
+                "remove internet_settings or use NAT mode."
+            )
+        return self
 
     @field_validator("extra_drives")
     @classmethod
@@ -671,20 +747,72 @@ class NetworkConfig(BaseModel):
     """Network configuration for a VM.
 
     Attributes:
-        guest_ip: IP address assigned to the guest.
-        gateway_ip: Gateway IP (host side of TAP).
-        netmask: Network mask.
+        guest_ip: IP address assigned to the guest (None in bridge mode).
+        gateway_ip: Gateway IP, host side of TAP (None in bridge mode).
+        netmask: Network mask (None in bridge mode).
         tap_device: Name of the TAP device.
         guest_mac: MAC address for the guest interface.
         ssh_host_port: Optional host TCP port forwarded to guest SSH (22).
+            None in bridge mode.
+        mode: Network mode — ``"nat"`` (default) or ``"bridge"``.
+        bridge: Bridge name when mode is ``"bridge"``; None for NAT.
     """
 
-    guest_ip: str
-    gateway_ip: str = "172.16.0.1"
-    netmask: str = "255.255.255.0"
+    guest_ip: str | None = None
+    gateway_ip: str | None = None
+    netmask: str | None = None
     tap_device: str
     guest_mac: str
     ssh_host_port: int | None = None
+    mode: Literal["nat", "bridge"] = "nat"
+    bridge: str | None = None
+
+    @model_validator(mode="before")
+    @classmethod
+    def _fill_nat_defaults(cls, data: Any) -> Any:
+        """Fill NAT defaults for backward compatibility."""
+        if not isinstance(data, dict):
+            return data
+        mode = data.get("mode", "nat")
+        if mode == "nat":
+            if data.get("gateway_ip") is None:
+                data.setdefault("gateway_ip", "172.16.0.1")
+            if data.get("netmask") is None:
+                data.setdefault("netmask", "255.255.255.0")
+        return data
+
+    @model_validator(mode="after")
+    def _check_nat_bridge_consistency(self) -> "NetworkConfig":
+        if self.mode == "bridge":
+            if self.bridge is None:
+                raise ValueError("mode='bridge' requires a bridge name")
+            if self.guest_ip is not None:
+                raise ValueError(
+                    "mode='bridge' must not set guest_ip; the guest manages its own address"
+                )
+            if self.gateway_ip is not None:
+                raise ValueError(
+                    "mode='bridge' must not set gateway_ip; the guest manages its own gateway"
+                )
+            if self.netmask is not None:
+                raise ValueError(
+                    "mode='bridge' must not set netmask; the guest manages its own netmask"
+                )
+            if self.ssh_host_port is not None:
+                raise ValueError(
+                    "mode='bridge' must not set ssh_host_port; "
+                    "use vsock (smolvm sandbox shell) instead"
+                )
+        elif self.mode == "nat":
+            if self.bridge is not None:
+                raise ValueError("mode='nat' must not set bridge")
+            if self.guest_ip is None:
+                raise ValueError("mode='nat' requires guest_ip")
+            if self.gateway_ip is None:
+                raise ValueError("mode='nat' requires gateway_ip")
+            if self.netmask is None:
+                raise ValueError("mode='nat' requires netmask")
+        return self
 
     model_config = {"frozen": True}
 

--- a/src/smolvm/vm.py
+++ b/src/smolvm/vm.py
@@ -1194,16 +1194,19 @@ class SmolVMManager:
         vm_config: VMConfig | None = None,
     ) -> None:
         """Ensure host-side network resources exist for a restored Firecracker VM."""
-        # Bridge mode: validate bridge and repair TAP, no NAT/route/forward.
+        # Bridge mode: reserve, validate, and repair the owned TAP only.
         if network.mode == "bridge":
-            bridge_name = network.bridge or ""
-            inspection = self.network.inspect_bridge(bridge_name)
-            if not inspection.ok:
+            if vm_config is None:
                 raise SmolVMError(
-                    inspection.reason,
-                    {"vm_id": vm_id, "bridge": bridge_name},
+                    f"Snapshot network settings are incomplete for sandbox '{vm_id}'; run "
+                    f"'smolvm sandbox delete {vm_id}' to remove the restore attempt."
                 )
-            self._repair_bridged_tap(vm_id, network.tap_device, bridge_name)
+            self._ensure_bridge_ready(
+                vm_id,
+                network,
+                config=vm_config,
+                backend=self._backend_for_config(vm_config),
+            )
             return
 
         user = os.environ.get("USER", "root")
@@ -1429,16 +1432,14 @@ class SmolVMManager:
 
         network = vm_info.network
 
-        # Bridge mode: just re-validate the bridge and repair the TAP if needed.
+        # Bridge mode has no host route or NAT to repair.
         if network.mode == "bridge":
-            inspection = self.network.inspect_bridge(network.bridge or "")
-            if not inspection.ok:
-                raise SmolVMError(
-                    inspection.reason,
-                    {"vm_id": vm_info.vm_id, "bridge": network.bridge},
-                )
-            # Repair the TAP if it disappeared (e.g. host reboot).
-            self._repair_bridged_tap(vm_info.vm_id, network.tap_device, network.bridge or "")
+            self._ensure_bridge_ready(
+                vm_info.vm_id,
+                network,
+                config=vm_info.config,
+                backend=backend,
+            )
             return
 
         self.network.add_route(network.guest_ip, network.tap_device)
@@ -1588,58 +1589,106 @@ class SmolVMManager:
         """Whether a VM uses NAT-mode networking (the default)."""
         return config.network_attachment.mode == "nat"
 
-    def _validate_bridge_mode(self, config: VMConfig, backend: str) -> None:
-        """Validate platform, backend, and feature combinations for bridge mode."""
+    def _validate_bridge_mode(
+        self,
+        config: VMConfig,
+        backend: str,
+        resolution: ChannelResolution | None = None,
+    ) -> None:
+        """Validate every bridge invariant before changing host networking."""
         import platform
 
         if platform.system() != "Linux":
             raise SmolVMError(
-                "Bridged networking is only supported on Linux.",
+                f"Bridged networking is unavailable on {platform.system()}; recreate sandbox "
+                f"'{config.vm_id}' with '--network nat'.",
                 {"vm_id": config.vm_id, "host_os": platform.system()},
             )
         if backend not in (BACKEND_FIRECRACKER, BACKEND_QEMU):
             raise SmolVMError(
-                f"Bridged networking is only supported with Firecracker and QEMU "
-                f"(got backend={backend!r}).",
+                f"Bridged networking is unavailable with backend '{backend}'; recreate sandbox "
+                f"'{config.vm_id}' with '--network nat'.",
                 {"vm_id": config.vm_id, "backend": backend},
             )
-        if config.comm_channel == "ssh":
+
+        resolution = resolution or self._resolve_control_channel_for_config(config, backend)
+        if resolution.kind != "vsock":
+            bridge_name = config.network_attachment.bridge
             raise SmolVMError(
-                "Bridged networking requires vsock for host-guest communication; "
-                "comm_channel='ssh' is not supported. Use --comm-channel vsock "
-                "or omit the flag to let SmolVM auto-select vsock.",
+                f"Bridged sandbox '{config.vm_id}' needs fast shell support; run "
+                f"'smolvm sandbox create --name {config.vm_id} --network bridge "
+                f"--bridge {bridge_name} --comm-channel vsock', or use '--network nat'.",
+                {"vm_id": config.vm_id, "resolved_channel": resolution.kind},
+            )
+        if config.guest_os is GuestOS.WINDOWS:
+            raise SmolVMError(
+                f"Bridged networking is unavailable for Windows sandbox '{config.vm_id}'; "
+                "recreate it with '--network nat'.",
+                {"vm_id": config.vm_id, "guest_os": config.guest_os.value},
+            )
+        if config.workspace_mounts:
+            raise SmolVMError(
+                f"Bridged sandbox '{config.vm_id}' cannot share host folders yet; remove "
+                "'--mount', or recreate it with '--network nat'.",
                 {"vm_id": config.vm_id},
             )
+        if config.port_forwards:
+            raise SmolVMError(
+                f"Bridged sandbox '{config.vm_id}' cannot use launch-time port forwarding; "
+                "remove the forwards and connect to its address on the bridged network.",
+                {"vm_id": config.vm_id},
+            )
+        if (
+            config.internet_settings is not None
+            and not config.internet_settings.is_allow_all_domains
+        ):
+            raise SmolVMError(
+                f"Domain controls do not apply to bridged sandbox '{config.vm_id}'; remove the "
+                "domain list, or recreate it with '--network nat'.",
+                {"vm_id": config.vm_id},
+            )
+
         bridge_name = config.network_attachment.bridge
         if not bridge_name:
             raise SmolVMError(
-                "Bridged networking requires a bridge name; "
-                f"run 'smolvm sandbox create --name {config.vm_id} "
-                "--network bridge --bridge <bridge_name>'.",
+                f"Bridged sandbox '{config.vm_id}' has no bridge; recreate it with "
+                f"'smolvm sandbox create --name {config.vm_id} --network bridge --bridge BRIDGE'.",
                 {"vm_id": config.vm_id},
             )
         inspection = self.network.inspect_bridge(bridge_name)
         if not inspection.ok:
             raise SmolVMError(inspection.reason, {"vm_id": config.vm_id, "bridge": bridge_name})
 
+    def _ensure_bridge_ready(
+        self,
+        vm_id: str,
+        network: NetworkConfig,
+        *,
+        config: VMConfig,
+        backend: str,
+    ) -> None:
+        """Validate persisted bridge settings and repair this sandbox's owned TAP."""
+        bridge_name = network.bridge or ""
+        if bridge_name != config.network_attachment.bridge:
+            raise SmolVMError(
+                f"Sandbox '{vm_id}' has inconsistent bridge settings; run "
+                f"'smolvm sandbox delete {vm_id}' to remove it.",
+                {"vm_id": vm_id},
+            )
+        self._validate_bridge_mode(config, backend)
+        self.state.reserve_tap_name(
+            vm_id,
+            mode="bridge",
+            bridge_name=bridge_name,
+            requested_tap=network.tap_device,
+        )
+        self._repair_bridged_tap(vm_id, network.tap_device, bridge_name)
+
     def _repair_bridged_tap(self, vm_id: str, tap_name: str, bridge_name: str) -> None:
-        """Recreate the bridged TAP if it disappeared (e.g. after host reboot)."""
-        from smolvm.utils import run_command
-
-        try:
-            run_command(["ip", "link", "show", tap_name], use_sudo=False)
-            # TAP exists — verify it's on the right bridge.
-            master = self.network._get_tap_master(tap_name)
-            if master == bridge_name:
-                return
-            # Wrong master — delete and recreate.
-            self.network.cleanup_tap(tap_name)
-        except SmolVMError:
-            pass  # TAP doesn't exist — create it below.
-
+        """Create or reattach this sandbox's owned bridge TAP."""
         user = os.environ.get("USER", "root")
-        self.network.prepare_bridged_tap(tap_name, bridge_name, user=user)
-        logger.info("Repaired bridged TAP %s on bridge %s for VM %s", tap_name, bridge_name, vm_id)
+        self.network.prepare_bridged_tap(tap_name, bridge_name, vm_id, user=user)
+        logger.info("Ensured bridged TAP %s on bridge %s for VM %s", tap_name, bridge_name, vm_id)
 
     @staticmethod
     def _local_tcp_port_is_available(host: str, port: int) -> bool:
@@ -1736,6 +1785,12 @@ class SmolVMManager:
         effective_config = config
         if effective_config.backend != backend:
             effective_config = effective_config.model_copy(update={"backend": backend})
+        if (
+            effective_config.network_attachment.mode == "bridge"
+            and backend == BACKEND_QEMU
+            and effective_config.qemu_network != "tap"
+        ):
+            effective_config = effective_config.model_copy(update={"qemu_network": "tap"})
 
         if effective_config.workspace_mounts and backend != BACKEND_QEMU:
             raise SmolVMError(
@@ -1745,6 +1800,9 @@ class SmolVMManager:
                 "used) or pass --backend qemu explicitly.",
                 {"vm_id": effective_config.vm_id, "backend": backend},
             )
+        if self._is_bridge_attachment(effective_config):
+            resolution = self._resolve_control_channel_for_config(effective_config, backend)
+            self._validate_bridge_mode(effective_config, backend, resolution)
 
         with self._vm_create_lock(effective_config.vm_id):
             self._ensure_vm_id_available(effective_config.vm_id)
@@ -1796,6 +1854,42 @@ class SmolVMManager:
 
         try:
             channel_resolution = self._resolve_control_channel_for_config(effective_config, backend)
+
+            if self._is_bridge_attachment(effective_config):
+                self._validate_bridge_mode(effective_config, backend, channel_resolution)
+                bridge_name = effective_config.network_attachment.bridge
+                assert bridge_name is not None
+                tap_name = self.state.reserve_tap_name(
+                    effective_config.vm_id,
+                    mode="bridge",
+                    bridge_name=bridge_name,
+                )
+                network_config = NetworkConfig(
+                    mode="bridge",
+                    bridge=bridge_name,
+                    tap_device=tap_name,
+                    guest_mac=self.network.generate_bridge_mac(tap_name),
+                )
+                vm_info = self.state.update_vm(
+                    effective_config.vm_id,
+                    network=network_config,
+                )
+                vm_info = self._maybe_enable_vsock(effective_config, backend, vm_info)
+                user = os.environ.get("USER", "root")
+                self.network.prepare_bridged_tap(
+                    tap_name,
+                    bridge_name,
+                    effective_config.vm_id,
+                    user=user,
+                )
+                logger.info(
+                    "VM created (bridge): %s (bridge=%s, TAP=%s)",
+                    effective_config.vm_id,
+                    bridge_name,
+                    tap_name,
+                )
+                return vm_info
+
             ssh_forward_required = self._should_reserve_ssh_forward(
                 effective_config,
                 backend,
@@ -1844,38 +1938,6 @@ class SmolVMManager:
                         effective_config.vm_id,
                         backend,
                     )
-                return vm_info
-
-            # --- Bridge mode ---
-            if self._is_bridge_attachment(effective_config):
-                self._validate_bridge_mode(effective_config, backend)
-
-                # Reserve TAP name and generate MAC without IP allocation.
-                bridge_name = effective_config.network_attachment.bridge
-                tap_name = self.state.reserve_tap_name(
-                    effective_config.vm_id,
-                    mode="bridge",
-                    bridge_name=bridge_name,
-                )
-                guest_mac = self.network.generate_bridge_mac()
-
-                user = os.environ.get("USER", "root")
-                self.network.prepare_bridged_tap(tap_name, bridge_name, user=user)
-
-                network_config = NetworkConfig(
-                    mode="bridge",
-                    bridge=bridge_name,
-                    tap_device=tap_name,
-                    guest_mac=guest_mac,
-                )
-                vm_info = self.state.update_vm(effective_config.vm_id, network=network_config)
-                vm_info = self._maybe_enable_vsock(effective_config, backend, vm_info)
-                logger.info(
-                    "VM created (bridge): %s (bridge=%s, TAP=%s)",
-                    effective_config.vm_id,
-                    bridge_name,
-                    tap_name,
-                )
                 return vm_info
 
             # --- NAT TAP mode (Firecracker or QEMU tap) ---
@@ -1993,16 +2055,14 @@ class SmolVMManager:
 
         backend = self._backend_for_vm(vm_info)
 
-        # Bridge mode: revalidate bridge and repair TAP before starting.
+        # Bridge mode: revalidate every dependency and repair the owned TAP.
         if vm_info.network is not None and vm_info.network.mode == "bridge":
-            bridge_name = vm_info.network.bridge or ""
-            inspection = self.network.inspect_bridge(bridge_name)
-            if not inspection.ok:
-                raise SmolVMError(
-                    inspection.reason,
-                    {"vm_id": vm_id, "bridge": bridge_name},
-                )
-            self._repair_bridged_tap(vm_id, vm_info.network.tap_device, bridge_name)
+            self._ensure_bridge_ready(
+                vm_id,
+                vm_info.network,
+                config=vm_info.config,
+                backend=backend,
+            )
 
         if backend == BACKEND_QEMU:
             self._check_qemu_slirp_host_forward_ports(vm_info)
@@ -2475,6 +2535,24 @@ class SmolVMManager:
             )
         effective_snapshot = snapshot.model_copy(update={"vm_config": restore_vm_config})
         adapter = self._runtime_adapter_for_snapshot(effective_snapshot)
+        if effective_snapshot.network_config.mode == "bridge":
+            configured_bridge = effective_snapshot.vm_config.network_attachment.bridge
+            restored_bridge = effective_snapshot.network_config.bridge
+            if configured_bridge != restored_bridge:
+                raise SmolVMError(
+                    f"Snapshot '{snapshot_id}' has inconsistent bridge settings; delete the "
+                    f"snapshot with 'smolvm sandbox snapshot delete {snapshot_id}'.",
+                    {"snapshot_id": snapshot_id, "vm_id": restore_vm_id},
+                )
+            resolution = self._resolve_control_channel_for_config(
+                effective_snapshot.vm_config,
+                effective_snapshot.backend,
+            )
+            self._validate_bridge_mode(
+                effective_snapshot.vm_config,
+                effective_snapshot.backend,
+                resolution,
+            )
         created_vm_record = False
         existing_disk_backup_path: Path | None = None
         existing_disk_sidecars: list[Path] = []
@@ -2498,7 +2576,17 @@ class SmolVMManager:
             if existing_vm is None:
                 self.state.create_vm(persisted_vm_config)
                 created_vm_record = True
-            if effective_snapshot.backend == BACKEND_FIRECRACKER:
+            bridge_restore = effective_snapshot.network_config.mode == "bridge"
+            if bridge_restore:
+                bridge_name = effective_snapshot.network_config.bridge
+                assert bridge_name is not None
+                self.state.reserve_tap_name(
+                    restore_vm_id,
+                    mode="bridge",
+                    bridge_name=bridge_name,
+                    requested_tap=effective_snapshot.network_config.tap_device,
+                )
+            elif effective_snapshot.backend == BACKEND_FIRECRACKER:
                 self.state.allocate_ip(
                     restore_vm_id,
                     effective_snapshot.network_config.tap_device,
@@ -2523,7 +2611,7 @@ class SmolVMManager:
                         "to remove this restore attempt."
                     ) from exc
             self.state.update_vm(restore_vm_id, network=effective_snapshot.network_config)
-            if effective_snapshot.backend == BACKEND_FIRECRACKER:
+            if bridge_restore or effective_snapshot.backend == BACKEND_FIRECRACKER:
                 self._ensure_firecracker_network_for_restore(
                     restore_vm_id,
                     effective_snapshot.network_config,
@@ -2758,6 +2846,12 @@ class SmolVMManager:
         vm_info = self.state.get_vm(vm_id)
         if vm_info.network is None:
             raise SmolVMError("VM has no network configuration", {"vm_id": vm_id})
+        if vm_info.network.mode == "bridge":
+            raise SmolVMError(
+                f"The host has no SSH path to bridged sandbox '{vm_id}'; use "
+                f"'smolvm sandbox shell {vm_id}', or connect from its bridged network.",
+                {"vm_id": vm_id, "network_mode": "bridge"},
+            )
 
         key_opt = ""
         if key_path is not None:
@@ -3184,11 +3278,7 @@ class SmolVMManager:
                 vm_info is not None
                 and vm_info.network is not None
                 and vm_info.network.mode == "bridge"
-            ) or (
-                vm_info is None
-                and tap_alloc is not None
-                and tap_alloc[1] == "bridge"
-            )
+            ) or (tap_alloc is not None and tap_alloc[1] == "bridge")
 
             # Firecracker and QEMU-on-TAP both provision host TAP/NAT/ssh-forward
             # resources; slirp-mode QEMU and libkrun do not. When vm_info is gone
@@ -3204,9 +3294,20 @@ class SmolVMManager:
             if is_bridge:
                 if tap_alloc:
                     tap_device = tap_alloc[0]
-                    with suppress(Exception):
-                        self.network.cleanup_tap(tap_device)
-                    self.state.release_tap_name(vm_id)
+                    try:
+                        self.network.cleanup_bridged_tap(tap_device, vm_id)
+                    except Exception as exc:
+                        # A same-named foreign interface must survive cleanup,
+                        # but it must not prevent the sandbox's other resources
+                        # and persisted reservation from being removed.
+                        logger.warning(
+                            "Did not remove bridge interface %s for %s: %s",
+                            tap_device,
+                            vm_id,
+                            exc,
+                        )
+                    finally:
+                        self.state.release_tap_name(vm_id)
             else:
                 # NAT mode cleanup
                 if uses_tap and ssh_host_port is not None and guest_ip:
@@ -3313,6 +3414,12 @@ class SmolVMManager:
         effective_config = config
         if effective_config.backend != backend:
             effective_config = effective_config.model_copy(update={"backend": backend})
+        if (
+            effective_config.network_attachment.mode == "bridge"
+            and backend == BACKEND_QEMU
+            and effective_config.qemu_network != "tap"
+        ):
+            effective_config = effective_config.model_copy(update={"qemu_network": "tap"})
 
         if effective_config.workspace_mounts and backend != BACKEND_QEMU:
             raise SmolVMError(
@@ -3321,6 +3428,14 @@ class SmolVMManager:
                 "--backend (SmolVM will auto-select QEMU when --mount is "
                 "used) or pass --backend qemu explicitly.",
                 {"vm_id": effective_config.vm_id, "backend": backend},
+            )
+        if self._is_bridge_attachment(effective_config):
+            resolution = self._resolve_control_channel_for_config(effective_config, backend)
+            await asyncio.to_thread(
+                self._validate_bridge_mode,
+                effective_config,
+                backend,
+                resolution,
             )
 
         async with self._async_vm_create_lock(effective_config.vm_id):
@@ -3382,6 +3497,47 @@ class SmolVMManager:
 
         try:
             channel_resolution = self._resolve_control_channel_for_config(effective_config, backend)
+
+            if self._is_bridge_attachment(effective_config):
+                await asyncio.to_thread(
+                    self._validate_bridge_mode,
+                    effective_config,
+                    backend,
+                    channel_resolution,
+                )
+                bridge_name = effective_config.network_attachment.bridge
+                assert bridge_name is not None
+                tap_name = self.state.reserve_tap_name(
+                    effective_config.vm_id,
+                    mode="bridge",
+                    bridge_name=bridge_name,
+                )
+                network_config = NetworkConfig(
+                    mode="bridge",
+                    bridge=bridge_name,
+                    tap_device=tap_name,
+                    guest_mac=self.network.generate_bridge_mac(tap_name),
+                )
+                vm_info = self.state.update_vm(
+                    effective_config.vm_id,
+                    network=network_config,
+                )
+                vm_info = self._maybe_enable_vsock(effective_config, backend, vm_info)
+                user = os.environ.get("USER", "root")
+                await self.network.async_prepare_bridged_tap(
+                    tap_name,
+                    bridge_name,
+                    effective_config.vm_id,
+                    user=user,
+                )
+                logger.info(
+                    "VM created (bridge, async): %s (bridge=%s, TAP=%s)",
+                    effective_config.vm_id,
+                    bridge_name,
+                    tap_name,
+                )
+                return vm_info
+
             ssh_forward_required = self._should_reserve_ssh_forward(
                 effective_config,
                 backend,
@@ -3415,37 +3571,6 @@ class SmolVMManager:
                 )
                 vm_info = self.state.update_vm(effective_config.vm_id, network=network_config)
                 vm_info = self._maybe_enable_vsock(effective_config, backend, vm_info)
-                return vm_info
-
-            # --- Bridge mode (async) ---
-            if self._is_bridge_attachment(effective_config):
-                await asyncio.to_thread(self._validate_bridge_mode, effective_config, backend)
-
-                bridge_name = effective_config.network_attachment.bridge
-                tap_name = self.state.reserve_tap_name(
-                    effective_config.vm_id,
-                    mode="bridge",
-                    bridge_name=bridge_name,
-                )
-                guest_mac = self.network.generate_bridge_mac()
-
-                user = os.environ.get("USER", "root")
-                await self.network.async_prepare_bridged_tap(tap_name, bridge_name, user=user)
-
-                network_config = NetworkConfig(
-                    mode="bridge",
-                    bridge=bridge_name,
-                    tap_device=tap_name,
-                    guest_mac=guest_mac,
-                )
-                vm_info = self.state.update_vm(effective_config.vm_id, network=network_config)
-                vm_info = self._maybe_enable_vsock(effective_config, backend, vm_info)
-                logger.info(
-                    "VM created (bridge, async): %s (bridge=%s, TAP=%s)",
-                    effective_config.vm_id,
-                    bridge_name,
-                    tap_name,
-                )
                 return vm_info
 
             # --- NAT TAP mode (async) ---
@@ -3526,20 +3651,14 @@ class SmolVMManager:
 
         backend = self._backend_for_vm(vm_info)
 
-        # Bridge mode: revalidate bridge and repair TAP before starting.
+        # Bridge mode: revalidate every dependency and repair the owned TAP.
         if vm_info.network is not None and vm_info.network.mode == "bridge":
-            bridge_name = vm_info.network.bridge or ""
-            inspection = await self.network.async_inspect_bridge(bridge_name)
-            if not inspection.ok:
-                raise SmolVMError(
-                    inspection.reason,
-                    {"vm_id": vm_id, "bridge": bridge_name},
-                )
             await asyncio.to_thread(
-                self._repair_bridged_tap,
+                self._ensure_bridge_ready,
                 vm_id,
-                vm_info.network.tap_device,
-                bridge_name,
+                vm_info.network,
+                config=vm_info.config,
+                backend=backend,
             )
 
         if backend == BACKEND_QEMU:
@@ -3785,11 +3904,7 @@ class SmolVMManager:
                 vm_info is not None
                 and vm_info.network is not None
                 and vm_info.network.mode == "bridge"
-            ) or (
-                vm_info is None
-                and tap_alloc is not None
-                and tap_alloc[1] == "bridge"
-            )
+            ) or (tap_alloc is not None and tap_alloc[1] == "bridge")
 
             # See the sync cleanup path for the TAP-vs-slirp rationale.
             if vm_info is not None:
@@ -3800,9 +3915,17 @@ class SmolVMManager:
             if is_bridge:
                 if tap_alloc:
                     tap_device = tap_alloc[0]
-                    with suppress(Exception):
-                        await self.network.async_cleanup_tap(tap_device)
-                    self.state.release_tap_name(vm_id)
+                    try:
+                        await self.network.async_cleanup_bridged_tap(tap_device, vm_id)
+                    except Exception as exc:
+                        logger.warning(
+                            "Did not remove bridge interface %s for %s: %s",
+                            tap_device,
+                            vm_id,
+                            exc,
+                        )
+                    finally:
+                        self.state.release_tap_name(vm_id)
             else:
                 if uses_tap and ssh_host_port is not None and guest_ip:
                     with suppress(Exception):

--- a/src/smolvm/vm.py
+++ b/src/smolvm/vm.py
@@ -43,6 +43,7 @@ from uuid import uuid4
 
 from smolvm.comm.select import ChannelResolution, VsockNotSupportedError, resolve_comm_channel
 from smolvm.exceptions import (
+    BridgeTapOwnershipError,
     NetworkError,
     SmolVMError,
     SnapshotAlreadyExistsError,
@@ -1598,16 +1599,29 @@ class SmolVMManager:
         """Validate every bridge invariant before changing host networking."""
         import platform
 
+        nat_command = f"smolvm sandbox create --name {config.vm_id} --network nat"
         if platform.system() != "Linux":
             raise SmolVMError(
-                f"Bridged networking is unavailable on {platform.system()}; recreate sandbox "
-                f"'{config.vm_id}' with '--network nat'.",
+                f"Bridged networking is unavailable on {platform.system()}; run '{nat_command}'.",
                 {"vm_id": config.vm_id, "host_os": platform.system()},
             )
         if backend not in (BACKEND_FIRECRACKER, BACKEND_QEMU):
             raise SmolVMError(
-                f"Bridged networking is unavailable with backend '{backend}'; recreate sandbox "
-                f"'{config.vm_id}' with '--network nat'.",
+                f"Bridged networking is unavailable with backend '{backend}'; run '{nat_command}'.",
+                {"vm_id": config.vm_id, "backend": backend},
+            )
+        if config.guest_os is GuestOS.WINDOWS:
+            raise SmolVMError(
+                f"Bridged networking is unavailable for Windows sandbox '{config.vm_id}'; "
+                f"run '{nat_command}'.",
+                {"vm_id": config.vm_id, "guest_os": config.guest_os.value},
+            )
+        if not config.guest_managed_networking:
+            bridge_name = config.network_attachment.bridge
+            raise SmolVMError(
+                f"The image for sandbox '{config.vm_id}' cannot configure bridged networking; "
+                f"run 'smolvm sandbox create --name {config.vm_id} --os alpine --backend "
+                f"{backend} --network bridge --bridge {bridge_name}'.",
                 {"vm_id": config.vm_id, "backend": backend},
             )
 
@@ -1617,25 +1631,19 @@ class SmolVMManager:
             raise SmolVMError(
                 f"Bridged sandbox '{config.vm_id}' needs fast shell support; run "
                 f"'smolvm sandbox create --name {config.vm_id} --network bridge "
-                f"--bridge {bridge_name} --comm-channel vsock', or use '--network nat'.",
+                f"--bridge {bridge_name} --comm-channel vsock', or run '{nat_command}'.",
                 {"vm_id": config.vm_id, "resolved_channel": resolution.kind},
-            )
-        if config.guest_os is GuestOS.WINDOWS:
-            raise SmolVMError(
-                f"Bridged networking is unavailable for Windows sandbox '{config.vm_id}'; "
-                "recreate it with '--network nat'.",
-                {"vm_id": config.vm_id, "guest_os": config.guest_os.value},
             )
         if config.workspace_mounts:
             raise SmolVMError(
-                f"Bridged sandbox '{config.vm_id}' cannot share host folders yet; remove "
-                "'--mount', or recreate it with '--network nat'.",
+                f"Bridged sandbox '{config.vm_id}' cannot share host folders yet; run "
+                f"'{nat_command}'.",
                 {"vm_id": config.vm_id},
             )
         if config.port_forwards:
             raise SmolVMError(
                 f"Bridged sandbox '{config.vm_id}' cannot use launch-time port forwarding; "
-                "remove the forwards and connect to its address on the bridged network.",
+                f"run '{nat_command}'.",
                 {"vm_id": config.vm_id},
             )
         if (
@@ -1643,16 +1651,15 @@ class SmolVMManager:
             and not config.internet_settings.is_allow_all_domains
         ):
             raise SmolVMError(
-                f"Domain controls do not apply to bridged sandbox '{config.vm_id}'; remove the "
-                "domain list, or recreate it with '--network nat'.",
+                f"Domain controls do not apply to bridged sandbox '{config.vm_id}'; run "
+                f"'{nat_command}'.",
                 {"vm_id": config.vm_id},
             )
 
         bridge_name = config.network_attachment.bridge
         if not bridge_name:
             raise SmolVMError(
-                f"Bridged sandbox '{config.vm_id}' has no bridge; recreate it with "
-                f"'smolvm sandbox create --name {config.vm_id} --network bridge --bridge BRIDGE'.",
+                f"Bridged sandbox '{config.vm_id}' has no bridge; run '{nat_command}'.",
                 {"vm_id": config.vm_id},
             )
         inspection = self.network.inspect_bridge(bridge_name)
@@ -2740,8 +2747,18 @@ class SmolVMManager:
         if vm_info.status in (VMState.RUNNING, VMState.PAUSED):
             self.stop(vm_id)
 
-        # Cleanup all resources
-        self._cleanup_resources(vm_id)
+        # Cleanup all resources. Bridge deletion is strict so an owned host
+        # interface never outlives the state needed to retry its cleanup.
+        require_bridge_cleanup = (
+            vm_info.network is not None and vm_info.network.mode == "bridge"
+        ) or (
+            (tap_alloc := self.state.get_tap_allocation(vm_id)) is not None
+            and tap_alloc[1] == "bridge"
+        )
+        self._cleanup_resources(
+            vm_id,
+            require_bridge_cleanup=require_bridge_cleanup,
+        )
 
         # Delete from database
         self.state.delete_vm(vm_id)
@@ -3242,13 +3259,21 @@ class SmolVMManager:
         )
         return f"{args} {ip_arg}".strip()
 
-    def _cleanup_resources(self, vm_id: str, *, preserve_managed_disk: bool = False) -> None:
+    def _cleanup_resources(
+        self,
+        vm_id: str,
+        *,
+        preserve_managed_disk: bool = False,
+        require_bridge_cleanup: bool = False,
+    ) -> None:
         """Clean up resources for a VM.
 
         Args:
             vm_id: The VM identifier.
             preserve_managed_disk: Keep the managed disk during create rollback
                 when it existed before this create attempt.
+            require_bridge_cleanup: Abort deletion and retain state when an owned
+                bridge interface cannot be removed.
         """
         try:
             vm_info = None
@@ -3292,22 +3317,37 @@ class SmolVMManager:
             # Bridge mode: clean up TAP and TAP allocation only.
             # No NAT, route, SSH forward, or egress rules to remove.
             if is_bridge:
-                if tap_alloc:
-                    tap_device = tap_alloc[0]
+                tap_device = tap_alloc[0] if tap_alloc else None
+                if tap_device is None and vm_info is not None and vm_info.network is not None:
+                    tap_device = vm_info.network.tap_device
+                if tap_device:
                     try:
                         self.network.cleanup_bridged_tap(tap_device, vm_id)
-                    except Exception as exc:
-                        # A same-named foreign interface must survive cleanup,
-                        # but it must not prevent the sandbox's other resources
-                        # and persisted reservation from being removed.
+                    except BridgeTapOwnershipError as exc:
+                        # The reservation is stale and the foreign replacement
+                        # must survive. It is safe to forget only this stale name.
                         logger.warning(
-                            "Did not remove bridge interface %s for %s: %s",
+                            "Did not remove foreign bridge interface %s for %s: %s",
                             tap_device,
                             vm_id,
                             exc,
                         )
-                    finally:
-                        self.state.release_tap_name(vm_id)
+                        if tap_alloc:
+                            self.state.release_tap_name(vm_id)
+                    except Exception:
+                        # Keep both the VM row and allocation so a later delete
+                        # can retry ownership-checked cleanup.
+                        if require_bridge_cleanup:
+                            raise
+                        logger.warning(
+                            "Could not remove owned bridge interface %s for %s; "
+                            "retaining its reservation",
+                            tap_device,
+                            vm_id,
+                        )
+                    else:
+                        if tap_alloc:
+                            self.state.release_tap_name(vm_id)
             else:
                 # NAT mode cleanup
                 if uses_tap and ssh_host_port is not None and guest_ip:
@@ -3397,6 +3437,8 @@ class SmolVMManager:
 
         except Exception as e:
             logger.warning("Error during cleanup for %s: %s", vm_id, e)
+            if require_bridge_cleanup:
+                raise
 
     # ==================================================================
     # Async lifecycle methods
@@ -3734,7 +3776,16 @@ class SmolVMManager:
         if vm_info.status in (VMState.RUNNING, VMState.PAUSED):
             await self.async_stop(vm_id)
 
-        await self._async_cleanup_resources(vm_id)
+        require_bridge_cleanup = (
+            vm_info.network is not None and vm_info.network.mode == "bridge"
+        ) or (
+            (tap_alloc := self.state.get_tap_allocation(vm_id)) is not None
+            and tap_alloc[1] == "bridge"
+        )
+        await self._async_cleanup_resources(
+            vm_id,
+            require_bridge_cleanup=require_bridge_cleanup,
+        )
         self.state.delete_vm(vm_id)
         logger.info("VM deleted (async): %s", vm_id)
 
@@ -3876,6 +3927,7 @@ class SmolVMManager:
         vm_id: str,
         *,
         preserve_managed_disk: bool = False,
+        require_bridge_cleanup: bool = False,
     ) -> None:
         """Async version of :meth:`_cleanup_resources`."""
         try:
@@ -3913,19 +3965,33 @@ class SmolVMManager:
                 uses_tap = lease is not None or tap_alloc is not None
 
             if is_bridge:
-                if tap_alloc:
-                    tap_device = tap_alloc[0]
+                tap_device = tap_alloc[0] if tap_alloc else None
+                if tap_device is None and vm_info is not None and vm_info.network is not None:
+                    tap_device = vm_info.network.tap_device
+                if tap_device:
                     try:
                         await self.network.async_cleanup_bridged_tap(tap_device, vm_id)
-                    except Exception as exc:
+                    except BridgeTapOwnershipError as exc:
                         logger.warning(
-                            "Did not remove bridge interface %s for %s: %s",
+                            "Did not remove foreign bridge interface %s for %s: %s",
                             tap_device,
                             vm_id,
                             exc,
                         )
-                    finally:
-                        self.state.release_tap_name(vm_id)
+                        if tap_alloc:
+                            self.state.release_tap_name(vm_id)
+                    except Exception:
+                        if require_bridge_cleanup:
+                            raise
+                        logger.warning(
+                            "Could not remove owned bridge interface %s for %s; "
+                            "retaining its reservation",
+                            tap_device,
+                            vm_id,
+                        )
+                    else:
+                        if tap_alloc:
+                            self.state.release_tap_name(vm_id)
             else:
                 if uses_tap and ssh_host_port is not None and guest_ip:
                     with suppress(Exception):
@@ -4007,3 +4073,5 @@ class SmolVMManager:
 
         except Exception as e:
             logger.warning("Error during async cleanup for %s: %s", vm_id, e)
+            if require_bridge_cleanup:
+                raise

--- a/src/smolvm/vm.py
+++ b/src/smolvm/vm.py
@@ -1194,6 +1194,18 @@ class SmolVMManager:
         vm_config: VMConfig | None = None,
     ) -> None:
         """Ensure host-side network resources exist for a restored Firecracker VM."""
+        # Bridge mode: validate bridge and repair TAP, no NAT/route/forward.
+        if network.mode == "bridge":
+            bridge_name = network.bridge or ""
+            inspection = self.network.inspect_bridge(bridge_name)
+            if not inspection.ok:
+                raise SmolVMError(
+                    inspection.reason,
+                    {"vm_id": vm_id, "bridge": bridge_name},
+                )
+            self._repair_bridged_tap(vm_id, network.tap_device, bridge_name)
+            return
+
         user = os.environ.get("USER", "root")
         self.network.prepare_tap_device(
             network.tap_device,
@@ -1416,6 +1428,19 @@ class SmolVMManager:
             return
 
         network = vm_info.network
+
+        # Bridge mode: just re-validate the bridge and repair the TAP if needed.
+        if network.mode == "bridge":
+            inspection = self.network.inspect_bridge(network.bridge or "")
+            if not inspection.ok:
+                raise SmolVMError(
+                    inspection.reason,
+                    {"vm_id": vm_info.vm_id, "bridge": network.bridge},
+                )
+            # Repair the TAP if it disappeared (e.g. host reboot).
+            self._repair_bridged_tap(vm_info.vm_id, network.tap_device, network.bridge or "")
+            return
+
         self.network.add_route(network.guest_ip, network.tap_device)
         self.network.setup_nat(network.tap_device)
 
@@ -1543,12 +1568,78 @@ class SmolVMManager:
         nftables NAT/isolation rules (egress masquerade, cross-sandbox drop,
         IMDS block); slirp VMs rely on QEMU userspace NAT + host port
         forwards instead.
+
+        Bridge-mode VMs also use a host TAP, but the TAP is attached to a
+        user-owned bridge rather than SmolVM's private NAT network.
         """
         if backend == BACKEND_FIRECRACKER:
             return True
         if backend == BACKEND_QEMU:
-            return config.qemu_network == "tap"
+            return config.qemu_network == "tap" or config.network_attachment.mode == "bridge"
         return False
+
+    @staticmethod
+    def _is_bridge_attachment(config: VMConfig) -> bool:
+        """Whether a VM uses bridge-mode networking."""
+        return config.network_attachment.mode == "bridge"
+
+    @staticmethod
+    def _is_nat_attachment(config: VMConfig) -> bool:
+        """Whether a VM uses NAT-mode networking (the default)."""
+        return config.network_attachment.mode == "nat"
+
+    def _validate_bridge_mode(self, config: VMConfig, backend: str) -> None:
+        """Validate platform, backend, and feature combinations for bridge mode."""
+        import platform
+
+        if platform.system() != "Linux":
+            raise SmolVMError(
+                "Bridged networking is only supported on Linux.",
+                {"vm_id": config.vm_id, "host_os": platform.system()},
+            )
+        if backend not in (BACKEND_FIRECRACKER, BACKEND_QEMU):
+            raise SmolVMError(
+                f"Bridged networking is only supported with Firecracker and QEMU "
+                f"(got backend={backend!r}).",
+                {"vm_id": config.vm_id, "backend": backend},
+            )
+        if config.comm_channel == "ssh":
+            raise SmolVMError(
+                "Bridged networking requires vsock for host-guest communication; "
+                "comm_channel='ssh' is not supported. Use --comm-channel vsock "
+                "or omit the flag to let SmolVM auto-select vsock.",
+                {"vm_id": config.vm_id},
+            )
+        bridge_name = config.network_attachment.bridge
+        if not bridge_name:
+            raise SmolVMError(
+                "Bridged networking requires a bridge name; "
+                f"run 'smolvm sandbox create --name {config.vm_id} "
+                "--network bridge --bridge <bridge_name>'.",
+                {"vm_id": config.vm_id},
+            )
+        inspection = self.network.inspect_bridge(bridge_name)
+        if not inspection.ok:
+            raise SmolVMError(inspection.reason, {"vm_id": config.vm_id, "bridge": bridge_name})
+
+    def _repair_bridged_tap(self, vm_id: str, tap_name: str, bridge_name: str) -> None:
+        """Recreate the bridged TAP if it disappeared (e.g. after host reboot)."""
+        from smolvm.utils import run_command
+
+        try:
+            run_command(["ip", "link", "show", tap_name], use_sudo=False)
+            # TAP exists — verify it's on the right bridge.
+            master = self.network._get_tap_master(tap_name)
+            if master == bridge_name:
+                return
+            # Wrong master — delete and recreate.
+            self.network.cleanup_tap(tap_name)
+        except SmolVMError:
+            pass  # TAP doesn't exist — create it below.
+
+        user = os.environ.get("USER", "root")
+        self.network.prepare_bridged_tap(tap_name, bridge_name, user=user)
+        logger.info("Repaired bridged TAP %s on bridge %s for VM %s", tap_name, bridge_name, vm_id)
 
     @staticmethod
     def _local_tcp_port_is_available(host: str, port: int) -> bool:
@@ -1755,6 +1846,39 @@ class SmolVMManager:
                     )
                 return vm_info
 
+            # --- Bridge mode ---
+            if self._is_bridge_attachment(effective_config):
+                self._validate_bridge_mode(effective_config, backend)
+
+                # Reserve TAP name and generate MAC without IP allocation.
+                bridge_name = effective_config.network_attachment.bridge
+                tap_name = self.state.reserve_tap_name(
+                    effective_config.vm_id,
+                    mode="bridge",
+                    bridge_name=bridge_name,
+                )
+                guest_mac = self.network.generate_bridge_mac()
+
+                user = os.environ.get("USER", "root")
+                self.network.prepare_bridged_tap(tap_name, bridge_name, user=user)
+
+                network_config = NetworkConfig(
+                    mode="bridge",
+                    bridge=bridge_name,
+                    tap_device=tap_name,
+                    guest_mac=guest_mac,
+                )
+                vm_info = self.state.update_vm(effective_config.vm_id, network=network_config)
+                vm_info = self._maybe_enable_vsock(effective_config, backend, vm_info)
+                logger.info(
+                    "VM created (bridge): %s (bridge=%s, TAP=%s)",
+                    effective_config.vm_id,
+                    bridge_name,
+                    tap_name,
+                )
+                return vm_info
+
+            # --- NAT TAP mode (Firecracker or QEMU tap) ---
             # Firecracker networking: allocate an IP first, then derive
             # a unique TAP name from its pool index within 172.16.0.0/16.
             guest_ip = self.state.allocate_ip(effective_config.vm_id, "pending")
@@ -1868,6 +1992,18 @@ class SmolVMManager:
         self._check_workspace_mounts(vm_info)
 
         backend = self._backend_for_vm(vm_info)
+
+        # Bridge mode: revalidate bridge and repair TAP before starting.
+        if vm_info.network is not None and vm_info.network.mode == "bridge":
+            bridge_name = vm_info.network.bridge or ""
+            inspection = self.network.inspect_bridge(bridge_name)
+            if not inspection.ok:
+                raise SmolVMError(
+                    inspection.reason,
+                    {"vm_id": vm_id, "bridge": bridge_name},
+                )
+            self._repair_bridged_tap(vm_id, vm_info.network.tap_device, bridge_name)
+
         if backend == BACKEND_QEMU:
             self._check_qemu_slirp_host_forward_ports(vm_info)
         log_path = self.data_dir / f"{vm_id}.log"
@@ -2997,6 +3133,12 @@ class SmolVMManager:
         if vm_info.network is None:
             return args
 
+        # Bridge mode: no SmolVM-managed IP; add guest-managed marker.
+        if vm_info.network.mode == "bridge":
+            if not any(part.startswith("ip=") for part in parts):
+                args = f"{args} smolvm.network=guest".strip()
+            return args
+
         if any(part.startswith("ip=") for part in parts):
             return args
 
@@ -3026,6 +3168,9 @@ class SmolVMManager:
 
             lease = self.state.get_ip_lease(vm_id)
 
+            # Check for a bridge-mode TAP allocation (no IP lease).
+            tap_alloc = self.state.get_tap_allocation(vm_id)
+
             ssh_host_port: int | None = None
             guest_ip: str | None = lease[0] if lease else None
             if vm_info and vm_info.network:
@@ -3034,44 +3179,64 @@ class SmolVMManager:
             else:
                 ssh_host_port = self.state.get_ssh_port(vm_id)
 
+            # Determine if this is a bridge-mode VM.
+            is_bridge = (
+                vm_info is not None
+                and vm_info.network is not None
+                and vm_info.network.mode == "bridge"
+            ) or (
+                vm_info is None
+                and tap_alloc is not None
+                and tap_alloc[1] == "bridge"
+            )
+
             # Firecracker and QEMU-on-TAP both provision host TAP/NAT/ssh-forward
             # resources; slirp-mode QEMU and libkrun do not. When vm_info is gone
-            # (early-failure cleanup) the IP lease is the definitive tell that a
-            # TAP existed — `backend` is the manager default and may not match
-            # the VM's real backend, so we can't rely on it here.
+            # (early-failure cleanup) the IP lease or TAP allocation is the
+            # definitive tell that a TAP existed.
             if vm_info is not None:
                 uses_tap = self._uses_host_tap_networking(vm_info.config, backend)
             else:
-                uses_tap = lease is not None
+                uses_tap = lease is not None or tap_alloc is not None
 
-            if uses_tap and ssh_host_port is not None and guest_ip:
-                with suppress(Exception):
-                    self.network.cleanup_ssh_port_forward(
-                        vm_id=vm_id,
-                        guest_ip=guest_ip,
-                        host_port=ssh_host_port,
-                    )
-
-            # Reconnect flows may not have in-memory local-forward state.
-            # Always remove any persisted localhost forwarding rules by vm_id.
-            with suppress(Exception):
-                self.network.cleanup_all_local_port_forwards(vm_id)
-
-            # Get IP lease info
-            if lease:
-                _, tap_device = lease
-
-                if uses_tap:
-                    # Tear down host TAP/NAT for backends that provisioned it.
+            # Bridge mode: clean up TAP and TAP allocation only.
+            # No NAT, route, SSH forward, or egress rules to remove.
+            if is_bridge:
+                if tap_alloc:
+                    tap_device = tap_alloc[0]
                     with suppress(Exception):
-                        self.network.remove_egress_rules(tap_device)
-                    self.network.cleanup_nat_rules(tap_device)
-                    self.network.cleanup_tap(tap_device)
+                        self.network.cleanup_tap(tap_device)
+                    self.state.release_tap_name(vm_id)
+            else:
+                # NAT mode cleanup
+                if uses_tap and ssh_host_port is not None and guest_ip:
+                    with suppress(Exception):
+                        self.network.cleanup_ssh_port_forward(
+                            vm_id=vm_id,
+                            guest_ip=guest_ip,
+                            host_port=ssh_host_port,
+                        )
 
-                # Release IP lease regardless of backend.
-                self.state.release_ip(vm_id)
+                # Reconnect flows may not have in-memory local-forward state.
+                # Always remove any persisted localhost forwarding rules by vm_id.
+                with suppress(Exception):
+                    self.network.cleanup_all_local_port_forwards(vm_id)
 
-            if ssh_host_port is not None:
+                # Get IP lease info
+                if lease:
+                    _, tap_device = lease
+
+                    if uses_tap:
+                        # Tear down host TAP/NAT for backends that provisioned it.
+                        with suppress(Exception):
+                            self.network.remove_egress_rules(tap_device)
+                        self.network.cleanup_nat_rules(tap_device)
+                        self.network.cleanup_tap(tap_device)
+
+                    # Release IP lease regardless of backend.
+                    self.state.release_ip(vm_id)
+
+            if ssh_host_port is not None and not is_bridge:
                 self.state.release_ssh_port(vm_id)
 
             for socket_path in (
@@ -3252,6 +3417,38 @@ class SmolVMManager:
                 vm_info = self._maybe_enable_vsock(effective_config, backend, vm_info)
                 return vm_info
 
+            # --- Bridge mode (async) ---
+            if self._is_bridge_attachment(effective_config):
+                await asyncio.to_thread(self._validate_bridge_mode, effective_config, backend)
+
+                bridge_name = effective_config.network_attachment.bridge
+                tap_name = self.state.reserve_tap_name(
+                    effective_config.vm_id,
+                    mode="bridge",
+                    bridge_name=bridge_name,
+                )
+                guest_mac = self.network.generate_bridge_mac()
+
+                user = os.environ.get("USER", "root")
+                await self.network.async_prepare_bridged_tap(tap_name, bridge_name, user=user)
+
+                network_config = NetworkConfig(
+                    mode="bridge",
+                    bridge=bridge_name,
+                    tap_device=tap_name,
+                    guest_mac=guest_mac,
+                )
+                vm_info = self.state.update_vm(effective_config.vm_id, network=network_config)
+                vm_info = self._maybe_enable_vsock(effective_config, backend, vm_info)
+                logger.info(
+                    "VM created (bridge, async): %s (bridge=%s, TAP=%s)",
+                    effective_config.vm_id,
+                    bridge_name,
+                    tap_name,
+                )
+                return vm_info
+
+            # --- NAT TAP mode (async) ---
             # Firecracker networking (async)
             guest_ip = self.state.allocate_ip(effective_config.vm_id, "pending")
             vm_number = ip_to_pool_index(guest_ip)
@@ -3328,6 +3525,23 @@ class SmolVMManager:
         self._check_workspace_mounts(vm_info)
 
         backend = self._backend_for_vm(vm_info)
+
+        # Bridge mode: revalidate bridge and repair TAP before starting.
+        if vm_info.network is not None and vm_info.network.mode == "bridge":
+            bridge_name = vm_info.network.bridge or ""
+            inspection = await self.network.async_inspect_bridge(bridge_name)
+            if not inspection.ok:
+                raise SmolVMError(
+                    inspection.reason,
+                    {"vm_id": vm_id, "bridge": bridge_name},
+                )
+            await asyncio.to_thread(
+                self._repair_bridged_tap,
+                vm_id,
+                vm_info.network.tap_device,
+                bridge_name,
+            )
+
         if backend == BACKEND_QEMU:
             self._check_qemu_slirp_host_forward_ports(vm_info)
         log_path = self.data_dir / f"{vm_id}.log"
@@ -3557,6 +3771,8 @@ class SmolVMManager:
 
             lease = self.state.get_ip_lease(vm_id)
 
+            tap_alloc = self.state.get_tap_allocation(vm_id)
+
             ssh_host_port: int | None = None
             guest_ip: str | None = lease[0] if lease else None
             if vm_info and vm_info.network:
@@ -3565,36 +3781,52 @@ class SmolVMManager:
             else:
                 ssh_host_port = self.state.get_ssh_port(vm_id)
 
-            # See the sync cleanup path for the TAP-vs-slirp rationale. When
-            # vm_info is gone the IP lease is the definitive tell a TAP existed.
+            is_bridge = (
+                vm_info is not None
+                and vm_info.network is not None
+                and vm_info.network.mode == "bridge"
+            ) or (
+                vm_info is None
+                and tap_alloc is not None
+                and tap_alloc[1] == "bridge"
+            )
+
+            # See the sync cleanup path for the TAP-vs-slirp rationale.
             if vm_info is not None:
                 uses_tap = self._uses_host_tap_networking(vm_info.config, backend)
             else:
-                uses_tap = lease is not None
+                uses_tap = lease is not None or tap_alloc is not None
 
-            if uses_tap and ssh_host_port is not None and guest_ip:
-                with suppress(Exception):
-                    await self.network.async_cleanup_ssh_port_forward(
-                        vm_id=vm_id,
-                        guest_ip=guest_ip,
-                        host_port=ssh_host_port,
-                    )
-
-            with suppress(Exception):
-                await self.network.async_cleanup_all_local_port_forwards(vm_id)
-
-            if lease:
-                _, tap_device = lease
-
-                if uses_tap:
+            if is_bridge:
+                if tap_alloc:
+                    tap_device = tap_alloc[0]
                     with suppress(Exception):
-                        await self.network.async_remove_egress_rules(tap_device)
-                    await self.network.async_cleanup_nat_rules(tap_device)
-                    await self.network.async_cleanup_tap(tap_device)
+                        await self.network.async_cleanup_tap(tap_device)
+                    self.state.release_tap_name(vm_id)
+            else:
+                if uses_tap and ssh_host_port is not None and guest_ip:
+                    with suppress(Exception):
+                        await self.network.async_cleanup_ssh_port_forward(
+                            vm_id=vm_id,
+                            guest_ip=guest_ip,
+                            host_port=ssh_host_port,
+                        )
 
-                self.state.release_ip(vm_id)
+                with suppress(Exception):
+                    await self.network.async_cleanup_all_local_port_forwards(vm_id)
 
-            if ssh_host_port is not None:
+                if lease:
+                    _, tap_device = lease
+
+                    if uses_tap:
+                        with suppress(Exception):
+                            await self.network.async_remove_egress_rules(tap_device)
+                        await self.network.async_cleanup_nat_rules(tap_device)
+                        await self.network.async_cleanup_tap(tap_device)
+
+                    self.state.release_ip(vm_id)
+
+            if ssh_host_port is not None and not is_bridge:
                 self.state.release_ssh_port(vm_id)
 
             for socket_path in (

--- a/tests/e2e/test_bridge_networking.py
+++ b/tests/e2e/test_bridge_networking.py
@@ -127,6 +127,17 @@ def bridge_lab() -> _BridgeLab:
         _run_privileged("ip", "link", "del", lab.uplink, check=False)
 
 
+def _wait_for_guest_network_init(sandbox: SmolVM, *, timeout: float = 30.0) -> None:
+    """Wait until PID 1 finishes its initial DHCP/static-network attempt."""
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        result = sandbox.run("grep -q 'stage=net-ready' /var/log/smolvm-boot.log")
+        if result.exit_code == 0:
+            return
+        time.sleep(0.25)
+    pytest.fail("Guest init did not finish its network setup before the timeout.")
+
+
 def _assert_namespace_can_ping(lab: _BridgeLab, *, timeout: float = 15.0) -> None:
     """Wait for guest init and bridge forwarding to make the guest reachable."""
     deadline = time.monotonic() + timeout
@@ -193,18 +204,21 @@ def test_bridge_connectivity_restart_restore_and_delete(
         sandbox.start(boot_timeout=BOOT_TIMEOUT)
         assert sandbox.status == VMState.RUNNING
         assert sandbox.run("echo managed-over-vsock").stdout.strip() == "managed-over-vsock"
+        # The guest agent intentionally starts before networking. Wait for the
+        # no-DHCP-server attempt to finish before replacing it with static setup.
+        _wait_for_guest_network_init(sandbox)
 
         configure = sandbox.run(
             "mkdir -p /etc/smolvm\n"
             "cat > /etc/smolvm/network.sh <<'EOF'\n"
             "#!/bin/sh\n"
+            "set -e\n"
             'ip addr flush dev "$1"\n'
             f'ip addr add {bridge_lab.guest_ip}/24 dev "$1"\n'
             'ip link set "$1" up\n'
             "EOF\n"
             "chmod +x /etc/smolvm/network.sh\n"
-            "/etc/smolvm/network.sh eth0\n"
-            "sync"
+            "/etc/smolvm/network.sh eth0 && sync"
         )
         assert configure.exit_code == 0, configure.stderr
         assert sandbox.run(f"ping -c 1 -W 3 {bridge_lab.peer_ip}").exit_code == 0

--- a/tests/e2e/test_bridge_networking.py
+++ b/tests/e2e/test_bridge_networking.py
@@ -200,6 +200,7 @@ def test_bridge_connectivity_restart_restore_and_delete(
     sandbox = SmolVM(config, ssh_key_path=ssh_key_path, comm_channel="vsock")
     restored: SmolVM | None = None
     tap_name: str | None = None
+    deleted = False
     try:
         sandbox.start(boot_timeout=BOOT_TIMEOUT)
         assert sandbox.status == VMState.RUNNING
@@ -243,12 +244,16 @@ def test_bridge_connectivity_restart_restore_and_delete(
         restored = SmolVM.from_snapshot(snapshot.snapshot_id, backend=backend, resume_vm=True)
         assert restored.run("echo restored-over-vsock").stdout.strip() == "restored-over-vsock"
         _assert_namespace_can_ping(bridge_lab)
+        restored.stop()
+        restored.delete()
+        deleted = True
     finally:
-        target = restored or sandbox
-        with suppress(Exception):
-            target.stop()
-        with suppress(Exception):
-            target.delete()
+        if not deleted:
+            target = restored or sandbox
+            with suppress(Exception):
+                target.stop()
+            with suppress(Exception):
+                target.delete()
 
     if tap_name is not None:
         assert _run_privileged("ip", "link", "show", tap_name, check=False).returncode != 0

--- a/tests/e2e/test_bridge_networking.py
+++ b/tests/e2e/test_bridge_networking.py
@@ -20,6 +20,7 @@ import os
 import platform
 import secrets
 import subprocess
+import time
 from contextlib import suppress
 from dataclasses import dataclass
 from shutil import which
@@ -126,21 +127,29 @@ def bridge_lab() -> _BridgeLab:
         _run_privileged("ip", "link", "del", lab.uplink, check=False)
 
 
-def _assert_namespace_can_ping(lab: _BridgeLab) -> None:
-    result = _run_privileged(
-        "ip",
-        "netns",
-        "exec",
-        lab.namespace,
-        "ping",
-        "-c",
-        "1",
-        "-W",
-        "3",
-        lab.guest_ip,
-        check=False,
-    )
-    assert result.returncode == 0, result.stderr or result.stdout
+def _assert_namespace_can_ping(lab: _BridgeLab, *, timeout: float = 15.0) -> None:
+    """Wait for guest init and bridge forwarding to make the guest reachable."""
+    deadline = time.monotonic() + timeout
+    result: subprocess.CompletedProcess[str] | None = None
+    while time.monotonic() < deadline:
+        result = _run_privileged(
+            "ip",
+            "netns",
+            "exec",
+            lab.namespace,
+            "ping",
+            "-c",
+            "1",
+            "-W",
+            "1",
+            lab.guest_ip,
+            check=False,
+        )
+        if result.returncode == 0:
+            return
+        time.sleep(0.5)
+    assert result is not None
+    pytest.fail(result.stderr or result.stdout)
 
 
 @pytest.mark.parametrize("backend", E2E_BACKENDS, ids=str)
@@ -194,7 +203,8 @@ def test_bridge_connectivity_restart_restore_and_delete(
             'ip link set "$1" up\n'
             "EOF\n"
             "chmod +x /etc/smolvm/network.sh\n"
-            "/etc/smolvm/network.sh eth0"
+            "/etc/smolvm/network.sh eth0\n"
+            "sync"
         )
         assert configure.exit_code == 0, configure.stderr
         assert sandbox.run(f"ping -c 1 -W 3 {bridge_lab.peer_ip}").exit_code == 0

--- a/tests/e2e/test_bridge_networking.py
+++ b/tests/e2e/test_bridge_networking.py
@@ -200,7 +200,6 @@ def test_bridge_connectivity_restart_restore_and_delete(
     sandbox = SmolVM(config, ssh_key_path=ssh_key_path, comm_channel="vsock")
     restored: SmolVM | None = None
     tap_name: str | None = None
-    deleted = False
     try:
         sandbox.start(boot_timeout=BOOT_TIMEOUT)
         assert sandbox.status == VMState.RUNNING
@@ -240,20 +239,18 @@ def test_bridge_connectivity_restart_restore_and_delete(
         snapshot = sandbox.snapshot(snapshot_type=snapshot_type)
         sandbox.stop()
         sandbox.delete()
+        assert _run_privileged("ip", "link", "show", tap_name, check=False).returncode != 0
 
         restored = SmolVM.from_snapshot(snapshot.snapshot_id, backend=backend, resume_vm=True)
         assert restored.run("echo restored-over-vsock").stdout.strip() == "restored-over-vsock"
         _assert_namespace_can_ping(bridge_lab)
-        restored.stop()
-        restored.delete()
-        deleted = True
     finally:
-        if not deleted:
-            target = restored or sandbox
-            with suppress(Exception):
-                target.stop()
-            with suppress(Exception):
-                target.delete()
-
-    if tap_name is not None:
-        assert _run_privileged("ip", "link", "show", tap_name, check=False).returncode != 0
+        # QEMU full-snapshot shutdown has separate lifecycle coverage and can
+        # outlive its stop timeout; do not make this bridge test own that path.
+        target = restored or sandbox
+        with suppress(Exception):
+            target.stop()
+        with suppress(Exception):
+            target.delete()
+        if tap_name is not None:
+            _run_privileged("ip", "link", "del", tap_name, check=False)

--- a/tests/e2e/test_bridge_networking.py
+++ b/tests/e2e/test_bridge_networking.py
@@ -1,0 +1,229 @@
+# Copyright 2026 Celesto AI
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Privileged end-to-end coverage for guest-managed bridged networking."""
+
+from __future__ import annotations
+
+import os
+import platform
+import secrets
+import subprocess
+from contextlib import suppress
+from dataclasses import dataclass
+from shutil import which
+
+import pytest
+from _util import (
+    BOOT_TIMEOUT,
+    E2E_BACKENDS,
+    E2EBackend,
+    require_backend_available,
+    selected_backend,
+)
+
+from smolvm import SmolVM
+from smolvm.comm import host_supports_vsock
+from smolvm.facade import _build_auto_config
+from smolvm.runtime.backends import BACKEND_FIRECRACKER
+from smolvm.types import NetworkAttachmentConfig, SnapshotType, VMState
+
+pytestmark = pytest.mark.e2e
+
+
+@dataclass(frozen=True, slots=True)
+class _BridgeLab:
+    bridge: str
+    uplink: str
+    peer: str
+    namespace: str
+    guest_ip: str
+    peer_ip: str
+
+
+def _privileged_prefix() -> list[str]:
+    if os.geteuid() == 0:
+        return []
+    if which("sudo") is None:
+        pytest.skip("Bridge e2e needs root or passwordless sudo to create temporary interfaces.")
+    check = subprocess.run(
+        ["sudo", "-n", "true"],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    if check.returncode != 0:
+        pytest.skip("Bridge e2e needs root or passwordless sudo to create temporary interfaces.")
+    return ["sudo", "-n"]
+
+
+def _run_privileged(*args: str, check: bool = True) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        [*_privileged_prefix(), *args],
+        check=check,
+        capture_output=True,
+        text=True,
+    )
+
+
+@pytest.fixture
+def bridge_lab() -> _BridgeLab:
+    """Create an address-free bridge with a network-namespace peer."""
+    if platform.system() != "Linux" or which("ip") is None:
+        pytest.skip("Bridge e2e requires Linux and the ip command.")
+
+    token = f"{os.getpid():x}{secrets.token_hex(2)}"[-7:]
+    octet = int(token[-2:], 16) % 200 + 20
+    lab = _BridgeLab(
+        bridge=f"svbr{token}",
+        uplink=f"svup{token}",
+        peer=f"svpr{token}",
+        namespace=f"smolvm-e2e-{token}",
+        guest_ip=f"198.18.{octet}.2",
+        peer_ip=f"198.18.{octet}.1",
+    )
+
+    _run_privileged("ip", "netns", "add", lab.namespace)
+    try:
+        _run_privileged("ip", "link", "add", lab.bridge, "type", "bridge")
+        _run_privileged("ip", "link", "add", lab.uplink, "type", "veth", "peer", "name", lab.peer)
+        _run_privileged("ip", "link", "set", lab.uplink, "master", lab.bridge)
+        # Keep both address-free host interfaces free of automatic IPv6 addresses.
+        _run_privileged("sysctl", "-q", "-w", f"net.ipv6.conf.{lab.bridge}.disable_ipv6=1")
+        _run_privileged("sysctl", "-q", "-w", f"net.ipv6.conf.{lab.uplink}.disable_ipv6=1")
+        _run_privileged("ip", "link", "set", lab.peer, "netns", lab.namespace)
+        _run_privileged("ip", "link", "set", lab.bridge, "up")
+        _run_privileged("ip", "link", "set", lab.uplink, "up")
+        _run_privileged(
+            "ip",
+            "netns",
+            "exec",
+            lab.namespace,
+            "ip",
+            "addr",
+            "add",
+            f"{lab.peer_ip}/24",
+            "dev",
+            lab.peer,
+        )
+        _run_privileged("ip", "netns", "exec", lab.namespace, "ip", "link", "set", "lo", "up")
+        _run_privileged("ip", "netns", "exec", lab.namespace, "ip", "link", "set", lab.peer, "up")
+        yield lab
+    finally:
+        _run_privileged("ip", "netns", "del", lab.namespace, check=False)
+        _run_privileged("ip", "link", "del", lab.bridge, check=False)
+        _run_privileged("ip", "link", "del", lab.uplink, check=False)
+
+
+def _assert_namespace_can_ping(lab: _BridgeLab) -> None:
+    result = _run_privileged(
+        "ip",
+        "netns",
+        "exec",
+        lab.namespace,
+        "ping",
+        "-c",
+        "1",
+        "-W",
+        "3",
+        lab.guest_ip,
+        check=False,
+    )
+    assert result.returncode == 0, result.stderr or result.stdout
+
+
+@pytest.mark.parametrize("backend", E2E_BACKENDS, ids=str)
+def test_bridge_connectivity_restart_restore_and_delete(
+    backend: E2EBackend,
+    bridge_lab: _BridgeLab,
+    request: pytest.FixtureRequest,
+) -> None:
+    """Exercise bridge connectivity, vsock management, repair, restore, and cleanup."""
+    selected = selected_backend(request.config)
+    if selected != "all" and backend != selected:
+        pytest.skip(
+            f"End-to-end tests for '{backend}' are skipped because this run selected "
+            f"'{selected}'; rerun all backends with: pytest tests/e2e."
+        )
+    require_backend_available(backend, request.config, sandbox_name=f"bridge-{backend}")
+    if backend == "qemu" and not host_supports_vsock():
+        pytest.skip("Bridge e2e requires /dev/vhost-vsock for QEMU.")
+
+    vm_name = f"e2e-bridge-{backend}-{secrets.token_hex(2)}"
+    config, ssh_key_path = _build_auto_config(
+        vm_name=vm_name,
+        os="alpine",
+        backend=backend,
+        qemu_machine="auto",
+        memory=None,
+        disk_size_mib=None,
+        ssh_key_path=None,
+    )
+    config = config.model_copy(
+        update={
+            "comm_channel": "vsock",
+            "network_attachment": NetworkAttachmentConfig(mode="bridge", bridge=bridge_lab.bridge),
+        }
+    )
+
+    sandbox = SmolVM(config, ssh_key_path=ssh_key_path, comm_channel="vsock")
+    restored: SmolVM | None = None
+    tap_name: str | None = None
+    try:
+        sandbox.start(boot_timeout=BOOT_TIMEOUT)
+        assert sandbox.status == VMState.RUNNING
+        assert sandbox.run("echo managed-over-vsock").stdout.strip() == "managed-over-vsock"
+
+        configure = sandbox.run(
+            "cat > /etc/smolvm/network.sh <<'EOF'\n"
+            "#!/bin/sh\n"
+            'ip addr flush dev "$1"\n'
+            f'ip addr add {bridge_lab.guest_ip}/24 dev "$1"\n'
+            'ip link set "$1" up\n'
+            "EOF\n"
+            "chmod +x /etc/smolvm/network.sh\n"
+            "/etc/smolvm/network.sh eth0"
+        )
+        assert configure.exit_code == 0, configure.stderr
+        assert sandbox.run(f"ping -c 1 -W 3 {bridge_lab.peer_ip}").exit_code == 0
+        _assert_namespace_can_ping(bridge_lab)
+
+        assert sandbox.info.network is not None
+        tap_name = sandbox.info.network.tap_device
+        assert tap_name
+
+        # A missing owned TAP is safely recreated on the next start.
+        sandbox.stop()
+        _run_privileged("ip", "link", "del", tap_name)
+        sandbox.start(boot_timeout=BOOT_TIMEOUT)
+        assert sandbox.run("echo restarted").stdout.strip() == "restarted"
+        _assert_namespace_can_ping(bridge_lab)
+
+        snapshot_type = SnapshotType.DISK if backend == BACKEND_FIRECRACKER else SnapshotType.FULL
+        snapshot = sandbox.snapshot(snapshot_type=snapshot_type)
+        sandbox.stop()
+        sandbox.delete()
+
+        restored = SmolVM.from_snapshot(snapshot.snapshot_id, backend=backend, resume_vm=True)
+        assert restored.run("echo restored-over-vsock").stdout.strip() == "restored-over-vsock"
+        _assert_namespace_can_ping(bridge_lab)
+    finally:
+        target = restored or sandbox
+        with suppress(Exception):
+            target.stop()
+        with suppress(Exception):
+            target.delete()
+
+    if tap_name is not None:
+        assert _run_privileged("ip", "link", "show", tap_name, check=False).returncode != 0

--- a/tests/e2e/test_bridge_networking.py
+++ b/tests/e2e/test_bridge_networking.py
@@ -131,7 +131,7 @@ def _wait_for_guest_network_init(sandbox: SmolVM, *, timeout: float = 30.0) -> N
     """Wait until PID 1 finishes its initial DHCP/static-network attempt."""
     deadline = time.monotonic() + timeout
     while time.monotonic() < deadline:
-        result = sandbox.run("grep -q 'stage=net-ready' /var/log/smolvm-boot.log")
+        result = sandbox.run("grep -q 'stage=net-config-done' /var/log/smolvm-boot.log")
         if result.exit_code == 0:
             return
         time.sleep(0.25)

--- a/tests/e2e/test_bridge_networking.py
+++ b/tests/e2e/test_bridge_networking.py
@@ -186,6 +186,7 @@ def test_bridge_connectivity_restart_restore_and_delete(
         assert sandbox.run("echo managed-over-vsock").stdout.strip() == "managed-over-vsock"
 
         configure = sandbox.run(
+            "mkdir -p /etc/smolvm\n"
             "cat > /etc/smolvm/network.sh <<'EOF'\n"
             "#!/bin/sh\n"
             'ip addr flush dev "$1"\n'

--- a/tests/test_bridge_networking.py
+++ b/tests/test_bridge_networking.py
@@ -528,6 +528,7 @@ class TestBridgedTapOwnership:
                 nm,
                 "_get_link_info",
                 side_effect=[
+                    None,
                     self._tap_info(alias=""),
                     self._tap_info(alias="smolvm-bridge:vm001", master="br10"),
                 ],
@@ -559,7 +560,7 @@ class TestBridgedTapOwnership:
                 "inspect_bridge",
                 return_value=BridgeInspection("br10", True),
             ),
-            patch.object(nm, "create_tap", return_value=False),
+            patch.object(nm, "create_tap", return_value=False) as create_tap,
             patch.object(
                 nm,
                 "_get_link_info",
@@ -571,8 +572,30 @@ class TestBridgedTapOwnership:
         ):
             nm.prepare_bridged_tap("svmb1234", "br10", "vm001")
 
+        create_tap.assert_not_called()
         set_master.assert_not_called()
         cleanup_tap.assert_not_called()
+
+    def test_prepare_reuses_existing_owned_tap_without_recreating(self) -> None:
+        from smolvm.host.network import BridgeInspection, NetworkManager
+
+        nm = NetworkManager()
+        owned = self._tap_info(alias="smolvm-bridge:vm001", master="br10")
+        with (
+            patch.object(
+                nm,
+                "inspect_bridge",
+                return_value=BridgeInspection("br10", True),
+            ),
+            patch.object(nm, "create_tap") as create_tap,
+            patch.object(nm, "_get_link_info", return_value=owned),
+            patch.object(nm, "_set_tap_master") as set_master,
+            patch("smolvm.host.network.run_command"),
+        ):
+            nm.prepare_bridged_tap("svmb1234", "br10", "vm001", user="alice")
+
+        create_tap.assert_not_called()
+        set_master.assert_called_once_with("svmb1234", "br10")
 
     def test_cleanup_refuses_foreign_interface(self) -> None:
         from smolvm.exceptions import NetworkError

--- a/tests/test_bridge_networking.py
+++ b/tests/test_bridge_networking.py
@@ -597,6 +597,25 @@ class TestBridgedTapOwnership:
         create_tap.assert_not_called()
         set_master.assert_called_once_with("svmb1234", "br10")
 
+    def test_cleanup_retries_until_owned_tap_disappears(self) -> None:
+        from smolvm.host.network import NetworkManager
+
+        nm = NetworkManager()
+        owned = self._tap_info(alias="smolvm-bridge:vm001")
+        with (
+            patch.object(
+                nm,
+                "_get_link_info",
+                side_effect=[owned, owned, owned, owned, owned, None],
+            ),
+            patch.object(nm, "cleanup_tap") as cleanup_tap,
+            patch("smolvm.host.network.time.sleep") as sleep,
+        ):
+            nm.cleanup_bridged_tap("svmb1234", "vm001")
+
+        assert cleanup_tap.call_count == 2
+        sleep.assert_called_once()
+
     def test_cleanup_refuses_foreign_interface(self) -> None:
         from smolvm.exceptions import NetworkError
         from smolvm.host.network import NetworkManager

--- a/tests/test_bridge_networking.py
+++ b/tests/test_bridge_networking.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import json
 from pathlib import Path
-from unittest.mock import MagicMock, patch
+from unittest.mock import ANY, MagicMock, patch
 
 import pytest
 from pydantic import ValidationError
@@ -75,8 +75,7 @@ def _make_vm_config_skip_paths(
         data["workspace_mounts"] = workspace_mounts
     if port_forwards is not None:
         data["port_forwards"] = [
-            {"host_port": pf.host_port, "guest_port": pf.guest_port}
-            for pf in port_forwards
+            {"host_port": pf.host_port, "guest_port": pf.guest_port} for pf in port_forwards
         ]
     if internet_settings is not None:
         data["internet_settings"] = {
@@ -189,26 +188,32 @@ class TestNetworkConfigBridgeMode:
                 guest_ip="172.16.0.2",
             )
 
-    def test_nat_defaults_filled(self) -> None:
-        nc = NetworkConfig(
-            guest_ip="172.16.0.2",
-            tap_device="tap0",
-            guest_mac="aa:fc:00:11:22:33",
-        )
+    @pytest.mark.parametrize("explicit_nulls", [False, True])
+    def test_nat_defaults_filled(self, explicit_nulls: bool) -> None:
+        values: dict[str, object] = {
+            "guest_ip": "172.16.0.2",
+            "tap_device": "tap0",
+            "guest_mac": "aa:fc:00:11:22:33",
+        }
+        if explicit_nulls:
+            values.update({"gateway_ip": None, "netmask": None})
+        nc = NetworkConfig(**values)
         assert nc.mode == "nat"
         assert nc.gateway_ip == "172.16.0.1"
         assert nc.netmask == "255.255.255.0"
 
     def test_old_json_compat(self) -> None:
         """Old JSON records without mode/bridge default to NAT."""
-        old = json.dumps({
-            "guest_ip": "172.16.0.2",
-            "gateway_ip": "172.16.0.1",
-            "netmask": "255.255.255.0",
-            "tap_device": "tap0",
-            "guest_mac": "aa:fc:00:11:22:33",
-            "ssh_host_port": 2200,
-        })
+        old = json.dumps(
+            {
+                "guest_ip": "172.16.0.2",
+                "gateway_ip": "172.16.0.1",
+                "netmask": "255.255.255.0",
+                "tap_device": "tap0",
+                "guest_mac": "aa:fc:00:11:22:33",
+                "ssh_host_port": 2200,
+            }
+        )
         nc = NetworkConfig.model_validate_json(old)
         assert nc.mode == "nat"
         assert nc.bridge is None
@@ -287,8 +292,10 @@ class TestBridgeInspection:
         from smolvm.host.network import NetworkManager
 
         nm = NetworkManager()
-        with patch("platform.system", return_value="Linux"), \
-             patch("smolvm.host.network.run_command", side_effect=SmolVMError("not found")):
+        with (
+            patch("platform.system", return_value="Linux"),
+            patch("smolvm.host.network.run_command", side_effect=SmolVMError("not found")),
+        ):
             result = nm.inspect_bridge("br10")
         assert result.ok is False
         assert "does not exist" in result.reason
@@ -298,9 +305,13 @@ class TestBridgeInspection:
 
         nm = NetworkManager()
         mock_response = MagicMock()
-        mock_response.stdout = json.dumps([{"link_type": "vlan", "flags": ["UP"]}])
-        with patch("platform.system", return_value="Linux"), \
-             patch("smolvm.host.network.run_command", return_value=mock_response):
+        mock_response.stdout = json.dumps(
+            [{"link_type": "ether", "linkinfo": {"info_kind": "vlan"}, "flags": ["UP"]}]
+        )
+        with (
+            patch("platform.system", return_value="Linux"),
+            patch("smolvm.host.network.run_command", return_value=mock_response),
+        ):
             result = nm.inspect_bridge("eno1.10")
         assert result.ok is False
         assert "not a bridge" in result.reason
@@ -310,67 +321,276 @@ class TestBridgeInspection:
 
         nm = NetworkManager()
         mock_response = MagicMock()
-        mock_response.stdout = json.dumps([{"link_type": "bridge", "flags": []}])
-        with patch("platform.system", return_value="Linux"), \
-             patch("smolvm.host.network.run_command", return_value=mock_response):
+        mock_response.stdout = json.dumps(
+            [{"link_type": "ether", "linkinfo": {"info_kind": "bridge"}, "flags": []}]
+        )
+        with (
+            patch("platform.system", return_value="Linux"),
+            patch("smolvm.host.network.run_command", return_value=mock_response),
+        ):
             result = nm.inspect_bridge("br10")
         assert result.ok is False
-        assert "not up" in result.reason
+        assert "not active" in result.reason
 
     def test_inspect_bridge_no_members(self) -> None:
         from smolvm.host.network import NetworkManager
 
         nm = NetworkManager()
         link_response = MagicMock()
-        link_response.stdout = json.dumps([{"link_type": "bridge", "flags": ["UP", "LOWER_UP"]}])
+        link_response.stdout = json.dumps(
+            [
+                {
+                    "link_type": "ether",
+                    "linkinfo": {"info_kind": "bridge"},
+                    "flags": ["UP", "LOWER_UP"],
+                }
+            ]
+        )
         members_response = MagicMock()
         members_response.stdout = "[]"
-        with patch("platform.system", return_value="Linux"), \
-             patch(
-                 "smolvm.host.network.run_command",
-                 side_effect=[link_response, members_response],
-             ):
+        with (
+            patch("platform.system", return_value="Linux"),
+            patch(
+                "smolvm.host.network.run_command",
+                side_effect=[link_response, members_response],
+            ),
+        ):
             result = nm.inspect_bridge("br10")
         assert result.ok is False
-        assert "no member" in result.reason.lower()
+        assert "not connected" in result.reason.lower()
+
+    def test_inspect_bridge_does_not_trust_tap_name_prefix(self) -> None:
+        from smolvm.host.network import NetworkManager
+
+        nm = NetworkManager()
+        bridge_info = {
+            "linkinfo": {"info_kind": "bridge"},
+            "flags": ["UP"],
+        }
+        user_veth_info = {
+            "ifname": "svmb-uplink",
+            "linkinfo": {"info_kind": "veth"},
+        }
+        with (
+            patch("platform.system", return_value="Linux"),
+            patch.object(nm, "_get_link_info", side_effect=[bridge_info, user_veth_info]),
+            patch.object(nm, "_get_bridge_members", return_value=["svmb-uplink"]),
+            patch.object(nm, "_check_bridge_addresses", return_value=""),
+        ):
+            result = nm.inspect_bridge("br10")
+
+        assert result.ok is True
+
+    def test_inspect_bridge_does_not_count_owned_tap_as_external_member(self) -> None:
+        from smolvm.host.network import NetworkManager
+
+        nm = NetworkManager()
+        bridge_info = {
+            "linkinfo": {"info_kind": "bridge"},
+            "flags": ["UP"],
+        }
+        owned_tap_info = {
+            "ifname": "svmb12345678",
+            "ifalias": "smolvm-bridge:vm001",
+            "linkinfo": {"info_kind": "tun", "info_data": {"type": "tap"}},
+        }
+        with (
+            patch("platform.system", return_value="Linux"),
+            patch.object(nm, "_get_link_info", side_effect=[bridge_info, owned_tap_info]),
+            patch.object(nm, "_get_bridge_members", return_value=["svmb12345678"]),
+        ):
+            result = nm.inspect_bridge("br10")
+
+        assert result.ok is False
+        assert "not connected" in result.reason
 
     def test_inspect_bridge_valid(self) -> None:
         from smolvm.host.network import NetworkManager
 
         nm = NetworkManager()
         link_response = MagicMock()
-        link_response.stdout = json.dumps([{"link_type": "bridge", "flags": ["UP", "LOWER_UP"]}])
+        link_response.stdout = json.dumps(
+            [
+                {
+                    "link_type": "ether",
+                    "linkinfo": {"info_kind": "bridge"},
+                    "flags": ["UP", "LOWER_UP"],
+                }
+            ]
+        )
         members_response = MagicMock()
         members_response.stdout = json.dumps([{"ifname": "eno1.10"}])
         empty_addr = MagicMock()
         empty_addr.stdout = json.dumps([{"addr_info": []}])
-        # inspect_bridge: 1 (link show) + 1 (members) + _check_bridge_addresses:
-        #   bridge: 2 (inet, inet6) + member: 2 (inet, inet6) = 6 total
-        with patch("platform.system", return_value="Linux"), \
-             patch("smolvm.host.network.run_command",
-                   side_effect=[link_response, members_response,
-                                empty_addr, empty_addr, empty_addr, empty_addr]):
+        with (
+            patch("platform.system", return_value="Linux"),
+            patch(
+                "smolvm.host.network.run_command",
+                side_effect=[link_response, members_response, empty_addr, empty_addr],
+            ) as run_command,
+        ):
             result = nm.inspect_bridge("br10")
         assert result.ok is True
+        assert all(call.kwargs["use_sudo"] is False for call in run_command.call_args_list)
+        assert all("show" in call.args[0] for call in run_command.call_args_list)
 
     def test_inspect_bridge_with_host_address(self) -> None:
         from smolvm.host.network import NetworkManager
 
         nm = NetworkManager()
         link_response = MagicMock()
-        link_response.stdout = json.dumps([{"link_type": "bridge", "flags": ["UP", "LOWER_UP"]}])
+        link_response.stdout = json.dumps(
+            [
+                {
+                    "link_type": "ether",
+                    "linkinfo": {"info_kind": "bridge"},
+                    "flags": ["UP", "LOWER_UP"],
+                }
+            ]
+        )
         members_response = MagicMock()
         members_response.stdout = json.dumps([{"ifname": "eno1.10"}])
         addr_response = MagicMock()
-        addr_response.stdout = json.dumps([{
-            "addr_info": [{"local": "192.168.10.2", "scope": "global"}]
-        }])
-        with patch("platform.system", return_value="Linux"), \
-             patch("smolvm.host.network.run_command",
-                   side_effect=[link_response, members_response, addr_response, addr_response]):
+        addr_response.stdout = json.dumps(
+            [{"addr_info": [{"local": "192.168.10.2", "scope": "global"}]}]
+        )
+        with (
+            patch("platform.system", return_value="Linux"),
+            patch(
+                "smolvm.host.network.run_command",
+                side_effect=[link_response, members_response, addr_response],
+            ),
+        ):
             result = nm.inspect_bridge("br10")
         assert result.ok is False
         assert "192.168.10.2" in result.reason
+        assert "addr flush" not in result.reason
+
+    def test_inspect_bridge_rejects_ipv6_link_local_address(self) -> None:
+        from smolvm.host.network import NetworkManager
+
+        nm = NetworkManager()
+        link_response = MagicMock()
+        link_response.stdout = json.dumps(
+            [
+                {
+                    "link_type": "ether",
+                    "linkinfo": {"info_kind": "bridge"},
+                    "flags": ["UP"],
+                }
+            ]
+        )
+        members_response = MagicMock()
+        members_response.stdout = json.dumps([{"ifname": "eno1.10"}])
+        address_response = MagicMock()
+        address_response.stdout = json.dumps(
+            [{"addr_info": [{"local": "fe80::1234", "scope": "link"}]}]
+        )
+        with (
+            patch("platform.system", return_value="Linux"),
+            patch(
+                "smolvm.host.network.run_command",
+                side_effect=[link_response, members_response, address_response],
+            ),
+        ):
+            result = nm.inspect_bridge("br10")
+
+        assert result.ok is False
+        assert "fe80::1234" in result.reason
+
+
+class TestBridgedTapOwnership:
+    """Tests for bridge TAP ownership and safe reuse."""
+
+    @staticmethod
+    def _tap_info(*, alias: str, master: str | None = None) -> dict[str, object]:
+        info: dict[str, object] = {
+            "ifname": "svmb1234",
+            "ifalias": alias,
+            "linkinfo": {"info_kind": "tun", "info_data": {"type": "tap"}},
+        }
+        if master is not None:
+            info["master"] = master
+        return info
+
+    def test_prepare_new_tap_marks_ownership_before_attaching(self) -> None:
+        from smolvm.host.network import BridgeInspection, NetworkManager
+
+        nm = NetworkManager()
+        with (
+            patch.object(
+                nm,
+                "inspect_bridge",
+                return_value=BridgeInspection("br10", True),
+            ),
+            patch.object(nm, "create_tap", return_value=True),
+            patch.object(
+                nm,
+                "_get_link_info",
+                side_effect=[
+                    self._tap_info(alias=""),
+                    self._tap_info(alias="smolvm-bridge:vm001", master="br10"),
+                ],
+            ),
+            patch.object(nm, "_set_tap_master") as set_master,
+            patch("smolvm.host.network.run_command") as run_command,
+        ):
+            nm.prepare_bridged_tap("svmb1234", "br10", "vm001", user="alice")
+
+        set_master.assert_called_once_with("svmb1234", "br10")
+        assert run_command.call_args_list[0].args[0] == [
+            "ip",
+            "link",
+            "set",
+            "dev",
+            "svmb1234",
+            "alias",
+            "smolvm-bridge:vm001",
+        ]
+
+    def test_prepare_refuses_existing_foreign_interface(self) -> None:
+        from smolvm.exceptions import NetworkError
+        from smolvm.host.network import BridgeInspection, NetworkManager
+
+        nm = NetworkManager()
+        with (
+            patch.object(
+                nm,
+                "inspect_bridge",
+                return_value=BridgeInspection("br10", True),
+            ),
+            patch.object(nm, "create_tap", return_value=False),
+            patch.object(
+                nm,
+                "_get_link_info",
+                return_value=self._tap_info(alias="someone-else"),
+            ),
+            patch.object(nm, "_set_tap_master") as set_master,
+            patch.object(nm, "cleanup_tap") as cleanup_tap,
+            pytest.raises(NetworkError, match="does not belong"),
+        ):
+            nm.prepare_bridged_tap("svmb1234", "br10", "vm001")
+
+        set_master.assert_not_called()
+        cleanup_tap.assert_not_called()
+
+    def test_cleanup_refuses_foreign_interface(self) -> None:
+        from smolvm.exceptions import NetworkError
+        from smolvm.host.network import NetworkManager
+
+        nm = NetworkManager()
+        with (
+            patch.object(
+                nm,
+                "_get_link_info",
+                return_value=self._tap_info(alias="someone-else"),
+            ),
+            patch.object(nm, "cleanup_tap") as cleanup_tap,
+            pytest.raises(NetworkError, match="does not belong"),
+        ):
+            nm.cleanup_bridged_tap("svmb1234", "vm001")
+
+        cleanup_tap.assert_not_called()
 
 
 class TestBridgeMacGeneration:
@@ -383,16 +603,22 @@ class TestBridgeMacGeneration:
         mac = nm.generate_bridge_mac()
         parts = mac.split(":")
         assert len(parts) == 6
-        # Locally administered unicast (AA:FC prefix)
-        assert parts[0].upper() == "AA"
-        assert parts[1].upper() == "FC"
+        # Locally administered unicast prefix.
+        assert parts[0].upper() == "02"
 
     def test_generate_bridge_mac_unique(self) -> None:
         from smolvm.host.network import NetworkManager
 
         nm = NetworkManager()
         macs = {nm.generate_bridge_mac() for _ in range(100)}
-        assert len(macs) > 90  # Allow a few collisions in 100 random MACs
+        assert len(macs) == 100
+
+    def test_reserved_tap_suffix_maps_to_collision_free_mac(self) -> None:
+        from smolvm.host.network import NetworkManager
+
+        nm = NetworkManager()
+        assert nm.generate_bridge_mac("svmb01020304") == "02:53:01:02:03:04"
+        assert nm.generate_bridge_mac("svmb01020305") == "02:53:01:02:03:05"
 
 
 class TestTapAllocation:
@@ -417,6 +643,28 @@ class TestTapAllocation:
         tap1 = manager.reserve_tap_name("test-vm-2", mode="bridge", bridge_name="br10")
         tap2 = manager.reserve_tap_name("test-vm-2", mode="bridge", bridge_name="br10")
         assert tap1 == tap2
+
+    def test_reserve_tap_name_rejects_changed_attachment(self, tmp_path: Path) -> None:
+        from smolvm.exceptions import NetworkError
+        from smolvm.storage._sqlite import SQLiteStateManager
+
+        manager = SQLiteStateManager(tmp_path / "test.db")
+        config = _make_vm_config(tmp_path, vm_id="test-vm-mismatch")
+        manager.create_vm(config)
+        manager.reserve_tap_name(
+            "test-vm-mismatch",
+            mode="bridge",
+            bridge_name="br10",
+            requested_tap="svmb1111",
+        )
+
+        with pytest.raises(NetworkError, match="already reserves"):
+            manager.reserve_tap_name(
+                "test-vm-mismatch",
+                mode="bridge",
+                bridge_name="br20",
+                requested_tap="svmb2222",
+            )
 
     def test_get_tap_allocation(self, tmp_path: Path) -> None:
         from smolvm.storage._sqlite import SQLiteStateManager
@@ -469,6 +717,273 @@ class TestTapAllocation:
         manager.reserve_tap_name("test-vm-6", mode="bridge", requested_tap="svmbconf1")
         with pytest.raises(NetworkError, match="already reserved"):
             manager.reserve_tap_name("test-vm-7", mode="bridge", requested_tap="svmbconf1")
+
+
+class TestBridgeLifecycle:
+    """Tests for bridge-specific lifecycle invariants."""
+
+    @staticmethod
+    def _manager(tmp_path: Path):
+        from smolvm.host.network import BridgeInspection
+        from smolvm.vm import SmolVMManager
+
+        manager = SmolVMManager(
+            data_dir=tmp_path / "data",
+            socket_dir=tmp_path / "sockets",
+            backend="qemu",
+        )
+        network = MagicMock()
+        network.inspect_bridge.return_value = BridgeInspection("br10", True)
+        network.generate_bridge_mac.return_value = "02:00:00:00:00:01"
+        manager.network = network
+        return manager, network
+
+    @staticmethod
+    def _config(tmp_path: Path, *, comm_channel: str | None = None) -> VMConfig:
+        return _make_vm_config(
+            tmp_path,
+            vm_id="bridge-lifecycle",
+            comm_channel=comm_channel,
+            network_attachment=NetworkAttachmentConfig(mode="bridge", bridge="br10"),
+        ).model_copy(update={"backend": "qemu", "disk_mode": "shared"})
+
+    def test_create_requires_resolved_vsock_before_network_mutation(self, tmp_path: Path) -> None:
+        from smolvm.comm.select import ChannelResolution
+        from smolvm.exceptions import SmolVMError
+
+        manager, network = self._manager(tmp_path)
+        config = self._config(tmp_path)
+        with (
+            patch("platform.system", return_value="Linux"),
+            patch.object(
+                manager,
+                "_resolve_control_channel_for_config",
+                return_value=ChannelResolution(kind="ssh"),
+            ),
+            pytest.raises(SmolVMError, match="needs fast shell support"),
+        ):
+            manager.create(config)
+
+        network.prepare_bridged_tap.assert_not_called()
+        assert manager.state.get_tap_allocation(config.vm_id) is None
+
+    def test_create_persists_network_before_preparing_owned_tap(self, tmp_path: Path) -> None:
+        from smolvm.comm.select import ChannelResolution
+
+        manager, network = self._manager(tmp_path)
+        config = self._config(tmp_path, comm_channel="vsock")
+        with (
+            patch("platform.system", return_value="Linux"),
+            patch.object(
+                manager,
+                "_resolve_control_channel_for_config",
+                return_value=ChannelResolution(kind="vsock"),
+            ),
+        ):
+            info = manager.create(config)
+
+        assert info.network is not None
+        assert info.network.mode == "bridge"
+        assert info.config.qemu_network == "tap"
+        network.generate_bridge_mac.assert_called_once_with(info.network.tap_device)
+        network.prepare_bridged_tap.assert_called_once_with(
+            info.network.tap_device,
+            "br10",
+            config.vm_id,
+            user=ANY,
+        )
+
+    def test_create_failure_cleans_reserved_owned_tap(self, tmp_path: Path) -> None:
+        from smolvm.comm.select import ChannelResolution
+
+        manager, network = self._manager(tmp_path)
+        config = self._config(tmp_path, comm_channel="vsock")
+        network.prepare_bridged_tap.side_effect = RuntimeError("attach failed")
+        with (
+            patch("platform.system", return_value="Linux"),
+            patch.object(
+                manager,
+                "_resolve_control_channel_for_config",
+                return_value=ChannelResolution(kind="vsock"),
+            ),
+            pytest.raises(RuntimeError, match="attach failed"),
+        ):
+            manager.create(config)
+
+        allocation = network.prepare_bridged_tap.call_args.args[0]
+        network.cleanup_bridged_tap.assert_called_once_with(allocation, config.vm_id)
+
+    def test_restore_network_reserves_and_repairs_bridge_tap_without_ip(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        manager, network = self._manager(tmp_path)
+        config = self._config(tmp_path, comm_channel="vsock")
+        manager.state.create_vm(config)
+        runtime_network = NetworkConfig(
+            mode="bridge",
+            bridge="br10",
+            tap_device="svmbrestore",
+            guest_mac="02:00:00:00:00:01",
+        )
+
+        from smolvm.comm.select import ChannelResolution
+
+        with (
+            patch("platform.system", return_value="Linux"),
+            patch.object(
+                manager,
+                "_resolve_control_channel_for_config",
+                return_value=ChannelResolution(kind="vsock"),
+            ),
+        ):
+            manager._ensure_firecracker_network_for_restore(
+                config.vm_id,
+                runtime_network,
+                vm_config=config,
+            )
+
+        assert manager.state.get_tap_allocation(config.vm_id) == (
+            "svmbrestore",
+            "bridge",
+            "br10",
+        )
+        assert manager.state.get_ip_lease(config.vm_id) is None
+        network.prepare_bridged_tap.assert_called_once_with(
+            "svmbrestore",
+            "br10",
+            config.vm_id,
+            user=ANY,
+        )
+
+    def test_start_rejects_inconsistent_persisted_bridge_before_network_mutation(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        from smolvm.exceptions import SmolVMError
+
+        manager, network = self._manager(tmp_path)
+        config = self._config(tmp_path, comm_channel="vsock")
+        manager.state.create_vm(config)
+        manager.state.update_vm(
+            config.vm_id,
+            network=NetworkConfig(
+                mode="bridge",
+                bridge="br11",
+                tap_device="svmbmismatch",
+                guest_mac="02:00:00:00:00:01",
+            ),
+        )
+
+        with pytest.raises(SmolVMError, match="inconsistent bridge settings"):
+            manager.start(config.vm_id)
+
+        network.prepare_bridged_tap.assert_not_called()
+
+    def test_cleanup_foreign_replacement_releases_only_persisted_reservation(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        from smolvm.exceptions import NetworkError
+
+        manager, network = self._manager(tmp_path)
+        config = self._config(tmp_path, comm_channel="vsock")
+        manager.state.create_vm(config)
+        tap_name = manager.state.reserve_tap_name(
+            config.vm_id,
+            mode="bridge",
+            bridge_name="br10",
+        )
+        manager.state.update_vm(
+            config.vm_id,
+            network=NetworkConfig(
+                mode="bridge",
+                bridge="br10",
+                tap_device=tap_name,
+                guest_mac="02:00:00:00:00:01",
+            ),
+        )
+        network.cleanup_bridged_tap.side_effect = NetworkError("foreign interface")
+
+        manager._cleanup_resources(config.vm_id)
+
+        network.cleanup_bridged_tap.assert_called_once_with(tap_name, config.vm_id)
+        assert manager.state.get_tap_allocation(config.vm_id) is None
+
+    def test_manager_rejects_mount_added_after_model_validation(self, tmp_path: Path) -> None:
+        from smolvm.comm.select import ChannelResolution
+        from smolvm.exceptions import SmolVMError
+        from smolvm.types import WorkspaceMount
+
+        manager, network = self._manager(tmp_path)
+        config = self._config(tmp_path, comm_channel="vsock")
+        workspace = tmp_path / "workspace"
+        workspace.mkdir()
+        config = config.model_copy(
+            update={"workspace_mounts": [WorkspaceMount(host_path=workspace)]}
+        )
+        with (
+            patch("platform.system", return_value="Linux"),
+            patch.object(
+                manager,
+                "_resolve_control_channel_for_config",
+                return_value=ChannelResolution(kind="vsock"),
+            ),
+            pytest.raises(SmolVMError, match="cannot share host folders"),
+        ):
+            manager.create(config)
+
+        network.prepare_bridged_tap.assert_not_called()
+
+
+class TestBridgeUnsupportedOperations:
+    """Bridge mode should reject host-IP-dependent operations immediately."""
+
+    @staticmethod
+    def _facade(tmp_path: Path):
+        from smolvm.facade import SmolVM
+        from smolvm.types import VMInfo, VMState
+
+        config = _make_vm_config(
+            tmp_path,
+            vm_id="bridge-ops",
+            comm_channel="vsock",
+            network_attachment=NetworkAttachmentConfig(mode="bridge", bridge="br10"),
+        ).model_copy(update={"backend": "qemu", "qemu_network": "tap"})
+        network = NetworkConfig(
+            mode="bridge",
+            bridge="br10",
+            tap_device="svmbops",
+            guest_mac="02:00:00:00:00:02",
+        )
+        vm = object.__new__(SmolVM)
+        vm._vm_id = config.vm_id
+        vm._info = VMInfo(
+            vm_id=config.vm_id,
+            status=VMState.RUNNING,
+            config=config,
+            network=network,
+        )
+        vm._local_forwards = {}
+        vm._sdk = MagicMock()
+        vm._refresh_info = MagicMock()
+        return vm
+
+    def test_ssh_endpoint_recommends_shell(self, tmp_path: Path) -> None:
+        from smolvm.exceptions import SmolVMError
+
+        vm = self._facade(tmp_path)
+        with pytest.raises(SmolVMError, match="sandbox shell"):
+            vm._ssh_endpoints()
+
+    def test_port_exposure_rejects_bridge_before_host_mutation(self, tmp_path: Path) -> None:
+        from smolvm.exceptions import SmolVMError
+
+        vm = self._facade(tmp_path)
+        with pytest.raises(SmolVMError, match="already connected directly"):
+            vm.expose_local(8080)
+
+        vm._sdk.ensure_network_connectivity.assert_not_called()
 
 
 class TestQemuArgsBridgeMode:

--- a/tests/test_bridge_networking.py
+++ b/tests/test_bridge_networking.py
@@ -38,6 +38,8 @@ def _make_vm_config(
     }
     if network_attachment is not None:
         kwargs["network_attachment"] = network_attachment
+        if network_attachment.mode == "bridge":
+            kwargs["guest_managed_networking"] = True
     if comm_channel is not None:
         kwargs["comm_channel"] = comm_channel
     if workspace_mounts is not None:
@@ -69,6 +71,8 @@ def _make_vm_config_skip_paths(
             "mode": network_attachment.mode,
             "bridge": network_attachment.bridge,
         }
+        if network_attachment.mode == "bridge":
+            data["guest_managed_networking"] = True
     if comm_channel is not None:
         data["comm_channel"] = comm_channel
     if workspace_mounts is not None:
@@ -294,11 +298,65 @@ class TestBridgeInspection:
         nm = NetworkManager()
         with (
             patch("platform.system", return_value="Linux"),
-            patch("smolvm.host.network.run_command", side_effect=SmolVMError("not found")),
+            patch(
+                "smolvm.host.network.run_command",
+                side_effect=SmolVMError('Device "br10" does not exist.'),
+            ),
         ):
             result = nm.inspect_bridge("br10")
         assert result.ok is False
         assert "does not exist" in result.reason
+
+    def test_inspect_bridge_propagates_link_probe_failure(self) -> None:
+        from smolvm.exceptions import SmolVMError
+        from smolvm.host.network import NetworkManager
+
+        nm = NetworkManager()
+        with (
+            patch("platform.system", return_value="Linux"),
+            patch(
+                "smolvm.host.network.run_command",
+                side_effect=SmolVMError("ip command timed out"),
+            ),
+            pytest.raises(SmolVMError, match="timed out"),
+        ):
+            nm.inspect_bridge("br10")
+
+    def test_inspect_bridge_propagates_member_probe_failure(self) -> None:
+        from smolvm.exceptions import SmolVMError
+        from smolvm.host.network import NetworkManager
+
+        nm = NetworkManager()
+        bridge = MagicMock()
+        bridge.stdout = json.dumps([{"linkinfo": {"info_kind": "bridge"}, "flags": ["UP"]}])
+        with (
+            patch("platform.system", return_value="Linux"),
+            patch(
+                "smolvm.host.network.run_command",
+                side_effect=[bridge, SmolVMError("member probe failed")],
+            ),
+            pytest.raises(SmolVMError, match="member probe failed"),
+        ):
+            nm.inspect_bridge("br10")
+
+    def test_inspect_bridge_propagates_address_probe_failure(self) -> None:
+        from smolvm.exceptions import SmolVMError
+        from smolvm.host.network import NetworkManager
+
+        nm = NetworkManager()
+        bridge = MagicMock()
+        bridge.stdout = json.dumps([{"linkinfo": {"info_kind": "bridge"}, "flags": ["UP"]}])
+        members = MagicMock()
+        members.stdout = json.dumps([{"ifname": "eno1"}])
+        with (
+            patch("platform.system", return_value="Linux"),
+            patch(
+                "smolvm.host.network.run_command",
+                side_effect=[bridge, members, SmolVMError("address probe failed")],
+            ),
+            pytest.raises(SmolVMError, match="address probe failed"),
+        ):
+            nm.inspect_bridge("br10")
 
     def test_inspect_bridge_wrong_type(self) -> None:
         from smolvm.host.network import NetworkManager
@@ -789,6 +847,30 @@ class TestBridgeLifecycle:
             network_attachment=NetworkAttachmentConfig(mode="bridge", bridge="br10"),
         ).model_copy(update={"backend": "qemu", "disk_mode": "shared"})
 
+    def test_create_rejects_image_without_guest_network_support_before_mutation(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        from smolvm.comm.select import ChannelResolution
+        from smolvm.exceptions import SmolVMError
+
+        manager, network = self._manager(tmp_path)
+        config = self._config(tmp_path, comm_channel="vsock").model_copy(
+            update={"guest_managed_networking": False}
+        )
+        with (
+            patch("platform.system", return_value="Linux"),
+            patch.object(
+                manager,
+                "_resolve_control_channel_for_config",
+                return_value=ChannelResolution(kind="vsock"),
+            ),
+            pytest.raises(SmolVMError, match="cannot configure bridged networking"),
+        ):
+            manager.create(config)
+
+        network.prepare_bridged_tap.assert_not_called()
+
     def test_create_requires_resolved_vsock_before_network_mutation(self, tmp_path: Path) -> None:
         from smolvm.comm.select import ChannelResolution
         from smolvm.exceptions import SmolVMError
@@ -926,6 +1008,36 @@ class TestBridgeLifecycle:
         self,
         tmp_path: Path,
     ) -> None:
+        from smolvm.exceptions import BridgeTapOwnershipError
+
+        manager, network = self._manager(tmp_path)
+        config = self._config(tmp_path, comm_channel="vsock")
+        manager.state.create_vm(config)
+        tap_name = manager.state.reserve_tap_name(
+            config.vm_id,
+            mode="bridge",
+            bridge_name="br10",
+        )
+        manager.state.update_vm(
+            config.vm_id,
+            network=NetworkConfig(
+                mode="bridge",
+                bridge="br10",
+                tap_device=tap_name,
+                guest_mac="02:00:00:00:00:01",
+            ),
+        )
+        network.cleanup_bridged_tap.side_effect = BridgeTapOwnershipError("foreign interface")
+
+        manager._cleanup_resources(config.vm_id)
+
+        network.cleanup_bridged_tap.assert_called_once_with(tap_name, config.vm_id)
+        assert manager.state.get_tap_allocation(config.vm_id) is None
+
+    def test_delete_retains_vm_and_reservation_when_owned_tap_cleanup_fails(
+        self,
+        tmp_path: Path,
+    ) -> None:
         from smolvm.exceptions import NetworkError
 
         manager, network = self._manager(tmp_path)
@@ -945,12 +1057,52 @@ class TestBridgeLifecycle:
                 guest_mac="02:00:00:00:00:01",
             ),
         )
-        network.cleanup_bridged_tap.side_effect = NetworkError("foreign interface")
+        network.cleanup_bridged_tap.side_effect = NetworkError("still busy")
 
-        manager._cleanup_resources(config.vm_id)
+        with pytest.raises(NetworkError, match="still busy"):
+            manager.delete(config.vm_id)
 
-        network.cleanup_bridged_tap.assert_called_once_with(tap_name, config.vm_id)
-        assert manager.state.get_tap_allocation(config.vm_id) is None
+        assert manager.state.get_vm(config.vm_id).vm_id == config.vm_id
+        assert manager.state.get_tap_allocation(config.vm_id) == (
+            tap_name,
+            "bridge",
+            "br10",
+        )
+
+    @pytest.mark.asyncio
+    async def test_async_delete_retains_reservation_when_owned_tap_cleanup_fails(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        from smolvm.exceptions import NetworkError
+
+        manager, network = self._manager(tmp_path)
+        config = self._config(tmp_path, comm_channel="vsock")
+        manager.state.create_vm(config)
+        tap_name = manager.state.reserve_tap_name(
+            config.vm_id,
+            mode="bridge",
+            bridge_name="br10",
+        )
+        manager.state.update_vm(
+            config.vm_id,
+            network=NetworkConfig(
+                mode="bridge",
+                bridge="br10",
+                tap_device=tap_name,
+                guest_mac="02:00:00:00:00:01",
+            ),
+        )
+        network.async_cleanup_bridged_tap.side_effect = NetworkError("still busy")
+
+        with pytest.raises(NetworkError, match="still busy"):
+            await manager.async_delete(config.vm_id)
+
+        assert manager.state.get_tap_allocation(config.vm_id) == (
+            tap_name,
+            "bridge",
+            "br10",
+        )
 
     def test_manager_rejects_mount_added_after_model_validation(self, tmp_path: Path) -> None:
         from smolvm.comm.select import ChannelResolution

--- a/tests/test_bridge_networking.py
+++ b/tests/test_bridge_networking.py
@@ -1,0 +1,510 @@
+"""Unit tests for bridged networking support."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+from pydantic import ValidationError
+
+from smolvm.types import (
+    NetworkAttachmentConfig,
+    NetworkConfig,
+    VMConfig,
+)
+
+
+def _make_vm_config(
+    tmp_path: Path,
+    *,
+    network_attachment: NetworkAttachmentConfig | None = None,
+    comm_channel: str | None = None,
+    workspace_mounts: list | None = None,
+    port_forwards: list | None = None,
+    internet_settings: object | None = None,
+    vm_id: str = "test-vm",
+) -> VMConfig:
+    """Build a VMConfig with real tmp files for path validation."""
+    kernel = tmp_path / "vmlinux"
+    rootfs = tmp_path / "rootfs.ext4"
+    kernel.touch()
+    rootfs.touch()
+    kwargs: dict = {
+        "vm_id": vm_id,
+        "kernel_path": kernel,
+        "rootfs_path": rootfs,
+    }
+    if network_attachment is not None:
+        kwargs["network_attachment"] = network_attachment
+    if comm_channel is not None:
+        kwargs["comm_channel"] = comm_channel
+    if workspace_mounts is not None:
+        kwargs["workspace_mounts"] = workspace_mounts
+    if port_forwards is not None:
+        kwargs["port_forwards"] = port_forwards
+    if internet_settings is not None:
+        kwargs["internet_settings"] = internet_settings
+    return VMConfig(**kwargs)
+
+
+def _make_vm_config_skip_paths(
+    *,
+    network_attachment: NetworkAttachmentConfig | None = None,
+    comm_channel: str | None = None,
+    workspace_mounts: list | None = None,
+    port_forwards: list | None = None,
+    internet_settings: object | None = None,
+    vm_id: str = "test-vm",
+) -> VMConfig:
+    """Build a VMConfig skipping path validation (for tests that don't need files)."""
+    data: dict = {
+        "vm_id": vm_id,
+        "kernel_path": "/dev/null",
+        "rootfs_path": "/dev/null",
+    }
+    if network_attachment is not None:
+        data["network_attachment"] = {
+            "mode": network_attachment.mode,
+            "bridge": network_attachment.bridge,
+        }
+    if comm_channel is not None:
+        data["comm_channel"] = comm_channel
+    if workspace_mounts is not None:
+        data["workspace_mounts"] = workspace_mounts
+    if port_forwards is not None:
+        data["port_forwards"] = [
+            {"host_port": pf.host_port, "guest_port": pf.guest_port}
+            for pf in port_forwards
+        ]
+    if internet_settings is not None:
+        data["internet_settings"] = {
+            "allowed_domains": internet_settings.allowed_domains,
+        }
+    return VMConfig.model_validate(data, context={"validate_paths": False})
+
+
+class TestNetworkAttachmentConfig:
+    """Tests for the NetworkAttachmentConfig model."""
+
+    def test_nat_default(self) -> None:
+        na = NetworkAttachmentConfig()
+        assert na.mode == "nat"
+        assert na.bridge is None
+
+    def test_bridge_with_name(self) -> None:
+        na = NetworkAttachmentConfig(mode="bridge", bridge="br10")
+        assert na.mode == "bridge"
+        assert na.bridge == "br10"
+
+    def test_bridge_requires_name(self) -> None:
+        with pytest.raises(Exception, match="requires a bridge name"):
+            NetworkAttachmentConfig(mode="bridge")
+
+    def test_nat_rejects_bridge(self) -> None:
+        with pytest.raises(Exception, match="does not accept a bridge name"):
+            NetworkAttachmentConfig(mode="nat", bridge="br10")
+
+    def test_bridge_name_empty_rejected(self) -> None:
+        with pytest.raises(Exception, match="cannot be empty"):
+            NetworkAttachmentConfig(mode="bridge", bridge="   ")
+
+    def test_bridge_name_too_long(self) -> None:
+        with pytest.raises(Exception, match="15 bytes or fewer"):
+            NetworkAttachmentConfig(mode="bridge", bridge="a" * 16)
+
+    def test_bridge_name_invalid_chars(self) -> None:
+        with pytest.raises(Exception, match="not valid in a Linux interface name"):
+            NetworkAttachmentConfig(mode="bridge", bridge="br bad")
+
+    def test_frozen(self) -> None:
+        na = NetworkAttachmentConfig()
+        with pytest.raises(ValidationError):
+            na.mode = "bridge"  # type: ignore[misc]
+
+
+class TestNetworkConfigBridgeMode:
+    """Tests for NetworkConfig in bridge mode."""
+
+    def test_bridge_network_config(self) -> None:
+        nc = NetworkConfig(
+            mode="bridge",
+            bridge="br10",
+            tap_device="svmb1234",
+            guest_mac="aa:fc:00:11:22:33",
+        )
+        assert nc.mode == "bridge"
+        assert nc.bridge == "br10"
+        assert nc.guest_ip is None
+        assert nc.gateway_ip is None
+        assert nc.netmask is None
+        assert nc.ssh_host_port is None
+
+    def test_bridge_rejects_guest_ip(self) -> None:
+        with pytest.raises(Exception, match="must not set guest_ip"):
+            NetworkConfig(
+                mode="bridge",
+                bridge="br10",
+                tap_device="svmb1",
+                guest_mac="aa:fc:00:11:22:33",
+                guest_ip="10.0.0.5",
+            )
+
+    def test_bridge_rejects_gateway_ip(self) -> None:
+        with pytest.raises(Exception, match="must not set gateway_ip"):
+            NetworkConfig(
+                mode="bridge",
+                bridge="br10",
+                tap_device="svmb1",
+                guest_mac="aa:fc:00:11:22:33",
+                gateway_ip="10.0.0.1",
+            )
+
+    def test_bridge_rejects_ssh_host_port(self) -> None:
+        with pytest.raises(Exception, match="must not set ssh_host_port"):
+            NetworkConfig(
+                mode="bridge",
+                bridge="br10",
+                tap_device="svmb1",
+                guest_mac="aa:fc:00:11:22:33",
+                ssh_host_port=2200,
+            )
+
+    def test_nat_requires_guest_ip(self) -> None:
+        with pytest.raises(Exception, match="requires guest_ip"):
+            NetworkConfig(
+                mode="nat",
+                tap_device="tap0",
+                guest_mac="aa:fc:00:11:22:33",
+            )
+
+    def test_nat_rejects_bridge(self) -> None:
+        with pytest.raises(Exception, match="must not set bridge"):
+            NetworkConfig(
+                mode="nat",
+                bridge="br10",
+                tap_device="tap0",
+                guest_mac="aa:fc:00:11:22:33",
+                guest_ip="172.16.0.2",
+            )
+
+    def test_nat_defaults_filled(self) -> None:
+        nc = NetworkConfig(
+            guest_ip="172.16.0.2",
+            tap_device="tap0",
+            guest_mac="aa:fc:00:11:22:33",
+        )
+        assert nc.mode == "nat"
+        assert nc.gateway_ip == "172.16.0.1"
+        assert nc.netmask == "255.255.255.0"
+
+    def test_old_json_compat(self) -> None:
+        """Old JSON records without mode/bridge default to NAT."""
+        old = json.dumps({
+            "guest_ip": "172.16.0.2",
+            "gateway_ip": "172.16.0.1",
+            "netmask": "255.255.255.0",
+            "tap_device": "tap0",
+            "guest_mac": "aa:fc:00:11:22:33",
+            "ssh_host_port": 2200,
+        })
+        nc = NetworkConfig.model_validate_json(old)
+        assert nc.mode == "nat"
+        assert nc.bridge is None
+
+
+class TestVMConfigBridgeMode:
+    """Tests for VMConfig bridge mode validation."""
+
+    def test_default_network_attachment_is_nat(self, tmp_path: Path) -> None:
+        config = _make_vm_config(tmp_path)
+        assert config.network_attachment.mode == "nat"
+
+    def test_bridge_mode_rejects_ssh_comm_channel(self, tmp_path: Path) -> None:
+        with pytest.raises(Exception, match="requires vsock"):
+            _make_vm_config(
+                tmp_path,
+                comm_channel="ssh",
+                network_attachment=NetworkAttachmentConfig(mode="bridge", bridge="br10"),
+            )
+
+    def test_bridge_mode_rejects_workspace_mounts(self, tmp_path: Path) -> None:
+        with pytest.raises(Exception, match="Workspace mounts are not supported"):
+            _make_vm_config_skip_paths(
+                network_attachment=NetworkAttachmentConfig(mode="bridge", bridge="br10"),
+                workspace_mounts=[{"host_path": "/tmp", "guest_path": "/workspace"}],
+            )
+
+    def test_bridge_mode_rejects_port_forwards(self, tmp_path: Path) -> None:
+        from smolvm.types import PortForwardConfig
+
+        with pytest.raises(Exception, match="Port forwards are not supported"):
+            _make_vm_config_skip_paths(
+                network_attachment=NetworkAttachmentConfig(mode="bridge", bridge="br10"),
+                port_forwards=[PortForwardConfig(host_port=8080, guest_port=80)],
+            )
+
+    def test_bridge_mode_rejects_domain_allowlist(self, tmp_path: Path) -> None:
+        from smolvm.types import InternetSettings
+
+        with pytest.raises(Exception, match="Domain allow-lists are not enforced"):
+            _make_vm_config_skip_paths(
+                network_attachment=NetworkAttachmentConfig(mode="bridge", bridge="br10"),
+                internet_settings=InternetSettings(allowed_domains=["example.com"]),
+            )
+
+    def test_nat_mode_accepts_normal_options(self, tmp_path: Path) -> None:
+        config = _make_vm_config(tmp_path, comm_channel="ssh")
+        assert config.network_attachment.mode == "nat"
+
+
+class TestBridgeInspection:
+    """Tests for BridgeInspection and inspect_bridge."""
+
+    def test_bridge_inspection_dataclass(self) -> None:
+        from smolvm.host.network import BridgeInspection
+
+        ok = BridgeInspection(bridge_name="br10", ok=True)
+        assert ok.ok is True
+        assert ok.reason == ""
+
+        bad = BridgeInspection(bridge_name="br10", ok=False, reason="not a bridge")
+        assert bad.ok is False
+        assert bad.reason == "not a bridge"
+
+    def test_inspect_bridge_non_linux(self) -> None:
+        from smolvm.host.network import NetworkManager
+
+        nm = NetworkManager()
+        with patch("platform.system", return_value="Darwin"):
+            result = nm.inspect_bridge("br10")
+        assert result.ok is False
+        assert "Linux" in result.reason
+
+    def test_inspect_bridge_missing(self) -> None:
+        from smolvm.exceptions import SmolVMError
+        from smolvm.host.network import NetworkManager
+
+        nm = NetworkManager()
+        with patch("platform.system", return_value="Linux"), \
+             patch("smolvm.host.network.run_command", side_effect=SmolVMError("not found")):
+            result = nm.inspect_bridge("br10")
+        assert result.ok is False
+        assert "does not exist" in result.reason
+
+    def test_inspect_bridge_wrong_type(self) -> None:
+        from smolvm.host.network import NetworkManager
+
+        nm = NetworkManager()
+        mock_response = MagicMock()
+        mock_response.stdout = json.dumps([{"link_type": "vlan", "flags": ["UP"]}])
+        with patch("platform.system", return_value="Linux"), \
+             patch("smolvm.host.network.run_command", return_value=mock_response):
+            result = nm.inspect_bridge("eno1.10")
+        assert result.ok is False
+        assert "not a bridge" in result.reason
+
+    def test_inspect_bridge_not_up(self) -> None:
+        from smolvm.host.network import NetworkManager
+
+        nm = NetworkManager()
+        mock_response = MagicMock()
+        mock_response.stdout = json.dumps([{"link_type": "bridge", "flags": []}])
+        with patch("platform.system", return_value="Linux"), \
+             patch("smolvm.host.network.run_command", return_value=mock_response):
+            result = nm.inspect_bridge("br10")
+        assert result.ok is False
+        assert "not up" in result.reason
+
+    def test_inspect_bridge_no_members(self) -> None:
+        from smolvm.host.network import NetworkManager
+
+        nm = NetworkManager()
+        link_response = MagicMock()
+        link_response.stdout = json.dumps([{"link_type": "bridge", "flags": ["UP", "LOWER_UP"]}])
+        members_response = MagicMock()
+        members_response.stdout = "[]"
+        with patch("platform.system", return_value="Linux"), \
+             patch(
+                 "smolvm.host.network.run_command",
+                 side_effect=[link_response, members_response],
+             ):
+            result = nm.inspect_bridge("br10")
+        assert result.ok is False
+        assert "no member" in result.reason.lower()
+
+    def test_inspect_bridge_valid(self) -> None:
+        from smolvm.host.network import NetworkManager
+
+        nm = NetworkManager()
+        link_response = MagicMock()
+        link_response.stdout = json.dumps([{"link_type": "bridge", "flags": ["UP", "LOWER_UP"]}])
+        members_response = MagicMock()
+        members_response.stdout = json.dumps([{"ifname": "eno1.10"}])
+        empty_addr = MagicMock()
+        empty_addr.stdout = json.dumps([{"addr_info": []}])
+        # inspect_bridge: 1 (link show) + 1 (members) + _check_bridge_addresses:
+        #   bridge: 2 (inet, inet6) + member: 2 (inet, inet6) = 6 total
+        with patch("platform.system", return_value="Linux"), \
+             patch("smolvm.host.network.run_command",
+                   side_effect=[link_response, members_response,
+                                empty_addr, empty_addr, empty_addr, empty_addr]):
+            result = nm.inspect_bridge("br10")
+        assert result.ok is True
+
+    def test_inspect_bridge_with_host_address(self) -> None:
+        from smolvm.host.network import NetworkManager
+
+        nm = NetworkManager()
+        link_response = MagicMock()
+        link_response.stdout = json.dumps([{"link_type": "bridge", "flags": ["UP", "LOWER_UP"]}])
+        members_response = MagicMock()
+        members_response.stdout = json.dumps([{"ifname": "eno1.10"}])
+        addr_response = MagicMock()
+        addr_response.stdout = json.dumps([{
+            "addr_info": [{"local": "192.168.10.2", "scope": "global"}]
+        }])
+        with patch("platform.system", return_value="Linux"), \
+             patch("smolvm.host.network.run_command",
+                   side_effect=[link_response, members_response, addr_response, addr_response]):
+            result = nm.inspect_bridge("br10")
+        assert result.ok is False
+        assert "192.168.10.2" in result.reason
+
+
+class TestBridgeMacGeneration:
+    """Tests for bridge MAC address generation."""
+
+    def test_generate_bridge_mac_format(self) -> None:
+        from smolvm.host.network import NetworkManager
+
+        nm = NetworkManager()
+        mac = nm.generate_bridge_mac()
+        parts = mac.split(":")
+        assert len(parts) == 6
+        # Locally administered unicast (AA:FC prefix)
+        assert parts[0].upper() == "AA"
+        assert parts[1].upper() == "FC"
+
+    def test_generate_bridge_mac_unique(self) -> None:
+        from smolvm.host.network import NetworkManager
+
+        nm = NetworkManager()
+        macs = {nm.generate_bridge_mac() for _ in range(100)}
+        assert len(macs) > 90  # Allow a few collisions in 100 random MACs
+
+
+class TestTapAllocation:
+    """Tests for TAP name reservation in storage."""
+
+    def test_reserve_tap_name_bridge(self, tmp_path: Path) -> None:
+        from smolvm.storage._sqlite import SQLiteStateManager
+
+        manager = SQLiteStateManager(tmp_path / "test.db")
+        config = _make_vm_config(tmp_path, vm_id="test-vm-1")
+        manager.create_vm(config)
+        tap = manager.reserve_tap_name("test-vm-1", mode="bridge", bridge_name="br10")
+        assert tap.startswith("svmb")
+        assert len(tap) <= 15
+
+    def test_reserve_tap_name_idempotent(self, tmp_path: Path) -> None:
+        from smolvm.storage._sqlite import SQLiteStateManager
+
+        manager = SQLiteStateManager(tmp_path / "test.db")
+        config = _make_vm_config(tmp_path, vm_id="test-vm-2")
+        manager.create_vm(config)
+        tap1 = manager.reserve_tap_name("test-vm-2", mode="bridge", bridge_name="br10")
+        tap2 = manager.reserve_tap_name("test-vm-2", mode="bridge", bridge_name="br10")
+        assert tap1 == tap2
+
+    def test_get_tap_allocation(self, tmp_path: Path) -> None:
+        from smolvm.storage._sqlite import SQLiteStateManager
+
+        manager = SQLiteStateManager(tmp_path / "test.db")
+        config = _make_vm_config(tmp_path, vm_id="test-vm-3")
+        manager.create_vm(config)
+        manager.reserve_tap_name("test-vm-3", mode="bridge", bridge_name="br10")
+        alloc = manager.get_tap_allocation("test-vm-3")
+        assert alloc is not None
+        assert alloc[1] == "bridge"
+        assert alloc[2] == "br10"
+
+    def test_get_tap_allocation_none(self, tmp_path: Path) -> None:
+        from smolvm.storage._sqlite import SQLiteStateManager
+
+        manager = SQLiteStateManager(tmp_path / "test.db")
+        assert manager.get_tap_allocation("nonexistent") is None
+
+    def test_release_tap_name(self, tmp_path: Path) -> None:
+        from smolvm.storage._sqlite import SQLiteStateManager
+
+        manager = SQLiteStateManager(tmp_path / "test.db")
+        config = _make_vm_config(tmp_path, vm_id="test-vm-4")
+        manager.create_vm(config)
+        manager.reserve_tap_name("test-vm-4", mode="bridge", bridge_name="br10")
+        manager.release_tap_name("test-vm-4")
+        assert manager.get_tap_allocation("test-vm-4") is None
+
+    def test_reserve_tap_name_requested(self, tmp_path: Path) -> None:
+        from smolvm.storage._sqlite import SQLiteStateManager
+
+        manager = SQLiteStateManager(tmp_path / "test.db")
+        config = _make_vm_config(tmp_path, vm_id="test-vm-5")
+        manager.create_vm(config)
+        tap = manager.reserve_tap_name(
+            "test-vm-5", mode="bridge", bridge_name="br10", requested_tap="svmb9999"
+        )
+        assert tap == "svmb9999"
+
+    def test_reserve_tap_name_conflict(self, tmp_path: Path) -> None:
+        from smolvm.exceptions import NetworkError
+        from smolvm.storage._sqlite import SQLiteStateManager
+
+        manager = SQLiteStateManager(tmp_path / "test.db")
+        config1 = _make_vm_config(tmp_path, vm_id="test-vm-6")
+        config2 = _make_vm_config(tmp_path, vm_id="test-vm-7")
+        manager.create_vm(config1)
+        manager.create_vm(config2)
+        manager.reserve_tap_name("test-vm-6", mode="bridge", requested_tap="svmbconf1")
+        with pytest.raises(NetworkError, match="already reserved"):
+            manager.reserve_tap_name("test-vm-7", mode="bridge", requested_tap="svmbconf1")
+
+
+class TestQemuArgsBridgeMode:
+    """Tests for QEMU args in bridge mode."""
+
+    def test_bridge_mode_selects_tap_transport(self, tmp_path: Path) -> None:
+        """QEMU should use TAP transport for bridge mode even with qemu_network='slirp'."""
+        from smolvm.runtime.guest_platforms import _LINUX_SPEC
+        from smolvm.runtime.qemu_args import build_qemu_argv
+        from smolvm.types import VMInfo, VMState
+
+        config = _make_vm_config(
+            tmp_path,
+            vm_id="test-bridge",
+            network_attachment=NetworkAttachmentConfig(mode="bridge", bridge="br10"),
+        )
+        config = config.model_copy(update={"qemu_network": "slirp"})
+        network = NetworkConfig(
+            mode="bridge",
+            bridge="br10",
+            tap_device="svmb1234",
+            guest_mac="aa:fc:00:11:22:33",
+        )
+        vm_info = VMInfo(
+            vm_id="test-bridge",
+            status=VMState.CREATED,
+            config=config,
+            network=network,
+        )
+        args = build_qemu_argv(
+            vm_info,
+            qemu_bin=Path("/usr/bin/qemu-system-x86_64"),
+            boot_args=vm_info.config.boot_args,
+            platform_spec=_LINUX_SPEC,
+            host_system="Linux",
+        )
+        netdev_args = [a for a in args if a.startswith("tap,id=net0")]
+        assert len(netdev_args) == 1
+        assert "svmb1234" in netdev_args[0]

--- a/tests/test_build.py
+++ b/tests/test_build.py
@@ -95,7 +95,39 @@ def test_init_script_honors_guest_network_hook_then_dhcp(script: str) -> None:
     assert "ifup eth0" in script
     assert "udhcpc -q -n -t 5 -i eth0" in script
     assert "dhclient -1 eth0" in script
+    assert 'log_ts "net-config-failed"' in script
+    assert "if configure_guest_managed_network; then" in script
     assert script.index("/etc/smolvm/network.sh eth0") < script.index("udhcpc -q -n")
+
+
+@pytest.mark.parametrize(
+    "script",
+    [
+        ImageBuilder()._default_init_script(),
+        Path("scripts/ci/preset-init.sh").read_text(),
+    ],
+)
+def test_guest_network_setup_returns_failure_when_no_configuration_works(
+    script: str,
+    tmp_path: Path,
+) -> None:
+    start = script.index("configure_guest_managed_network()")
+    end = script.index('\n}\n\nif [ -n "$GUEST_MANAGED" ]', start) + 3
+    function = script[start:end]
+    fake_ip = tmp_path / "ip"
+    fake_ip.write_text("#!/bin/sh\nexit 0\n")
+    fake_ip.chmod(0o755)
+
+    result = subprocess.run(
+        ["/bin/sh", "-c", f"{function}\nconfigure_guest_managed_network"],
+        check=False,
+        capture_output=True,
+        text=True,
+        env={"PATH": str(tmp_path)},
+    )
+
+    assert result.returncode == 1
+    assert "no guest network configuration" in result.stderr
 
 
 def test_base_init_script_keeps_tmp_on_root_disk() -> None:

--- a/tests/test_build.py
+++ b/tests/test_build.py
@@ -82,6 +82,22 @@ def test_preset_init_script_uses_cmdline_netmask_and_gateway_dns() -> None:
     assert 'ip addr add "${GUEST_IP}/24"' not in script
 
 
+@pytest.mark.parametrize(
+    "script",
+    [
+        ImageBuilder()._default_init_script(),
+        Path("scripts/ci/preset-init.sh").read_text(),
+    ],
+)
+def test_init_script_honors_guest_network_hook_then_dhcp(script: str) -> None:
+    assert "smolvm.network=guest" in script
+    assert "/etc/smolvm/network.sh eth0" in script
+    assert "ifup eth0" in script
+    assert "udhcpc -q -n -t 5 -i eth0" in script
+    assert "dhclient -1 eth0" in script
+    assert script.index("/etc/smolvm/network.sh eth0") < script.index("udhcpc -q -n")
+
+
 def test_base_init_script_keeps_tmp_on_root_disk() -> None:
     script = ImageBuilder()._default_init_script()
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -64,6 +64,8 @@ def _make_vm_info(
         vm.network = MagicMock(spec=NetworkConfig)
         vm.network.guest_ip = guest_ip
         vm.network.ssh_host_port = ssh_host_port
+        vm.network.mode = "nat"
+        vm.network.bridge = None
     else:
         vm.network = None
     return vm
@@ -3156,6 +3158,8 @@ class TestCliInfo:
             vm.network = MagicMock(spec=NetworkConfig)
             vm.network.guest_ip = guest_ip
             vm.network.ssh_host_port = ssh_host_port
+            vm.network.mode = "nat"
+            vm.network.bridge = None
         else:
             vm.network = None
         return vm
@@ -3284,6 +3288,8 @@ class TestCliInfo:
             "memory": 1024,
             "memory_used": None,
             "disk_size": 3,
+            "network_mode": "nat",
+            "bridge": None,
         }
 
     def test_info_not_found(

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -984,6 +984,41 @@ class TestCliCreate:
         assert payload["data"]["next"]["ssh_command"] == "smolvm sandbox ssh project-spacex"
         assert payload["data"]["next"]["info_command"] == "smolvm sandbox info project-spacex"
 
+    @patch("smolvm.facade._build_auto_config")
+    @patch("smolvm.facade.SmolVM")
+    def test_create_bridge_does_not_recommend_unsupported_ssh(
+        self,
+        mock_vm_cls: MagicMock,
+        mock_build_auto_config: MagicMock,
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        config = MagicMock(vm_id="bridge-demo")
+        mock_build_auto_config.return_value = (config, "/tmp/id_ed25519")
+        vm = MagicMock(vm_id="bridge-demo")
+        vm.info.status = VMState.RUNNING
+        vm.info.network = MagicMock(spec=NetworkConfig)
+        vm.info.network.mode = "bridge"
+        mock_vm_cls.return_value = vm
+
+        ret = main(
+            [
+                "sandbox",
+                "create",
+                "--name",
+                "bridge-demo",
+                "--network",
+                "bridge",
+                "--bridge",
+                "br10",
+                "--json",
+            ]
+        )
+
+        assert ret == 0
+        payload = json.loads(capsys.readouterr().out)
+        assert payload["data"]["next"]["shell_command"] == ("smolvm sandbox shell bridge-demo")
+        assert payload["data"]["next"]["ssh_command"] is None
+
     @patch("smolvm.facade.platform.machine", return_value="x86_64")
     @patch("smolvm.facade.build_seed_iso")
     @patch("smolvm.facade.ImageManager")
@@ -1144,8 +1179,55 @@ class TestCliCreate:
         assert "Invalid value for '--os'" in capsys.readouterr().err
 
 
+class TestCliBridgeCheck:
+    """Tests for the read-only bridge preflight command."""
+
+    @patch("smolvm.host.network.NetworkManager.inspect_bridge")
+    def test_bridge_check_json_uses_shared_envelope(
+        self,
+        inspect_bridge: MagicMock,
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        from smolvm.host.network import BridgeInspection
+
+        inspect_bridge.return_value = BridgeInspection("br10", True)
+
+        assert main(["bridge", "check", "br10", "--json"]) == 0
+        payload = json.loads(capsys.readouterr().out)
+        assert payload["command"] == "bridge.check"
+        assert payload["exit_code"] == 0
+        assert payload["data"] == {"bridge": "br10", "ok": True, "reason": None}
+
+
 class TestCliCreateImage:
     """Tests for `smolvm sandbox create --image`."""
+
+    @patch("smolvm.cli.main._build_and_boot_with_progress")
+    def test_s3_human_create_propagates_bridge_options(
+        self,
+        mock_build_and_boot: MagicMock,
+    ) -> None:
+        vm = _make_vm_info(vm_id="bridge-s3", status=VMState.RUNNING)
+        facade = MagicMock(vm_id="bridge-s3", info=vm)
+        mock_build_and_boot.return_value = facade
+
+        ret = main(
+            [
+                "sandbox",
+                "create",
+                "--image",
+                "s3://bucket/images/test/",
+                "--network",
+                "bridge",
+                "--bridge",
+                "br10",
+            ]
+        )
+
+        assert ret == 0
+        assert mock_build_and_boot.call_args.kwargs["network_mode"] == "bridge"
+        assert mock_build_and_boot.call_args.kwargs["bridge_name"] == "br10"
+        facade.close.assert_called_once()
 
     @patch("smolvm.cli.main._run_create", return_value=0)
     def test_image_flag_parsed(self, mock_run_create: MagicMock) -> None:
@@ -3280,6 +3362,31 @@ class TestCliInfo:
             "network_mode": "nat",
             "bridge": None,
         }
+
+    def test_info_bridge_uses_human_copy_but_json_ip_is_null(
+        self,
+        mock_sdk_cls: MagicMock,
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        vm = self._make_info_vm(status=VMState.STOPPED)
+        vm.network.guest_ip = None
+        vm.network.ssh_host_port = None
+        vm.network.mode = "bridge"
+        vm.network.bridge = "br10"
+        mock_sdk_cls.return_value.state.get_vm.return_value = vm
+
+        assert main(["sandbox", "info", "sbx-pauling"]) == 0
+        human = capsys.readouterr().out
+        assert "Network Mode" in human
+        assert "bridge" in human
+        assert "br10" in human
+        assert "Managed inside guest" in human
+
+        assert main(["sandbox", "info", "sbx-pauling", "--json"]) == 0
+        payload = json.loads(capsys.readouterr().out)
+        assert payload["data"]["vm"]["ip_address"] is None
+        assert payload["data"]["vm"]["network_mode"] == "bridge"
+        assert payload["data"]["vm"]["bridge"] == "br10"
 
     def test_info_not_found(
         self,

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -983,6 +983,7 @@ class TestCliCreate:
         assert payload["data"]["next"]["shell_command"] == "smolvm sandbox shell project-spacex"
         assert payload["data"]["next"]["ssh_command"] == "smolvm sandbox ssh project-spacex"
         assert payload["data"]["next"]["info_command"] == "smolvm sandbox info project-spacex"
+        assert payload["data"]["warnings"] == []
 
     @patch("smolvm.facade._build_auto_config")
     @patch("smolvm.facade.SmolVM")
@@ -1018,6 +1019,7 @@ class TestCliCreate:
         payload = json.loads(capsys.readouterr().out)
         assert payload["data"]["next"]["shell_command"] == ("smolvm sandbox shell bridge-demo")
         assert payload["data"]["next"]["ssh_command"] is None
+        assert "smolvm sandbox shell bridge-demo" in payload["data"]["warnings"][0]
 
     @patch("smolvm.facade.platform.machine", return_value="x86_64")
     @patch("smolvm.facade.build_seed_iso")

--- a/tests/test_facade.py
+++ b/tests/test_facade.py
@@ -506,6 +506,7 @@ class TestVMInit:
 
         assert config.vm_id == "project-spacex"
         assert ssh_key_path == str(private_key)
+        assert config.guest_managed_networking is True
         assert "init=/init" in config.boot_args
         mock_builder.build_alpine_ssh_key.assert_called_once()
 
@@ -553,6 +554,7 @@ class TestVMInit:
         assert config.guest_os is GuestOS.UBUNTU
         assert config.initrd_path is None
         assert config.ssh_capable is True
+        assert config.guest_managed_networking is False
         assert config.disk_size_mib == 8192
         assert config.grow_filesystem is True
         assert "init=/init" in config.boot_args


### PR DESCRIPTION
## Summary

Implements opt-in bridged networking that connects a sandbox directly to an existing host bridge (e.g. `br10`), so the VM appears as a regular machine on that network with its own MAC and guest-managed IP address, bypassing SmolVM's private NAT network.

NAT mode remains the safe default. Bridge mode is explicit and opt-in via `--network bridge --bridge br10`.

## What's included

### Data model (`types.py`)
- `NetworkAttachmentConfig` model with `mode` (nat/bridge) and `bridge` fields, with validation
- `NetworkConfig` extended with `mode` and `bridge` fields; `guest_ip`/`gateway_ip`/`netmask` optional for bridge mode
- Backward-compatible: old JSON records default to NAT mode
- `VMConfig` validator rejects incompatible features in bridge mode (SSH comm channel, workspace mounts, port forwards, domain allow-lists)

### Host networking (`network.py`)
- `BridgeInspection` dataclass and `inspect_bridge()` for read-only validation (checks: Linux host, interface exists, is a bridge, is up, has members, no host IP addresses)
- `prepare_bridged_tap()` / `async_prepare_bridged_tap()` for creating TAP devices attached to a bridge with rollback on failure
- `generate_bridge_mac()` for random locally-administered MAC addresses

### Storage (`_sqlite.py`, `_postgres.py`, `_protocol.py`)
- `tap_allocations` table in both SQLite and PostgreSQL
- `reserve_tap_name()`, `get_tap_allocation()`, `release_tap_name()` methods
- TAP names are Linux-safe (`svmb` + 8 hex chars, 12 bytes total)

### Lifecycle (`vm.py`)
- Bridge-mode create path (sync + async): validates bridge, reserves TAP, creates bridged TAP, persists bridge `NetworkConfig` without IP/NAT/route/SSH-forward
- Start/restart revalidates bridge and repairs TAP if missing
- Cleanup removes only SmolVM-owned TAP, never the user's bridge
- Boot args add `smolvm.network=guest` marker for bridge mode
- Snapshot restore validates and reattaches to persisted bridge

### Guest init scripts (`builder.py`, `preset-init.sh`)
- Handle `smolvm.network=guest` marker: bring link up without configuring an address

### CLI (`app.py`, `main.py`)
- `--network` (nat/bridge) and `--bridge` options on `smolvm sandbox create`
- `smolvm bridge check <bridge>` preflight command
- `sandbox info` and `sandbox list` output includes `network_mode` and `bridge` fields
- `get_ip()` raises clear error for bridge-mode sandboxes

### Tests (`test_bridge_networking.py`)
- 40 unit tests covering: config validation, bridge inspection (7 scenarios), MAC generation, TAP allocation (7 tests), QEMU args TAP transport selection
- Updated existing CLI test mocks for new `mode`/`bridge` fields

## Usage

```bash
# Default (unchanged)
smolvm sandbox create --name demo

# Bridged mode
smolvm sandbox create --name demo --network bridge --bridge br10

# Preflight check
smolvm bridge check br10
```

## Test results

- All 372 tests pass (types, storage, network, qemu_args, comm_select, cli, bridge_networking)
- `ruff check` passes on all changed files
- Pre-existing macOS-only failures (vsock unavailable, sparse file copy) are unrelated

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Linux bridged networking end-to-end (sandbox create, VM boot/start, snapshot/restore).
  * New CLI options: `--network {nat,bridge}`, `--bridge`, plus `bridge check` (human + JSON).
  * VM `info` now includes `network_mode` and `bridge`; bridged VMs show “Managed inside guest” and omit the JSON SSH “next” step.
  * Persistent bridged TAP naming for more reliable restart/restore.
  * Guest-managed init networking now supports `/etc/smolvm/network.sh eth0` with DHCP fallback.
* **Bug Fixes**
  * Improved bridge validation and bridged TAP ownership/repair behavior.
  * Bridged mode now blocks unsupported host SSH and localhost port-forwarding with clearer errors.
* **Documentation**
  * Expanded networking guide and CLI reference for bridge usage and limits.
* **Tests**
  * Added unit + privileged end-to-end coverage for bridge connectivity and guest networking behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->