### PR TITLE
Fix ENOENT when creating multiple SmolVM sandboxes concurrently

### DIFF
--- a/src/smolvm/images/published.py
+++ b/src/smolvm/images/published.py
@@ -414,6 +414,7 @@ def _decompress_zstd(src: Path, dst: Path) -> None:
     reflink support.
     """
     from smolvm.host.disk import decompress_zstd_sparse
+
     staging = dst.with_name(f".{dst.name}.{uuid4().hex}.partial")
     try:
         decompress_zstd_sparse(src, staging, chunk_size=_SPARSE_DECOMPRESS_CHUNK_SIZE)

--- a/src/smolvm/images/published.py
+++ b/src/smolvm/images/published.py
@@ -46,6 +46,7 @@ from pydantic import BaseModel, ConfigDict
 from smolvm import __version__
 from smolvm.exceptions import ImageError
 from smolvm.images.manager import ImageManager, ImageSource, LocalImage
+from uuid import uuid4
 
 Arch = Literal["amd64", "arm64"]
 Preset = Literal["codex", "claude-code", "openclaw", "hermes", "pi", "ubuntu"]
@@ -413,11 +414,13 @@ def _decompress_zstd(src: Path, dst: Path) -> None:
     reflink support.
     """
     from smolvm.host.disk import decompress_zstd_sparse
-
+    staging = dst.with_name(f".{dst.name}.{uuid4().hex}.partial")
     try:
-        decompress_zstd_sparse(src, dst, chunk_size=_SPARSE_DECOMPRESS_CHUNK_SIZE)
+        decompress_zstd_sparse(src, staging, chunk_size=_SPARSE_DECOMPRESS_CHUNK_SIZE)
+        staging.replace(dst)
     except OSError as exc:
-        (dst.parent / (dst.name + ".tmp")).unlink(missing_ok=True)
+        (staging.parent / (staging.name + ".tmp")).unlink(missing_ok=True)
+        staging.unlink(missing_ok=True)
         if _looks_like_zstd_decode_error(exc):
             import zstandard
 


### PR DESCRIPTION
## Summary

Constructing more than one SmolVM concurrently on a cold image cache fails for all but one of them:

OSError: No such file or directory (os error 2)

SmolVM.__init__ lazily decompresses the published zstd rootfs, so N concurrent constructors all enter _decompress_zstd for the same target. It writes through a fixed temp path (<target>.tmp), so the calls share one temp file: whichever finishes first renames it onto the target, and the rest fail on the vanished path.

Observed on 0.0.26; the code is unchanged on main.

```
  File "smolvm/facade.py", line 1058, in __init__
    config, ssh_key_path = _build_auto_config(...)
  File "smolvm/facade.py", line 596, in _build_auto_config
    local_image = ensure_published_image(...)
  File "smolvm/images/published.py", line 492, in ensure_published_image
    _decompress_zstd(local.rootfs_path, decompressed_path)
  File "smolvm/images/published.py", line 418, in _decompress_zstd
    decompress_zstd_sparse(src, dst, chunk_size=_SPARSE_DECOMPRESS_CHUNK_SIZE)
  File "smolvm/host/disk.py", line 84, in decompress_zstd_sparse
    method = str(core_disk.decompress_zstd_sparse(str(source), str(target), chunk_size))
OSError: No such file or directory (os error 2)
```

## **Why it's easy to miss**

It only bites on a cold cache — once the image is decompressed the branch is skipped, so a retry always succeeds and everything self-heals. In our case it surfaced as sandboxes appearing to be created twice: the failure went back to the caller, which retried and succeeded, so the only visible artifact was a duplicate create_sandbox. Each affected caller still burns the 
Reproduction

Four threads calling _decompress_zstd(src, dst) with the same dst, against a stub decompress_zstd_sparse that mirrors the real contract (write <target>.tmp, then rename onto <target>):

before:  succeeded 1/4,  3 × FileNotFoundError [Errno 2] ... 'rootfs.ext4.tmp' -> 'rootfs.ext4'
after:   succeeded 4/4,  0 failures

Equivalently, in a real environment: construct 2+ SmolVM(os="ubuntu") concurrently with no decompressed rootfs in the cache.

## **Fix**

Decompress to a per-call staging path, then rename it onto the target:

staging = dst.with_name(f".{dst.name}.{uuid4().hex}.partial")
try:
    decompress_zstd_sparse(src, staging, chunk_size=_SPARSE_DECOMPRESS_CHUNK_SIZE)
    staging.replace(dst)
except OSError as exc:
    (staging.parent / (staging.name + ".tmp")).unlink(missing_ok=True)
    staging.unlink(missing_ok=True)
    ...

Each call now owns its <staging>.tmp, so concurrent streams can't clobber each other, and the final replace is atomic — a concurrent reader sees either the old file or a complete new one, never a partial. This mirrors the approach build_seed_iso in images/cloud_init.py already uses (uuid-unique temp + atomic replace).

Behaviour for the single-caller path is unchanged.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability when decompressing disk images by staging decompression and only replacing the destination after success.
  * Enhanced failure handling by expanding cleanup of temporary artifacts to prevent leftover partial/in-progress files.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->