### PR TITLE
Fix published image import order

### DIFF
--- a/src/smolvm/images/published.py
+++ b/src/smolvm/images/published.py
@@ -40,13 +40,13 @@ import os
 from collections.abc import Callable
 from pathlib import Path
 from typing import Literal
+from uuid import uuid4
 
 from pydantic import BaseModel, ConfigDict
 
 from smolvm import __version__
 from smolvm.exceptions import ImageError
 from smolvm.images.manager import ImageManager, ImageSource, LocalImage
-from uuid import uuid4
 
 Arch = Literal["amd64", "arm64"]
 Preset = Literal["codex", "claude-code", "openclaw", "hermes", "pi", "ubuntu"]


### PR DESCRIPTION
## Summary
- move the standard-library UUID import into the sorted import block

## Validation
- `uv run ruff check --output-format github .`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Reorganized internal imports without changing application behavior or functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->