### PR TITLE
feat: Add smolvm image command group and configurable image storage

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -172,7 +172,7 @@ jobs:
           release_downloads = []
           expected_agent = Path("/tmp/fake-smolvm-guest-agent")
 
-          def fake_download_guest_agent_binary():
+          def fake_download_guest_agent_binary(image_cache_dir=None):
               release_downloads.append("download")
               return expected_agent
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -39,6 +39,10 @@ SmolVM is specifically designed to provide a secure "sandbox" for AI agents to e
 - When adding a new harness or resource, register it as a top-level
   subcommand and put its actions underneath, instead of overloading a
   global verb.
+- Documented exceptions: the top-level `smolvm prune` and `smolvm images`
+  aliases exist for muscle memory (`images` mirrors `docker images`); both
+  delegate to their NOUN-VERB homes (`image prune`, `image list`). Do not
+  add further top-level aliases without discussion.
 
 
 ### Core writing principles

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -9,7 +9,7 @@ The CLI creates and manages disposable sandboxes. Run `smolvm COMMAND --help` fo
 | `smolvm setup` | Install or check local runtime dependencies. |
 | `smolvm doctor` | Check whether this machine can run sandboxes. |
 | `smolvm update` | Upgrade to the latest stable release. |
-| `smolvm prune` | Remove stale cached images. |
+| `smolvm prune` | Remove stale cached images (alias for `smolvm image prune`). |
 
 ## Work with sandboxes
 
@@ -36,6 +36,19 @@ Run these in the order you need them:
 ## Start a prepared agent
 
 `smolvm codex start`, `smolvm claude start`, `smolvm pi start`, `smolvm hermes start`, and `smolvm openclaw start` create a sandbox and install that agent. See [Agent presets](../guides/agent-presets.md).
+
+## Manage downloaded images
+
+The first time you start a sandbox or agent, SmolVM downloads the files it boots from and keeps them on disk so later starts are fast. These commands manage that storage:
+
+| Command | Use it to |
+| --- | --- |
+| `smolvm image pull <preset>` | Download an image ahead of time, for example before going offline. |
+| `smolvm image list` | See which images are downloaded and how much space they use. |
+| `smolvm image rm <name>` | Remove a downloaded image to free disk space. |
+| `smolvm image prune` | Remove images left behind by older SmolVM versions. |
+
+Images are stored in `~/.smolvm/images`. To store them somewhere else, set the `SMOLVM_IMAGE_DIR` environment variable, or pass `--image-dir` to any `smolvm image` command.
 
 ## Browser, local services, and Windows
 

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -48,7 +48,7 @@ The first time you start a sandbox or agent, SmolVM downloads the files it boots
 | `smolvm image rm <name>` | Remove a downloaded image to free disk space. |
 | `smolvm image prune` | Remove images left behind by older SmolVM versions. |
 
-Images are stored in `~/.smolvm/images`. To store them somewhere else, set the `SMOLVM_IMAGE_DIR` environment variable, or pass `--image-dir` to any `smolvm image` command.
+Images are stored in `~/.smolvm/images`. To keep them somewhere else, set the `SMOLVM_IMAGE_DIR` environment variable — sandboxes read it too, so images you pull are found when a sandbox starts. The `--image-dir` option points a single `smolvm image` command at a different folder; sandboxes do not read that folder.
 
 ## Browser, local services, and Windows
 

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -39,12 +39,16 @@ Run these in the order you need them:
 
 ## Manage downloaded images
 
-The first time you start a sandbox or agent, SmolVM downloads the files it boots from and keeps them on disk so later starts are fast. These commands manage that storage:
+The first time you start a sandbox or agent, SmolVM downloads the files it boots from and keeps them on disk so later starts are fast. These commands manage that storage, and they work like Docker's image commands if you know those:
 
 | Command | Use it to |
 | --- | --- |
 | `smolvm image pull <preset>` | Download an image ahead of time, for example before going offline. |
-| `smolvm image list` | See which images are downloaded and how much space they use. |
+| `smolvm image pull --all` | Download every image available for this machine in one go. |
+| `smolvm images` (or `image list` / `image ls`) | See which images are downloaded, when, and how much space they use. |
+| `smolvm image inspect <name>` | See one image in detail: files, checksums, and where it came from. |
+| `smolvm image build -t NAME .` | Build a custom image from a Dockerfile (needs Docker installed). |
+| `smolvm image save <name> -o FILE` / `image load -i FILE` | Copy an image to a machine without internet access. |
 | `smolvm image rm <name>` | Remove a downloaded image to free disk space. |
 | `smolvm image prune` | Remove images left behind by older SmolVM versions. |
 

--- a/src/smolvm/cli/_kvm_session.py
+++ b/src/smolvm/cli/_kvm_session.py
@@ -69,9 +69,11 @@ _SKIP_FIRST_ARGS: frozenset[str] = frozenset(
         "prune",
         "ui",
         "server",
-        # Image-cache management (pull/list/rm/prune) — downloads and file
-        # operations that never open /dev/kvm.
+        # Image-cache management (pull/list/rm/prune/...) — downloads and
+        # file operations that never open /dev/kvm. "images" is the
+        # docker-style top-level alias for "image list".
         "image",
+        "images",
     }
 )
 

--- a/src/smolvm/cli/_kvm_session.py
+++ b/src/smolvm/cli/_kvm_session.py
@@ -69,6 +69,9 @@ _SKIP_FIRST_ARGS: frozenset[str] = frozenset(
         "prune",
         "ui",
         "server",
+        # Image-cache management (pull/list/rm/prune) — downloads and file
+        # operations that never open /dev/kvm.
+        "image",
     }
 )
 

--- a/src/smolvm/cli/commands/app.py
+++ b/src/smolvm/cli/commands/app.py
@@ -374,8 +374,13 @@ def image() -> None:
 
 
 @image.command("pull")
-@click.argument("preset", metavar="preset", required=False, default=None)
-@click.option("--all", "all_images", is_flag=True, help="Download every image for this machine.")
+@click.argument("preset", metavar="[preset]", required=False, default=None)
+@click.option(
+    "--all",
+    "all_images",
+    is_flag=True,
+    help="Download every image for this machine (all operating systems).",
+)
 @click.option(
     "--arch",
     type=click.Choice(["amd64", "arm64"]),
@@ -393,7 +398,8 @@ def image() -> None:
     "os_name",
     type=click.Choice(["ubuntu", "alpine"]),
     default=None,
-    help="Operating system inside the image; defaults to ubuntu.",
+    help="Operating system inside the image; single pulls default to ubuntu, "
+    "and with --all this limits the download.",
 )
 @image_dir_option
 @json_option
@@ -407,11 +413,11 @@ def image_pull(
     json_output: bool,
 ) -> Any:
     """Download a sandbox image before first use."""
-    _before_command(json_output=json_output)
     if bool(preset) == all_images:
         raise click.UsageError(
             "Choose one target: 'smolvm image pull codex' or 'smolvm image pull --all'."
         )
+    _before_command(json_output=json_output)
     if all_images:
         from smolvm.cli.image import run_image_pull_all
 

--- a/src/smolvm/cli/commands/app.py
+++ b/src/smolvm/cli/commands/app.py
@@ -359,12 +359,13 @@ def update(check_only: bool, json_output: bool) -> Any:
 @cli.command("prune", help="Remove stale image-cache entries (alias for 'smolvm image prune').")
 @click.option("--dry-run", is_flag=True, help="Show what would be removed.")
 @click.option("--cache-dir", default=None, hidden=True)
+@image_dir_option
 @json_option
-def prune(dry_run: bool, cache_dir: str | None, json_output: bool) -> Any:
+def prune(dry_run: bool, cache_dir: str | None, image_dir: str | None, json_output: bool) -> Any:
     _before_command(json_output=json_output)
     from smolvm.cli.prune import run_prune
 
-    return run_prune(dry_run=dry_run, json_output=json_output, cache_dir=cache_dir)
+    return run_prune(dry_run=dry_run, json_output=json_output, cache_dir=image_dir or cache_dir)
 
 
 @cli.group(context_settings=CONTEXT_SETTINGS)
@@ -378,20 +379,20 @@ def image() -> None:
     "--arch",
     type=click.Choice(["amd64", "arm64"]),
     default=None,
-    help="Guest CPU architecture; defaults to this machine's.",
+    help="Processor type of the image; defaults to this machine's.",
 )
 @click.option(
     "--vmm",
     type=click.Choice(["firecracker", "qemu", "libkrun"]),
     default=None,
-    help="Hypervisor the kernel is built for; defaults to this machine's runtime.",
+    help="Virtual machine engine that boots the image; defaults to what this machine uses.",
 )
 @click.option(
     "--os",
     "os_name",
     type=click.Choice(["ubuntu", "alpine"]),
     default=None,
-    help="Guest OS flavour; defaults to ubuntu.",
+    help="Operating system inside the image; defaults to ubuntu.",
 )
 @image_dir_option
 @json_option

--- a/src/smolvm/cli/commands/app.py
+++ b/src/smolvm/cli/commands/app.py
@@ -13,6 +13,7 @@ from smolvm.cli.commands.options import (
     backend_option,
     boot_timeout_option,
     comm_channel_option,
+    image_dir_option,
     json_option,
     positive_float_type,
     positive_int_type,
@@ -355,7 +356,7 @@ def update(check_only: bool, json_output: bool) -> Any:
     return run_update(check=check_only, json_output=json_output)
 
 
-@cli.command("prune", help="Remove stale image-cache entries.")
+@cli.command("prune", help="Remove stale image-cache entries (alias for 'smolvm image prune').")
 @click.option("--dry-run", is_flag=True, help="Show what would be removed.")
 @click.option("--cache-dir", default=None, hidden=True)
 @json_option
@@ -364,6 +365,101 @@ def prune(dry_run: bool, cache_dir: str | None, json_output: bool) -> Any:
     from smolvm.cli.prune import run_prune
 
     return run_prune(dry_run=dry_run, json_output=json_output, cache_dir=cache_dir)
+
+
+@cli.group(context_settings=CONTEXT_SETTINGS)
+def image() -> None:
+    """Download and manage cached sandbox images."""
+
+
+@image.command("pull")
+@click.argument("preset", metavar="preset")
+@click.option(
+    "--arch",
+    type=click.Choice(["amd64", "arm64"]),
+    default=None,
+    help="Guest CPU architecture; defaults to this machine's.",
+)
+@click.option(
+    "--vmm",
+    type=click.Choice(["firecracker", "qemu", "libkrun"]),
+    default=None,
+    help="Hypervisor the kernel is built for; defaults to this machine's runtime.",
+)
+@click.option(
+    "--os",
+    "os_name",
+    type=click.Choice(["ubuntu", "alpine"]),
+    default=None,
+    help="Guest OS flavour; defaults to ubuntu.",
+)
+@image_dir_option
+@json_option
+def image_pull(
+    preset: str,
+    arch: str | None,
+    vmm: str | None,
+    os_name: str | None,
+    image_dir: str | None,
+    json_output: bool,
+) -> Any:
+    """Download a sandbox image before first use."""
+    _before_command(json_output=json_output)
+    from smolvm.cli.image import run_image_pull
+
+    return run_image_pull(
+        preset=preset,
+        arch=arch,
+        vmm=vmm,
+        os_name=os_name,
+        image_dir=image_dir,
+        json_output=json_output,
+    )
+
+
+@image.command("list")
+@image_dir_option
+@json_option
+def image_list(image_dir: str | None, json_output: bool) -> Any:
+    """Show downloaded images and how much space they use."""
+    _before_command(json_output=json_output)
+    from smolvm.cli.image import run_image_list
+
+    return run_image_list(image_dir=image_dir, json_output=json_output)
+
+
+@image.command("rm")
+@click.argument("name", metavar="name-or-preset")
+@click.option("--dry-run", is_flag=True, help="Show what would be removed.")
+@image_dir_option
+@json_option
+def image_rm(name: str, dry_run: bool, image_dir: str | None, json_output: bool) -> Any:
+    """Remove a downloaded image to free disk space."""
+    _before_command(json_output=json_output)
+    from smolvm.cli.image import run_image_rm
+
+    return run_image_rm(
+        name=name,
+        image_dir=image_dir,
+        dry_run=dry_run,
+        json_output=json_output,
+    )
+
+
+@image.command("prune", help="Remove image caches left behind by older SmolVM versions.")
+@click.option("--dry-run", is_flag=True, help="Show what would be removed.")
+@image_dir_option
+@json_option
+def image_prune(dry_run: bool, image_dir: str | None, json_output: bool) -> Any:
+    _before_command(json_output=json_output)
+    from smolvm.cli.prune import run_prune
+
+    return run_prune(
+        dry_run=dry_run,
+        json_output=json_output,
+        cache_dir=image_dir,
+        command_name="image.prune",
+    )
 
 
 @cli.command("ui", help="Start the local dashboard.")

--- a/src/smolvm/cli/commands/app.py
+++ b/src/smolvm/cli/commands/app.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import importlib.metadata
 from types import SimpleNamespace
-from typing import Any
+from typing import Any, cast
 
 import click
 
@@ -374,7 +374,8 @@ def image() -> None:
 
 
 @image.command("pull")
-@click.argument("preset", metavar="preset")
+@click.argument("preset", metavar="preset", required=False, default=None)
+@click.option("--all", "all_images", is_flag=True, help="Download every image for this machine.")
 @click.option(
     "--arch",
     type=click.Choice(["amd64", "arm64"]),
@@ -397,7 +398,8 @@ def image() -> None:
 @image_dir_option
 @json_option
 def image_pull(
-    preset: str,
+    preset: str | None,
+    all_images: bool,
     arch: str | None,
     vmm: str | None,
     os_name: str | None,
@@ -406,10 +408,24 @@ def image_pull(
 ) -> Any:
     """Download a sandbox image before first use."""
     _before_command(json_output=json_output)
+    if bool(preset) == all_images:
+        raise click.UsageError(
+            "Choose one target: 'smolvm image pull codex' or 'smolvm image pull --all'."
+        )
+    if all_images:
+        from smolvm.cli.image import run_image_pull_all
+
+        return run_image_pull_all(
+            arch=arch,
+            vmm=vmm,
+            os_name=os_name,
+            image_dir=image_dir,
+            json_output=json_output,
+        )
     from smolvm.cli.image import run_image_pull
 
     return run_image_pull(
-        preset=preset,
+        preset=cast(str, preset),
         arch=arch,
         vmm=vmm,
         os_name=os_name,
@@ -429,6 +445,32 @@ def image_list(image_dir: str | None, json_output: bool) -> Any:
     return run_image_list(image_dir=image_dir, json_output=json_output)
 
 
+# Docker-familiar spelling; same command, same "image.list" JSON envelope.
+image.add_command(image_list, name="ls")
+
+
+@cli.command("images", help="Show downloaded images (alias for 'smolvm image list').")
+@image_dir_option
+@json_option
+def images(image_dir: str | None, json_output: bool) -> Any:
+    _before_command(json_output=json_output)
+    from smolvm.cli.image import run_image_list
+
+    return run_image_list(image_dir=image_dir, json_output=json_output, command_name="images")
+
+
+@image.command("inspect")
+@click.argument("name", metavar="name-or-preset")
+@image_dir_option
+@json_option
+def image_inspect(name: str, image_dir: str | None, json_output: bool) -> Any:
+    """Show one image in detail: files, checksums, and where it came from."""
+    _before_command(json_output=json_output)
+    from smolvm.cli.image import run_image_inspect
+
+    return run_image_inspect(name=name, image_dir=image_dir, json_output=json_output)
+
+
 @image.command("rm")
 @click.argument("name", metavar="name-or-preset")
 @click.option("--dry-run", is_flag=True, help="Show what would be removed.")
@@ -443,6 +485,95 @@ def image_rm(name: str, dry_run: bool, image_dir: str | None, json_output: bool)
         name=name,
         image_dir=image_dir,
         dry_run=dry_run,
+        json_output=json_output,
+    )
+
+
+@image.command("build")
+@click.argument("context_path", metavar="path", default=".")
+@click.option("-t", "--tag", required=True, metavar="NAME", help="Name for the built image.")
+@click.option("-f", "--file", "dockerfile", default=None, metavar="PATH", help="Dockerfile path.")
+@click.option(
+    "--size-mb",
+    type=positive_int_type(),
+    default=512,
+    show_default=True,
+    help="Disk size of the built image.",
+)
+@click.option(
+    "--build-arg",
+    "build_args",
+    multiple=True,
+    metavar="KEY=VALUE",
+    help="Values passed to the Dockerfile's ARG lines.",
+)
+@click.option(
+    "--arch",
+    type=click.Choice(["amd64", "arm64"]),
+    default=None,
+    help="Processor type to build for; defaults to this machine's.",
+)
+@backend_option(default="auto")
+@click.option("--init", default="/init", show_default=True, help="Program the image starts with.")
+@image_dir_option
+@json_option
+def image_build(
+    context_path: str,
+    tag: str,
+    dockerfile: str | None,
+    size_mb: int,
+    build_args: tuple[str, ...],
+    arch: str | None,
+    backend: str,
+    init: str,
+    image_dir: str | None,
+    json_output: bool,
+) -> Any:
+    """Build a custom image from a Dockerfile. Needs Docker installed."""
+    _before_command(json_output=json_output)
+    from smolvm.cli.image import run_image_build
+
+    return run_image_build(
+        tag=tag,
+        context_path=context_path,
+        dockerfile=dockerfile,
+        size_mb=size_mb,
+        build_args=build_args,
+        arch=arch,
+        backend=backend,
+        init=init,
+        image_dir=image_dir,
+        json_output=json_output,
+    )
+
+
+@image.command("save")
+@click.argument("name", metavar="name")
+@click.option("-o", "--output", required=True, metavar="FILE", help="Where to write the archive.")
+@image_dir_option
+@json_option
+def image_save(name: str, output: str, image_dir: str | None, json_output: bool) -> Any:
+    """Pack a downloaded image into a file you can copy to another machine."""
+    _before_command(json_output=json_output)
+    from smolvm.cli.image_transfer import run_image_save
+
+    return run_image_save(name=name, output=output, image_dir=image_dir, json_output=json_output)
+
+
+@image.command("load")
+@click.option("-i", "--input", "input_file", required=True, metavar="FILE", help="Archive to load.")
+@click.option("--force", is_flag=True, help="Replace the image if it already exists.")
+@image_dir_option
+@json_option
+def image_load(input_file: str, force: bool, image_dir: str | None, json_output: bool) -> Any:
+    """Unpack an image archive created with 'smolvm image save'."""
+    _before_command(json_output=json_output)
+    from smolvm.cli.image_transfer import run_image_load
+
+    return run_image_load(
+        input_file=input_file,
+        image_dir=image_dir,
+        force=force,
         json_output=json_output,
     )
 

--- a/src/smolvm/cli/commands/options.py
+++ b/src/smolvm/cli/commands/options.py
@@ -52,6 +52,15 @@ def json_option(fn: F) -> F:
     return click.option("--json", "json_output", is_flag=True, help="Output a JSON envelope.")(fn)
 
 
+def image_dir_option(fn: F) -> F:
+    return click.option(
+        "--image-dir",
+        default=None,
+        metavar="PATH",
+        help="Image cache directory (default: $SMOLVM_IMAGE_DIR or ~/.smolvm/images).",
+    )(fn)
+
+
 def backend_option(*, default: str | None = None) -> Callable[[F], F]:
     return click.option(
         "--backend",

--- a/src/smolvm/cli/image.py
+++ b/src/smolvm/cli/image.py
@@ -1031,6 +1031,7 @@ def run_image_inspect(
             str(exc),
             json_output=json_output,
             code="invalid_input",
+            recovery="Retry with one of the full names above.",
             exit_code=2,
         )
     except OSError as exc:
@@ -1126,6 +1127,7 @@ def run_image_rm(
             str(exc),
             json_output=json_output,
             code="invalid_input",
+            recovery="Retry with one of the full names above.",
             exit_code=2,
         )
     except OSError as exc:
@@ -1322,9 +1324,10 @@ def run_image_build(
     except ValueError as exc:
         return _fail(
             command_name,
-            str(exc),
+            _brief_error(exc),
             json_output=json_output,
             code="invalid_input",
+            recovery=f"Fix the value above, then retry '{retry_command}'.",
             exit_code=2,
         )
 

--- a/src/smolvm/cli/image.py
+++ b/src/smolvm/cli/image.py
@@ -1,0 +1,470 @@
+# Copyright 2026 Celesto AI
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""SmolVM image-cache management — pull, list, and remove cached images.
+
+Backs the ``smolvm image`` command group. Images normally download lazily
+the first time a sandbox starts; ``image pull`` fetches them ahead of time
+(offline prep, CI warm-up), ``image list`` shows what is cached, and
+``image rm`` frees disk space for a single image. All commands operate on
+the directory returned by :func:`smolvm.images.manager.resolve_image_dir`.
+"""
+
+from __future__ import annotations
+
+import re
+import shutil
+from pathlib import Path
+from typing import Any, TypedDict, cast
+
+from smolvm import __version__
+from smolvm.cli.output import (
+    console_stdout,
+    emit_error,
+    emit_success,
+    render_empty,
+    render_error,
+)
+from smolvm.cli.prune import _format_bytes, _total_size
+from smolvm.images.manager import resolve_image_dir
+
+# Cache directory names produced by ``published.cache_name()``:
+# ``{preset}-v{cli_version}-{arch}-{vmm}`` with a ``-alpine`` suffix for
+# Alpine rootfs builds (Ubuntu carries no suffix for backward compat).
+# The preset group is non-greedy so hyphenated presets (``claude-code``)
+# parse correctly against the ``-v<semver>-`` anchor.
+_IMAGE_DIR_NAME_RE = re.compile(
+    r"^(?P<preset>[a-z0-9-]+?)-v(?P<version>\d+\.\d+\.\d+[a-z0-9]*)"
+    r"-(?P<arch>amd64|arm64)-(?P<vmm>firecracker|qemu|libkrun)(?:-(?P<os>alpine))?$"
+)
+
+# Base kernel dirs from ``published.ensure_base_kernel()``.
+_KERNEL_DIR_NAME_RE = re.compile(
+    r"^base-kernel-v(?P<version>\d+\.\d+\.\d+[a-z0-9]*)-(?P<arch>amd64|arm64)$"
+)
+
+# Public CLI names that differ from the manifest preset name.
+_PRESET_ALIASES = {"claude": "claude-code"}
+
+
+class ImageRow(TypedDict):
+    """One cached entry in the image directory."""
+
+    name: str
+    kind: str  # "image" | "kernel" | "other"
+    preset: str | None
+    version: str | None
+    arch: str | None
+    vmm: str | None
+    os: str | None
+    current: bool | None  # matches this CLI version; None when unversioned
+    size_bytes: int
+    path: str
+
+
+class ImageListPayload(TypedDict):
+    image_dir: str
+    images: list[ImageRow]
+    total_size_bytes: int
+
+
+class ImagePullPayload(TypedDict):
+    preset: str
+    arch: str
+    vmm: str
+    os: str
+    version: str
+    name: str
+    kernel_path: str
+    rootfs_path: str
+    size_bytes: int
+    already_cached: bool
+
+
+class RemovedEntry(TypedDict):
+    name: str
+    path: str
+    size_bytes: int
+
+
+class ImageRmPayload(TypedDict):
+    removed: list[RemovedEntry]
+    freed_bytes: int
+
+
+def _fail(
+    command_name: str,
+    message: str,
+    *,
+    json_output: bool,
+    code: str = "runtime_error",
+    recovery: str | None = None,
+    exit_code: int = 1,
+) -> int:
+    """Report a failure in JSON or Rich form and return the exit code."""
+    if json_output:
+        return emit_error(command_name, code, message, recovery=recovery, exit_code=exit_code)
+    render_error(message, hint=recovery)
+    return exit_code
+
+
+def _classify(path: Path) -> ImageRow:
+    """Build an :class:`ImageRow` for one child directory of the image dir."""
+    name = path.name
+    size = _total_size(path)
+    image_match = _IMAGE_DIR_NAME_RE.match(name)
+    if image_match:
+        return ImageRow(
+            name=name,
+            kind="image",
+            preset=image_match["preset"],
+            version=image_match["version"],
+            arch=image_match["arch"],
+            vmm=image_match["vmm"],
+            os=image_match["os"] or "ubuntu",
+            current=image_match["version"] == __version__,
+            size_bytes=size,
+            path=str(path),
+        )
+    kernel_match = _KERNEL_DIR_NAME_RE.match(name)
+    if kernel_match:
+        return ImageRow(
+            name=name,
+            kind="kernel",
+            preset=None,
+            version=kernel_match["version"],
+            arch=kernel_match["arch"],
+            vmm=None,
+            os=None,
+            current=kernel_match["version"] == __version__,
+            size_bytes=size,
+            path=str(path),
+        )
+    return ImageRow(
+        name=name,
+        kind="other",
+        preset=None,
+        version=None,
+        arch=None,
+        vmm=None,
+        os=None,
+        current=None,
+        size_bytes=size,
+        path=str(path),
+    )
+
+
+def _cached_rows(root: Path) -> list[ImageRow]:
+    """Classify every child directory of *root* (empty when it's missing)."""
+    if not root.is_dir():
+        return []
+    return [_classify(child) for child in sorted(root.iterdir()) if child.is_dir()]
+
+
+def run_image_pull(
+    *,
+    preset: str,
+    arch: str | None = None,
+    vmm: str | None = None,
+    os_name: str | None = None,
+    image_dir: str | None = None,
+    json_output: bool = False,
+    command_name: str = "image.pull",
+) -> int:
+    """Execute ``smolvm image pull``."""
+    from smolvm.cli.main import _host_arch_for_published, _vmm_for_host
+    from smolvm.images.published import (
+        MANIFEST,
+        Arch,
+        Os,
+        Preset,
+        Vmm,
+        cache_name,
+        ensure_published_image,
+        is_preset_published,
+    )
+
+    canonical = _PRESET_ALIASES.get(preset, preset)
+
+    try:
+        resolved_arch = arch or _host_arch_for_published()
+        resolved_vmm = vmm or _vmm_for_host()
+    except RuntimeError as exc:
+        return _fail(
+            command_name,
+            f"{exc} Pass the platform explicitly, e.g. "
+            f"'smolvm image pull {preset} --arch amd64 --vmm firecracker'.",
+            json_output=json_output,
+            code="invalid_input",
+            exit_code=2,
+        )
+    resolved_os = os_name or "ubuntu"
+
+    if not is_preset_published(
+        canonical, cast(Arch, resolved_arch), cast(Vmm, resolved_vmm), cast(Os, resolved_os)
+    ):
+        known_presets = sorted({key[0] for key in MANIFEST})
+        if canonical not in known_presets:
+            return _fail(
+                command_name,
+                f"'{preset}' is not a published image. Choose one of: {', '.join(known_presets)}.",
+                json_output=json_output,
+                code="invalid_input",
+                exit_code=2,
+            )
+        return _fail(
+            command_name,
+            f"No published image for '{preset}' on "
+            f"{resolved_arch}/{resolved_vmm} with os '{resolved_os}'. Run "
+            f"'smolvm image pull {preset}' to use the defaults for this machine.",
+            json_output=json_output,
+            code="invalid_input",
+            exit_code=2,
+        )
+
+    root = resolve_image_dir(image_dir)
+    name = cache_name(
+        cast(Preset, canonical),
+        cast(Arch, resolved_arch),
+        cast(Vmm, resolved_vmm),
+        os=cast(Os, resolved_os),
+    )
+    downloaded_labels: set[str] = set()
+
+    try:
+        if json_output:
+
+            def on_download(label: str, chunk: int, total: int | None) -> None:
+                downloaded_labels.add(label)
+
+            local = ensure_published_image(
+                cast(Preset, canonical),
+                cast(Arch, resolved_arch),
+                cast(Vmm, resolved_vmm),
+                cast(Os, resolved_os),
+                cache_dir=root,
+                on_download=on_download,
+            )
+        else:
+            from rich.progress import (
+                BarColumn,
+                DownloadColumn,
+                Progress,
+                SpinnerColumn,
+                TextColumn,
+                TimeElapsedColumn,
+                TransferSpeedColumn,
+            )
+
+            with Progress(
+                SpinnerColumn(),
+                TextColumn("[progress.description]{task.description}"),
+                BarColumn(),
+                DownloadColumn(),
+                TransferSpeedColumn(),
+                TimeElapsedColumn(),
+                console=console_stdout(),
+                transient=True,
+            ) as progress:
+                download_tasks: dict[str, Any] = {}
+
+                def on_progress(label: str, chunk: int, total: int | None) -> None:
+                    downloaded_labels.add(label)
+                    if label not in download_tasks:
+                        download_tasks[label] = progress.add_task(
+                            f"Downloading {label}", total=total
+                        )
+                    progress.update(download_tasks[label], advance=chunk)
+
+                local = ensure_published_image(
+                    cast("Preset", canonical),
+                    cast("Arch", resolved_arch),
+                    cast("Vmm", resolved_vmm),
+                    cast("Os", resolved_os),
+                    cache_dir=root,
+                    on_download=on_progress,
+                )
+    except Exception as exc:
+        return _fail(
+            command_name,
+            f"Could not download the image: {exc}",
+            json_output=json_output,
+            recovery=f"Check your network connection and retry 'smolvm image pull {preset}'.",
+        )
+
+    payload = ImagePullPayload(
+        preset=canonical,
+        arch=resolved_arch,
+        vmm=resolved_vmm,
+        os=resolved_os,
+        version=__version__,
+        name=name,
+        kernel_path=str(local.kernel_path),
+        rootfs_path=str(local.rootfs_path),
+        size_bytes=_total_size(root / name),
+        already_cached=not downloaded_labels,
+    )
+    if json_output:
+        return emit_success(command_name, payload)
+
+    console = console_stdout()
+    size = _format_bytes(payload["size_bytes"])
+    if payload["already_cached"]:
+        console.print(f"Already cached: [bold]{name}[/bold] ({size})")
+    else:
+        console.print(f"Pulled [bold]{name}[/bold] ({size})")
+    console.print(f"  kernel: {payload['kernel_path']}")
+    console.print(f"  rootfs: {payload['rootfs_path']}")
+    return 0
+
+
+def run_image_list(
+    *,
+    image_dir: str | None = None,
+    json_output: bool = False,
+    command_name: str = "image.list",
+) -> int:
+    """Execute ``smolvm image list``."""
+    root = resolve_image_dir(image_dir)
+    rows = _cached_rows(root)
+    payload = ImageListPayload(
+        image_dir=str(root),
+        images=rows,
+        total_size_bytes=sum(row["size_bytes"] for row in rows),
+    )
+    if json_output:
+        return emit_success(command_name, payload)
+
+    if not rows:
+        render_empty(
+            "Images",
+            f"No cached images in {root}. Run 'smolvm image pull <preset>' to download one.",
+        )
+        return 0
+
+    from rich.table import Table
+
+    table = Table(title="Cached Images")
+    table.add_column("Name")
+    table.add_column("Kind")
+    table.add_column("Platform")
+    table.add_column("Version")
+    table.add_column("Size", justify="right")
+    for row in rows:
+        platform_parts = [part for part in (row["arch"], row["vmm"], row["os"]) if part]
+        version = row["version"] or "-"
+        if row["current"] is False:
+            version = f"[yellow]{version} (stale)[/yellow]"
+        table.add_row(
+            row["name"],
+            row["kind"],
+            "/".join(platform_parts) or "-",
+            version,
+            _format_bytes(row["size_bytes"]),
+        )
+    console = console_stdout()
+    console.print(table)
+    console.print(
+        f"Total: {len(rows)} entr{'y' if len(rows) == 1 else 'ies'}, "
+        f"{_format_bytes(payload['total_size_bytes'])} in {root}"
+    )
+    return 0
+
+
+def run_image_rm(
+    *,
+    name: str,
+    image_dir: str | None = None,
+    dry_run: bool = False,
+    json_output: bool = False,
+    command_name: str = "image.rm",
+) -> int:
+    """Execute ``smolvm image rm``."""
+    root = resolve_image_dir(image_dir)
+
+    if not name or "/" in name or "\\" in name or name in {".", ".."}:
+        return _fail(
+            command_name,
+            f"'{name}' is not a cached image name.",
+            json_output=json_output,
+            code="invalid_input",
+            recovery="Run 'smolvm image list' to see cached images.",
+            exit_code=2,
+        )
+
+    targets: list[Path] = []
+    exact = root / name
+    if exact.is_dir():
+        targets = [exact]
+    elif root.is_dir():
+        # Fall back to preset-wide removal: every cached image whose parsed
+        # preset matches, across versions, arches, vmms, and oses.
+        canonical = _PRESET_ALIASES.get(name, name)
+        for child in sorted(root.iterdir()):
+            if not child.is_dir():
+                continue
+            match = _IMAGE_DIR_NAME_RE.match(child.name)
+            if match and match["preset"] == canonical:
+                targets.append(child)
+
+    if not targets:
+        return _fail(
+            command_name,
+            f"No cached image named '{name}'.",
+            json_output=json_output,
+            recovery="Run 'smolvm image list' to see cached images.",
+        )
+
+    resolved_root = root.resolve()
+    entries: list[RemovedEntry] = []
+    for target in targets:
+        # Deletion is confined to direct children of the image directory;
+        # a symlinked entry pointing elsewhere is refused rather than
+        # followed.
+        if target.resolve().parent != resolved_root:
+            return _fail(
+                command_name,
+                f"'{target.name}' points outside the image directory and was not removed.",
+                json_output=json_output,
+                recovery=f"Remove it manually: {target}",
+            )
+        entries.append(
+            RemovedEntry(name=target.name, path=str(target), size_bytes=_total_size(target))
+        )
+
+    freed = sum(entry["size_bytes"] for entry in entries)
+
+    if dry_run:
+        if json_output:
+            return emit_success(
+                command_name,
+                {"dry_run": True, "would_remove": entries, "would_free_bytes": freed},
+            )
+        console = console_stdout()
+        console.print(
+            f"[bold]Would remove {len(entries)} image(s) ({_format_bytes(freed)}):[/bold]"
+        )
+        for entry in entries:
+            console.print(f"  {entry['name']}  ({_format_bytes(entry['size_bytes'])})")
+        return 0
+
+    for target in targets:
+        shutil.rmtree(target)
+
+    payload = ImageRmPayload(removed=entries, freed_bytes=freed)
+    if json_output:
+        return emit_success(command_name, payload)
+    console = console_stdout()
+    console.print(f"Removed {len(entries)} image(s), freed {_format_bytes(freed)}.")
+    return 0

--- a/src/smolvm/cli/image.py
+++ b/src/smolvm/cli/image.py
@@ -150,7 +150,7 @@ def _valid_entry_name(requested: str) -> bool:
     return (
         segments[0] == _CUSTOM_DIR
         and len(segments) in {2, 3}
-        and all(_SAFE_SEGMENT_RE.match(seg) for seg in segments[1:])
+        and all(_SAFE_SEGMENT_RE.match(seg) and not seg.startswith(".") for seg in segments[1:])
     )
 
 
@@ -273,6 +273,17 @@ def _entry_kind(path: Path, root: Path) -> str:
     if _KERNEL_DIR_NAME_RE.match(path.name):
         return "kernel"
     return "other"
+
+
+def _brief_error(exc: BaseException, limit: int = 160) -> str:
+    """One short line of an exception, for user-facing messages.
+
+    Full tracebacks, multi-line output, and long URLs belong in logs, not
+    in error envelopes.
+    """
+    text = str(exc).strip()
+    text = text.splitlines()[0] if text else exc.__class__.__name__
+    return text if len(text) <= limit else text[: limit - 1] + "…"
 
 
 def _classify(path: Path, size_bytes: int | None = None) -> ImageRow:
@@ -711,14 +722,14 @@ def run_image_pull(
     except ImageError as exc:
         return _fail(
             command_name,
-            f"Could not download the image: {exc}",
+            f"Could not download the image: {_brief_error(exc)}",
             json_output=json_output,
             recovery=f"Check your network connection and retry '{retry_command}'.",
         )
     except OSError as exc:
         return _fail(
             command_name,
-            f"Could not save the image: {exc}",
+            f"Could not save the image: {_brief_error(exc)}",
             json_output=json_output,
             recovery=f"Free up disk space or fix permissions on '{root}', "
             f"then retry '{retry_command}'.",
@@ -726,7 +737,7 @@ def run_image_pull(
     except Exception as exc:
         return _fail(
             command_name,
-            f"Could not get the image: {exc}",
+            f"Could not get the image: {_brief_error(exc)}",
             json_output=json_output,
             recovery=f"Retry '{retry_command}'.",
         )
@@ -817,7 +828,9 @@ def run_image_pull_all(
                     )
                 )
             except Exception as exc:
-                failed.append(PullFailure(preset=target_preset, os=target_os, error=str(exc)))
+                failed.append(
+                    PullFailure(preset=target_preset, os=target_os, error=_brief_error(exc))
+                )
 
     payload = ImagePullAllPayload(
         arch=resolved_arch,
@@ -874,7 +887,7 @@ def run_image_list(
     except OSError as exc:
         return _fail(
             command_name,
-            f"Could not read the image folder '{root}': {exc}",
+            f"Could not read the image folder '{root}': {_brief_error(exc)}",
             json_output=json_output,
             recovery="Fix the folder's permissions and run 'smolvm image list' again.",
         )
@@ -1023,7 +1036,7 @@ def run_image_inspect(
     except OSError as exc:
         return _fail(
             command_name,
-            f"Could not read the image folder '{root}': {exc}",
+            f"Could not read the image folder '{root}': {_brief_error(exc)}",
             json_output=json_output,
             recovery="Fix the folder's permissions, then retry "
             f"'smolvm image inspect {requested}'.",
@@ -1118,7 +1131,7 @@ def run_image_rm(
     except OSError as exc:
         return _fail(
             command_name,
-            f"Could not read the image folder '{root}': {exc}",
+            f"Could not read the image folder '{root}': {_brief_error(exc)}",
             json_output=json_output,
             recovery=permission_recovery,
         )
@@ -1217,9 +1230,10 @@ def run_image_build(
         tag, context_path, dockerfile, size_mb, build_args, arch, backend, init, image_dir
     )
 
-    if not _SAFE_SEGMENT_RE.match(tag) or tag in {".", ".."}:
-        # The builder's own charset is slightly looser (it allows "." and
-        # ".."), which would let a tag escape the custom/ namespace.
+    if not _SAFE_SEGMENT_RE.match(tag) or tag.startswith("."):
+        # The builder's own charset is slightly looser: ".." would escape
+        # the custom/ namespace, and dot-prefixed names would be hidden by
+        # 'image list'.
         return _fail(
             command_name,
             f"'{tag}' can't be used as an image name. Use letters, numbers, "
@@ -1272,20 +1286,28 @@ def run_image_build(
     # "Dockerfile" (any depth) are reserved by the builder and skipped.
     context: dict[str, DockerContextValue] = {}
     warnings: list[str] = []
-    resolved_dockerfile = dockerfile_path.resolve()
-    for f in sorted(context_dir.rglob("*")):
-        if f.is_symlink() or not f.is_file():
-            continue
-        if f.resolve() == resolved_dockerfile:
-            continue
-        if f.name.lower() == "dockerfile":
-            skipped_path = f.relative_to(context_dir).as_posix()
-            warnings.append(
-                f"Skipped '{skipped_path}': files named Dockerfile can't be "
-                "part of the build context. Rename it to include it."
-            )
-            continue
-        context[f.relative_to(context_dir).as_posix()] = f
+    try:
+        resolved_dockerfile = dockerfile_path.resolve()
+        for f in sorted(context_dir.rglob("*")):
+            if f.is_symlink() or not f.is_file():
+                continue
+            if f.resolve() == resolved_dockerfile:
+                continue
+            if f.name.lower() == "dockerfile":
+                skipped_path = f.relative_to(context_dir).as_posix()
+                warnings.append(
+                    f"Skipped '{skipped_path}': files named Dockerfile can't be "
+                    "part of the build context. Rename it to include it."
+                )
+                continue
+            context[f.relative_to(context_dir).as_posix()] = f
+    except OSError as exc:
+        return _fail(
+            command_name,
+            f"Could not read the folder '{context_path}': {_brief_error(exc)}",
+            json_output=json_output,
+            recovery=f"Fix the folder's permissions, then retry '{retry_command}'.",
+        )
 
     try:
         builder = DockerRootfsBuilder(
@@ -1328,7 +1350,7 @@ def run_image_build(
     except (ImageError, ValueError) as exc:
         return _fail(
             command_name,
-            str(exc),
+            _brief_error(exc, limit=400),
             json_output=json_output,
             code="invalid_input" if isinstance(exc, ValueError) else "runtime_error",
             recovery=f"Fix the problem above, then retry '{retry_command}'.",
@@ -1337,7 +1359,7 @@ def run_image_build(
     except OSError as exc:
         return _fail(
             command_name,
-            f"Could not write the image: {exc}",
+            f"Could not write the image: {_brief_error(exc)}",
             json_output=json_output,
             recovery=f"Free up disk space, then retry '{retry_command}'.",
         )
@@ -1379,11 +1401,11 @@ def run_image_build(
             f"  kernel: {payload['kernel_path']}\n\n"
             "Boot it from Python with:\n"
             "  [bold]from smolvm import BootImage, DirectKernelBoot, SmolVM\n"
-            f'  image = BootImage(name="{tag}",\n'
-            f'                    rootfs_path="{payload["rootfs_path"]}",\n'
-            f'                    rootfs_format="raw-ext4",\n'
-            f'                    kernel_path="{payload["kernel_path"]}",\n'
-            f'                    boot=DirectKernelBoot(init="{init}"))\n'
+            f"  image = BootImage(name={tag!r},\n"
+            f"                    rootfs_path={payload['rootfs_path']!r},\n"
+            f"                    rootfs_format='raw-ext4',\n"
+            f"                    kernel_path={payload['kernel_path']!r},\n"
+            f"                    boot=DirectKernelBoot(init={init!r}))\n"
             "  with SmolVM.from_image(image) as vm:\n"
             "      vm.start()[/bold]\n\n"
             f"Manage it with 'smolvm image list' and 'smolvm image rm {_CUSTOM_DIR}/{tag}'.",

--- a/src/smolvm/cli/image.py
+++ b/src/smolvm/cli/image.py
@@ -24,9 +24,21 @@ the directory returned by :func:`smolvm.images.manager.resolve_image_dir`.
 from __future__ import annotations
 
 import re
+import shlex
 import shutil
+from contextlib import AbstractContextManager, nullcontext
 from pathlib import Path
 from typing import Any, TypedDict, cast
+
+from rich.progress import (
+    BarColumn,
+    DownloadColumn,
+    Progress,
+    SpinnerColumn,
+    TextColumn,
+    TimeElapsedColumn,
+    TransferSpeedColumn,
+)
 
 from smolvm import __version__
 from smolvm.cli.output import (
@@ -36,26 +48,39 @@ from smolvm.cli.output import (
     render_empty,
     render_error,
 )
-from smolvm.cli.prune import _format_bytes, _total_size
+from smolvm.cli.prune import _VERSION_PATTERN, _format_bytes, _total_size
 from smolvm.images.manager import resolve_image_dir
 
 # Cache directory names produced by ``published.cache_name()``:
 # ``{preset}-v{cli_version}-{arch}-{vmm}`` with a ``-alpine`` suffix for
 # Alpine rootfs builds (Ubuntu carries no suffix for backward compat).
 # The preset group is non-greedy so hyphenated presets (``claude-code``)
-# parse correctly against the ``-v<semver>-`` anchor.
+# parse correctly against the ``-v<version>-`` anchor; the version
+# fragment is shared with prune so list/rm/prune agree on what counts as
+# a versioned cache directory (a test round-trips it against cache_name()).
 _IMAGE_DIR_NAME_RE = re.compile(
-    r"^(?P<preset>[a-z0-9-]+?)-v(?P<version>\d+\.\d+\.\d+[a-z0-9]*)"
+    rf"^(?P<preset>[a-z0-9-]+?)-v(?P<version>{_VERSION_PATTERN})"
     r"-(?P<arch>amd64|arm64)-(?P<vmm>firecracker|qemu|libkrun)(?:-(?P<os>alpine))?$"
 )
 
 # Base kernel dirs from ``published.ensure_base_kernel()``.
 _KERNEL_DIR_NAME_RE = re.compile(
-    r"^base-kernel-v(?P<version>\d+\.\d+\.\d+[a-z0-9]*)-(?P<arch>amd64|arm64)$"
+    rf"^base-kernel-v(?P<version>{_VERSION_PATTERN})-(?P<arch>amd64|arm64)$"
 )
 
-# Public CLI names that differ from the manifest preset name.
-_PRESET_ALIASES = {"claude": "claude-code"}
+
+def _canonical_preset(name: str) -> str:
+    """Map a public CLI alias (e.g. ``claude``) to its manifest preset name.
+
+    Alias data lives on the preset definitions themselves so a new alias
+    automatically works here without touching this module.
+    """
+    from smolvm.presets import list_presets
+
+    for preset in list_presets():
+        if name == preset.name or name in preset.aliases:
+            return preset.name
+    return name
 
 
 class ImageRow(TypedDict):
@@ -90,6 +115,7 @@ class ImagePullPayload(TypedDict):
     rootfs_path: str
     size_bytes: int
     already_cached: bool
+    warnings: list[str]
 
 
 class RemovedEntry(TypedDict):
@@ -172,6 +198,40 @@ def _cached_rows(root: Path) -> list[ImageRow]:
     return [_classify(child) for child in sorted(root.iterdir()) if child.is_dir()]
 
 
+def _download_progress() -> Progress:
+    """The download progress renderer shared with the sandbox boot flow."""
+    return Progress(
+        SpinnerColumn(),
+        TextColumn("[progress.description]{task.description}"),
+        BarColumn(),
+        DownloadColumn(),
+        TransferSpeedColumn(),
+        TimeElapsedColumn(),
+        console=console_stdout(),
+        transient=True,
+    )
+
+
+def _pull_retry_command(
+    preset: str,
+    arch: str | None,
+    vmm: str | None,
+    os_name: str | None,
+    image_dir: str | None,
+) -> str:
+    """The user's pull invocation, reconstructed for recovery messages."""
+    parts = ["smolvm", "image", "pull", preset]
+    if arch:
+        parts += ["--arch", arch]
+    if vmm:
+        parts += ["--vmm", vmm]
+    if os_name:
+        parts += ["--os", os_name]
+    if image_dir:
+        parts += ["--image-dir", shlex.quote(image_dir)]
+    return " ".join(parts)
+
+
 def run_image_pull(
     *,
     preset: str,
@@ -184,6 +244,7 @@ def run_image_pull(
 ) -> int:
     """Execute ``smolvm image pull``."""
     from smolvm.cli.main import _host_arch_for_published, _vmm_for_host
+    from smolvm.exceptions import ImageError
     from smolvm.images.published import (
         MANIFEST,
         Arch,
@@ -195,25 +256,25 @@ def run_image_pull(
         is_preset_published,
     )
 
-    canonical = _PRESET_ALIASES.get(preset, preset)
+    canonical = _canonical_preset(preset)
+    retry_command = _pull_retry_command(preset, arch, vmm, os_name, image_dir)
 
     try:
-        resolved_arch = arch or _host_arch_for_published()
-        resolved_vmm = vmm or _vmm_for_host()
-    except RuntimeError as exc:
+        resolved_arch = cast("Arch", arch) if arch else _host_arch_for_published()
+        resolved_vmm = cast("Vmm", vmm) if vmm else _vmm_for_host()
+    except RuntimeError:
         return _fail(
             command_name,
-            f"{exc} Pass the platform explicitly, e.g. "
-            f"'smolvm image pull {preset} --arch amd64 --vmm firecracker'.",
+            "SmolVM doesn't publish prebuilt images for this machine. Pass the "
+            f"platform explicitly, e.g. 'smolvm image pull {preset} --arch amd64 "
+            "--vmm firecracker'.",
             json_output=json_output,
             code="invalid_input",
             exit_code=2,
         )
-    resolved_os = os_name or "ubuntu"
+    resolved_os: Os = cast("Os", os_name) if os_name else "ubuntu"
 
-    if not is_preset_published(
-        canonical, cast(Arch, resolved_arch), cast(Vmm, resolved_vmm), cast(Os, resolved_os)
-    ):
+    if not is_preset_published(canonical, resolved_arch, resolved_vmm, resolved_os):
         known_presets = sorted({key[0] for key in MANIFEST})
         if canonical not in known_presets:
             return _fail(
@@ -233,76 +294,82 @@ def run_image_pull(
             exit_code=2,
         )
 
+    published_preset = cast("Preset", canonical)
     root = resolve_image_dir(image_dir)
-    name = cache_name(
-        cast(Preset, canonical),
-        cast(Arch, resolved_arch),
-        cast(Vmm, resolved_vmm),
-        os=cast(Os, resolved_os),
-    )
-    downloaded_labels: set[str] = set()
+    name = cache_name(published_preset, resolved_arch, resolved_vmm, os=resolved_os)
+    target_dir = root / name
 
+    # "Already cached" must mean the pull was a no-op. Downloads are
+    # observable through on_download, but rootfs decompression is not, so
+    # also watch the cache directory itself: any file (re)created in it —
+    # by download or decompression — bumps its mtime.
+    pre_mtime = target_dir.stat().st_mtime_ns if target_dir.is_dir() else None
+    downloaded = False
+
+    progress_cm: AbstractContextManager[Progress | None] = (
+        nullcontext(None) if json_output else _download_progress()
+    )
     try:
-        if json_output:
+        with progress_cm as progress:
+            download_tasks: dict[str, Any] = {}
+            if progress is not None:
+                # Visible immediately: SHA verification of cached files and
+                # rootfs decompression run without download callbacks and
+                # can take a while on multi-GB images.
+                progress.add_task("Preparing image...", total=None)
 
             def on_download(label: str, chunk: int, total: int | None) -> None:
-                downloaded_labels.add(label)
+                nonlocal downloaded
+                downloaded = True
+                if progress is None:
+                    return
+                if label not in download_tasks:
+                    download_tasks[label] = progress.add_task(f"Downloading {label}", total=total)
+                progress.update(download_tasks[label], advance=chunk)
 
             local = ensure_published_image(
-                cast(Preset, canonical),
-                cast(Arch, resolved_arch),
-                cast(Vmm, resolved_vmm),
-                cast(Os, resolved_os),
+                published_preset,
+                resolved_arch,
+                resolved_vmm,
+                resolved_os,
                 cache_dir=root,
                 on_download=on_download,
             )
-        else:
-            from rich.progress import (
-                BarColumn,
-                DownloadColumn,
-                Progress,
-                SpinnerColumn,
-                TextColumn,
-                TimeElapsedColumn,
-                TransferSpeedColumn,
-            )
-
-            with Progress(
-                SpinnerColumn(),
-                TextColumn("[progress.description]{task.description}"),
-                BarColumn(),
-                DownloadColumn(),
-                TransferSpeedColumn(),
-                TimeElapsedColumn(),
-                console=console_stdout(),
-                transient=True,
-            ) as progress:
-                download_tasks: dict[str, Any] = {}
-
-                def on_progress(label: str, chunk: int, total: int | None) -> None:
-                    downloaded_labels.add(label)
-                    if label not in download_tasks:
-                        download_tasks[label] = progress.add_task(
-                            f"Downloading {label}", total=total
-                        )
-                    progress.update(download_tasks[label], advance=chunk)
-
-                local = ensure_published_image(
-                    cast("Preset", canonical),
-                    cast("Arch", resolved_arch),
-                    cast("Vmm", resolved_vmm),
-                    cast("Os", resolved_os),
-                    cache_dir=root,
-                    on_download=on_progress,
-                )
-    except Exception as exc:
+    except ImageError as exc:
         return _fail(
             command_name,
             f"Could not download the image: {exc}",
             json_output=json_output,
-            recovery=f"Check your network connection and retry 'smolvm image pull {preset}'.",
+            recovery=f"Check your network connection and retry '{retry_command}'.",
+        )
+    except OSError as exc:
+        return _fail(
+            command_name,
+            f"Could not save the image: {exc}",
+            json_output=json_output,
+            recovery=f"Free up disk space or fix permissions on '{root}', "
+            f"then retry '{retry_command}'.",
+        )
+    except Exception as exc:
+        return _fail(
+            command_name,
+            f"Could not get the image: {exc}",
+            json_output=json_output,
+            recovery=f"Retry '{retry_command}'.",
         )
 
+    post_mtime = target_dir.stat().st_mtime_ns if target_dir.is_dir() else None
+    already_cached = not downloaded and pre_mtime is not None and post_mtime == pre_mtime
+
+    warnings: list[str] = []
+    default_root = resolve_image_dir(None)
+    if root != default_root:
+        warnings.append(
+            f"Sandboxes look for images in '{default_root}'. Set "
+            f"SMOLVM_IMAGE_DIR={shlex.quote(str(root))} so they use this download."
+        )
+
+    size_bytes = _total_size(target_dir)
     payload = ImagePullPayload(
         preset=canonical,
         arch=resolved_arch,
@@ -312,20 +379,23 @@ def run_image_pull(
         name=name,
         kernel_path=str(local.kernel_path),
         rootfs_path=str(local.rootfs_path),
-        size_bytes=_total_size(root / name),
-        already_cached=not downloaded_labels,
+        size_bytes=size_bytes,
+        already_cached=already_cached,
+        warnings=warnings,
     )
     if json_output:
         return emit_success(command_name, payload)
 
     console = console_stdout()
-    size = _format_bytes(payload["size_bytes"])
-    if payload["already_cached"]:
+    size = _format_bytes(size_bytes)
+    if already_cached:
         console.print(f"Already cached: [bold]{name}[/bold] ({size})")
     else:
         console.print(f"Pulled [bold]{name}[/bold] ({size})")
-    console.print(f"  kernel: {payload['kernel_path']}")
-    console.print(f"  rootfs: {payload['rootfs_path']}")
+    console.print(f"  kernel: {local.kernel_path}")
+    console.print(f"  rootfs: {local.rootfs_path}")
+    for warning in warnings:
+        console.print(f"[yellow]{warning}[/yellow]")
     return 0
 
 
@@ -337,7 +407,15 @@ def run_image_list(
 ) -> int:
     """Execute ``smolvm image list``."""
     root = resolve_image_dir(image_dir)
-    rows = _cached_rows(root)
+    try:
+        rows = _cached_rows(root)
+    except OSError as exc:
+        return _fail(
+            command_name,
+            f"Could not read the image folder '{root}': {exc}",
+            json_output=json_output,
+            recovery="Fix the folder's permissions and run 'smolvm image list' again.",
+        )
     payload = ImageListPayload(
         image_dir=str(root),
         images=rows,
@@ -349,14 +427,16 @@ def run_image_list(
     if not rows:
         render_empty(
             "Images",
-            f"No cached images in {root}. Run 'smolvm image pull <preset>' to download one.",
+            f"No cached images in {root}. Run 'smolvm image pull codex' to download one.",
         )
         return 0
 
     from rich.table import Table
 
     table = Table(title="Cached Images")
-    table.add_column("Name")
+    # Fold long names instead of truncating: the full name is the handle
+    # `smolvm image rm <name>` needs.
+    table.add_column("Name", overflow="fold")
     table.add_column("Kind")
     table.add_column("Platform")
     table.add_column("Version")
@@ -382,6 +462,20 @@ def run_image_list(
     return 0
 
 
+def _normalize_rm_name(name: str, root: Path) -> str:
+    """Normalize what the user typed to a bare cache-entry name.
+
+    Accepts trailing path separators (shell tab completion) and the
+    absolute path that ``image list`` prints, as long as it points at a
+    direct child of the image directory.
+    """
+    requested = name.rstrip("/\\")
+    candidate = Path(requested)
+    if candidate.is_absolute() and candidate.parent in {root, root.resolve()}:
+        return candidate.name
+    return requested
+
+
 def run_image_rm(
     *,
     name: str,
@@ -392,8 +486,9 @@ def run_image_rm(
 ) -> int:
     """Execute ``smolvm image rm``."""
     root = resolve_image_dir(image_dir)
+    requested = _normalize_rm_name(name, root)
 
-    if not name or "/" in name or "\\" in name or name in {".", ".."}:
+    if not requested or "/" in requested or "\\" in requested or requested in {".", ".."}:
         return _fail(
             command_name,
             f"'{name}' is not a cached image name.",
@@ -403,41 +498,55 @@ def run_image_rm(
             exit_code=2,
         )
 
-    targets: list[Path] = []
-    exact = root / name
-    if exact.is_dir():
-        targets = [exact]
-    elif root.is_dir():
-        # Fall back to preset-wide removal: every cached image whose parsed
-        # preset matches, across versions, arches, vmms, and oses.
-        canonical = _PRESET_ALIASES.get(name, name)
-        for child in sorted(root.iterdir()):
-            if not child.is_dir():
-                continue
-            match = _IMAGE_DIR_NAME_RE.match(child.name)
-            if match and match["preset"] == canonical:
-                targets.append(child)
-
-    if not targets:
+    permission_recovery = f"Fix the folder's permissions, then retry 'smolvm image rm {requested}'."
+    matches: list[Path] = []
+    try:
+        exact = root / requested
+        if exact.is_dir() or exact.is_symlink():
+            matches = [exact]
+        elif root.is_dir():
+            # Fall back to preset-wide removal: every cached image whose
+            # parsed preset matches, across versions, arches, vmms, and oses.
+            canonical = _canonical_preset(requested)
+            for child in sorted(root.iterdir()):
+                if not child.is_dir():
+                    continue
+                match = _IMAGE_DIR_NAME_RE.match(child.name)
+                if match and match["preset"] == canonical:
+                    matches.append(child)
+    except OSError as exc:
         return _fail(
             command_name,
-            f"No cached image named '{name}'.",
+            f"Could not read the image folder '{root}': {exc}",
+            json_output=json_output,
+            recovery=permission_recovery,
+        )
+
+    if not matches:
+        return _fail(
+            command_name,
+            f"No cached image named '{requested}'.",
             json_output=json_output,
             recovery="Run 'smolvm image list' to see cached images.",
         )
 
     resolved_root = root.resolve()
     entries: list[RemovedEntry] = []
-    for target in targets:
-        # Deletion is confined to direct children of the image directory;
-        # a symlinked entry pointing elsewhere is refused rather than
-        # followed.
+    for target in matches:
+        if target.is_symlink():
+            # A link is removed with unlink() — what it points at is never
+            # touched — so removing it frees no space.
+            entries.append(RemovedEntry(name=target.name, path=str(target), size_bytes=0))
+            continue
+        # Names are validated above and matches are direct children, so a
+        # real directory escaping the root should be impossible; keep a
+        # hard stop in front of the recursive delete anyway.
         if target.resolve().parent != resolved_root:
             return _fail(
                 command_name,
-                f"'{target.name}' points outside the image directory and was not removed.",
+                f"'{target.name}' could not be removed safely.",
                 json_output=json_output,
-                recovery=f"Remove it manually: {target}",
+                recovery=f"Delete it yourself if needed: '{target}'.",
             )
         entries.append(
             RemovedEntry(name=target.name, path=str(target), size_bytes=_total_size(target))
@@ -459,8 +568,19 @@ def run_image_rm(
             console.print(f"  {entry['name']}  ({_format_bytes(entry['size_bytes'])})")
         return 0
 
-    for target in targets:
-        shutil.rmtree(target)
+    for target in matches:
+        try:
+            if target.is_symlink():
+                target.unlink()
+            else:
+                shutil.rmtree(target)
+        except OSError as exc:
+            return _fail(
+                command_name,
+                f"Could not remove '{target.name}': {exc}",
+                json_output=json_output,
+                recovery=permission_recovery,
+            )
 
     payload = ImageRmPayload(removed=entries, freed_bytes=freed)
     if json_output:

--- a/src/smolvm/cli/image.py
+++ b/src/smolvm/cli/image.py
@@ -12,21 +12,26 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""SmolVM image-cache management — pull, list, and remove cached images.
+"""SmolVM image-cache management — pull, list, inspect, build, and remove.
 
 Backs the ``smolvm image`` command group. Images normally download lazily
 the first time a sandbox starts; ``image pull`` fetches them ahead of time
-(offline prep, CI warm-up), ``image list`` shows what is cached, and
-``image rm`` frees disk space for a single image. All commands operate on
-the directory returned by :func:`smolvm.images.manager.resolve_image_dir`.
+(offline prep, CI warm-up), ``image list`` shows what is cached,
+``image inspect`` shows one image in detail, ``image build`` bakes a custom
+image from a Dockerfile, and ``image rm`` frees disk space. All commands
+operate on the directory returned by
+:func:`smolvm.images.manager.resolve_image_dir`.
 """
 
 from __future__ import annotations
 
+import json
 import re
 import shlex
 import shutil
+import time
 from contextlib import AbstractContextManager, nullcontext
+from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, TypedDict, cast
 
@@ -48,7 +53,7 @@ from smolvm.cli.output import (
     render_empty,
     render_error,
 )
-from smolvm.cli.prune import _VERSION_PATTERN, _format_bytes, _total_size
+from smolvm.cli.prune import _VERSION_PATTERN, _format_bytes, _size_on_disk, _total_size
 from smolvm.images.manager import resolve_image_dir
 
 # Cache directory names produced by ``published.cache_name()``:
@@ -68,6 +73,13 @@ _KERNEL_DIR_NAME_RE = re.compile(
     rf"^base-kernel-v(?P<version>{_VERSION_PATTERN})-(?P<arch>amd64|arm64)$"
 )
 
+# One path segment of a cache-entry name. Deliberately mirrors the builder's
+# _safe_cache_name charset; "." and ".." are rejected separately.
+_SAFE_SEGMENT_RE = re.compile(r"^[A-Za-z0-9_.-]+$")
+
+# Custom builds live under this subdirectory: custom/<name>/<fingerprint>/.
+_CUSTOM_DIR = "custom"
+
 
 def _canonical_preset(name: str) -> str:
     """Map a public CLI alias (e.g. ``claude``) to its manifest preset name.
@@ -83,17 +95,66 @@ def _canonical_preset(name: str) -> str:
     return name
 
 
+def _created_iso(path: Path) -> str | None:
+    """ISO 8601 UTC creation marker for a cache entry (its dir mtime)."""
+    try:
+        return datetime.fromtimestamp(path.stat().st_mtime, tz=timezone.utc).isoformat()
+    except OSError:
+        return None
+
+
+def _relative_time(iso_ts: str | None, *, now: datetime | None = None) -> str:
+    """Docker-style relative age ("2 hours ago") for an ISO timestamp."""
+    if not iso_ts:
+        return "-"
+    try:
+        then = datetime.fromisoformat(iso_ts)
+    except ValueError:
+        return "-"
+    current = now if now is not None else datetime.now(timezone.utc)
+    seconds = max(0, int((current - then).total_seconds()))
+    for unit, span in (
+        ("year", 31_536_000),
+        ("month", 2_592_000),
+        ("week", 604_800),
+        ("day", 86_400),
+        ("hour", 3_600),
+        ("minute", 60),
+    ):
+        count = seconds // span
+        if count:
+            return f"{count} {unit}{'s' if count != 1 else ''} ago"
+    return f"{seconds} second{'s' if seconds != 1 else ''} ago"
+
+
+def _valid_entry_name(requested: str) -> bool:
+    """Whether *requested* is a well-formed cache-entry name.
+
+    Plain entries are a single path segment; custom builds may be addressed
+    as ``custom/<name>`` or ``custom/<name>/<fingerprint>``.
+    """
+    if not requested or "\\" in requested:
+        return False
+    segments = requested.split("/")
+    if any(seg in {"", ".", ".."} or not _SAFE_SEGMENT_RE.match(seg) for seg in segments):
+        return False
+    if len(segments) == 1:
+        return True
+    return segments[0] == _CUSTOM_DIR and len(segments) in {2, 3}
+
+
 class ImageRow(TypedDict):
     """One cached entry in the image directory."""
 
     name: str
-    kind: str  # "image" | "kernel" | "other"
+    kind: str  # "image" | "kernel" | "custom" | "other"
     preset: str | None
     version: str | None
     arch: str | None
     vmm: str | None
     os: str | None
     current: bool | None  # matches this CLI version; None when unversioned
+    created: str | None  # ISO 8601 UTC, from the entry dir's mtime
     size_bytes: int
     path: str
 
@@ -116,6 +177,52 @@ class ImagePullPayload(TypedDict):
     size_bytes: int
     already_cached: bool
     warnings: list[str]
+
+
+class PullFailure(TypedDict):
+    preset: str
+    os: str
+    error: str
+
+
+class ImagePullAllPayload(TypedDict):
+    arch: str
+    vmm: str
+    pulled: list[ImagePullPayload]
+    failed: list[PullFailure]
+    warnings: list[str]
+
+
+class ImageFileEntry(TypedDict):
+    name: str
+    size_bytes: int  # apparent size
+    size_on_disk_bytes: int  # allocated blocks, sparse-aware
+
+
+class ImageManifestInfo(TypedDict):
+    kernel_url: str
+    kernel_sha256: str
+    rootfs_url: str
+    rootfs_sha256: str
+    images_release_tag: str
+
+
+class ImageInspectEntry(ImageRow):
+    files: list[ImageFileEntry]
+    rootfs_sidecar: str | None
+    manifest: ImageManifestInfo | None
+
+
+class ImageBuildPayload(TypedDict):
+    name: str
+    fingerprint: str
+    rootfs_path: str
+    kernel_path: str
+    boot_args: str
+    arch: str
+    backend: str
+    size_bytes: int
+    cached: bool
 
 
 class RemovedEntry(TypedDict):
@@ -149,6 +256,7 @@ def _classify(path: Path) -> ImageRow:
     """Build an :class:`ImageRow` for one child directory of the image dir."""
     name = path.name
     size = _total_size(path)
+    created = _created_iso(path)
     image_match = _IMAGE_DIR_NAME_RE.match(name)
     if image_match:
         return ImageRow(
@@ -160,6 +268,7 @@ def _classify(path: Path) -> ImageRow:
             vmm=image_match["vmm"],
             os=image_match["os"] or "ubuntu",
             current=image_match["version"] == __version__,
+            created=created,
             size_bytes=size,
             path=str(path),
         )
@@ -174,6 +283,7 @@ def _classify(path: Path) -> ImageRow:
             vmm=None,
             os=None,
             current=kernel_match["version"] == __version__,
+            created=created,
             size_bytes=size,
             path=str(path),
         )
@@ -186,16 +296,119 @@ def _classify(path: Path) -> ImageRow:
         vmm=None,
         os=None,
         current=None,
+        created=created,
         size_bytes=size,
         path=str(path),
     )
 
 
+def _custom_row(fingerprint_dir: Path) -> ImageRow:
+    """Build an :class:`ImageRow` for one ``custom/<name>/<fingerprint>`` dir."""
+    arch: str | None = None
+    metadata = fingerprint_dir / "metadata.json"
+    if metadata.is_file():
+        try:
+            parsed = json.loads(metadata.read_text())
+            if isinstance(parsed, dict) and isinstance(parsed.get("arch"), str):
+                arch = parsed["arch"]
+        except (OSError, ValueError):
+            arch = None
+    return ImageRow(
+        name=f"{_CUSTOM_DIR}/{fingerprint_dir.parent.name}",
+        kind="custom",
+        preset=None,
+        version=fingerprint_dir.name[:12],
+        arch=arch,
+        vmm=None,
+        os=None,
+        current=None,
+        created=_created_iso(fingerprint_dir),
+        size_bytes=_total_size(fingerprint_dir),
+        path=str(fingerprint_dir),
+    )
+
+
+def _custom_rows(custom_root: Path) -> list[ImageRow]:
+    """One row per built custom image (``custom/<name>/<fingerprint>``)."""
+    rows: list[ImageRow] = []
+    for name_dir in sorted(custom_root.iterdir()):
+        if not name_dir.is_dir() or name_dir.name.startswith("."):
+            continue
+        for fingerprint_dir in sorted(name_dir.iterdir()):
+            if not fingerprint_dir.is_dir() or fingerprint_dir.name.startswith("."):
+                continue
+            rows.append(_custom_row(fingerprint_dir))
+    return rows
+
+
 def _cached_rows(root: Path) -> list[ImageRow]:
-    """Classify every child directory of *root* (empty when it's missing)."""
+    """Classify every cache entry under *root* (empty when it's missing)."""
     if not root.is_dir():
         return []
-    return [_classify(child) for child in sorted(root.iterdir()) if child.is_dir()]
+    rows: list[ImageRow] = []
+    for child in sorted(root.iterdir()):
+        if not child.is_dir() or child.name.startswith("."):
+            continue
+        if child.name == _CUSTOM_DIR:
+            rows.extend(_custom_rows(child))
+        else:
+            rows.append(_classify(child))
+    return rows
+
+
+def _normalize_rm_name(name: str, root: Path) -> str:
+    """Normalize what the user typed to a cache-entry name.
+
+    Accepts trailing path separators (shell tab completion) and the
+    absolute path that ``image list`` prints, as long as it points inside
+    the image directory.
+    """
+    requested = name.rstrip("/\\")
+    candidate = Path(requested)
+    if candidate.is_absolute():
+        for base in (root, root.resolve()):
+            try:
+                return candidate.relative_to(base).as_posix()
+            except ValueError:
+                continue
+    return requested
+
+
+def _resolve_entries(requested: str, root: Path) -> list[Path]:
+    """Match a validated entry name to cache directories.
+
+    Exact names (including the ``custom/...`` namespace) win; otherwise the
+    name is treated as a preset and every cached variant matches.
+    """
+    exact = root / requested
+    if exact.is_dir() or exact.is_symlink():
+        return [exact]
+    if "/" in requested or not root.is_dir():
+        return []
+    canonical = _canonical_preset(requested)
+    matches: list[Path] = []
+    for child in sorted(root.iterdir()):
+        if not child.is_dir():
+            continue
+        match = _IMAGE_DIR_NAME_RE.match(child.name)
+        if match and match["preset"] == canonical:
+            matches.append(child)
+    return matches
+
+
+def _expand_custom_entries(matches: list[Path], root: Path) -> list[Path]:
+    """Expand a ``custom/<name>`` match into its fingerprint directories."""
+    expanded: list[Path] = []
+    for match in matches:
+        if match.parent == root / _CUSTOM_DIR:
+            expanded.extend(
+                child
+                for child in sorted(match.iterdir())
+                if child.is_dir() and not child.name.startswith(".")
+            )
+        else:
+            expanded.append(match)
+    return expanded
 
 
 def _download_progress() -> Progress:
@@ -232,6 +445,84 @@ def _pull_retry_command(
     return " ".join(parts)
 
 
+def _non_default_dir_warnings(root: Path) -> list[str]:
+    """Warn when downloads land somewhere sandbox starts will not look."""
+    default_root = resolve_image_dir(None)
+    if root == default_root:
+        return []
+    return [
+        f"Sandboxes look for images in '{default_root}'. Set "
+        f"SMOLVM_IMAGE_DIR={shlex.quote(str(root))} so they use this download."
+    ]
+
+
+def _execute_pull(
+    *,
+    preset: str,
+    arch: str,
+    vmm: str,
+    os_name: str,
+    root: Path,
+    progress: Progress | None,
+    label_prefix: str = "",
+) -> ImagePullPayload:
+    """Download one published image, reporting progress; raises on failure.
+
+    The (preset, arch, vmm, os) tuple must already be validated against the
+    manifest by the caller.
+    """
+    from smolvm.images.published import Arch, Os, Preset, Vmm, cache_name, ensure_published_image
+
+    name = cache_name(
+        cast("Preset", preset), cast("Arch", arch), cast("Vmm", vmm), os=cast("Os", os_name)
+    )
+    target_dir = root / name
+
+    # "Already cached" must mean the pull was a no-op. Downloads are
+    # observable through on_download, but rootfs decompression is not, so
+    # also watch the cache directory itself: any file (re)created in it —
+    # by download or decompression — bumps its mtime.
+    pre_mtime = target_dir.stat().st_mtime_ns if target_dir.is_dir() else None
+    downloaded = False
+    download_tasks: dict[str, Any] = {}
+
+    def on_download(label: str, chunk: int, total: int | None) -> None:
+        nonlocal downloaded
+        downloaded = True
+        if progress is None:
+            return
+        key = f"{label_prefix}{label}"
+        if key not in download_tasks:
+            download_tasks[key] = progress.add_task(f"Downloading {key}", total=total)
+        progress.update(download_tasks[key], advance=chunk)
+
+    local = ensure_published_image(
+        cast("Preset", preset),
+        cast("Arch", arch),
+        cast("Vmm", vmm),
+        cast("Os", os_name),
+        cache_dir=root,
+        on_download=on_download,
+    )
+
+    post_mtime = target_dir.stat().st_mtime_ns if target_dir.is_dir() else None
+    already_cached = not downloaded and pre_mtime is not None and post_mtime == pre_mtime
+
+    return ImagePullPayload(
+        preset=preset,
+        arch=arch,
+        vmm=vmm,
+        os=os_name,
+        version=__version__,
+        name=name,
+        kernel_path=str(local.kernel_path),
+        rootfs_path=str(local.rootfs_path),
+        size_bytes=_total_size(target_dir),
+        already_cached=already_cached,
+        warnings=[],
+    )
+
+
 def run_image_pull(
     *,
     preset: str,
@@ -245,23 +536,14 @@ def run_image_pull(
     """Execute ``smolvm image pull``."""
     from smolvm.cli.main import _host_arch_for_published, _vmm_for_host
     from smolvm.exceptions import ImageError
-    from smolvm.images.published import (
-        MANIFEST,
-        Arch,
-        Os,
-        Preset,
-        Vmm,
-        cache_name,
-        ensure_published_image,
-        is_preset_published,
-    )
+    from smolvm.images.published import MANIFEST, is_preset_published
 
     canonical = _canonical_preset(preset)
     retry_command = _pull_retry_command(preset, arch, vmm, os_name, image_dir)
 
     try:
-        resolved_arch = cast("Arch", arch) if arch else _host_arch_for_published()
-        resolved_vmm = cast("Vmm", vmm) if vmm else _vmm_for_host()
+        resolved_arch = arch or _host_arch_for_published()
+        resolved_vmm = vmm or _vmm_for_host()
     except RuntimeError:
         return _fail(
             command_name,
@@ -272,9 +554,9 @@ def run_image_pull(
             code="invalid_input",
             exit_code=2,
         )
-    resolved_os: Os = cast("Os", os_name) if os_name else "ubuntu"
+    resolved_os = os_name or "ubuntu"
 
-    if not is_preset_published(canonical, resolved_arch, resolved_vmm, resolved_os):
+    if not is_preset_published(canonical, resolved_arch, resolved_vmm, resolved_os):  # type: ignore[arg-type]
         known_presets = sorted({key[0] for key in MANIFEST})
         if canonical not in known_presets:
             return _fail(
@@ -294,46 +576,24 @@ def run_image_pull(
             exit_code=2,
         )
 
-    published_preset = cast("Preset", canonical)
     root = resolve_image_dir(image_dir)
-    name = cache_name(published_preset, resolved_arch, resolved_vmm, os=resolved_os)
-    target_dir = root / name
-
-    # "Already cached" must mean the pull was a no-op. Downloads are
-    # observable through on_download, but rootfs decompression is not, so
-    # also watch the cache directory itself: any file (re)created in it —
-    # by download or decompression — bumps its mtime.
-    pre_mtime = target_dir.stat().st_mtime_ns if target_dir.is_dir() else None
-    downloaded = False
-
     progress_cm: AbstractContextManager[Progress | None] = (
         nullcontext(None) if json_output else _download_progress()
     )
     try:
         with progress_cm as progress:
-            download_tasks: dict[str, Any] = {}
             if progress is not None:
                 # Visible immediately: SHA verification of cached files and
                 # rootfs decompression run without download callbacks and
                 # can take a while on multi-GB images.
                 progress.add_task("Preparing image...", total=None)
-
-            def on_download(label: str, chunk: int, total: int | None) -> None:
-                nonlocal downloaded
-                downloaded = True
-                if progress is None:
-                    return
-                if label not in download_tasks:
-                    download_tasks[label] = progress.add_task(f"Downloading {label}", total=total)
-                progress.update(download_tasks[label], advance=chunk)
-
-            local = ensure_published_image(
-                published_preset,
-                resolved_arch,
-                resolved_vmm,
-                resolved_os,
-                cache_dir=root,
-                on_download=on_download,
+            payload = _execute_pull(
+                preset=canonical,
+                arch=resolved_arch,
+                vmm=resolved_vmm,
+                os_name=resolved_os,
+                root=root,
+                progress=progress,
             )
     except ImageError as exc:
         return _fail(
@@ -358,44 +618,129 @@ def run_image_pull(
             recovery=f"Retry '{retry_command}'.",
         )
 
-    post_mtime = target_dir.stat().st_mtime_ns if target_dir.is_dir() else None
-    already_cached = not downloaded and pre_mtime is not None and post_mtime == pre_mtime
-
-    warnings: list[str] = []
-    default_root = resolve_image_dir(None)
-    if root != default_root:
-        warnings.append(
-            f"Sandboxes look for images in '{default_root}'. Set "
-            f"SMOLVM_IMAGE_DIR={shlex.quote(str(root))} so they use this download."
-        )
-
-    size_bytes = _total_size(target_dir)
-    payload = ImagePullPayload(
-        preset=canonical,
-        arch=resolved_arch,
-        vmm=resolved_vmm,
-        os=resolved_os,
-        version=__version__,
-        name=name,
-        kernel_path=str(local.kernel_path),
-        rootfs_path=str(local.rootfs_path),
-        size_bytes=size_bytes,
-        already_cached=already_cached,
-        warnings=warnings,
-    )
+    payload["warnings"] = _non_default_dir_warnings(root)
     if json_output:
         return emit_success(command_name, payload)
 
     console = console_stdout()
-    size = _format_bytes(size_bytes)
-    if already_cached:
-        console.print(f"Already cached: [bold]{name}[/bold] ({size})")
+    size = _format_bytes(payload["size_bytes"])
+    if payload["already_cached"]:
+        console.print(f"Already cached: [bold]{payload['name']}[/bold] ({size})")
     else:
-        console.print(f"Pulled [bold]{name}[/bold] ({size})")
-    console.print(f"  kernel: {local.kernel_path}")
-    console.print(f"  rootfs: {local.rootfs_path}")
-    for warning in warnings:
+        console.print(f"Pulled [bold]{payload['name']}[/bold] ({size})")
+    console.print(f"  kernel: {payload['kernel_path']}")
+    console.print(f"  rootfs: {payload['rootfs_path']}")
+    for warning in payload["warnings"]:
         console.print(f"[yellow]{warning}[/yellow]")
+    return 0
+
+
+def run_image_pull_all(
+    *,
+    arch: str | None = None,
+    vmm: str | None = None,
+    os_name: str | None = None,
+    image_dir: str | None = None,
+    json_output: bool = False,
+    command_name: str = "image.pull",
+) -> int:
+    """Execute ``smolvm image pull --all``."""
+    from smolvm.cli.main import _host_arch_for_published, _vmm_for_host
+    from smolvm.images.published import MANIFEST
+
+    try:
+        resolved_arch = arch or _host_arch_for_published()
+        resolved_vmm = vmm or _vmm_for_host()
+    except RuntimeError:
+        return _fail(
+            command_name,
+            "SmolVM doesn't publish prebuilt images for this machine. Pass the "
+            "platform explicitly, e.g. 'smolvm image pull --all --arch amd64 "
+            "--vmm firecracker'.",
+            json_output=json_output,
+            code="invalid_input",
+            exit_code=2,
+        )
+
+    targets = sorted(
+        {(p, o) for (p, a, v, o) in MANIFEST if a == resolved_arch and v == resolved_vmm}
+    )
+    if os_name:
+        targets = [(p, o) for (p, o) in targets if o == os_name]
+    if not targets:
+        return _fail(
+            command_name,
+            f"No published images for {resolved_arch}/{resolved_vmm}"
+            f"{f' with os {os_name!r}' if os_name else ''}.",
+            json_output=json_output,
+            code="invalid_input",
+            exit_code=2,
+        )
+
+    root = resolve_image_dir(image_dir)
+    pulled: list[ImagePullPayload] = []
+    failed: list[PullFailure] = []
+    progress_cm: AbstractContextManager[Progress | None] = (
+        nullcontext(None) if json_output else _download_progress()
+    )
+    with progress_cm as progress:
+        overall = (
+            progress.add_task("Preparing images...", total=None) if progress is not None else None
+        )
+        for target_preset, target_os in targets:
+            if progress is not None and overall is not None:
+                progress.update(overall, description=f"Preparing {target_preset} ({target_os})...")
+            try:
+                pulled.append(
+                    _execute_pull(
+                        preset=target_preset,
+                        arch=resolved_arch,
+                        vmm=resolved_vmm,
+                        os_name=target_os,
+                        root=root,
+                        progress=progress,
+                        label_prefix=f"{target_preset}/{target_os} ",
+                    )
+                )
+            except Exception as exc:
+                failed.append(PullFailure(preset=target_preset, os=target_os, error=str(exc)))
+
+    payload = ImagePullAllPayload(
+        arch=resolved_arch,
+        vmm=resolved_vmm,
+        pulled=pulled,
+        failed=failed,
+        warnings=_non_default_dir_warnings(root),
+    )
+
+    if json_output:
+        if failed:
+            return emit_error(
+                command_name,
+                "runtime_error",
+                f"Could not download {len(failed)} of {len(targets)} images.",
+                recovery="Check your network connection and retry 'smolvm image pull --all'.",
+                details=payload,
+                exit_code=1,
+            )
+        return emit_success(command_name, payload)
+
+    console = console_stdout()
+    for item in pulled:
+        state = "Already cached" if item["already_cached"] else "Pulled"
+        console.print(f"{state}: [bold]{item['name']}[/bold] ({_format_bytes(item['size_bytes'])})")
+    for failure in failed:
+        console.print(
+            f"[red]Failed: {failure['preset']} ({failure['os']}) — {failure['error']}[/red]"
+        )
+    for warning in payload["warnings"]:
+        console.print(f"[yellow]{warning}[/yellow]")
+    if failed:
+        render_error(
+            f"Could not download {len(failed)} of {len(targets)} images.",
+            hint="Check your network connection and retry 'smolvm image pull --all'.",
+        )
+        return 1
     return 0
 
 
@@ -440,6 +785,7 @@ def run_image_list(
     table.add_column("Kind")
     table.add_column("Platform")
     table.add_column("Version")
+    table.add_column("Created")
     table.add_column("Size", justify="right")
     for row in rows:
         platform_parts = [part for part in (row["arch"], row["vmm"], row["os"]) if part]
@@ -451,6 +797,7 @@ def run_image_list(
             row["kind"],
             "/".join(platform_parts) or "-",
             version,
+            _relative_time(row["created"]),
             _format_bytes(row["size_bytes"]),
         )
     console = console_stdout()
@@ -462,18 +809,143 @@ def run_image_list(
     return 0
 
 
-def _normalize_rm_name(name: str, root: Path) -> str:
-    """Normalize what the user typed to a bare cache-entry name.
+def _inspect_entry(path: Path, root: Path) -> ImageInspectEntry:
+    """Build the detailed inspect record for one cache directory."""
+    row = _custom_row(path) if path.parent != root else _classify(path)
 
-    Accepts trailing path separators (shell tab completion) and the
-    absolute path that ``image list`` prints, as long as it points at a
-    direct child of the image directory.
-    """
-    requested = name.rstrip("/\\")
-    candidate = Path(requested)
-    if candidate.is_absolute() and candidate.parent in {root, root.resolve()}:
-        return candidate.name
-    return requested
+    files: list[ImageFileEntry] = []
+    try:
+        for f in sorted(path.rglob("*")):
+            try:
+                if not f.is_file():
+                    continue
+                st = f.stat()
+                files.append(
+                    ImageFileEntry(
+                        name=f.relative_to(path).as_posix(),
+                        size_bytes=st.st_size,
+                        size_on_disk_bytes=_size_on_disk(st),
+                    )
+                )
+            except OSError:
+                continue
+    except OSError:
+        pass
+
+    sidecar_path = path / "rootfs.ext4.from-sha256"
+    sidecar: str | None = None
+    if sidecar_path.is_file():
+        try:
+            sidecar = sidecar_path.read_text().strip()
+        except OSError:
+            sidecar = None
+
+    manifest_info: ImageManifestInfo | None = None
+    if row["kind"] == "image" and row["current"]:
+        from smolvm.images.published import IMAGES_RELEASE_TAG, MANIFEST, ManifestKey
+
+        key = cast("ManifestKey", (row["preset"], row["arch"], row["vmm"], row["os"]))
+        entry = MANIFEST.get(key)
+        if entry is not None:
+            manifest_info = ImageManifestInfo(
+                kernel_url=entry.kernel_url,
+                kernel_sha256=entry.kernel_sha256,
+                rootfs_url=entry.rootfs_url,
+                rootfs_sha256=entry.rootfs_sha256,
+                images_release_tag=IMAGES_RELEASE_TAG,
+            )
+
+    return ImageInspectEntry(
+        **row,
+        files=files,
+        rootfs_sidecar=sidecar,
+        manifest=manifest_info,
+    )
+
+
+def run_image_inspect(
+    *,
+    name: str,
+    image_dir: str | None = None,
+    json_output: bool = False,
+    command_name: str = "image.inspect",
+) -> int:
+    """Execute ``smolvm image inspect``."""
+    root = resolve_image_dir(image_dir)
+    requested = _normalize_rm_name(name, root)
+
+    if not _valid_entry_name(requested):
+        return _fail(
+            command_name,
+            f"'{name}' is not a cached image name.",
+            json_output=json_output,
+            code="invalid_input",
+            recovery="Run 'smolvm image list' to see cached images.",
+            exit_code=2,
+        )
+
+    try:
+        matches = _expand_custom_entries(_resolve_entries(requested, root), root)
+    except OSError as exc:
+        return _fail(
+            command_name,
+            f"Could not read the image folder '{root}': {exc}",
+            json_output=json_output,
+            recovery="Fix the folder's permissions, then retry "
+            f"'smolvm image inspect {requested}'.",
+        )
+
+    if not matches:
+        return _fail(
+            command_name,
+            f"No cached image named '{requested}'.",
+            json_output=json_output,
+            recovery="Run 'smolvm image list' to see cached images.",
+        )
+
+    entries = [_inspect_entry(path, root) for path in matches]
+    if json_output:
+        # Docker-style: inspect always returns an array.
+        return emit_success(command_name, entries)
+
+    from rich.table import Table
+
+    console = console_stdout()
+    for entry in entries:
+        table = Table(title=entry["name"], show_header=False)
+        table.add_column("Field")
+        table.add_column("Value", overflow="fold")
+        table.add_row("Kind", entry["kind"])
+        if entry["preset"]:
+            table.add_row("Preset", entry["preset"])
+        platform_parts = [p for p in (entry["arch"], entry["vmm"], entry["os"]) if p]
+        table.add_row("Platform", "/".join(platform_parts) or "-")
+        version = entry["version"] or "-"
+        if entry["current"] is False:
+            version = f"[yellow]{version} (stale)[/yellow]"
+        table.add_row("Version", version)
+        created = entry["created"]
+        table.add_row("Created", f"{_relative_time(created)} ({created})" if created else "-")
+        table.add_row("Size", _format_bytes(entry["size_bytes"]))
+        table.add_row("Path", entry["path"])
+        manifest = entry["manifest"]
+        if manifest is not None:
+            table.add_row("Release tag", manifest["images_release_tag"])
+            table.add_row("Kernel URL", manifest["kernel_url"])
+            table.add_row("Kernel SHA-256", manifest["kernel_sha256"])
+            table.add_row("Rootfs URL", manifest["rootfs_url"])
+            table.add_row("Rootfs SHA-256", manifest["rootfs_sha256"])
+        if entry["rootfs_sidecar"]:
+            table.add_row("Rootfs sidecar", entry["rootfs_sidecar"])
+        if entry["files"]:
+            file_lines = "\n".join(
+                f"{f['name']}  {_format_bytes(f['size_bytes'])}"
+                f" ({_format_bytes(f['size_on_disk_bytes'])} on disk)"
+                for f in entry["files"]
+            )
+            table.add_row("Files", file_lines)
+        console.print(table)
+    return 0
 
 
 def run_image_rm(
@@ -488,7 +960,7 @@ def run_image_rm(
     root = resolve_image_dir(image_dir)
     requested = _normalize_rm_name(name, root)
 
-    if not requested or "/" in requested or "\\" in requested or requested in {".", ".."}:
+    if not _valid_entry_name(requested):
         return _fail(
             command_name,
             f"'{name}' is not a cached image name.",
@@ -499,21 +971,8 @@ def run_image_rm(
         )
 
     permission_recovery = f"Fix the folder's permissions, then retry 'smolvm image rm {requested}'."
-    matches: list[Path] = []
     try:
-        exact = root / requested
-        if exact.is_dir() or exact.is_symlink():
-            matches = [exact]
-        elif root.is_dir():
-            # Fall back to preset-wide removal: every cached image whose
-            # parsed preset matches, across versions, arches, vmms, and oses.
-            canonical = _canonical_preset(requested)
-            for child in sorted(root.iterdir()):
-                if not child.is_dir():
-                    continue
-                match = _IMAGE_DIR_NAME_RE.match(child.name)
-                if match and match["preset"] == canonical:
-                    matches.append(child)
+        matches = _resolve_entries(requested, root)
     except OSError as exc:
         return _fail(
             command_name,
@@ -533,24 +992,23 @@ def run_image_rm(
     resolved_root = root.resolve()
     entries: list[RemovedEntry] = []
     for target in matches:
+        display = target.relative_to(root).as_posix()
         if target.is_symlink():
             # A link is removed with unlink() — what it points at is never
             # touched — so removing it frees no space.
-            entries.append(RemovedEntry(name=target.name, path=str(target), size_bytes=0))
+            entries.append(RemovedEntry(name=display, path=str(target), size_bytes=0))
             continue
-        # Names are validated above and matches are direct children, so a
-        # real directory escaping the root should be impossible; keep a
-        # hard stop in front of the recursive delete anyway.
-        if target.resolve().parent != resolved_root:
+        # Names are validated above and matches sit under the root, so a
+        # real directory escaping it should be impossible; keep a hard stop
+        # in front of the recursive delete anyway.
+        if resolved_root not in target.resolve().parents:
             return _fail(
                 command_name,
-                f"'{target.name}' could not be removed safely.",
+                f"'{display}' could not be removed safely.",
                 json_output=json_output,
                 recovery=f"Delete it yourself if needed: '{target}'.",
             )
-        entries.append(
-            RemovedEntry(name=target.name, path=str(target), size_bytes=_total_size(target))
-        )
+        entries.append(RemovedEntry(name=display, path=str(target), size_bytes=_total_size(target)))
 
     freed = sum(entry["size_bytes"] for entry in entries)
 
@@ -587,4 +1045,162 @@ def run_image_rm(
         return emit_success(command_name, payload)
     console = console_stdout()
     console.print(f"Removed {len(entries)} image(s), freed {_format_bytes(freed)}.")
+    return 0
+
+
+def run_image_build(
+    *,
+    tag: str,
+    context_path: str,
+    dockerfile: str | None = None,
+    size_mb: int = 512,
+    build_args: tuple[str, ...] = (),
+    arch: str | None = None,
+    backend: str = "auto",
+    init: str = "/init",
+    image_dir: str | None = None,
+    json_output: bool = False,
+    command_name: str = "image.build",
+) -> int:
+    """Execute ``smolvm image build``."""
+    from smolvm.exceptions import ImageError
+    from smolvm.images.boot import DirectKernelBoot
+    from smolvm.images.builder import DockerRootfsBuilder
+
+    retry_command = f"smolvm image build -t {tag} {shlex.quote(context_path)}"
+    context_dir = Path(context_path)
+    dockerfile_path = Path(dockerfile) if dockerfile else context_dir / "Dockerfile"
+    try:
+        dockerfile_text = dockerfile_path.read_text()
+    except OSError:
+        return _fail(
+            command_name,
+            f"No Dockerfile at '{dockerfile_path}'.",
+            json_output=json_output,
+            code="invalid_input",
+            recovery=f"Pass one with 'smolvm image build -t {tag} "
+            f"-f path/to/Dockerfile {shlex.quote(context_path)}'.",
+            exit_code=2,
+        )
+
+    parsed_args: dict[str, str] = {}
+    for item in build_args:
+        key, sep, value = item.partition("=")
+        if not sep or not key:
+            return _fail(
+                command_name,
+                f"'{item}' is not a valid build argument.",
+                json_output=json_output,
+                code="invalid_input",
+                recovery="Use KEY=VALUE, e.g. --build-arg VERSION=1.2.",
+                exit_code=2,
+            )
+        parsed_args[key] = value
+
+    # Everything in the context folder is sent to the build. Files named
+    # "Dockerfile" (any depth) are reserved by the builder and skipped.
+    context: dict[str, Path] = {}
+    skipped: list[str] = []
+    if context_dir.is_dir():
+        resolved_dockerfile = dockerfile_path.resolve()
+        for f in sorted(context_dir.rglob("*")):
+            if f.is_symlink() or not f.is_file():
+                continue
+            if f.resolve() == resolved_dockerfile:
+                continue
+            if f.name.lower() == "dockerfile":
+                skipped.append(f.relative_to(context_dir).as_posix())
+                continue
+            context[f.relative_to(context_dir).as_posix()] = f
+
+    try:
+        builder = DockerRootfsBuilder(
+            name=tag,
+            dockerfile=dockerfile_text,
+            context=context,
+            rootfs_size_mb=size_mb,
+            cache_dir=resolve_image_dir(image_dir),
+            build_args=parsed_args,
+            ssh_capable=False,
+        )
+    except ValueError as exc:
+        return _fail(
+            command_name,
+            str(exc),
+            json_output=json_output,
+            code="invalid_input",
+            exit_code=2,
+        )
+
+    start = time.time()
+    try:
+        boot_image = builder.build_boot_image(
+            backend=backend,
+            arch=arch or "host",
+            boot=DirectKernelBoot(init=init),
+        )
+    except ImageError as exc:
+        return _fail(
+            command_name,
+            str(exc),
+            json_output=json_output,
+            recovery=f"Fix the problem above, then retry '{retry_command}'.",
+        )
+    except OSError as exc:
+        return _fail(
+            command_name,
+            f"Could not write the image: {exc}",
+            json_output=json_output,
+            recovery=f"Free up disk space, then retry '{retry_command}'.",
+        )
+
+    fingerprint_dir = boot_image.rootfs_path.parent
+    try:
+        cached = boot_image.rootfs_path.stat().st_mtime < start
+    except OSError:
+        cached = False
+
+    payload = ImageBuildPayload(
+        name=tag,
+        fingerprint=fingerprint_dir.name,
+        rootfs_path=str(boot_image.rootfs_path),
+        kernel_path=str(boot_image.kernel_path),
+        boot_args=boot_image.render_boot_args(),
+        arch=str(boot_image.arch or arch or "host"),
+        backend=str(boot_image.backend or backend),
+        size_bytes=_total_size(fingerprint_dir),
+        cached=cached,
+    )
+    if json_output:
+        return emit_success(command_name, payload)
+
+    from rich.panel import Panel
+
+    console = console_stdout()
+    for path in skipped:
+        console.print(
+            f"[yellow]Skipped '{path}': files named Dockerfile can't be "
+            "part of the build context.[/yellow]"
+        )
+    verb = "Reusing cached" if cached else "Built"
+    console.print(
+        Panel.fit(
+            f"{verb} custom image [bold]{_CUSTOM_DIR}/{tag}[/bold] "
+            f"({_format_bytes(payload['size_bytes'])})\n"
+            f"  rootfs: {payload['rootfs_path']}\n"
+            f"  kernel: {payload['kernel_path']}\n\n"
+            "Boot it from Python with:\n"
+            "  [bold]from smolvm import BootImage, DirectKernelBoot, SmolVM\n"
+            f'  image = BootImage(name="{tag}",\n'
+            f'                    rootfs_path="{payload["rootfs_path"]}",\n'
+            f'                    rootfs_format="raw-ext4",\n'
+            f'                    kernel_path="{payload["kernel_path"]}",\n'
+            f'                    boot=DirectKernelBoot(init="{init}"))\n'
+            "  with SmolVM.from_image(image) as vm:\n"
+            "      vm.start()[/bold]\n\n"
+            f"Manage it with 'smolvm image list' and 'smolvm image rm {_CUSTOM_DIR}/{tag}'.",
+            title="Custom image ready",
+            border_style="green",
+        )
+    )
     return 0

--- a/src/smolvm/cli/image.py
+++ b/src/smolvm/cli/image.py
@@ -29,7 +29,6 @@ import json
 import re
 import shlex
 import shutil
-import time
 from contextlib import AbstractContextManager, nullcontext
 from datetime import datetime, timezone
 from pathlib import Path
@@ -111,6 +110,10 @@ def _relative_time(iso_ts: str | None, *, now: datetime | None = None) -> str:
         then = datetime.fromisoformat(iso_ts)
     except ValueError:
         return "-"
+    if then.tzinfo is None:
+        # A naive timestamp can't be compared to the aware clock; degrade
+        # like any other unusable input instead of raising.
+        return "-"
     current = now if now is not None else datetime.now(timezone.utc)
     seconds = max(0, int((current - then).total_seconds()))
     for unit, span in (
@@ -130,17 +133,25 @@ def _relative_time(iso_ts: str | None, *, now: datetime | None = None) -> str:
 def _valid_entry_name(requested: str) -> bool:
     """Whether *requested* is a well-formed cache-entry name.
 
-    Plain entries are a single path segment; custom builds may be addressed
-    as ``custom/<name>`` or ``custom/<name>/<fingerprint>``.
+    Plain entries are a single path segment — any real directory name works,
+    since users may drop oddly named dirs into the cache. Custom builds are
+    addressed as ``custom/<name>`` or ``custom/<name>/<fingerprint>`` with
+    the builder's conservative charset. The bare namespace directory
+    ``custom`` is NOT an entry: accepting it would let one rm wipe every
+    build at once.
     """
     if not requested or "\\" in requested:
         return False
     segments = requested.split("/")
-    if any(seg in {"", ".", ".."} or not _SAFE_SEGMENT_RE.match(seg) for seg in segments):
+    if any(seg in {"", ".", ".."} for seg in segments):
         return False
     if len(segments) == 1:
-        return True
-    return segments[0] == _CUSTOM_DIR and len(segments) in {2, 3}
+        return segments[0] != _CUSTOM_DIR
+    return (
+        segments[0] == _CUSTOM_DIR
+        and len(segments) in {2, 3}
+        and all(_SAFE_SEGMENT_RE.match(seg) for seg in segments[1:])
+    )
 
 
 class ImageRow(TypedDict):
@@ -223,6 +234,7 @@ class ImageBuildPayload(TypedDict):
     backend: str
     size_bytes: int
     cached: bool
+    warnings: list[str]
 
 
 class RemovedEntry(TypedDict):
@@ -252,10 +264,21 @@ def _fail(
     return exit_code
 
 
-def _classify(path: Path) -> ImageRow:
+def _entry_kind(path: Path, root: Path) -> str:
+    """The row kind an entry directory would get, without walking it."""
+    if path.parent != root:
+        return "custom"
+    if _IMAGE_DIR_NAME_RE.match(path.name):
+        return "image"
+    if _KERNEL_DIR_NAME_RE.match(path.name):
+        return "kernel"
+    return "other"
+
+
+def _classify(path: Path, size_bytes: int | None = None) -> ImageRow:
     """Build an :class:`ImageRow` for one child directory of the image dir."""
     name = path.name
-    size = _total_size(path)
+    size = size_bytes if size_bytes is not None else _total_size(path)
     created = _created_iso(path)
     image_match = _IMAGE_DIR_NAME_RE.match(name)
     if image_match:
@@ -302,7 +325,7 @@ def _classify(path: Path) -> ImageRow:
     )
 
 
-def _custom_row(fingerprint_dir: Path) -> ImageRow:
+def _custom_row(fingerprint_dir: Path, size_bytes: int | None = None) -> ImageRow:
     """Build an :class:`ImageRow` for one ``custom/<name>/<fingerprint>`` dir."""
     arch: str | None = None
     metadata = fingerprint_dir / "metadata.json"
@@ -323,7 +346,7 @@ def _custom_row(fingerprint_dir: Path) -> ImageRow:
         os=None,
         current=None,
         created=_created_iso(fingerprint_dir),
-        size_bytes=_total_size(fingerprint_dir),
+        size_bytes=size_bytes if size_bytes is not None else _total_size(fingerprint_dir),
         path=str(fingerprint_dir),
     )
 
@@ -342,12 +365,17 @@ def _custom_rows(custom_root: Path) -> list[ImageRow]:
 
 
 def _cached_rows(root: Path) -> list[ImageRow]:
-    """Classify every cache entry under *root* (empty when it's missing)."""
+    """Classify every cache entry under *root* (empty when it's missing).
+
+    Top-level dot-directories (e.g. an interrupted load's ``.partial``
+    staging dir) are shown as "other" rows so their disk usage is never
+    invisible to the user.
+    """
     if not root.is_dir():
         return []
     rows: list[ImageRow] = []
     for child in sorted(root.iterdir()):
-        if not child.is_dir() or child.name.startswith("."):
+        if not child.is_dir():
             continue
         if child.name == _CUSTOM_DIR:
             rows.extend(_custom_rows(child))
@@ -377,13 +405,48 @@ def _normalize_rm_name(name: str, root: Path) -> str:
 def _resolve_entries(requested: str, root: Path) -> list[Path]:
     """Match a validated entry name to cache directories.
 
-    Exact names (including the ``custom/...`` namespace) win; otherwise the
-    name is treated as a preset and every cached variant matches.
+    Exact names (including the ``custom/...`` namespace) win; a custom
+    fingerprint may be shortened to a unique prefix (the 12 characters
+    ``image list`` shows are enough); otherwise the name is treated as a
+    preset and every cached variant matches.
+
+    Raises ``ValueError`` when a fingerprint prefix matches more than one
+    build — callers surface it as an invalid-input error.
     """
+    if "/" in requested:
+        segments = requested.split("/")
+        # A symlinked intermediate component could redirect the whole
+        # operation at a different entry; refuse rather than follow.
+        for depth in range(1, len(segments)):
+            if (root / "/".join(segments[:depth])).is_symlink():
+                return []
+        exact = root / requested
+        if exact.is_dir() or exact.is_symlink():
+            return [exact]
+        if len(segments) == 3:
+            # Docker-style short ids: a unique fingerprint prefix works.
+            name_dir = root / segments[0] / segments[1]
+            if name_dir.is_dir():
+                prefix_matches = [
+                    child
+                    for child in sorted(name_dir.iterdir())
+                    if child.is_dir()
+                    and not child.name.startswith(".")
+                    and child.name.startswith(segments[2])
+                ]
+                if len(prefix_matches) > 1:
+                    options = ", ".join(
+                        f"{segments[0]}/{segments[1]}/{child.name}" for child in prefix_matches
+                    )
+                    raise ValueError(
+                        f"'{requested}' matches more than one build. Pick one of: {options}."
+                    )
+                return prefix_matches
+        return []
     exact = root / requested
     if exact.is_dir() or exact.is_symlink():
         return [exact]
-    if "/" in requested or not root.is_dir():
+    if not root.is_dir():
         return []
     canonical = _canonical_preset(requested)
     matches: list[Path] = []
@@ -434,6 +497,56 @@ def _pull_retry_command(
 ) -> str:
     """The user's pull invocation, reconstructed for recovery messages."""
     parts = ["smolvm", "image", "pull", preset]
+    if arch:
+        parts += ["--arch", arch]
+    if vmm:
+        parts += ["--vmm", vmm]
+    if os_name:
+        parts += ["--os", os_name]
+    if image_dir:
+        parts += ["--image-dir", shlex.quote(image_dir)]
+    return " ".join(parts)
+
+
+def _build_retry_command(
+    tag: str,
+    context_path: str,
+    dockerfile: str | None,
+    size_mb: int,
+    build_args: tuple[str, ...],
+    arch: str | None,
+    backend: str,
+    init: str,
+    image_dir: str | None,
+) -> str:
+    """The user's build invocation, reconstructed for recovery messages."""
+    parts = ["smolvm", "image", "build", "-t", tag]
+    if dockerfile:
+        parts += ["-f", shlex.quote(dockerfile)]
+    if size_mb != 512:
+        parts += ["--size-mb", str(size_mb)]
+    for item in build_args:
+        parts += ["--build-arg", shlex.quote(item)]
+    if arch:
+        parts += ["--arch", arch]
+    if backend != "auto":
+        parts += ["--backend", backend]
+    if init != "/init":
+        parts += ["--init", shlex.quote(init)]
+    if image_dir:
+        parts += ["--image-dir", shlex.quote(image_dir)]
+    parts.append(shlex.quote(context_path))
+    return " ".join(parts)
+
+
+def _pull_all_retry_command(
+    arch: str | None,
+    vmm: str | None,
+    os_name: str | None,
+    image_dir: str | None,
+) -> str:
+    """The user's ``pull --all`` invocation, reconstructed for recovery."""
+    parts = ["smolvm", "image", "pull", "--all"]
     if arch:
         parts += ["--arch", arch]
     if vmm:
@@ -646,7 +759,9 @@ def run_image_pull_all(
 ) -> int:
     """Execute ``smolvm image pull --all``."""
     from smolvm.cli.main import _host_arch_for_published, _vmm_for_host
-    from smolvm.images.published import MANIFEST
+    from smolvm.images.published import Arch, Vmm, published_targets
+
+    retry_command = _pull_all_retry_command(arch, vmm, os_name, image_dir)
 
     try:
         resolved_arch = arch or _host_arch_for_published()
@@ -662,18 +777,17 @@ def run_image_pull_all(
             exit_code=2,
         )
 
-    targets = sorted(
-        {(p, o) for (p, a, v, o) in MANIFEST if a == resolved_arch and v == resolved_vmm}
-    )
+    targets = published_targets(cast("Arch", resolved_arch), cast("Vmm", resolved_vmm))
     if os_name:
         targets = [(p, o) for (p, o) in targets if o == os_name]
     if not targets:
+        no_filter_command = _pull_all_retry_command(arch, vmm, None, image_dir)
         return _fail(
             command_name,
-            f"No published images for {resolved_arch}/{resolved_vmm}"
-            f"{f' with os {os_name!r}' if os_name else ''}.",
+            "No published images match this machine and the options you passed.",
             json_output=json_output,
             code="invalid_input",
+            recovery=f"Run '{no_filter_command}' to download every available image.",
             exit_code=2,
         )
 
@@ -713,13 +827,16 @@ def run_image_pull_all(
         warnings=_non_default_dir_warnings(root),
     )
 
+    failure_recovery = (
+        f"Check your network connection and disk space, then retry '{retry_command}'."
+    )
     if json_output:
         if failed:
             return emit_error(
                 command_name,
                 "runtime_error",
                 f"Could not download {len(failed)} of {len(targets)} images.",
-                recovery="Check your network connection and retry 'smolvm image pull --all'.",
+                recovery=failure_recovery,
                 details=payload,
                 exit_code=1,
             )
@@ -738,7 +855,7 @@ def run_image_pull_all(
     if failed:
         render_error(
             f"Could not download {len(failed)} of {len(targets)} images.",
-            hint="Check your network connection and retry 'smolvm image pull --all'.",
+            hint=failure_recovery,
         )
         return 1
     return 0
@@ -811,8 +928,6 @@ def run_image_list(
 
 def _inspect_entry(path: Path, root: Path) -> ImageInspectEntry:
     """Build the detailed inspect record for one cache directory."""
-    row = _custom_row(path) if path.parent != root else _classify(path)
-
     files: list[ImageFileEntry] = []
     try:
         for f in sorted(path.rglob("*")):
@@ -832,6 +947,14 @@ def _inspect_entry(path: Path, root: Path) -> ImageInspectEntry:
     except OSError:
         pass
 
+    # The files walk already collected on-disk sizes — reuse them for the
+    # row instead of walking the tree a second time.
+    size_on_disk = sum(f["size_on_disk_bytes"] for f in files)
+    if _entry_kind(path, root) == "custom":
+        row = _custom_row(path, size_bytes=size_on_disk)
+    else:
+        row = _classify(path, size_bytes=size_on_disk)
+
     sidecar_path = path / "rootfs.ext4.from-sha256"
     sidecar: str | None = None
     if sidecar_path.is_file():
@@ -842,10 +965,13 @@ def _inspect_entry(path: Path, root: Path) -> ImageInspectEntry:
 
     manifest_info: ImageManifestInfo | None = None
     if row["kind"] == "image" and row["current"]:
-        from smolvm.images.published import IMAGES_RELEASE_TAG, MANIFEST, ManifestKey
+        from smolvm.exceptions import ImageError
+        from smolvm.images.published import IMAGES_RELEASE_TAG, lookup
 
-        key = cast("ManifestKey", (row["preset"], row["arch"], row["vmm"], row["os"]))
-        entry = MANIFEST.get(key)
+        try:
+            entry = lookup(row["preset"], row["arch"], row["vmm"], row["os"])  # type: ignore[arg-type]
+        except ImageError:
+            entry = None
         if entry is not None:
             manifest_info = ImageManifestInfo(
                 kernel_url=entry.kernel_url,
@@ -886,6 +1012,14 @@ def run_image_inspect(
 
     try:
         matches = _expand_custom_entries(_resolve_entries(requested, root), root)
+    except ValueError as exc:
+        return _fail(
+            command_name,
+            str(exc),
+            json_output=json_output,
+            code="invalid_input",
+            exit_code=2,
+        )
     except OSError as exc:
         return _fail(
             command_name,
@@ -973,6 +1107,14 @@ def run_image_rm(
     permission_recovery = f"Fix the folder's permissions, then retry 'smolvm image rm {requested}'."
     try:
         matches = _resolve_entries(requested, root)
+    except ValueError as exc:
+        return _fail(
+            command_name,
+            str(exc),
+            json_output=json_output,
+            code="invalid_input",
+            exit_code=2,
+        )
     except OSError as exc:
         return _fail(
             command_name,
@@ -989,7 +1131,6 @@ def run_image_rm(
             recovery="Run 'smolvm image list' to see cached images.",
         )
 
-    resolved_root = root.resolve()
     entries: list[RemovedEntry] = []
     for target in matches:
         display = target.relative_to(root).as_posix()
@@ -998,10 +1139,15 @@ def run_image_rm(
             # touched — so removing it frees no space.
             entries.append(RemovedEntry(name=display, path=str(target), size_bytes=0))
             continue
-        # Names are validated above and matches sit under the root, so a
-        # real directory escaping it should be impossible; keep a hard stop
-        # in front of the recursive delete anyway.
-        if resolved_root not in target.resolve().parents:
+        # Names and intermediate components are validated above, so a real
+        # directory escaping its parent should be impossible; keep a hard
+        # stop in front of the recursive delete anyway: the target must
+        # resolve to a direct child of its own (resolved) parent inside the
+        # image directory.
+        resolved_parent = target.parent.resolve()
+        resolved_root = root.resolve()
+        inside_root = resolved_parent == resolved_root or resolved_root in resolved_parent.parents
+        if target.resolve().parent != resolved_parent or not inside_root:
             return _fail(
                 command_name,
                 f"'{display}' could not be removed safely.",
@@ -1026,7 +1172,7 @@ def run_image_rm(
             console.print(f"  {entry['name']}  ({_format_bytes(entry['size_bytes'])})")
         return 0
 
-    for target in matches:
+    for target, entry in zip(matches, entries, strict=True):
         try:
             if target.is_symlink():
                 target.unlink()
@@ -1035,7 +1181,7 @@ def run_image_rm(
         except OSError as exc:
             return _fail(
                 command_name,
-                f"Could not remove '{target.name}': {exc}",
+                f"Could not remove '{entry['name']}': {exc}",
                 json_output=json_output,
                 recovery=permission_recovery,
             )
@@ -1065,10 +1211,36 @@ def run_image_build(
     """Execute ``smolvm image build``."""
     from smolvm.exceptions import ImageError
     from smolvm.images.boot import DirectKernelBoot
-    from smolvm.images.builder import DockerRootfsBuilder
+    from smolvm.images.builder import DockerContextValue, DockerRootfsBuilder
 
-    retry_command = f"smolvm image build -t {tag} {shlex.quote(context_path)}"
+    retry_command = _build_retry_command(
+        tag, context_path, dockerfile, size_mb, build_args, arch, backend, init, image_dir
+    )
+
+    if not _SAFE_SEGMENT_RE.match(tag) or tag in {".", ".."}:
+        # The builder's own charset is slightly looser (it allows "." and
+        # ".."), which would let a tag escape the custom/ namespace.
+        return _fail(
+            command_name,
+            f"'{tag}' can't be used as an image name. Use letters, numbers, "
+            "dots, dashes, and underscores.",
+            json_output=json_output,
+            code="invalid_input",
+            exit_code=2,
+        )
+
     context_dir = Path(context_path)
+    if not context_dir.is_dir():
+        return _fail(
+            command_name,
+            f"'{context_path}' is not a folder.",
+            json_output=json_output,
+            code="invalid_input",
+            recovery="Pass the folder with the files your Dockerfile copies "
+            f"(use '.' for the current one), e.g. 'smolvm image build -t {tag} .'.",
+            exit_code=2,
+        )
+
     dockerfile_path = Path(dockerfile) if dockerfile else context_dir / "Dockerfile"
     try:
         dockerfile_text = dockerfile_path.read_text()
@@ -1078,8 +1250,7 @@ def run_image_build(
             f"No Dockerfile at '{dockerfile_path}'.",
             json_output=json_output,
             code="invalid_input",
-            recovery=f"Pass one with 'smolvm image build -t {tag} "
-            f"-f path/to/Dockerfile {shlex.quote(context_path)}'.",
+            recovery="Create it, or point at one with the -f option.",
             exit_code=2,
         )
 
@@ -1099,19 +1270,22 @@ def run_image_build(
 
     # Everything in the context folder is sent to the build. Files named
     # "Dockerfile" (any depth) are reserved by the builder and skipped.
-    context: dict[str, Path] = {}
-    skipped: list[str] = []
-    if context_dir.is_dir():
-        resolved_dockerfile = dockerfile_path.resolve()
-        for f in sorted(context_dir.rglob("*")):
-            if f.is_symlink() or not f.is_file():
-                continue
-            if f.resolve() == resolved_dockerfile:
-                continue
-            if f.name.lower() == "dockerfile":
-                skipped.append(f.relative_to(context_dir).as_posix())
-                continue
-            context[f.relative_to(context_dir).as_posix()] = f
+    context: dict[str, DockerContextValue] = {}
+    warnings: list[str] = []
+    resolved_dockerfile = dockerfile_path.resolve()
+    for f in sorted(context_dir.rglob("*")):
+        if f.is_symlink() or not f.is_file():
+            continue
+        if f.resolve() == resolved_dockerfile:
+            continue
+        if f.name.lower() == "dockerfile":
+            skipped_path = f.relative_to(context_dir).as_posix()
+            warnings.append(
+                f"Skipped '{skipped_path}': files named Dockerfile can't be "
+                "part of the build context. Rename it to include it."
+            )
+            continue
+        context[f.relative_to(context_dir).as_posix()] = f
 
     try:
         builder = DockerRootfsBuilder(
@@ -1132,19 +1306,33 @@ def run_image_build(
             exit_code=2,
         )
 
-    start = time.time()
+    # Clock-free cache detection: a build was reused iff its rootfs existed
+    # before the call and was not rewritten (wall-clock comparisons break
+    # under VM clock drift and coarse filesystem timestamps).
+    existing_builds: dict[str, int] = {}
+    tag_dir = builder.cache_dir / _CUSTOM_DIR / tag
+    if tag_dir.is_dir():
+        for child in tag_dir.iterdir():
+            try:
+                if child.is_dir():
+                    existing_builds[child.name] = (child / "rootfs.ext4").stat().st_mtime_ns
+            except OSError:
+                continue
+
     try:
         boot_image = builder.build_boot_image(
             backend=backend,
             arch=arch or "host",
             boot=DirectKernelBoot(init=init),
         )
-    except ImageError as exc:
+    except (ImageError, ValueError) as exc:
         return _fail(
             command_name,
             str(exc),
             json_output=json_output,
+            code="invalid_input" if isinstance(exc, ValueError) else "runtime_error",
             recovery=f"Fix the problem above, then retry '{retry_command}'.",
+            exit_code=2 if isinstance(exc, ValueError) else 1,
         )
     except OSError as exc:
         return _fail(
@@ -1156,7 +1344,9 @@ def run_image_build(
 
     fingerprint_dir = boot_image.rootfs_path.parent
     try:
-        cached = boot_image.rootfs_path.stat().st_mtime < start
+        cached = (
+            existing_builds.get(fingerprint_dir.name) == boot_image.rootfs_path.stat().st_mtime_ns
+        )
     except OSError:
         cached = False
 
@@ -1170,6 +1360,7 @@ def run_image_build(
         backend=str(boot_image.backend or backend),
         size_bytes=_total_size(fingerprint_dir),
         cached=cached,
+        warnings=warnings,
     )
     if json_output:
         return emit_success(command_name, payload)
@@ -1177,11 +1368,8 @@ def run_image_build(
     from rich.panel import Panel
 
     console = console_stdout()
-    for path in skipped:
-        console.print(
-            f"[yellow]Skipped '{path}': files named Dockerfile can't be "
-            "part of the build context.[/yellow]"
-        )
+    for warning in warnings:
+        console.print(f"[yellow]{warning}[/yellow]")
     verb = "Reusing cached" if cached else "Built"
     console.print(
         Panel.fit(

--- a/src/smolvm/cli/image_transfer.py
+++ b/src/smolvm/cli/image_transfer.py
@@ -16,9 +16,10 @@
 
 The archive is a plain tar containing exactly one ``manifest.json``
 (schema_version 1) that describes every ``files/<path>`` member: its
-encoding (``raw`` bytes or a ``zstd`` stream) and its decoded size. Member
-names never carry encoding suffixes, so sibling files like ``x`` and
-``x.zst`` can't collide. Large files travel as zstd streams so sparse
+encoding (``raw`` bytes or a ``zstd`` stream), its decoded size, and the
+SHA-256 digest of the stored bytes, all verified on load. Member names
+never carry encoding suffixes, so sibling files like ``x`` and ``x.zst``
+can't collide. Large files travel as zstd streams so sparse
 rootfs images stay small; the decompressed ``rootfs.ext4`` and its sidecar
 are omitted entirely when the compressed ``rootfs.ext4.zst`` is present and
 are recreated on load, byte-compatible with what ``ensure_published_image``
@@ -30,6 +31,8 @@ from __future__ import annotations
 import hashlib
 import io
 import json
+import os
+import re
 import shlex
 import shutil
 import tarfile
@@ -42,6 +45,7 @@ from typing import Any, TypedDict
 from smolvm import __version__
 from smolvm.cli.image import (
     _IMAGE_DIR_NAME_RE,
+    _brief_error,
     _entry_kind,
     _expand_custom_entries,
     _fail,
@@ -82,6 +86,17 @@ class ImageLoadPayload(TypedDict):
     size_bytes: int
     files: int
     warnings: list[str]
+
+
+_SHA256_RE = re.compile(r"^[0-9a-f]{64}$")
+
+
+def _sha256_file(path: Path) -> str:
+    hasher = hashlib.sha256()
+    with open(path, "rb") as f:
+        while chunk := f.read(_COPY_CHUNK):
+            hasher.update(chunk)
+    return hasher.hexdigest()
 
 
 def _valid_relative_file_path(path: str) -> bool:
@@ -147,7 +162,7 @@ def run_image_save(
     except OSError as exc:
         return _fail(
             command_name,
-            f"Could not read the image folder '{root}': {exc}",
+            f"Could not read the image folder '{root}': {_brief_error(exc)}",
             json_output=json_output,
             recovery=f"Fix the folder's permissions, then retry '{retry_command}'.",
         )
@@ -172,7 +187,10 @@ def run_image_save(
     entry = matches[0]
     archive_name = entry.relative_to(root).as_posix()
 
-    zst_present = (entry / _ROOTFS_ZST).is_file()
+    zst_path = entry / _ROOTFS_ZST
+    # A symlinked wire file is skipped by the archive loop below, so
+    # treating it as present would produce an archive with no rootfs.
+    zst_present = zst_path.is_file() and not zst_path.is_symlink()
     excluded = {_DECOMPRESSED_ROOTFS, _ROOTFS_SIDECAR} if zst_present else set()
     sidecar_value: str | None = None
     if zst_present and (entry / _ROOTFS_SIDECAR).is_file():
@@ -185,7 +203,7 @@ def run_image_save(
     files_meta: list[dict[str, Any]] = []
     # Write to a sibling temp file and rename at the end so a failed save
     # never destroys an existing archive at the -o path.
-    partial_archive = out_path.with_name(out_path.name + ".partial")
+    partial_archive = out_path.with_name(f"{out_path.name}.partial-{os.getpid()}")
     compressor = zstandard.ZstdCompressor(threads=-1)
     try:
         tmp_parent = str(out_path.parent) if out_path.parent.is_dir() else None
@@ -207,14 +225,28 @@ def run_image_save(
                 if rel in excluded or rel == ".build.lock":
                     continue
                 if rel.endswith(".zst"):
-                    files_meta.append({"path": rel, "encoding": "raw", "size": f.stat().st_size})
+                    files_meta.append(
+                        {
+                            "path": rel,
+                            "encoding": "raw",
+                            "size": f.stat().st_size,
+                            "sha256": _sha256_file(f),
+                        }
+                    )
                     tar.add(f, arcname=f"files/{rel}", recursive=False)
                 else:
                     # Compress into one reused scratch file, add, discard —
                     # scratch usage stays bounded by a single member.
                     with open(f, "rb") as src, open(scratch, "wb") as dst:
                         compressor.copy_stream(src, dst)
-                    files_meta.append({"path": rel, "encoding": "zstd", "size": f.stat().st_size})
+                    files_meta.append(
+                        {
+                            "path": rel,
+                            "encoding": "zstd",
+                            "size": f.stat().st_size,
+                            "sha256": _sha256_file(scratch),
+                        }
+                    )
                     tar.add(scratch, arcname=f"files/{rel}", recursive=False)
                     scratch.unlink()
 
@@ -237,7 +269,7 @@ def run_image_save(
             partial_archive.unlink(missing_ok=True)
         return _fail(
             command_name,
-            f"Could not write '{out_path}': {exc}",
+            f"Could not write '{out_path}': {_brief_error(exc)}",
             json_output=json_output,
             recovery=f"Free up disk space or fix permissions, then retry '{retry_command}'.",
         )
@@ -305,7 +337,7 @@ def run_image_load(
     except (OSError, tarfile.TarError) as exc:
         return _fail(
             command_name,
-            f"Could not open '{in_path}': {exc}",
+            f"Could not open '{in_path}': {_brief_error(exc)}",
             json_output=json_output,
             code="invalid_input",
             recovery=not_an_archive,
@@ -356,6 +388,8 @@ def run_image_load(
                 or not isinstance(meta.get("size"), int)
                 or isinstance(meta.get("size"), bool)
                 or meta["size"] < 0
+                or not isinstance(meta.get("sha256"), str)
+                or not _SHA256_RE.match(meta["sha256"])
                 or not _valid_relative_file_path(meta["path"])
             ):
                 return bad_archive()
@@ -389,7 +423,7 @@ def run_image_load(
         have_sidecar = isinstance(manifest_sidecar, str) and bool(manifest_sidecar)
 
         target.parent.mkdir(parents=True, exist_ok=True)
-        partial = target.parent / f".{target.name}.partial"
+        partial = target.parent / f".{target.name}.partial-{os.getpid()}"
         shutil.rmtree(partial, ignore_errors=True)
         try:
             partial.mkdir()
@@ -401,32 +435,36 @@ def run_image_load(
                 source = tar.extractfile(member)
                 if source is None:
                     raise tarfile.TarError(f"could not read '{member.name}' from the archive")
+                # Every member's bytes are verified against the manifest
+                # digest before use; the rootfs digest doubles as the
+                # sidecar fallback.
+                hasher = hashlib.sha256()
                 if meta["encoding"] == "raw":
-                    # The digest feeds the sidecar fallback; skip the work
-                    # when the manifest already carries the sidecar value.
-                    hasher = (
-                        hashlib.sha256()
-                        if meta["path"] == _ROOTFS_ZST and not have_sidecar
-                        else None
-                    )
                     with source, open(destination, "wb") as out:
                         while chunk := source.read(_COPY_CHUNK):
                             out.write(chunk)
-                            if hasher is not None:
-                                hasher.update(chunk)
-                    if hasher is not None:
-                        zst_sha = hasher.hexdigest()
+                            hasher.update(chunk)
+                    digest = hasher.hexdigest()
+                    if digest != meta["sha256"]:
+                        raise zstandard.ZstdError(f"'{meta['path']}' failed its integrity check")
                 else:
                     tmp_zst = destination.with_name(destination.name + ".tmp.zst")
                     with source, open(tmp_zst, "wb") as out:
                         while chunk := source.read(_COPY_CHUNK):
                             out.write(chunk)
+                            hasher.update(chunk)
+                    digest = hasher.hexdigest()
+                    if digest != meta["sha256"]:
+                        tmp_zst.unlink()
+                        raise zstandard.ZstdError(f"'{meta['path']}' failed its integrity check")
                     decompress_zstd_sparse(tmp_zst, destination)
                     tmp_zst.unlink()
                 if destination.stat().st_size != meta["size"]:
                     raise zstandard.ZstdError(
                         f"'{meta['path']}' does not match the size the archive declares"
                     )
+                if meta["path"] == _ROOTFS_ZST:
+                    zst_sha = digest
 
             # Recreate what save deliberately left out, byte-compatible with
             # what ensure_published_image validates on the next start.
@@ -452,7 +490,7 @@ def run_image_load(
             shutil.rmtree(partial, ignore_errors=True)
             return _fail(
                 command_name,
-                f"Could not load the image: {exc}",
+                f"Could not load the image: {_brief_error(exc)}",
                 json_output=json_output,
                 recovery="Free up disk space or fix permissions, then retry "
                 f"'smolvm image load -i {quoted_input}'.",

--- a/src/smolvm/cli/image_transfer.py
+++ b/src/smolvm/cli/image_transfer.py
@@ -20,7 +20,9 @@ encoding (``raw`` bytes or a ``zstd`` stream), its decoded size, and the
 SHA-256 digest of the stored bytes, all verified on load. Member names
 never carry encoding suffixes, so sibling files like ``x`` and ``x.zst``
 can't collide. Large files travel as zstd streams so sparse
-rootfs images stay small; the decompressed ``rootfs.ext4`` and its sidecar
+rootfs images stay small; files that are already ``.zst`` always travel
+raw (never re-compressed), so their manifest digest is also the digest of
+the installed file. The decompressed ``rootfs.ext4`` and its sidecar
 are omitted entirely when the compressed ``rootfs.ext4.zst`` is present and
 are recreated on load, byte-compatible with what ``ensure_published_image``
 expects.
@@ -69,6 +71,12 @@ _MANIFEST_SIZE_CAP = 10 * 1024 * 1024
 _DECOMPRESSED_ROOTFS = "rootfs.ext4"
 _ROOTFS_ZST = "rootfs.ext4.zst"
 _ROOTFS_SIDECAR = "rootfs.ext4.from-sha256"
+# Builders hold this lock while rewriting an entry (see builder.py).
+_BUILD_LOCK = ".build.lock"
+
+
+class _EntryChangedError(Exception):
+    """A file in the image shrank while it was being archived."""
 
 
 class ImageSavePayload(TypedDict):
@@ -135,6 +143,8 @@ def run_image_save(
     command_name: str = "image.save",
 ) -> int:
     """Execute ``smolvm image save``."""
+    import fcntl
+
     import zstandard
 
     root = resolve_image_dir(image_dir)
@@ -224,9 +234,14 @@ def run_image_save(
     try:
         tmp_parent = str(out_path.parent) if out_path.parent.is_dir() else None
         with (
+            (entry / _BUILD_LOCK).open("a") as build_lock,
             tempfile.TemporaryDirectory(dir=tmp_parent) as tmp,
             tarfile.open(partial_archive, "w") as tar,
         ):
+            # Hold the entry's build lock so the archive is one consistent
+            # generation, not a mix of two builds; non-blocking so a running
+            # build reports as busy instead of hanging the save.
+            fcntl.flock(build_lock.fileno(), fcntl.LOCK_EX | fcntl.LOCK_NB)
             scratch = Path(tmp) / "member.zst"
             for f in sorted(entry.rglob("*")):
                 if f.is_symlink():
@@ -238,7 +253,11 @@ def run_image_save(
                 if not f.is_file():
                     continue
                 rel = f.relative_to(entry).as_posix()
-                if rel in excluded or rel == ".build.lock":
+                if rel in excluded:
+                    continue
+                # Dot-prefixed names are lock files and builders' in-progress
+                # temp artifacts, never part of the image.
+                if any(segment.startswith(".") for segment in rel.split("/")):
                     continue
                 if rel.endswith(".zst"):
                     # Hash while tar reads the file so the manifest digest
@@ -247,9 +266,19 @@ def run_image_save(
                     # producing a silently inconsistent archive.
                     hasher = hashlib.sha256()
                     with open(f, "rb") as src:
-                        info = tarfile.TarInfo(f"files/{rel}")
+                        info = tar.gettarinfo(arcname=f"files/{rel}", fileobj=src)
+                        # Force a plain file member: gettarinfo turns a second
+                        # hardlink to an already-added file into a link entry
+                        # the manifest cannot describe.
+                        info.type = tarfile.REGTYPE
+                        info.linkname = ""
                         info.size = os.fstat(src.fileno()).st_size
-                        tar.addfile(info, _HashingReader(src, hasher))
+                        try:
+                            tar.addfile(info, _HashingReader(src, hasher))
+                        except OSError as exc:
+                            if os.fstat(src.fileno()).st_size < info.size:
+                                raise _EntryChangedError(rel) from exc
+                            raise
                     files_meta.append(
                         {
                             "path": rel,
@@ -260,10 +289,8 @@ def run_image_save(
                     )
                 else:
                     # Compress into one reused scratch file, add, discard —
-                    # scratch usage stays bounded by a single member. The
-                    # recorded size counts the bytes actually compressed, so
-                    # manifest and stream stay consistent under concurrent
-                    # source changes.
+                    # scratch usage stays bounded by a single member, and the
+                    # recorded size counts the bytes actually compressed.
                     with open(f, "rb") as src, open(scratch, "wb") as dst:
                         read_bytes, _ = compressor.copy_stream(src, dst)
                     files_meta.append(
@@ -291,6 +318,24 @@ def run_image_save(
             info.size = len(manifest_bytes)
             tar.addfile(info, io.BytesIO(manifest_bytes))
         partial_archive.replace(out_path)
+    except _EntryChangedError as exc:
+        with suppress(OSError):
+            partial_archive.unlink(missing_ok=True)
+        return _fail(
+            command_name,
+            f"The image changed while it was being saved ('{exc.args[0]}' shrank).",
+            json_output=json_output,
+            recovery=f"Wait until nothing is using the image, then retry '{retry_command}'.",
+        )
+    except BlockingIOError:
+        with suppress(OSError):
+            partial_archive.unlink(missing_ok=True)
+        return _fail(
+            command_name,
+            f"'{archive_name}' is being built right now.",
+            json_output=json_output,
+            recovery=f"Wait for the build to finish, then retry '{retry_command}'.",
+        )
     except OSError as exc:
         with suppress(OSError):
             partial_archive.unlink(missing_ok=True)
@@ -299,6 +344,15 @@ def run_image_save(
             f"Could not write '{out_path}': {_brief_error(exc)}",
             json_output=json_output,
             recovery=f"Free up disk space or fix permissions, then retry '{retry_command}'.",
+        )
+    except zstandard.ZstdError as exc:
+        with suppress(OSError):
+            partial_archive.unlink(missing_ok=True)
+        return _fail(
+            command_name,
+            f"Could not save the image: {_brief_error(exc)}",
+            json_output=json_output,
+            recovery=f"Retry '{retry_command}'.",
         )
     except BaseException:
         with suppress(OSError):
@@ -412,6 +466,10 @@ def run_image_load(
                 not isinstance(meta, dict)
                 or not isinstance(meta.get("path"), str)
                 or meta.get("encoding") not in {"raw", "zstd"}
+                # .zst files always travel raw; a re-compressed one would
+                # install bytes that differ from the digest the manifest
+                # (and the regenerated rootfs sidecar) describes.
+                or (meta["path"].endswith(".zst") and meta["encoding"] != "raw")
                 or not isinstance(meta.get("size"), int)
                 or isinstance(meta.get("size"), bool)
                 or meta["size"] < 0
@@ -462,8 +520,9 @@ def run_image_load(
                 source = tar.extractfile(member)
                 if source is None:
                     raise tarfile.TarError(f"could not read '{member.name}' from the archive")
-                # Every member's bytes are verified against the manifest
-                # digest before use; the rootfs digest doubles as the
+                # Every member's stored bytes are verified against the
+                # manifest digest before use; for the always-raw
+                # rootfs.ext4.zst, that same digest doubles as the
                 # sidecar fallback.
                 hasher = hashlib.sha256()
                 if meta["encoding"] == "raw":
@@ -491,11 +550,9 @@ def run_image_load(
                         f"'{meta['path']}' does not match the size the archive declares"
                     )
                 if meta["path"] == _ROOTFS_ZST:
-                    # The sidecar must describe the installed file's bytes.
-                    # With raw encoding those are exactly the verified stored
-                    # bytes; a zstd-encoded member was decompressed on the way
-                    # in, so hash what actually landed on disk.
-                    zst_sha = digest if meta["encoding"] == "raw" else _sha256_file(destination)
+                    # Always raw (validated above), so this digest is also
+                    # the digest of the installed file.
+                    zst_sha = digest
 
             # Recreate what save deliberately left out, byte-compatible with
             # what ensure_published_image validates on the next start.

--- a/src/smolvm/cli/image_transfer.py
+++ b/src/smolvm/cli/image_transfer.py
@@ -99,6 +99,19 @@ def _sha256_file(path: Path) -> str:
     return hasher.hexdigest()
 
 
+class _HashingReader:
+    """Wrap a binary file so a digest covers exactly the bytes tar reads."""
+
+    def __init__(self, fileobj: io.BufferedReader, hasher: hashlib._Hash) -> None:
+        self._fileobj = fileobj
+        self._hasher = hasher
+
+    def read(self, size: int = -1) -> bytes:
+        chunk = self._fileobj.read(size)
+        self._hasher.update(chunk)
+        return chunk
+
+
 def _valid_relative_file_path(path: str) -> bool:
     if not path or path.startswith("/") or "\\" in path:
         return False
@@ -228,25 +241,36 @@ def run_image_save(
                 if rel in excluded or rel == ".build.lock":
                     continue
                 if rel.endswith(".zst"):
+                    # Hash while tar reads the file so the manifest digest
+                    # matches the archived bytes even if the source changes
+                    # mid-save; a shrinking source fails the save instead of
+                    # producing a silently inconsistent archive.
+                    hasher = hashlib.sha256()
+                    with open(f, "rb") as src:
+                        info = tarfile.TarInfo(f"files/{rel}")
+                        info.size = os.fstat(src.fileno()).st_size
+                        tar.addfile(info, _HashingReader(src, hasher))
                     files_meta.append(
                         {
                             "path": rel,
                             "encoding": "raw",
-                            "size": f.stat().st_size,
-                            "sha256": _sha256_file(f),
+                            "size": info.size,
+                            "sha256": hasher.hexdigest(),
                         }
                     )
-                    tar.add(f, arcname=f"files/{rel}", recursive=False)
                 else:
                     # Compress into one reused scratch file, add, discard —
-                    # scratch usage stays bounded by a single member.
+                    # scratch usage stays bounded by a single member. The
+                    # recorded size counts the bytes actually compressed, so
+                    # manifest and stream stay consistent under concurrent
+                    # source changes.
                     with open(f, "rb") as src, open(scratch, "wb") as dst:
-                        compressor.copy_stream(src, dst)
+                        read_bytes, _ = compressor.copy_stream(src, dst)
                     files_meta.append(
                         {
                             "path": rel,
                             "encoding": "zstd",
-                            "size": f.stat().st_size,
+                            "size": read_bytes,
                             "sha256": _sha256_file(scratch),
                         }
                     )
@@ -467,7 +491,11 @@ def run_image_load(
                         f"'{meta['path']}' does not match the size the archive declares"
                     )
                 if meta["path"] == _ROOTFS_ZST:
-                    zst_sha = digest
+                    # The sidecar must describe the installed file's bytes.
+                    # With raw encoding those are exactly the verified stored
+                    # bytes; a zstd-encoded member was decompressed on the way
+                    # in, so hash what actually landed on disk.
+                    zst_sha = digest if meta["encoding"] == "raw" else _sha256_file(destination)
 
             # Recreate what save deliberately left out, byte-compatible with
             # what ensure_published_image validates on the next start.

--- a/src/smolvm/cli/image_transfer.py
+++ b/src/smolvm/cli/image_transfer.py
@@ -157,6 +157,7 @@ def run_image_save(
             str(exc),
             json_output=json_output,
             code="invalid_input",
+            recovery="Retry with one of the full names above.",
             exit_code=2,
         )
     except OSError as exc:
@@ -181,6 +182,8 @@ def run_image_save(
             f"'{requested}' matches more than one cached image. Pick one of: {options}.",
             json_output=json_output,
             code="invalid_input",
+            recovery=f"Retry with the full name, e.g. 'smolvm image save "
+            f"{options.split(', ')[0]} -o {shlex.quote(str(out_path))}'.",
             exit_code=2,
         )
 
@@ -485,7 +488,7 @@ def run_image_load(
             partial.rename(target)
         except (tarfile.TarError, zstandard.ZstdError) as exc:
             shutil.rmtree(partial, ignore_errors=True)
-            return bad_archive(f"'{in_path}' is damaged and was not loaded: {exc}.")
+            return bad_archive(f"'{in_path}' is damaged and was not loaded: {_brief_error(exc)}.")
         except OSError as exc:
             shutil.rmtree(partial, ignore_errors=True)
             return _fail(

--- a/src/smolvm/cli/image_transfer.py
+++ b/src/smolvm/cli/image_transfer.py
@@ -1,0 +1,412 @@
+# Copyright 2026 Celesto AI
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""``smolvm image save`` / ``smolvm image load`` — move images between machines.
+
+The archive is a plain tar whose first member is ``manifest.json``
+(schema_version 1) describing every other member. Large files are stored as
+zstd streams so sparse rootfs images stay small; the decompressed
+``rootfs.ext4`` and its sidecar are omitted entirely when the compressed
+``rootfs.ext4.zst`` is present and are recreated on load, byte-compatible
+with what ``ensure_published_image`` expects.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import io
+import json
+import shlex
+import shutil
+import tarfile
+import tempfile
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, TypedDict
+
+from smolvm import __version__
+from smolvm.cli.image import (
+    _IMAGE_DIR_NAME_RE,
+    _classify,
+    _expand_custom_entries,
+    _fail,
+    _non_default_dir_warnings,
+    _normalize_rm_name,
+    _resolve_entries,
+    _valid_entry_name,
+)
+from smolvm.cli.output import console_stdout, emit_success
+from smolvm.cli.prune import _format_bytes, _total_size
+from smolvm.images.manager import resolve_image_dir
+
+_SCHEMA_VERSION = 1
+_COPY_CHUNK = 1024 * 1024
+
+# The decompressed rootfs and its sidecar are recreated on load from the
+# compressed wire file, so archives never carry them alongside it.
+_DECOMPRESSED_ROOTFS = "rootfs.ext4"
+_ROOTFS_ZST = "rootfs.ext4.zst"
+_ROOTFS_SIDECAR = "rootfs.ext4.from-sha256"
+
+
+class ImageSavePayload(TypedDict):
+    name: str
+    archive_path: str
+    archive_size_bytes: int
+    files: int
+    excluded_decompressed_rootfs: bool
+
+
+class ImageLoadPayload(TypedDict):
+    name: str
+    path: str
+    size_bytes: int
+    files: int
+    warnings: list[str]
+
+
+def _valid_relative_file_path(path: str) -> bool:
+    if not path or path.startswith("/") or "\\" in path:
+        return False
+    return all(segment not in {"", ".", ".."} for segment in path.split("/"))
+
+
+def run_image_save(
+    *,
+    name: str,
+    output: str,
+    image_dir: str | None = None,
+    json_output: bool = False,
+    command_name: str = "image.save",
+) -> int:
+    """Execute ``smolvm image save``."""
+    import zstandard
+
+    root = resolve_image_dir(image_dir)
+    requested = _normalize_rm_name(name, root)
+
+    if not _valid_entry_name(requested):
+        return _fail(
+            command_name,
+            f"'{name}' is not a cached image name.",
+            json_output=json_output,
+            code="invalid_input",
+            recovery="Run 'smolvm image list' to see cached images.",
+            exit_code=2,
+        )
+
+    try:
+        matches = _expand_custom_entries(_resolve_entries(requested, root), root)
+    except OSError as exc:
+        return _fail(
+            command_name,
+            f"Could not read the image folder '{root}': {exc}",
+            json_output=json_output,
+            recovery=f"Fix the folder's permissions, then retry 'smolvm image save {requested}'.",
+        )
+
+    if not matches:
+        return _fail(
+            command_name,
+            f"No cached image named '{requested}'.",
+            json_output=json_output,
+            recovery="Run 'smolvm image list' to see cached images.",
+        )
+    if len(matches) > 1:
+        options = ", ".join(sorted(m.relative_to(root).as_posix() for m in matches))
+        return _fail(
+            command_name,
+            f"'{requested}' matches more than one cached image. Pick one of: {options}.",
+            json_output=json_output,
+            code="invalid_input",
+            exit_code=2,
+        )
+
+    entry = matches[0]
+    archive_name = entry.relative_to(root).as_posix()
+    out_path = Path(output)
+    retry_command = f"smolvm image save {archive_name} -o {shlex.quote(str(out_path))}"
+
+    zst_present = (entry / _ROOTFS_ZST).is_file()
+    excluded = {_DECOMPRESSED_ROOTFS, _ROOTFS_SIDECAR} if zst_present else set()
+    sidecar_value: str | None = None
+    if zst_present and (entry / _ROOTFS_SIDECAR).is_file():
+        try:
+            sidecar_value = (entry / _ROOTFS_SIDECAR).read_text().strip()
+        except OSError:
+            sidecar_value = None
+
+    files_meta: list[dict[str, Any]] = []
+    try:
+        tmp_parent = str(out_path.parent) if out_path.parent.is_dir() else None
+        with tempfile.TemporaryDirectory(dir=tmp_parent) as tmp:
+            # (source path on disk, archive member name)
+            staged: list[tuple[Path, str]] = []
+            for f in sorted(entry.rglob("*")):
+                if f.is_symlink() or not f.is_file():
+                    continue
+                rel = f.relative_to(entry).as_posix()
+                if rel in excluded or rel == ".build.lock":
+                    continue
+                if rel.endswith(".zst"):
+                    files_meta.append({"path": rel, "encoding": "raw", "size": f.stat().st_size})
+                    staged.append((f, f"files/{rel}"))
+                else:
+                    compressed = Path(tmp) / f"{len(staged)}.zst"
+                    with open(f, "rb") as src, open(compressed, "wb") as dst:
+                        zstandard.ZstdCompressor().copy_stream(src, dst)
+                    files_meta.append({"path": rel, "encoding": "zstd", "size": f.stat().st_size})
+                    staged.append((compressed, f"files/{rel}.zst"))
+
+            manifest = {
+                "schema_version": _SCHEMA_VERSION,
+                "saved_by": __version__,
+                "created": datetime.now(timezone.utc).isoformat(),
+                "name": archive_name,
+                "kind": _classify(entry)["kind"] if "/" not in archive_name else "custom",
+                "rootfs_sidecar": sidecar_value,
+                "files": files_meta,
+            }
+            manifest_bytes = json.dumps(manifest, indent=2).encode()
+            with tarfile.open(out_path, "w") as tar:
+                info = tarfile.TarInfo("manifest.json")
+                info.size = len(manifest_bytes)
+                tar.addfile(info, io.BytesIO(manifest_bytes))
+                for source, arcname in staged:
+                    tar.add(source, arcname=arcname, recursive=False)
+    except OSError as exc:
+        out_path.unlink(missing_ok=True)
+        return _fail(
+            command_name,
+            f"Could not write '{out_path}': {exc}",
+            json_output=json_output,
+            recovery=f"Free up disk space or fix permissions, then retry '{retry_command}'.",
+        )
+
+    payload = ImageSavePayload(
+        name=archive_name,
+        archive_path=str(out_path),
+        archive_size_bytes=out_path.stat().st_size,
+        files=len(files_meta),
+        excluded_decompressed_rootfs=zst_present,
+    )
+    if json_output:
+        return emit_success(command_name, payload)
+    console = console_stdout()
+    console.print(
+        f"Saved [bold]{archive_name}[/bold] to {out_path} "
+        f"({_format_bytes(payload['archive_size_bytes'])}). Load it on another "
+        f"machine with 'smolvm image load -i {shlex.quote(str(out_path))}'."
+    )
+    return 0
+
+
+def run_image_load(
+    *,
+    input_file: str,
+    image_dir: str | None = None,
+    force: bool = False,
+    json_output: bool = False,
+    command_name: str = "image.load",
+) -> int:
+    """Execute ``smolvm image load``."""
+    import zstandard
+
+    from smolvm.host.disk import decompress_zstd_sparse
+
+    root = resolve_image_dir(image_dir)
+    in_path = Path(input_file)
+    quoted_input = shlex.quote(str(input_file))
+    not_an_archive = "Check that the file was created by 'smolvm image save' and is not corrupted."
+
+    try:
+        tar = tarfile.open(in_path, "r:")  # noqa: SIM115 — closed by `with tar:` below
+    except (OSError, tarfile.TarError) as exc:
+        return _fail(
+            command_name,
+            f"Could not open '{in_path}': {exc}",
+            json_output=json_output,
+            code="invalid_input",
+            recovery=not_an_archive,
+            exit_code=2,
+        )
+
+    with tar:
+        members = tar.getmembers()
+        if not members or members[0].name != "manifest.json" or not members[0].isreg():
+            return _fail(
+                command_name,
+                f"'{in_path}' is not a SmolVM image archive.",
+                json_output=json_output,
+                code="invalid_input",
+                recovery=not_an_archive,
+                exit_code=2,
+            )
+        manifest_file = tar.extractfile(members[0])
+        try:
+            manifest = json.load(manifest_file) if manifest_file else None
+        except ValueError:
+            manifest = None
+        if not isinstance(manifest, dict):
+            return _fail(
+                command_name,
+                f"'{in_path}' is not a SmolVM image archive.",
+                json_output=json_output,
+                code="invalid_input",
+                recovery=not_an_archive,
+                exit_code=2,
+            )
+
+        schema = manifest.get("schema_version")
+        if isinstance(schema, int) and schema > _SCHEMA_VERSION:
+            return _fail(
+                command_name,
+                "This archive was saved by a newer SmolVM.",
+                json_output=json_output,
+                code="invalid_input",
+                recovery=f"Run 'smolvm update', then retry 'smolvm image load -i {quoted_input}'.",
+                exit_code=2,
+            )
+        name = manifest.get("name")
+        if schema != _SCHEMA_VERSION or not isinstance(name, str) or not _valid_entry_name(name):
+            return _fail(
+                command_name,
+                f"'{in_path}' is not a SmolVM image archive.",
+                json_output=json_output,
+                code="invalid_input",
+                recovery=not_an_archive,
+                exit_code=2,
+            )
+
+        # Only members declared in the manifest, as regular files, at safe
+        # relative paths, are ever written to disk — extraction below builds
+        # its own destination paths and never uses tar member names as paths.
+        allowed: dict[str, dict[str, Any]] = {}
+        raw_files = manifest.get("files")
+        for meta in raw_files if isinstance(raw_files, list) else [None]:
+            if (
+                not isinstance(meta, dict)
+                or not isinstance(meta.get("path"), str)
+                or meta.get("encoding") not in {"raw", "zstd"}
+                or not _valid_relative_file_path(meta["path"])
+            ):
+                return _fail(
+                    command_name,
+                    f"'{in_path}' is not a SmolVM image archive.",
+                    json_output=json_output,
+                    code="invalid_input",
+                    recovery=not_an_archive,
+                    exit_code=2,
+                )
+            suffix = ".zst" if meta["encoding"] == "zstd" else ""
+            allowed[f"files/{meta['path']}{suffix}"] = meta
+        for member in members[1:]:
+            if not member.isreg() or member.name not in allowed:
+                return _fail(
+                    command_name,
+                    f"'{in_path}' contains unexpected entries and was not loaded.",
+                    json_output=json_output,
+                    code="invalid_input",
+                    recovery="Recreate the archive with 'smolvm image save'.",
+                    exit_code=2,
+                )
+
+        target = root / name
+        if target.exists() and not force:
+            return _fail(
+                command_name,
+                f"'{name}' already exists.",
+                json_output=json_output,
+                recovery=f"Run 'smolvm image load -i {quoted_input} --force' to replace it.",
+            )
+
+        target.parent.mkdir(parents=True, exist_ok=True)
+        partial = target.parent / f".{target.name}.partial"
+        shutil.rmtree(partial, ignore_errors=True)
+        try:
+            partial.mkdir()
+            zst_sha: str | None = None
+            for member in members[1:]:
+                meta = allowed[member.name]
+                destination = partial / meta["path"]
+                destination.parent.mkdir(parents=True, exist_ok=True)
+                source = tar.extractfile(member)
+                if source is None:
+                    raise OSError(f"could not read '{member.name}' from the archive")
+                if meta["encoding"] == "raw":
+                    hasher = hashlib.sha256() if meta["path"] == _ROOTFS_ZST else None
+                    with source, open(destination, "wb") as out:
+                        while chunk := source.read(_COPY_CHUNK):
+                            out.write(chunk)
+                            if hasher is not None:
+                                hasher.update(chunk)
+                    if hasher is not None:
+                        zst_sha = hasher.hexdigest()
+                else:
+                    tmp_zst = destination.with_name(destination.name + ".tmp.zst")
+                    with source, open(tmp_zst, "wb") as out:
+                        while chunk := source.read(_COPY_CHUNK):
+                            out.write(chunk)
+                    decompress_zstd_sparse(tmp_zst, destination)
+                    tmp_zst.unlink()
+
+            # Recreate what save deliberately left out, byte-compatible with
+            # what ensure_published_image validates on the next start.
+            zst = partial / _ROOTFS_ZST
+            rootfs = partial / _DECOMPRESSED_ROOTFS
+            if zst.is_file() and not rootfs.is_file():
+                decompress_zstd_sparse(zst, rootfs)
+                sidecar_value = manifest.get("rootfs_sidecar")
+                if not isinstance(sidecar_value, str) or not sidecar_value:
+                    sidecar_value = f"sparse-v1:{zst_sha}" if zst_sha else None
+                if sidecar_value:
+                    (partial / _ROOTFS_SIDECAR).write_text(sidecar_value)
+
+            if target.exists():
+                shutil.rmtree(target)
+            partial.rename(target)
+        except (OSError, tarfile.TarError, zstandard.ZstdError) as exc:
+            shutil.rmtree(partial, ignore_errors=True)
+            return _fail(
+                command_name,
+                f"Could not load the image: {exc}",
+                json_output=json_output,
+                recovery=f"Free up disk space, then retry 'smolvm image load -i {quoted_input}'.",
+            )
+
+    warnings = _non_default_dir_warnings(root)
+    stale_match = _IMAGE_DIR_NAME_RE.match(name)
+    if stale_match and stale_match["version"] != __version__:
+        warnings.append(
+            "This image comes from a different SmolVM version, so it shows "
+            "as (stale) in 'smolvm image list'."
+        )
+
+    payload = ImageLoadPayload(
+        name=name,
+        path=str(target),
+        size_bytes=_total_size(target),
+        files=len(members) - 1,
+        warnings=warnings,
+    )
+    if json_output:
+        return emit_success(command_name, payload)
+    console = console_stdout()
+    console.print(
+        f"Loaded [bold]{name}[/bold] ({_format_bytes(payload['size_bytes'])}). "
+        "Run 'smolvm image list' to confirm."
+    )
+    for warning in warnings:
+        console.print(f"[yellow]{warning}[/yellow]")
+    return 0

--- a/src/smolvm/cli/image_transfer.py
+++ b/src/smolvm/cli/image_transfer.py
@@ -14,12 +14,15 @@
 
 """``smolvm image save`` / ``smolvm image load`` — move images between machines.
 
-The archive is a plain tar whose first member is ``manifest.json``
-(schema_version 1) describing every other member. Large files are stored as
-zstd streams so sparse rootfs images stay small; the decompressed
-``rootfs.ext4`` and its sidecar are omitted entirely when the compressed
-``rootfs.ext4.zst`` is present and are recreated on load, byte-compatible
-with what ``ensure_published_image`` expects.
+The archive is a plain tar containing exactly one ``manifest.json``
+(schema_version 1) that describes every ``files/<path>`` member: its
+encoding (``raw`` bytes or a ``zstd`` stream) and its decoded size. Member
+names never carry encoding suffixes, so sibling files like ``x`` and
+``x.zst`` can't collide. Large files travel as zstd streams so sparse
+rootfs images stay small; the decompressed ``rootfs.ext4`` and its sidecar
+are omitted entirely when the compressed ``rootfs.ext4.zst`` is present and
+are recreated on load, byte-compatible with what ``ensure_published_image``
+expects.
 """
 
 from __future__ import annotations
@@ -31,6 +34,7 @@ import shlex
 import shutil
 import tarfile
 import tempfile
+from contextlib import suppress
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, TypedDict
@@ -38,7 +42,7 @@ from typing import Any, TypedDict
 from smolvm import __version__
 from smolvm.cli.image import (
     _IMAGE_DIR_NAME_RE,
-    _classify,
+    _entry_kind,
     _expand_custom_entries,
     _fail,
     _non_default_dir_warnings,
@@ -52,6 +56,9 @@ from smolvm.images.manager import resolve_image_dir
 
 _SCHEMA_VERSION = 1
 _COPY_CHUNK = 1024 * 1024
+_MANIFEST_MEMBER = "manifest.json"
+# Real manifests are a few KB; anything huge is not one of our archives.
+_MANIFEST_SIZE_CAP = 10 * 1024 * 1024
 
 # The decompressed rootfs and its sidecar are recreated on load from the
 # compressed wire file, so archives never carry them alongside it.
@@ -66,6 +73,7 @@ class ImageSavePayload(TypedDict):
     archive_size_bytes: int
     files: int
     excluded_decompressed_rootfs: bool
+    warnings: list[str]
 
 
 class ImageLoadPayload(TypedDict):
@@ -82,6 +90,14 @@ def _valid_relative_file_path(path: str) -> bool:
     return all(segment not in {"", ".", ".."} for segment in path.split("/"))
 
 
+def _remove_existing_entry(path: Path) -> None:
+    """Remove a cache entry in whatever form it exists (dir, link, file)."""
+    if path.is_symlink() or path.is_file():
+        path.unlink()
+    else:
+        shutil.rmtree(path)
+
+
 def run_image_save(
     *,
     name: str,
@@ -95,6 +111,7 @@ def run_image_save(
 
     root = resolve_image_dir(image_dir)
     requested = _normalize_rm_name(name, root)
+    out_path = Path(output)
 
     if not _valid_entry_name(requested):
         return _fail(
@@ -105,15 +122,34 @@ def run_image_save(
             recovery="Run 'smolvm image list' to see cached images.",
             exit_code=2,
         )
+    if out_path.is_dir():
+        return _fail(
+            command_name,
+            f"'{out_path}' is a folder; -o needs a file name.",
+            json_output=json_output,
+            code="invalid_input",
+            recovery=f"Retry with a file path, e.g. 'smolvm image save {requested} "
+            f"-o {shlex.quote(str(out_path / (requested.replace('/', '-') + '.tar')))}'.",
+            exit_code=2,
+        )
 
+    retry_command = f"smolvm image save {requested} -o {shlex.quote(str(out_path))}"
     try:
         matches = _expand_custom_entries(_resolve_entries(requested, root), root)
+    except ValueError as exc:
+        return _fail(
+            command_name,
+            str(exc),
+            json_output=json_output,
+            code="invalid_input",
+            exit_code=2,
+        )
     except OSError as exc:
         return _fail(
             command_name,
             f"Could not read the image folder '{root}': {exc}",
             json_output=json_output,
-            recovery=f"Fix the folder's permissions, then retry 'smolvm image save {requested}'.",
+            recovery=f"Fix the folder's permissions, then retry '{retry_command}'.",
         )
 
     if not matches:
@@ -135,8 +171,6 @@ def run_image_save(
 
     entry = matches[0]
     archive_name = entry.relative_to(root).as_posix()
-    out_path = Path(output)
-    retry_command = f"smolvm image save {archive_name} -o {shlex.quote(str(out_path))}"
 
     zst_present = (entry / _ROOTFS_ZST).is_file()
     excluded = {_DECOMPRESSED_ROOTFS, _ROOTFS_SIDECAR} if zst_present else set()
@@ -147,52 +181,70 @@ def run_image_save(
         except OSError:
             sidecar_value = None
 
+    warnings: list[str] = []
     files_meta: list[dict[str, Any]] = []
+    # Write to a sibling temp file and rename at the end so a failed save
+    # never destroys an existing archive at the -o path.
+    partial_archive = out_path.with_name(out_path.name + ".partial")
+    compressor = zstandard.ZstdCompressor(threads=-1)
     try:
         tmp_parent = str(out_path.parent) if out_path.parent.is_dir() else None
-        with tempfile.TemporaryDirectory(dir=tmp_parent) as tmp:
-            # (source path on disk, archive member name)
-            staged: list[tuple[Path, str]] = []
+        with (
+            tempfile.TemporaryDirectory(dir=tmp_parent) as tmp,
+            tarfile.open(partial_archive, "w") as tar,
+        ):
+            scratch = Path(tmp) / "member.zst"
             for f in sorted(entry.rglob("*")):
-                if f.is_symlink() or not f.is_file():
+                if f.is_symlink():
+                    warnings.append(
+                        f"Skipped '{f.relative_to(entry).as_posix()}': links are "
+                        "not saved into archives."
+                    )
+                    continue
+                if not f.is_file():
                     continue
                 rel = f.relative_to(entry).as_posix()
                 if rel in excluded or rel == ".build.lock":
                     continue
                 if rel.endswith(".zst"):
                     files_meta.append({"path": rel, "encoding": "raw", "size": f.stat().st_size})
-                    staged.append((f, f"files/{rel}"))
+                    tar.add(f, arcname=f"files/{rel}", recursive=False)
                 else:
-                    compressed = Path(tmp) / f"{len(staged)}.zst"
-                    with open(f, "rb") as src, open(compressed, "wb") as dst:
-                        zstandard.ZstdCompressor().copy_stream(src, dst)
+                    # Compress into one reused scratch file, add, discard —
+                    # scratch usage stays bounded by a single member.
+                    with open(f, "rb") as src, open(scratch, "wb") as dst:
+                        compressor.copy_stream(src, dst)
                     files_meta.append({"path": rel, "encoding": "zstd", "size": f.stat().st_size})
-                    staged.append((compressed, f"files/{rel}.zst"))
+                    tar.add(scratch, arcname=f"files/{rel}", recursive=False)
+                    scratch.unlink()
 
             manifest = {
                 "schema_version": _SCHEMA_VERSION,
                 "saved_by": __version__,
                 "created": datetime.now(timezone.utc).isoformat(),
                 "name": archive_name,
-                "kind": _classify(entry)["kind"] if "/" not in archive_name else "custom",
+                "kind": _entry_kind(entry, root),
                 "rootfs_sidecar": sidecar_value,
                 "files": files_meta,
             }
             manifest_bytes = json.dumps(manifest, indent=2).encode()
-            with tarfile.open(out_path, "w") as tar:
-                info = tarfile.TarInfo("manifest.json")
-                info.size = len(manifest_bytes)
-                tar.addfile(info, io.BytesIO(manifest_bytes))
-                for source, arcname in staged:
-                    tar.add(source, arcname=arcname, recursive=False)
+            info = tarfile.TarInfo(_MANIFEST_MEMBER)
+            info.size = len(manifest_bytes)
+            tar.addfile(info, io.BytesIO(manifest_bytes))
+        partial_archive.replace(out_path)
     except OSError as exc:
-        out_path.unlink(missing_ok=True)
+        with suppress(OSError):
+            partial_archive.unlink(missing_ok=True)
         return _fail(
             command_name,
             f"Could not write '{out_path}': {exc}",
             json_output=json_output,
             recovery=f"Free up disk space or fix permissions, then retry '{retry_command}'.",
         )
+    except BaseException:
+        with suppress(OSError):
+            partial_archive.unlink(missing_ok=True)
+        raise
 
     payload = ImageSavePayload(
         name=archive_name,
@@ -200,6 +252,7 @@ def run_image_save(
         archive_size_bytes=out_path.stat().st_size,
         files=len(files_meta),
         excluded_decompressed_rootfs=zst_present,
+        warnings=warnings,
     )
     if json_output:
         return emit_success(command_name, payload)
@@ -209,6 +262,8 @@ def run_image_save(
         f"({_format_bytes(payload['archive_size_bytes'])}). Load it on another "
         f"machine with 'smolvm image load -i {shlex.quote(str(out_path))}'."
     )
+    for warning in warnings:
+        console.print(f"[yellow]{warning}[/yellow]")
     return 0
 
 
@@ -224,11 +279,26 @@ def run_image_load(
     import zstandard
 
     from smolvm.host.disk import decompress_zstd_sparse
+    from smolvm.images.published import _decompressed_rootfs_sidecar_value
 
     root = resolve_image_dir(image_dir)
     in_path = Path(input_file)
     quoted_input = shlex.quote(str(input_file))
     not_an_archive = "Check that the file was created by 'smolvm image save' and is not corrupted."
+
+    def bad_archive(
+        message: str | None = None,
+        *,
+        recovery: str | None = None,
+    ) -> int:
+        return _fail(
+            command_name,
+            message or f"'{in_path}' is not a SmolVM image archive.",
+            json_output=json_output,
+            code="invalid_input",
+            recovery=recovery or not_an_archive,
+            exit_code=2,
+        )
 
     try:
         tar = tarfile.open(in_path, "r:")  # noqa: SIM115 — closed by `with tar:` below
@@ -243,51 +313,35 @@ def run_image_load(
         )
 
     with tar:
-        members = tar.getmembers()
-        if not members or members[0].name != "manifest.json" or not members[0].isreg():
-            return _fail(
-                command_name,
-                f"'{in_path}' is not a SmolVM image archive.",
-                json_output=json_output,
-                code="invalid_input",
-                recovery=not_an_archive,
-                exit_code=2,
-            )
-        manifest_file = tar.extractfile(members[0])
+        # A truncated archive can fail while listing members or reading the
+        # manifest — that's damage, not a crash.
         try:
+            members = tar.getmembers()
+            manifest_members = [m for m in members if m.name == _MANIFEST_MEMBER]
+            if (
+                len(manifest_members) != 1
+                or not manifest_members[0].isreg()
+                or manifest_members[0].size > _MANIFEST_SIZE_CAP
+            ):
+                return bad_archive()
+            manifest_file = tar.extractfile(manifest_members[0])
             manifest = json.load(manifest_file) if manifest_file else None
+        except tarfile.TarError:
+            return bad_archive(f"'{in_path}' is damaged and was not loaded.")
         except ValueError:
             manifest = None
         if not isinstance(manifest, dict):
-            return _fail(
-                command_name,
-                f"'{in_path}' is not a SmolVM image archive.",
-                json_output=json_output,
-                code="invalid_input",
-                recovery=not_an_archive,
-                exit_code=2,
-            )
+            return bad_archive()
 
         schema = manifest.get("schema_version")
         if isinstance(schema, int) and schema > _SCHEMA_VERSION:
-            return _fail(
-                command_name,
+            return bad_archive(
                 "This archive was saved by a newer SmolVM.",
-                json_output=json_output,
-                code="invalid_input",
                 recovery=f"Run 'smolvm update', then retry 'smolvm image load -i {quoted_input}'.",
-                exit_code=2,
             )
         name = manifest.get("name")
         if schema != _SCHEMA_VERSION or not isinstance(name, str) or not _valid_entry_name(name):
-            return _fail(
-                command_name,
-                f"'{in_path}' is not a SmolVM image archive.",
-                json_output=json_output,
-                code="invalid_input",
-                recovery=not_an_archive,
-                exit_code=2,
-            )
+            return bad_archive()
 
         # Only members declared in the manifest, as regular files, at safe
         # relative paths, are ever written to disk — extraction below builds
@@ -299,28 +353,28 @@ def run_image_load(
                 not isinstance(meta, dict)
                 or not isinstance(meta.get("path"), str)
                 or meta.get("encoding") not in {"raw", "zstd"}
+                or not isinstance(meta.get("size"), int)
+                or isinstance(meta.get("size"), bool)
+                or meta["size"] < 0
                 or not _valid_relative_file_path(meta["path"])
             ):
-                return _fail(
-                    command_name,
-                    f"'{in_path}' is not a SmolVM image archive.",
-                    json_output=json_output,
-                    code="invalid_input",
-                    recovery=not_an_archive,
-                    exit_code=2,
-                )
-            suffix = ".zst" if meta["encoding"] == "zstd" else ""
-            allowed[f"files/{meta['path']}{suffix}"] = meta
-        for member in members[1:]:
+                return bad_archive()
+            allowed[f"files/{meta['path']}"] = meta
+        data_members = [m for m in members if m.name != _MANIFEST_MEMBER]
+        for member in data_members:
             if not member.isreg() or member.name not in allowed:
                 return _fail(
                     command_name,
                     f"'{in_path}' contains unexpected entries and was not loaded.",
                     json_output=json_output,
                     code="invalid_input",
-                    recovery="Recreate the archive with 'smolvm image save'.",
+                    recovery="Recreate it on the source machine with "
+                    f"'smolvm image save {name} -o {shlex.quote(in_path.name)}'.",
                     exit_code=2,
                 )
+        missing = set(allowed) - {m.name for m in data_members}
+        if missing:
+            return bad_archive(f"'{in_path}' is incomplete and was not loaded.")
 
         target = root / name
         if target.exists() and not force:
@@ -331,21 +385,30 @@ def run_image_load(
                 recovery=f"Run 'smolvm image load -i {quoted_input} --force' to replace it.",
             )
 
+        manifest_sidecar = manifest.get("rootfs_sidecar")
+        have_sidecar = isinstance(manifest_sidecar, str) and bool(manifest_sidecar)
+
         target.parent.mkdir(parents=True, exist_ok=True)
         partial = target.parent / f".{target.name}.partial"
         shutil.rmtree(partial, ignore_errors=True)
         try:
             partial.mkdir()
             zst_sha: str | None = None
-            for member in members[1:]:
+            for member in data_members:
                 meta = allowed[member.name]
                 destination = partial / meta["path"]
                 destination.parent.mkdir(parents=True, exist_ok=True)
                 source = tar.extractfile(member)
                 if source is None:
-                    raise OSError(f"could not read '{member.name}' from the archive")
+                    raise tarfile.TarError(f"could not read '{member.name}' from the archive")
                 if meta["encoding"] == "raw":
-                    hasher = hashlib.sha256() if meta["path"] == _ROOTFS_ZST else None
+                    # The digest feeds the sidecar fallback; skip the work
+                    # when the manifest already carries the sidecar value.
+                    hasher = (
+                        hashlib.sha256()
+                        if meta["path"] == _ROOTFS_ZST and not have_sidecar
+                        else None
+                    )
                     with source, open(destination, "wb") as out:
                         while chunk := source.read(_COPY_CHUNK):
                             out.write(chunk)
@@ -360,6 +423,10 @@ def run_image_load(
                             out.write(chunk)
                     decompress_zstd_sparse(tmp_zst, destination)
                     tmp_zst.unlink()
+                if destination.stat().st_size != meta["size"]:
+                    raise zstandard.ZstdError(
+                        f"'{meta['path']}' does not match the size the archive declares"
+                    )
 
             # Recreate what save deliberately left out, byte-compatible with
             # what ensure_published_image validates on the next start.
@@ -367,23 +434,34 @@ def run_image_load(
             rootfs = partial / _DECOMPRESSED_ROOTFS
             if zst.is_file() and not rootfs.is_file():
                 decompress_zstd_sparse(zst, rootfs)
-                sidecar_value = manifest.get("rootfs_sidecar")
-                if not isinstance(sidecar_value, str) or not sidecar_value:
-                    sidecar_value = f"sparse-v1:{zst_sha}" if zst_sha else None
+                sidecar_value: str | None
+                if have_sidecar:
+                    sidecar_value = str(manifest_sidecar)
+                else:
+                    sidecar_value = _decompressed_rootfs_sidecar_value(zst_sha) if zst_sha else None
                 if sidecar_value:
                     (partial / _ROOTFS_SIDECAR).write_text(sidecar_value)
 
             if target.exists():
-                shutil.rmtree(target)
+                _remove_existing_entry(target)
             partial.rename(target)
-        except (OSError, tarfile.TarError, zstandard.ZstdError) as exc:
+        except (tarfile.TarError, zstandard.ZstdError) as exc:
+            shutil.rmtree(partial, ignore_errors=True)
+            return bad_archive(f"'{in_path}' is damaged and was not loaded: {exc}.")
+        except OSError as exc:
             shutil.rmtree(partial, ignore_errors=True)
             return _fail(
                 command_name,
                 f"Could not load the image: {exc}",
                 json_output=json_output,
-                recovery=f"Free up disk space, then retry 'smolvm image load -i {quoted_input}'.",
+                recovery="Free up disk space or fix permissions, then retry "
+                f"'smolvm image load -i {quoted_input}'.",
             )
+        except BaseException:
+            # Ctrl-C and other non-Exception exits must not orphan the
+            # multi-GB staging directory.
+            shutil.rmtree(partial, ignore_errors=True)
+            raise
 
     warnings = _non_default_dir_warnings(root)
     stale_match = _IMAGE_DIR_NAME_RE.match(name)
@@ -397,7 +475,7 @@ def run_image_load(
         name=name,
         path=str(target),
         size_bytes=_total_size(target),
-        files=len(members) - 1,
+        files=len(data_members),
         warnings=warnings,
     )
     if json_output:

--- a/src/smolvm/cli/main.py
+++ b/src/smolvm/cli/main.py
@@ -3065,6 +3065,10 @@ def _command_name_from_argv(args: Sequence[str]) -> str:
         "hermes",
         "pi",
     }:
+        if tokens[0] == "image" and tokens[1] == "ls":
+            # "ls" is an alias of "list"; successful runs report
+            # "image.list", so parse errors must too.
+            return "image.list"
         return f"{tokens[0]}.{tokens[1]}"
     return tokens[0]
 

--- a/src/smolvm/cli/main.py
+++ b/src/smolvm/cli/main.py
@@ -3058,6 +3058,7 @@ def _command_name_from_argv(args: Sequence[str]) -> str:
         "windows",
         "browser",
         "server",
+        "image",
         "codex",
         "claude",
         "openclaw",

--- a/src/smolvm/cli/prune.py
+++ b/src/smolvm/cli/prune.py
@@ -22,7 +22,7 @@ from pathlib import Path
 
 from smolvm import __version__
 from smolvm.cli.output import console_stdout, emit_json
-from smolvm.images.manager import ImageManager
+from smolvm.images.manager import resolve_image_dir
 
 
 def _total_size(path: Path) -> int:
@@ -53,7 +53,7 @@ def find_stale_caches(
     differs from ``current_version`` are considered stale. Unversioned
     directories (e.g. ``s3/``) and the current version are left alone.
     """
-    root = cache_dir or ImageManager.DEFAULT_CACHE_DIR
+    root = resolve_image_dir(cache_dir)
     if not root.is_dir():
         return []
     stale: list[Path] = []
@@ -71,14 +71,15 @@ def run_prune(
     dry_run: bool = False,
     json_output: bool = False,
     cache_dir: str | None = None,
+    command_name: str = "prune",
 ) -> int:
-    """Execute ``smolvm prune``."""
+    """Execute ``smolvm prune`` (also exposed as ``smolvm image prune``)."""
     cache_root = Path(cache_dir) if cache_dir else None
     stale = find_stale_caches(cache_dir=cache_root)
 
     if not stale:
         if json_output:
-            emit_json("prune", 0, data={"removed": [], "freed_bytes": 0})
+            emit_json(command_name, 0, data={"removed": [], "freed_bytes": 0})
         else:
             console = console_stdout()
             console.print("Nothing to prune — cache is clean.")
@@ -94,7 +95,7 @@ def run_prune(
     if dry_run:
         if json_output:
             emit_json(
-                "prune",
+                command_name,
                 0,
                 data={
                     "dry_run": True,
@@ -119,7 +120,7 @@ def run_prune(
 
     if json_output:
         emit_json(
-            "prune",
+            command_name,
             0,
             data={
                 "removed": [str(p) for p in stale],

--- a/src/smolvm/cli/prune.py
+++ b/src/smolvm/cli/prune.py
@@ -16,6 +16,7 @@
 
 from __future__ import annotations
 
+import os
 import re
 import shutil
 from pathlib import Path
@@ -25,22 +26,49 @@ from smolvm.cli.output import console_stdout, emit_json
 from smolvm.images.manager import resolve_image_dir
 
 
+def _size_on_disk(st: os.stat_result) -> int:
+    """Bytes a file actually occupies — sparse-aware where the OS reports it."""
+    blocks = getattr(st, "st_blocks", None)
+    return blocks * 512 if blocks is not None else st.st_size
+
+
 def _total_size(path: Path) -> int:
-    """Recursively sum file sizes under *path*."""
-    if path.is_file():
-        return path.stat().st_size
-    return sum(f.stat().st_size for f in path.rglob("*") if f.is_file())
+    """Recursively sum on-disk usage under *path*.
+
+    Uses allocated blocks rather than apparent size so sparse rootfs
+    images (deliberately decompressed with holes) report what deleting
+    them would actually free. Tolerates files vanishing mid-walk.
+    """
+    total = 0
+    try:
+        if path.is_file():
+            return _size_on_disk(path.stat())
+        for f in path.rglob("*"):
+            try:
+                if f.is_file():
+                    total += _size_on_disk(f.stat())
+            except OSError:
+                continue
+    except OSError:
+        pass
+    return total
 
 
 def _format_bytes(n: int) -> str:
+    value = float(n)
     for unit in ("B", "KiB", "MiB", "GiB"):
-        if abs(n) < 1024:
-            return f"{n:.1f} {unit}"
-        n //= 1024
-    return f"{n:.1f} TiB"
+        if abs(value) < 1024:
+            return f"{value:.1f} {unit}"
+        value /= 1024
+    return f"{value:.1f} TiB"
 
 
-_VERSION_RE = re.compile(r"-v(\d+\.\d+\.\d+[a-z0-9]*)-")
+# One version fragment shared by every parser of cache-dir names (this
+# module and cli/image.py). Covers plain semver, compact pre-releases
+# ("0.0.14a0"), and dotted suffixes actually shipped ("0.0.24.post3").
+_VERSION_PATTERN = r"\d+\.\d+\.\d+[a-z0-9]*(?:\.[a-z0-9]+)*"
+
+_VERSION_RE = re.compile(rf"-v({_VERSION_PATTERN})-")
 
 
 def find_stale_caches(

--- a/src/smolvm/cli/prune.py
+++ b/src/smolvm/cli/prune.py
@@ -144,7 +144,12 @@ def run_prune(
         return 0
 
     for path in stale:
-        shutil.rmtree(path)
+        # A stale-named entry may be a symlink; remove the link itself
+        # rather than following it (rmtree refuses symlinks anyway).
+        if path.is_symlink():
+            path.unlink()
+        else:
+            shutil.rmtree(path)
 
     if json_output:
         emit_json(

--- a/src/smolvm/images/builder.py
+++ b/src/smolvm/images/builder.py
@@ -2211,7 +2211,7 @@ class DockerRootfsBuilder:
         self.dockerfile = dockerfile
         self.context = dict(context or {})
         self.rootfs_size_mb = rootfs_size_mb
-        self.cache_dir = cache_dir or ImageBuilder().cache_dir
+        self.cache_dir = resolve_image_dir(cache_dir)
         self.fingerprint_inputs = dict(fingerprint_inputs or {})
         self.build_args = dict(build_args or {})
         self.docker_platform = docker_platform

--- a/src/smolvm/images/builder.py
+++ b/src/smolvm/images/builder.py
@@ -212,6 +212,7 @@ def _guest_agent_release_asset() -> tuple[str, str, str]:
 
 
 def _guest_agent_binary_cache_dir(cache_dir: Path | None = None) -> Path:
+    """Return the guest-agent subdirectory of the resolved image cache dir."""
     return resolve_image_dir(cache_dir) / "_guest-agent"
 
 

--- a/src/smolvm/images/builder.py
+++ b/src/smolvm/images/builder.py
@@ -211,17 +211,17 @@ def _guest_agent_release_asset() -> tuple[str, str, str]:
     return url, asset_name, expected_sha256
 
 
-def _guest_agent_binary_cache_dir() -> Path:
-    return resolve_image_dir() / "_guest-agent"
+def _guest_agent_binary_cache_dir(cache_dir: Path | None = None) -> Path:
+    return resolve_image_dir(cache_dir) / "_guest-agent"
 
 
-def _download_guest_agent_binary() -> Path:
+def _download_guest_agent_binary(image_cache_dir: Path | None = None) -> Path:
     """Download and cache the pinned Rust guest-agent binary for installed wheels."""
     from smolvm.images.published import _images_release_tag
 
     url, asset_name, expected_sha256 = _guest_agent_release_asset()
     cache_dir = (
-        _guest_agent_binary_cache_dir()
+        _guest_agent_binary_cache_dir(image_cache_dir)
         / _images_release_tag()
         / to_published_arch(platform.machine())
     )
@@ -269,13 +269,13 @@ def _download_guest_agent_binary() -> Path:
                 tmp_path.unlink()
 
 
-def _guest_agent_binary() -> Path:
+def _guest_agent_binary(cache_dir: Path | None = None) -> Path:
     """Build and return the Rust guest-agent binary used by rootfs builders."""
     configured = _configured_guest_agent_binary()
     if configured is not None:
         return configured
     if not _has_guest_agent_source_checkout():
-        return _download_guest_agent_binary()
+        return _download_guest_agent_binary(cache_dir)
 
     target = _guest_agent_target_triple()
     binary_path = _guest_agent_binary_path()
@@ -2118,7 +2118,7 @@ echo "Device-approver running with PID=${DEVICE_APPROVER_PID}"
             # Write Dockerfile and init script
             (tmp_path / "Dockerfile").write_text(dockerfile_content)
             (tmp_path / "init").write_text(init_script)
-            shutil.copy2(_guest_agent_binary(), tmp_path / _GUEST_AGENT_BUILD_FILE)
+            shutil.copy2(_guest_agent_binary(self.cache_dir), tmp_path / _GUEST_AGENT_BUILD_FILE)
             if extra_files:
                 for filename, content in extra_files.items():
                     (tmp_path / filename).write_text(content)

--- a/src/smolvm/images/builder.py
+++ b/src/smolvm/images/builder.py
@@ -37,6 +37,7 @@ from pathlib import Path
 
 from smolvm.exceptions import ImageError, SmolVMError
 from smolvm.images.boot import BootImage, DirectKernelBoot
+from smolvm.images.manager import resolve_image_dir
 from smolvm.kernels import KernelArch, ensure_base_kernel_for_backend
 from smolvm.runtime.backends import resolve_backend
 from smolvm.runtime.boot_profiles import (
@@ -211,7 +212,7 @@ def _guest_agent_release_asset() -> tuple[str, str, str]:
 
 
 def _guest_agent_binary_cache_dir() -> Path:
-    return Path.home() / ".smolvm" / "images" / "_guest-agent"
+    return resolve_image_dir() / "_guest-agent"
 
 
 def _download_guest_agent_binary() -> Path:
@@ -428,9 +429,9 @@ class ImageBuilder:
 
         Args:
             cache_dir: Directory to store built images.
-                Defaults to ~/.smolvm/images/
+                Defaults to $SMOLVM_IMAGE_DIR or ~/.smolvm/images/
         """
-        self.cache_dir = cache_dir or (Path.home() / ".smolvm" / "images")
+        self.cache_dir = resolve_image_dir(cache_dir)
 
     def check_docker(self) -> bool:
         """Check if Docker is available and the daemon is reachable."""

--- a/src/smolvm/images/manager.py
+++ b/src/smolvm/images/manager.py
@@ -48,19 +48,33 @@ _DOWNLOAD_CHUNK_SIZE = 8192
 IMAGE_DIR_ENV = "SMOLVM_IMAGE_DIR"
 
 
+def _expand_image_dir(path: Path) -> Path:
+    try:
+        return path.expanduser()
+    except RuntimeError:
+        # "~unknownuser/..." with no resolvable home — keep the path as
+        # written rather than crashing; consumers treat a missing directory
+        # as an empty cache.
+        return path
+
+
 def resolve_image_dir(image_dir: Path | str | None = None) -> Path:
     """Resolve the image cache directory.
 
     Priority: explicit argument, then ``$SMOLVM_IMAGE_DIR``, then
-    ``~/.smolvm/images``. The directory is not created here — read-only
-    consumers (listing, pruning) must tolerate a missing directory, and
-    downloads create it at write time.
+    ``~/.smolvm/images``. An empty or whitespace-only argument falls
+    through to the environment/default so ``--image-dir "$UNSET_VAR"``
+    never targets the current working directory. The directory is not
+    created here — read-only consumers (listing, pruning) must tolerate
+    a missing directory, and downloads create it at write time.
     """
-    if image_dir is not None:
-        return Path(image_dir).expanduser()
+    if isinstance(image_dir, Path):
+        return _expand_image_dir(image_dir)
+    if image_dir is not None and image_dir.strip():
+        return _expand_image_dir(Path(image_dir.strip()))
     env_dir = os.environ.get(IMAGE_DIR_ENV, "").strip()
     if env_dir:
-        return Path(env_dir).expanduser()
+        return _expand_image_dir(Path(env_dir))
     return Path.home() / ".smolvm" / "images"
 
 

--- a/src/smolvm/images/manager.py
+++ b/src/smolvm/images/manager.py
@@ -24,6 +24,7 @@ from __future__ import annotations
 import hashlib
 import json
 import logging
+import os
 import tempfile
 from collections.abc import Callable
 from pathlib import Path
@@ -42,6 +43,25 @@ logger = logging.getLogger(__name__)
 
 # Chunk size for streaming downloads (8 KB)
 _DOWNLOAD_CHUNK_SIZE = 8192
+
+# Environment variable overriding where images and kernels are cached.
+IMAGE_DIR_ENV = "SMOLVM_IMAGE_DIR"
+
+
+def resolve_image_dir(image_dir: Path | str | None = None) -> Path:
+    """Resolve the image cache directory.
+
+    Priority: explicit argument, then ``$SMOLVM_IMAGE_DIR``, then
+    ``~/.smolvm/images``. The directory is not created here — read-only
+    consumers (listing, pruning) must tolerate a missing directory, and
+    downloads create it at write time.
+    """
+    if image_dir is not None:
+        return Path(image_dir).expanduser()
+    env_dir = os.environ.get(IMAGE_DIR_ENV, "").strip()
+    if env_dir:
+        return Path(env_dir).expanduser()
+    return Path.home() / ".smolvm" / "images"
 
 
 class ImageSource(BaseModel):
@@ -307,12 +327,12 @@ BUILTIN_IMAGES: dict[str, ImageSource] = {}
 class ImageManager:
     """Manages VM image downloads, caching, and verification.
 
-    Images are cached under ``~/.smolvm/images/<name>/``.
-    Downloads are atomic: written to a temporary file, SHA-256 verified,
-    then renamed into place so a partial download never corrupts the cache.
+    Images are cached under the directory returned by
+    :func:`resolve_image_dir` (``~/.smolvm/images`` unless overridden by
+    ``$SMOLVM_IMAGE_DIR``). Downloads are atomic: written to a temporary
+    file, SHA-256 verified, then renamed into place so a partial download
+    never corrupts the cache.
     """
-
-    DEFAULT_CACHE_DIR = Path.home() / ".smolvm" / "images"
 
     def __init__(
         self,
@@ -326,7 +346,7 @@ class ImageManager:
             registry: Override the built-in image registry.
                 Useful for testing or adding custom images.
         """
-        self.cache_dir = cache_dir or self.DEFAULT_CACHE_DIR
+        self.cache_dir = resolve_image_dir(cache_dir)
         self.registry = registry if registry is not None else dict(BUILTIN_IMAGES)
 
     def list_available(self) -> list[str]:

--- a/src/smolvm/images/published.py
+++ b/src/smolvm/images/published.py
@@ -358,6 +358,22 @@ def lookup(
     return entry
 
 
+def published_targets(
+    arch: Arch,
+    vmm: Vmm,
+    *,
+    manifest: dict[ManifestKey, PublishedImage] | None = None,
+) -> list[tuple[Preset, Os]]:
+    """Every ``(preset, os)`` combination published for one platform.
+
+    Keeps the manifest key shape private to this module — callers (e.g.
+    ``smolvm image pull --all``) get the download targets without
+    destructuring :data:`MANIFEST` themselves.
+    """
+    catalog = MANIFEST if manifest is None else manifest
+    return sorted({(p, o) for (p, a, v, o) in catalog if a == arch and v == vmm})
+
+
 def is_preset_published(
     preset: str,
     arch: Arch,

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -4336,7 +4336,7 @@ class TestCliImage:
 
         result = CliRunner().invoke(build_cli(), ["image", "--help"])
         assert result.exit_code == 0
-        for verb in ("pull", "list", "rm", "prune"):
+        for verb in ("pull", "list", "ls", "inspect", "build", "save", "load", "rm", "prune"):
             assert verb in result.output
 
     @patch("smolvm.images.published.ensure_published_image")

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -4350,7 +4350,9 @@ class TestCliImage:
         tmp_path: Path,
         capsys: pytest.CaptureFixture,
     ) -> None:
-        """A cache hit (no download callback fired) reports already_cached."""
+        """A true no-op (cache dir untouched, nothing downloaded) reports
+        already_cached, and pulling to a non-default dir warns that
+        sandboxes won't read it."""
         from smolvm.images.manager import LocalImage
         from smolvm.images.published import cache_name
 
@@ -4358,6 +4360,8 @@ class TestCliImage:
         rootfs = tmp_path / "rootfs.ext4"
         kernel.touch()
         rootfs.touch()
+        # The cache dir must pre-exist for the pull to count as a no-op.
+        (tmp_path / cache_name("codex", "amd64", "firecracker")).mkdir()
         mock_ensure_published.return_value = LocalImage(
             name="codex-cache",
             kernel_path=kernel,
@@ -4376,10 +4380,96 @@ class TestCliImage:
         assert payload["data"]["os"] == "ubuntu"
         assert payload["data"]["name"] == cache_name("codex", "amd64", "firecracker")
         assert payload["data"]["already_cached"] is True
+        # tmp_path is not where sandbox starts look for images.
+        assert len(payload["data"]["warnings"]) == 1
+        assert "SMOLVM_IMAGE_DIR" in payload["data"]["warnings"][0]
         mock_ensure_published.assert_called_once()
         call = mock_ensure_published.call_args
         assert call.args == ("codex", "amd64", "firecracker", "ubuntu")
         assert call.kwargs["cache_dir"] == tmp_path
+
+    @patch("smolvm.images.published.ensure_published_image")
+    @patch("smolvm.cli.main._vmm_for_host", return_value="firecracker")
+    @patch("smolvm.cli.main._host_arch_for_published", return_value="amd64")
+    def test_image_pull_decompression_is_not_already_cached(
+        self,
+        mock_arch: MagicMock,
+        mock_vmm: MagicMock,
+        mock_ensure_published: MagicMock,
+        tmp_path: Path,
+        capsys: pytest.CaptureFixture,
+    ) -> None:
+        """Work without downloads (e.g. rootfs decompression) must not be
+        reported as a cache hit (regression)."""
+        from smolvm.images.manager import LocalImage
+        from smolvm.images.published import cache_name
+
+        cache_dir = tmp_path / cache_name("codex", "amd64", "firecracker")
+        cache_dir.mkdir()
+
+        def fake_ensure(*args: object, **kwargs: object) -> LocalImage:
+            # Simulate decompression: a file appears in the cache dir
+            # without any on_download callback firing.
+            rootfs = cache_dir / "rootfs.ext4"
+            rootfs.write_text("decompressed")
+            return LocalImage(
+                name="codex-cache", kernel_path=cache_dir / "vmlinux.bin", rootfs_path=rootfs
+            )
+
+        mock_ensure_published.side_effect = fake_ensure
+
+        ret = main(["image", "pull", "codex", "--image-dir", str(tmp_path), "--json"])
+
+        assert ret == 0
+        payload = json.loads(capsys.readouterr().out)
+        assert payload["data"]["already_cached"] is False
+
+    @patch("smolvm.images.published.ensure_published_image")
+    @patch("smolvm.cli.main._vmm_for_host", return_value="firecracker")
+    @patch("smolvm.cli.main._host_arch_for_published", return_value="amd64")
+    def test_image_pull_disk_error_names_disk_recovery(
+        self,
+        mock_arch: MagicMock,
+        mock_vmm: MagicMock,
+        mock_ensure_published: MagicMock,
+        tmp_path: Path,
+        capsys: pytest.CaptureFixture,
+    ) -> None:
+        """Disk failures must not be blamed on the network (regression)."""
+        mock_ensure_published.side_effect = OSError(28, "No space left on device")
+
+        ret = main(["image", "pull", "codex", "--image-dir", str(tmp_path), "--json"])
+
+        assert ret == 1
+        payload = json.loads(capsys.readouterr().out)
+        assert "network" not in payload["error"]["recovery"].lower()
+        assert "disk space" in payload["error"]["recovery"]
+
+    @patch("smolvm.images.published.ensure_published_image")
+    @patch("smolvm.cli.main._vmm_for_host", return_value="firecracker")
+    @patch("smolvm.cli.main._host_arch_for_published", return_value="amd64")
+    def test_image_pull_retry_command_keeps_flags(
+        self,
+        mock_arch: MagicMock,
+        mock_vmm: MagicMock,
+        mock_ensure_published: MagicMock,
+        tmp_path: Path,
+        capsys: pytest.CaptureFixture,
+    ) -> None:
+        """The suggested retry reproduces the user's invocation (regression:
+        it used to drop --os/--image-dir)."""
+        from smolvm.exceptions import ImageError
+
+        mock_ensure_published.side_effect = ImageError("Download failed")
+
+        ret = main(
+            ["image", "pull", "codex", "--os", "alpine", "--image-dir", str(tmp_path), "--json"]
+        )
+
+        assert ret == 1
+        payload = json.loads(capsys.readouterr().out)
+        assert "--os alpine" in payload["error"]["recovery"]
+        assert "--image-dir" in payload["error"]["recovery"]
 
     @patch("smolvm.images.published.ensure_published_image")
     @patch("smolvm.cli.main._vmm_for_host", return_value="firecracker")
@@ -4443,6 +4533,41 @@ class TestCliImage:
         payload = json.loads(capsys.readouterr().out)
         assert payload["data"]["preset"] == "claude-code"
         assert mock_ensure_published.call_args.args == ("claude-code", "arm64", "qemu", "ubuntu")
+
+    @patch("smolvm.images.published.ensure_published_image")
+    @patch("smolvm.cli.main._vmm_for_host", return_value="firecracker")
+    @patch("smolvm.cli.main._host_arch_for_published", return_value="amd64")
+    def test_image_pull_registry_alias(
+        self,
+        mock_arch: MagicMock,
+        mock_vmm: MagicMock,
+        mock_ensure_published: MagicMock,
+        tmp_path: Path,
+        capsys: pytest.CaptureFixture,
+    ) -> None:
+        """Aliases resolve from the presets registry, so openclaw's 'claw'
+        works without a hand-maintained map (regression)."""
+        from smolvm.images.manager import LocalImage
+
+        kernel = tmp_path / "vmlinux.bin"
+        rootfs = tmp_path / "rootfs.ext4"
+        kernel.touch()
+        rootfs.touch()
+        mock_ensure_published.return_value = LocalImage(
+            name="claw-cache", kernel_path=kernel, rootfs_path=rootfs
+        )
+
+        ret = main(["image", "pull", "claw", "--image-dir", str(tmp_path), "--json"])
+
+        assert ret == 0
+        payload = json.loads(capsys.readouterr().out)
+        assert payload["data"]["preset"] == "openclaw"
+        assert mock_ensure_published.call_args.args == (
+            "openclaw",
+            "amd64",
+            "firecracker",
+            "ubuntu",
+        )
 
     @patch("smolvm.cli.main._vmm_for_host", return_value="firecracker")
     @patch("smolvm.cli.main._host_arch_for_published", return_value="amd64")

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -4326,3 +4326,201 @@ class TestPublishedImageLaunchPath:
         mock_vm.stop.assert_called_once()
         mock_vm.delete.assert_called_once()
         mock_vm.close.assert_called_once()
+
+
+class TestCliImage:
+    """Tests for the `smolvm image` command group."""
+
+    def test_image_group_help(self) -> None:
+        from click.testing import CliRunner
+
+        result = CliRunner().invoke(build_cli(), ["image", "--help"])
+        assert result.exit_code == 0
+        for verb in ("pull", "list", "rm", "prune"):
+            assert verb in result.output
+
+    @patch("smolvm.images.published.ensure_published_image")
+    @patch("smolvm.cli.main._vmm_for_host", return_value="firecracker")
+    @patch("smolvm.cli.main._host_arch_for_published", return_value="amd64")
+    def test_image_pull_json_already_cached(
+        self,
+        mock_arch: MagicMock,
+        mock_vmm: MagicMock,
+        mock_ensure_published: MagicMock,
+        tmp_path: Path,
+        capsys: pytest.CaptureFixture,
+    ) -> None:
+        """A cache hit (no download callback fired) reports already_cached."""
+        from smolvm.images.manager import LocalImage
+        from smolvm.images.published import cache_name
+
+        kernel = tmp_path / "vmlinux.bin"
+        rootfs = tmp_path / "rootfs.ext4"
+        kernel.touch()
+        rootfs.touch()
+        mock_ensure_published.return_value = LocalImage(
+            name="codex-cache",
+            kernel_path=kernel,
+            rootfs_path=rootfs,
+        )
+
+        ret = main(["image", "pull", "codex", "--image-dir", str(tmp_path), "--json"])
+
+        assert ret == 0
+        payload = json.loads(capsys.readouterr().out)
+        assert payload["command"] == "image.pull"
+        assert payload["ok"] is True
+        assert payload["data"]["preset"] == "codex"
+        assert payload["data"]["arch"] == "amd64"
+        assert payload["data"]["vmm"] == "firecracker"
+        assert payload["data"]["os"] == "ubuntu"
+        assert payload["data"]["name"] == cache_name("codex", "amd64", "firecracker")
+        assert payload["data"]["already_cached"] is True
+        mock_ensure_published.assert_called_once()
+        call = mock_ensure_published.call_args
+        assert call.args == ("codex", "amd64", "firecracker", "ubuntu")
+        assert call.kwargs["cache_dir"] == tmp_path
+
+    @patch("smolvm.images.published.ensure_published_image")
+    @patch("smolvm.cli.main._vmm_for_host", return_value="firecracker")
+    @patch("smolvm.cli.main._host_arch_for_published", return_value="amd64")
+    def test_image_pull_json_downloads(
+        self,
+        mock_arch: MagicMock,
+        mock_vmm: MagicMock,
+        mock_ensure_published: MagicMock,
+        tmp_path: Path,
+        capsys: pytest.CaptureFixture,
+    ) -> None:
+        """A fresh download (callback fired) reports already_cached=False."""
+        from smolvm.images.manager import LocalImage
+
+        kernel = tmp_path / "vmlinux.bin"
+        rootfs = tmp_path / "rootfs.ext4"
+        kernel.touch()
+        rootfs.touch()
+
+        def fake_ensure(*args: object, **kwargs: object) -> LocalImage:
+            on_download = kwargs["on_download"]
+            assert callable(on_download)
+            on_download("kernel", 1024, 2048)
+            on_download("rootfs", 512, 512)
+            return LocalImage(name="codex-cache", kernel_path=kernel, rootfs_path=rootfs)
+
+        mock_ensure_published.side_effect = fake_ensure
+
+        ret = main(["image", "pull", "codex", "--image-dir", str(tmp_path), "--json"])
+
+        assert ret == 0
+        payload = json.loads(capsys.readouterr().out)
+        assert payload["data"]["already_cached"] is False
+
+    @patch("smolvm.images.published.ensure_published_image")
+    @patch("smolvm.cli.main._vmm_for_host", return_value="qemu")
+    @patch("smolvm.cli.main._host_arch_for_published", return_value="arm64")
+    def test_image_pull_claude_alias(
+        self,
+        mock_arch: MagicMock,
+        mock_vmm: MagicMock,
+        mock_ensure_published: MagicMock,
+        tmp_path: Path,
+        capsys: pytest.CaptureFixture,
+    ) -> None:
+        """The public `claude` name maps to the claude-code manifest preset."""
+        from smolvm.images.manager import LocalImage
+
+        kernel = tmp_path / "vmlinux.bin"
+        rootfs = tmp_path / "rootfs.ext4"
+        kernel.touch()
+        rootfs.touch()
+        mock_ensure_published.return_value = LocalImage(
+            name="claude-cache", kernel_path=kernel, rootfs_path=rootfs
+        )
+
+        ret = main(["image", "pull", "claude", "--image-dir", str(tmp_path), "--json"])
+
+        assert ret == 0
+        payload = json.loads(capsys.readouterr().out)
+        assert payload["data"]["preset"] == "claude-code"
+        assert mock_ensure_published.call_args.args == ("claude-code", "arm64", "qemu", "ubuntu")
+
+    @patch("smolvm.cli.main._vmm_for_host", return_value="firecracker")
+    @patch("smolvm.cli.main._host_arch_for_published", return_value="amd64")
+    def test_image_pull_unknown_preset_json(
+        self,
+        mock_arch: MagicMock,
+        mock_vmm: MagicMock,
+        capsys: pytest.CaptureFixture,
+    ) -> None:
+        ret = main(["image", "pull", "nosuchpreset", "--json"])
+
+        assert ret == 2
+        payload = json.loads(capsys.readouterr().out)
+        assert payload["command"] == "image.pull"
+        assert payload["ok"] is False
+        assert payload["error"]["code"] == "invalid_input"
+        assert "codex" in payload["error"]["message"]
+
+    @patch("smolvm.cli.main._vmm_for_host", return_value="firecracker")
+    @patch("smolvm.cli.main._host_arch_for_published", return_value="amd64")
+    def test_image_pull_unpublished_combo_json(
+        self,
+        mock_arch: MagicMock,
+        mock_vmm: MagicMock,
+        capsys: pytest.CaptureFixture,
+    ) -> None:
+        """A valid preset with an unpublished os flavour names the default recovery."""
+        ret = main(["image", "pull", "hermes", "--os", "alpine", "--json"])
+
+        assert ret == 2
+        payload = json.loads(capsys.readouterr().out)
+        assert payload["error"]["code"] == "invalid_input"
+        assert "smolvm image pull hermes" in payload["error"]["message"]
+
+    @patch(
+        "smolvm.cli.main._host_arch_for_published",
+        side_effect=RuntimeError("Unsupported host architecture for published images: 'mips'."),
+    )
+    def test_image_pull_unsupported_host_json(
+        self,
+        mock_arch: MagicMock,
+        capsys: pytest.CaptureFixture,
+    ) -> None:
+        """An undetectable host platform asks for explicit --arch/--vmm."""
+        ret = main(["image", "pull", "codex", "--json"])
+
+        assert ret == 2
+        payload = json.loads(capsys.readouterr().out)
+        assert payload["error"]["code"] == "invalid_input"
+        assert "--arch amd64 --vmm firecracker" in payload["error"]["message"]
+
+    @patch("smolvm.images.published.ensure_published_image")
+    @patch("smolvm.cli.main._vmm_for_host", return_value="firecracker")
+    @patch("smolvm.cli.main._host_arch_for_published", return_value="amd64")
+    def test_image_pull_download_failure_json(
+        self,
+        mock_arch: MagicMock,
+        mock_vmm: MagicMock,
+        mock_ensure_published: MagicMock,
+        tmp_path: Path,
+        capsys: pytest.CaptureFixture,
+    ) -> None:
+        from smolvm.exceptions import ImageError
+
+        mock_ensure_published.side_effect = ImageError("Download failed for https://…: 403")
+
+        ret = main(["image", "pull", "codex", "--image-dir", str(tmp_path), "--json"])
+
+        assert ret == 1
+        payload = json.loads(capsys.readouterr().out)
+        assert payload["ok"] is False
+        assert "smolvm image pull codex" in payload["error"]["recovery"]
+
+    def test_image_pull_parse_error_command_name(self, capsys: pytest.CaptureFixture) -> None:
+        """Parse-time errors carry the dotted image.pull command name."""
+        ret = main(["image", "pull", "--not-a-flag", "--json"])
+
+        assert ret == 2
+        payload = json.loads(capsys.readouterr().out)
+        assert payload["command"] == "image.pull"
+        assert "smolvm image pull --help" in payload["error"]["recovery"]

--- a/tests/test_guest_agent_image.py
+++ b/tests/test_guest_agent_image.py
@@ -279,7 +279,9 @@ def test_guest_agent_binary_downloads_release_without_source_checkout(
 
     monkeypatch.delenv("SMOLVM_GUEST_AGENT_BINARY", raising=False)
     monkeypatch.setattr(builder_mod, "_has_guest_agent_source_checkout", lambda: False)
-    monkeypatch.setattr(builder_mod, "_guest_agent_binary_cache_dir", lambda: tmp_path)
+    monkeypatch.setattr(
+        builder_mod, "_guest_agent_binary_cache_dir", lambda cache_dir=None: tmp_path
+    )
     monkeypatch.setattr(builder_mod.platform, "machine", lambda: "x86_64")
     monkeypatch.setattr(
         builder_mod,
@@ -315,7 +317,9 @@ def test_guest_agent_binary_rejects_bad_release_sha(
             self.close()
 
     monkeypatch.delenv("SMOLVM_GUEST_AGENT_BINARY", raising=False)
-    monkeypatch.setattr(builder_mod, "_guest_agent_binary_cache_dir", lambda: tmp_path)
+    monkeypatch.setattr(
+        builder_mod, "_guest_agent_binary_cache_dir", lambda cache_dir=None: tmp_path
+    )
     monkeypatch.setattr(builder_mod.platform, "machine", lambda: "x86_64")
     monkeypatch.setattr(
         builder_mod,

--- a/tests/test_guest_agent_image.py
+++ b/tests/test_guest_agent_image.py
@@ -280,7 +280,7 @@ def test_guest_agent_binary_downloads_release_without_source_checkout(
     monkeypatch.delenv("SMOLVM_GUEST_AGENT_BINARY", raising=False)
     monkeypatch.setattr(builder_mod, "_has_guest_agent_source_checkout", lambda: False)
     monkeypatch.setattr(
-        builder_mod, "_guest_agent_binary_cache_dir", lambda cache_dir=None: tmp_path
+        builder_mod, "_guest_agent_binary_cache_dir", lambda _cache_dir=None: tmp_path
     )
     monkeypatch.setattr(builder_mod.platform, "machine", lambda: "x86_64")
     monkeypatch.setattr(
@@ -318,7 +318,7 @@ def test_guest_agent_binary_rejects_bad_release_sha(
 
     monkeypatch.delenv("SMOLVM_GUEST_AGENT_BINARY", raising=False)
     monkeypatch.setattr(
-        builder_mod, "_guest_agent_binary_cache_dir", lambda cache_dir=None: tmp_path
+        builder_mod, "_guest_agent_binary_cache_dir", lambda _cache_dir=None: tmp_path
     )
     monkeypatch.setattr(builder_mod.platform, "machine", lambda: "x86_64")
     monkeypatch.setattr(

--- a/tests/test_image_build_cmd.py
+++ b/tests/test_image_build_cmd.py
@@ -184,7 +184,7 @@ class TestImageBuild:
         payload = json.loads(capsys.readouterr().out)
         assert payload["error"]["code"] == "invalid_input"
         assert "No Dockerfile" in payload["error"]["message"]
-        assert "-f path/to/Dockerfile" in payload["error"]["recovery"]
+        assert "-f option" in payload["error"]["recovery"]
 
     def test_bad_build_arg(self, build_ctx: Path, capsys: pytest.CaptureFixture) -> None:
         ret = main(
@@ -301,3 +301,118 @@ class TestImageBuild:
         out = capsys.readouterr().out
         assert "SmolVM.from_image" in out
         assert "smolvm image rm custom/myimg" in out
+
+
+class TestBuildValidation:
+    def test_tag_cannot_escape_custom_namespace(
+        self, build_ctx: Path, tmp_path: Path, capsys: pytest.CaptureFixture
+    ) -> None:
+        """-t '..' would write outside custom/ (regression)."""
+        ret = main(
+            [
+                "image",
+                "build",
+                "-t",
+                "..",
+                str(build_ctx),
+                "--image-dir",
+                str(tmp_path / "cache"),
+                "--json",
+            ]
+        )
+
+        assert ret == 2
+        payload = json.loads(capsys.readouterr().out)
+        assert payload["error"]["code"] == "invalid_input"
+        assert not (tmp_path / "cache").exists()
+
+    def test_invalid_init_gets_clean_envelope(
+        self, build_ctx: Path, tmp_path: Path, capsys: pytest.CaptureFixture
+    ) -> None:
+        """A bad --init used to escape as a raw ValueError traceback
+        (regression)."""
+        ret = main(
+            [
+                "image",
+                "build",
+                "-t",
+                "x",
+                str(build_ctx),
+                "--init",
+                "bad init",
+                "--image-dir",
+                str(tmp_path / "cache"),
+                "--json",
+            ]
+        )
+
+        assert ret == 2
+        payload = json.loads(capsys.readouterr().out)
+        assert payload["ok"] is False
+        assert payload["error"]["code"] == "invalid_input"
+
+    def test_missing_context_folder(self, tmp_path: Path, capsys: pytest.CaptureFixture) -> None:
+        """A typo'd context path must not silently build with no files
+        (regression)."""
+        dockerfile = tmp_path / "Dockerfile"
+        dockerfile.write_text("FROM scratch\n")
+
+        ret = main(
+            [
+                "image",
+                "build",
+                "-t",
+                "x",
+                "-f",
+                str(dockerfile),
+                str(tmp_path / "nope"),
+                "--json",
+            ]
+        )
+
+        assert ret == 2
+        payload = json.loads(capsys.readouterr().out)
+        assert "not a folder" in payload["error"]["message"]
+
+    @patch("smolvm.images.builder.DockerRootfsBuilder._build_rootfs")
+    @patch("smolvm.images.builder.ensure_base_kernel_for_backend")
+    @patch("smolvm.images.builder.ImageBuilder.check_docker", return_value=True)
+    def test_skipped_dockerfiles_reach_json_warnings(
+        self,
+        _mock_docker: MagicMock,
+        mock_kernel: MagicMock,
+        mock_build: MagicMock,
+        build_ctx: Path,
+        tmp_path: Path,
+        capsys: pytest.CaptureFixture,
+    ) -> None:
+        """JSON callers must see the same skip warnings humans do
+        (regression)."""
+        nested = build_ctx / "sub"
+        nested.mkdir()
+        (nested / "Dockerfile").write_text("FROM other\n")
+        kernel = tmp_path / "vmlinux.image"
+        kernel.write_bytes(b"k")
+        mock_kernel.return_value = kernel
+        mock_build.side_effect = _fake_build_rootfs
+
+        ret = main(
+            [
+                "image",
+                "build",
+                "-t",
+                "myimg",
+                str(build_ctx),
+                "--backend",
+                "qemu",
+                "--arch",
+                "amd64",
+                "--image-dir",
+                str(tmp_path / "cache"),
+                "--json",
+            ]
+        )
+
+        assert ret == 0
+        payload = json.loads(capsys.readouterr().out)
+        assert any("sub/Dockerfile" in w for w in payload["data"]["warnings"])

--- a/tests/test_image_build_cmd.py
+++ b/tests/test_image_build_cmd.py
@@ -1,0 +1,303 @@
+# Copyright 2026 Celesto AI
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for `smolvm image build` (Docker is always mocked)."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from smolvm.cli.main import main
+
+
+def _fake_build_rootfs(**kwargs: Any) -> None:
+    rootfs_path = kwargs["rootfs_path"]
+    assert isinstance(rootfs_path, Path)
+    rootfs_path.write_bytes(b"ext4")
+
+
+@pytest.fixture
+def build_ctx(tmp_path: Path) -> Path:
+    ctx = tmp_path / "ctx"
+    ctx.mkdir()
+    (ctx / "Dockerfile").write_text("FROM scratch\nCOPY init /init\n")
+    (ctx / "init").write_text("#!/bin/sh\n")
+    return ctx
+
+
+class TestImageBuild:
+    @patch("smolvm.images.builder.DockerRootfsBuilder._build_rootfs")
+    @patch("smolvm.images.builder.ensure_base_kernel_for_backend")
+    @patch("smolvm.images.builder.ImageBuilder.check_docker", return_value=True)
+    def test_build_json_payload(
+        self,
+        _mock_docker: MagicMock,
+        mock_kernel: MagicMock,
+        mock_build: MagicMock,
+        build_ctx: Path,
+        tmp_path: Path,
+        capsys: pytest.CaptureFixture,
+    ) -> None:
+        kernel = tmp_path / "vmlinux.image"
+        kernel.write_bytes(b"k")
+        mock_kernel.return_value = kernel
+        mock_build.side_effect = _fake_build_rootfs
+
+        ret = main(
+            [
+                "image",
+                "build",
+                "-t",
+                "myimg",
+                str(build_ctx),
+                "--backend",
+                "qemu",
+                "--arch",
+                "amd64",
+                "--image-dir",
+                str(tmp_path / "cache"),
+                "--json",
+            ]
+        )
+
+        assert ret == 0
+        payload = json.loads(capsys.readouterr().out)
+        assert payload["command"] == "image.build"
+        data = payload["data"]
+        assert data["name"] == "myimg"
+        assert data["cached"] is False
+        assert data["arch"] == "amd64"
+        assert Path(data["rootfs_path"]).is_file()
+        assert Path(data["rootfs_path"]).parent.name == data["fingerprint"]
+        assert "root=/dev/vda" in data["boot_args"]
+        # The build landed in the custom namespace of the chosen image dir.
+        assert str(tmp_path / "cache" / "custom" / "myimg") in data["rootfs_path"]
+
+    @patch("smolvm.images.builder.DockerRootfsBuilder._build_rootfs")
+    @patch("smolvm.images.builder.ensure_base_kernel_for_backend")
+    @patch("smolvm.images.builder.ImageBuilder.check_docker", return_value=True)
+    def test_second_build_reports_cached(
+        self,
+        _mock_docker: MagicMock,
+        mock_kernel: MagicMock,
+        mock_build: MagicMock,
+        build_ctx: Path,
+        tmp_path: Path,
+        capsys: pytest.CaptureFixture,
+    ) -> None:
+        kernel = tmp_path / "vmlinux.image"
+        kernel.write_bytes(b"k")
+        mock_kernel.return_value = kernel
+        mock_build.side_effect = _fake_build_rootfs
+
+        args = [
+            "image",
+            "build",
+            "-t",
+            "myimg",
+            str(build_ctx),
+            "--backend",
+            "qemu",
+            "--arch",
+            "amd64",
+            "--image-dir",
+            str(tmp_path / "cache"),
+            "--json",
+        ]
+        assert main(args) == 0
+        capsys.readouterr()
+        assert main(args) == 0
+        payload = json.loads(capsys.readouterr().out)
+        assert payload["data"]["cached"] is True
+        assert mock_build.call_count == 1  # cache hit skipped Docker entirely
+
+    @patch("smolvm.images.builder.DockerRootfsBuilder._build_rootfs")
+    @patch("smolvm.images.builder.ensure_base_kernel_for_backend")
+    @patch("smolvm.images.builder.ImageBuilder.check_docker", return_value=True)
+    def test_built_image_appears_in_list_and_rm(
+        self,
+        _mock_docker: MagicMock,
+        mock_kernel: MagicMock,
+        mock_build: MagicMock,
+        build_ctx: Path,
+        tmp_path: Path,
+        capsys: pytest.CaptureFixture,
+    ) -> None:
+        kernel = tmp_path / "vmlinux.image"
+        kernel.write_bytes(b"k")
+        mock_kernel.return_value = kernel
+        mock_build.side_effect = _fake_build_rootfs
+        cache = str(tmp_path / "cache")
+
+        assert (
+            main(
+                [
+                    "image",
+                    "build",
+                    "-t",
+                    "myimg",
+                    str(build_ctx),
+                    "--backend",
+                    "qemu",
+                    "--arch",
+                    "amd64",
+                    "--image-dir",
+                    cache,
+                    "--json",
+                ]
+            )
+            == 0
+        )
+        capsys.readouterr()
+
+        assert main(["image", "list", "--image-dir", cache, "--json"]) == 0
+        rows = json.loads(capsys.readouterr().out)["data"]["images"]
+        assert any(r["kind"] == "custom" and r["name"] == "custom/myimg" for r in rows)
+
+        assert main(["image", "rm", "custom/myimg", "--image-dir", cache, "--json"]) == 0
+        capsys.readouterr()
+        assert not (tmp_path / "cache" / "custom" / "myimg").exists()
+
+    def test_missing_dockerfile(self, tmp_path: Path, capsys: pytest.CaptureFixture) -> None:
+        empty = tmp_path / "empty"
+        empty.mkdir()
+
+        ret = main(["image", "build", "-t", "x", str(empty), "--json"])
+
+        assert ret == 2
+        payload = json.loads(capsys.readouterr().out)
+        assert payload["error"]["code"] == "invalid_input"
+        assert "No Dockerfile" in payload["error"]["message"]
+        assert "-f path/to/Dockerfile" in payload["error"]["recovery"]
+
+    def test_bad_build_arg(self, build_ctx: Path, capsys: pytest.CaptureFixture) -> None:
+        ret = main(
+            ["image", "build", "-t", "x", str(build_ctx), "--build-arg", "NOEQUALS", "--json"]
+        )
+
+        assert ret == 2
+        payload = json.loads(capsys.readouterr().out)
+        assert "KEY=VALUE" in payload["error"]["recovery"]
+
+    @patch("smolvm.images.builder.ImageBuilder.check_docker", return_value=False)
+    def test_docker_unavailable_error_envelope(
+        self,
+        _mock_docker: MagicMock,
+        build_ctx: Path,
+        tmp_path: Path,
+        capsys: pytest.CaptureFixture,
+    ) -> None:
+        ret = main(
+            [
+                "image",
+                "build",
+                "-t",
+                "x",
+                str(build_ctx),
+                "--image-dir",
+                str(tmp_path / "cache"),
+                "--json",
+            ]
+        )
+
+        assert ret == 1
+        payload = json.loads(capsys.readouterr().out)
+        assert payload["ok"] is False
+        assert "Docker" in payload["error"]["message"]
+        assert "smolvm image build" in payload["error"]["recovery"]
+
+    @patch("smolvm.images.builder.DockerRootfsBuilder._build_rootfs")
+    @patch("smolvm.images.builder.ensure_base_kernel_for_backend")
+    @patch("smolvm.images.builder.ImageBuilder.check_docker", return_value=True)
+    def test_nested_dockerfiles_are_skipped(
+        self,
+        _mock_docker: MagicMock,
+        mock_kernel: MagicMock,
+        mock_build: MagicMock,
+        build_ctx: Path,
+        tmp_path: Path,
+        capsys: pytest.CaptureFixture,
+    ) -> None:
+        """The builder reserves the name Dockerfile; nested ones must not
+        abort the build."""
+        nested = build_ctx / "sub"
+        nested.mkdir()
+        (nested / "Dockerfile").write_text("FROM other\n")
+        kernel = tmp_path / "vmlinux.image"
+        kernel.write_bytes(b"k")
+        mock_kernel.return_value = kernel
+        mock_build.side_effect = _fake_build_rootfs
+
+        ret = main(
+            [
+                "image",
+                "build",
+                "-t",
+                "myimg",
+                str(build_ctx),
+                "--backend",
+                "qemu",
+                "--arch",
+                "amd64",
+                "--image-dir",
+                str(tmp_path / "cache"),
+                "--json",
+            ]
+        )
+
+        assert ret == 0
+        json.loads(capsys.readouterr().out)
+
+    @patch("smolvm.images.builder.DockerRootfsBuilder._build_rootfs")
+    @patch("smolvm.images.builder.ensure_base_kernel_for_backend")
+    @patch("smolvm.images.builder.ImageBuilder.check_docker", return_value=True)
+    def test_human_output_names_sdk_boot_path(
+        self,
+        _mock_docker: MagicMock,
+        mock_kernel: MagicMock,
+        mock_build: MagicMock,
+        build_ctx: Path,
+        tmp_path: Path,
+        capsys: pytest.CaptureFixture,
+    ) -> None:
+        kernel = tmp_path / "vmlinux.image"
+        kernel.write_bytes(b"k")
+        mock_kernel.return_value = kernel
+        mock_build.side_effect = _fake_build_rootfs
+
+        ret = main(
+            [
+                "image",
+                "build",
+                "-t",
+                "myimg",
+                str(build_ctx),
+                "--backend",
+                "qemu",
+                "--arch",
+                "amd64",
+                "--image-dir",
+                str(tmp_path / "cache"),
+            ]
+        )
+
+        assert ret == 0
+        out = capsys.readouterr().out
+        assert "SmolVM.from_image" in out
+        assert "smolvm image rm custom/myimg" in out

--- a/tests/test_image_build_cmd.py
+++ b/tests/test_image_build_cmd.py
@@ -416,3 +416,68 @@ class TestBuildValidation:
         assert ret == 0
         payload = json.loads(capsys.readouterr().out)
         assert any("sub/Dockerfile" in w for w in payload["data"]["warnings"])
+
+
+class TestUpstreamReviewRegressions:
+    def test_leading_dot_tag_rejected(
+        self, build_ctx: Path, tmp_path: Path, capsys: pytest.CaptureFixture
+    ) -> None:
+        """A dot-prefixed tag would build an image invisible to image list
+        (regression)."""
+        ret = main(
+            [
+                "image",
+                "build",
+                "-t",
+                ".hidden",
+                str(build_ctx),
+                "--image-dir",
+                str(tmp_path / "cache"),
+                "--json",
+            ]
+        )
+
+        assert ret == 2
+        payload = json.loads(capsys.readouterr().out)
+        assert payload["error"]["code"] == "invalid_input"
+
+    @patch("smolvm.images.builder.DockerRootfsBuilder._build_rootfs")
+    @patch("smolvm.images.builder.ensure_base_kernel_for_backend")
+    @patch("smolvm.images.builder.ImageBuilder.check_docker", return_value=True)
+    def test_snippet_paths_are_repr_escaped(
+        self,
+        _mock_docker: MagicMock,
+        mock_kernel: MagicMock,
+        mock_build: MagicMock,
+        tmp_path: Path,
+        capsys: pytest.CaptureFixture,
+    ) -> None:
+        """The printed Python snippet must stay valid for paths containing
+        quotes (regression)."""
+        ctx = tmp_path / 'ctx "quoted"'
+        ctx.mkdir()
+        (ctx / "Dockerfile").write_text("FROM scratch\n")
+        kernel = tmp_path / "vmlinux.image"
+        kernel.write_bytes(b"k")
+        mock_kernel.return_value = kernel
+        mock_build.side_effect = _fake_build_rootfs
+
+        ret = main(
+            [
+                "image",
+                "build",
+                "-t",
+                "myimg",
+                str(ctx),
+                "--backend",
+                "qemu",
+                "--arch",
+                "amd64",
+                "--image-dir",
+                str(tmp_path / "cache"),
+            ]
+        )
+
+        assert ret == 0
+        out = capsys.readouterr().out
+        assert "rootfs_path='" in out.replace("\n", "")

--- a/tests/test_image_cmd.py
+++ b/tests/test_image_cmd.py
@@ -859,3 +859,155 @@ class TestCustomImages:
         assert ret == 2
         payload = json.loads(capsys.readouterr().out)
         assert payload["error"]["code"] == "invalid_input"
+
+
+class TestRmSafety:
+    def test_rm_bare_custom_is_rejected(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture
+    ) -> None:
+        """'custom' is the namespace, not an entry — one rm must never wipe
+        every build (regression)."""
+        fp = tmp_path / "custom" / "myimg" / "abc123def4567890"
+        fp.mkdir(parents=True)
+        (fp / "rootfs.ext4").write_bytes(b"x")
+
+        ret = main(["image", "rm", "custom", "--image-dir", str(tmp_path), "--json"])
+
+        assert ret == 2
+        payload = json.loads(capsys.readouterr().out)
+        assert payload["error"]["code"] == "invalid_input"
+        assert fp.exists()
+
+    def test_rm_refuses_symlinked_middle_component(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture
+    ) -> None:
+        """A symlinked component under custom/ must not redirect the delete
+        at a different entry (regression)."""
+        published = tmp_path / "codex-v9.9.9-amd64-firecracker"
+        published.mkdir()
+        (published / "rootfs.ext4").write_bytes(b"keep me")
+        (tmp_path / "custom").mkdir()
+        (tmp_path / "custom" / "link").symlink_to(tmp_path)
+
+        ret = main(
+            [
+                "image",
+                "rm",
+                "custom/link/codex-v9.9.9-amd64-firecracker",
+                "--image-dir",
+                str(tmp_path),
+                "--json",
+            ]
+        )
+
+        assert ret == 1
+        payload = json.loads(capsys.readouterr().out)
+        assert payload["ok"] is False
+        assert (published / "rootfs.ext4").exists()
+
+    def test_rm_accepts_unusual_directory_names(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture
+    ) -> None:
+        """Any real top-level directory is removable, not just charset-clean
+        names (regression: 'my old image' became undeletable)."""
+        odd = tmp_path / "my old image"
+        odd.mkdir()
+        (odd / "blob").write_bytes(b"x")
+
+        ret = main(["image", "rm", "my old image", "--image-dir", str(tmp_path), "--json"])
+
+        assert ret == 0
+        capsys.readouterr()
+        assert not odd.exists()
+
+    def test_rm_fingerprint_prefix(self, tmp_path: Path, capsys: pytest.CaptureFixture) -> None:
+        """Docker-style short ids: the 12-char version shown by list works."""
+        a = tmp_path / "custom" / "web" / "aaaa1111bbbb2222"
+        b = tmp_path / "custom" / "web" / "cccc3333dddd4444"
+        a.mkdir(parents=True)
+        b.mkdir(parents=True)
+
+        ret = main(
+            ["image", "rm", "custom/web/aaaa1111bbbb", "--image-dir", str(tmp_path), "--json"]
+        )
+
+        assert ret == 0
+        capsys.readouterr()
+        assert not a.exists()
+        assert b.exists()
+
+    def test_rm_ambiguous_fingerprint_prefix(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture
+    ) -> None:
+        a = tmp_path / "custom" / "web" / "aaaa1111bbbb2222"
+        b = tmp_path / "custom" / "web" / "aaaa1111cccc3333"
+        a.mkdir(parents=True)
+        b.mkdir(parents=True)
+
+        ret = main(["image", "rm", "custom/web/aaaa", "--image-dir", str(tmp_path), "--json"])
+
+        assert ret == 2
+        payload = json.loads(capsys.readouterr().out)
+        assert payload["error"]["code"] == "invalid_input"
+        assert "aaaa1111bbbb2222" in payload["error"]["message"]
+        assert "aaaa1111cccc3333" in payload["error"]["message"]
+        assert a.exists() and b.exists()
+
+    def test_list_shows_top_level_dot_dirs(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture
+    ) -> None:
+        """Orphaned staging dirs must not be invisible disk usage."""
+        staging = tmp_path / ".codex-v0.0.1-amd64-firecracker.partial"
+        staging.mkdir()
+        (staging / "rootfs.ext4").write_bytes(b"x" * 10)
+
+        ret = main(["image", "list", "--image-dir", str(tmp_path), "--json"])
+
+        assert ret == 0
+        rows = json.loads(capsys.readouterr().out)["data"]["images"]
+        assert [r["kind"] for r in rows] == ["other"]
+        assert rows[0]["size_bytes"] > 0
+
+
+class TestPullAllRecovery:
+    @patch("smolvm.images.published.ensure_published_image")
+    @patch("smolvm.cli.main._vmm_for_host", return_value="firecracker")
+    @patch("smolvm.cli.main._host_arch_for_published", return_value="amd64")
+    def test_failure_recovery_keeps_flags(
+        self,
+        mock_arch: MagicMock,
+        mock_vmm: MagicMock,
+        mock_ensure: MagicMock,
+        tmp_path: Path,
+        capsys: pytest.CaptureFixture,
+    ) -> None:
+        from smolvm.exceptions import ImageError
+
+        mock_ensure.side_effect = ImageError("boom")
+
+        ret = main(["image", "pull", "--all", "--image-dir", str(tmp_path), "--json"])
+
+        assert ret == 1
+        payload = json.loads(capsys.readouterr().out)
+        assert "--image-dir" in payload["error"]["recovery"]
+
+    @patch("smolvm.images.published.published_targets", return_value=[])
+    @patch("smolvm.cli.main._vmm_for_host", return_value="firecracker")
+    @patch("smolvm.cli.main._host_arch_for_published", return_value="amd64")
+    def test_no_targets_names_recovery(
+        self,
+        mock_arch: MagicMock,
+        mock_vmm: MagicMock,
+        mock_targets: MagicMock,
+        tmp_path: Path,
+        capsys: pytest.CaptureFixture,
+    ) -> None:
+        ret = main(
+            ["image", "pull", "--all", "--os", "alpine", "--image-dir", str(tmp_path), "--json"]
+        )
+
+        assert ret == 2
+        payload = json.loads(capsys.readouterr().out)
+        recovery = payload["error"]["recovery"]
+        assert "smolvm image pull --all" in recovery
+        assert "--os" not in recovery

--- a/tests/test_image_cmd.py
+++ b/tests/test_image_cmd.py
@@ -1,0 +1,340 @@
+# Copyright 2026 Celesto AI
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for smolvm image list/rm and the SMOLVM_IMAGE_DIR resolution."""
+
+from __future__ import annotations
+
+import json
+import re
+from pathlib import Path
+
+import pytest
+
+from smolvm import __version__
+from smolvm.cli.main import main
+from smolvm.cli.prune import find_stale_caches
+from smolvm.images.manager import IMAGE_DIR_ENV, ImageManager, resolve_image_dir
+
+
+def _make_cache_dirs(root: Path) -> None:
+    """Populate an image dir with representative cache entries."""
+    entries = {
+        "codex-v0.0.1-amd64-firecracker": 5,
+        "claude-code-v0.0.1-arm64-qemu-alpine": 3,
+        f"codex-v{__version__}-arm64-qemu": 7,
+        "base-kernel-v0.0.1-amd64": 2,
+    }
+    for name, size in entries.items():
+        d = root / name
+        d.mkdir(parents=True)
+        (d / "blob").write_bytes(b"x" * size)
+    (root / "s3").mkdir()
+    (root / "_guest-agent").mkdir()
+    (root / "stray-file.txt").write_text("not a dir")
+
+
+class TestResolveImageDir:
+    def test_default_is_home_smolvm_images(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.delenv(IMAGE_DIR_ENV, raising=False)
+        assert resolve_image_dir() == Path.home() / ".smolvm" / "images"
+
+    def test_env_var_overrides_default(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv(IMAGE_DIR_ENV, str(tmp_path / "custom"))
+        assert resolve_image_dir() == tmp_path / "custom"
+
+    def test_explicit_arg_beats_env_var(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv(IMAGE_DIR_ENV, str(tmp_path / "from-env"))
+        assert resolve_image_dir(tmp_path / "explicit") == tmp_path / "explicit"
+        assert resolve_image_dir(str(tmp_path / "explicit")) == tmp_path / "explicit"
+
+    def test_blank_env_var_falls_through(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv(IMAGE_DIR_ENV, "  ")
+        assert resolve_image_dir() == Path.home() / ".smolvm" / "images"
+
+    def test_does_not_create_the_directory(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        target = tmp_path / "never-created"
+        monkeypatch.setenv(IMAGE_DIR_ENV, str(target))
+        resolve_image_dir()
+        assert not target.exists()
+
+    def test_image_manager_honors_env_set_after_import(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Resolution happens at construction time, not module-import time."""
+        monkeypatch.setenv(IMAGE_DIR_ENV, str(tmp_path / "late-env"))
+        assert ImageManager().cache_dir == tmp_path / "late-env"
+
+    def test_image_manager_explicit_cache_dir_wins(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv(IMAGE_DIR_ENV, str(tmp_path / "from-env"))
+        assert ImageManager(cache_dir=tmp_path / "explicit").cache_dir == tmp_path / "explicit"
+
+    def test_guest_agent_cache_dir_honors_env(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        from smolvm.images.builder import _guest_agent_binary_cache_dir
+
+        monkeypatch.setenv(IMAGE_DIR_ENV, str(tmp_path / "img"))
+        assert _guest_agent_binary_cache_dir() == tmp_path / "img" / "_guest-agent"
+
+    def test_image_builder_honors_env(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        from smolvm.images.builder import ImageBuilder
+
+        monkeypatch.setenv(IMAGE_DIR_ENV, str(tmp_path / "img"))
+        assert ImageBuilder().cache_dir == tmp_path / "img"
+
+    def test_find_stale_caches_honors_env(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        stale = tmp_path / "codex-v0.0.1-amd64-firecracker"
+        stale.mkdir()
+        monkeypatch.setenv(IMAGE_DIR_ENV, str(tmp_path))
+        assert find_stale_caches(current_version="9.9.9") == [stale]
+
+
+class TestImageList:
+    def test_list_json_classifies_entries(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture
+    ) -> None:
+        _make_cache_dirs(tmp_path)
+
+        ret = main(["image", "list", "--image-dir", str(tmp_path), "--json"])
+
+        assert ret == 0
+        payload = json.loads(capsys.readouterr().out)
+        assert payload["command"] == "image.list"
+        assert payload["ok"] is True
+        assert payload["data"]["image_dir"] == str(tmp_path)
+        rows = {row["name"]: row for row in payload["data"]["images"]}
+        # The stray file is skipped; the six directories are classified.
+        assert len(rows) == 6
+
+        codex = rows["codex-v0.0.1-amd64-firecracker"]
+        assert codex["kind"] == "image"
+        assert codex["preset"] == "codex"
+        assert codex["arch"] == "amd64"
+        assert codex["vmm"] == "firecracker"
+        assert codex["os"] == "ubuntu"
+        assert codex["current"] is False
+        assert codex["size_bytes"] == 5
+
+        # Non-greedy preset parse: hyphenated preset with alpine suffix.
+        claude = rows["claude-code-v0.0.1-arm64-qemu-alpine"]
+        assert claude["preset"] == "claude-code"
+        assert claude["os"] == "alpine"
+        assert claude["vmm"] == "qemu"
+
+        current = rows[f"codex-v{__version__}-arm64-qemu"]
+        assert current["current"] is True
+
+        kernel = rows["base-kernel-v0.0.1-amd64"]
+        assert kernel["kind"] == "kernel"
+        assert kernel["arch"] == "amd64"
+        assert kernel["preset"] is None
+
+        assert rows["s3"]["kind"] == "other"
+        assert rows["s3"]["current"] is None
+        assert rows["_guest-agent"]["kind"] == "other"
+
+        assert payload["data"]["total_size_bytes"] == 17
+
+    def test_list_missing_dir_is_empty(self, tmp_path: Path, capsys: pytest.CaptureFixture) -> None:
+        ret = main(["image", "list", "--image-dir", str(tmp_path / "missing"), "--json"])
+
+        assert ret == 0
+        payload = json.loads(capsys.readouterr().out)
+        assert payload["data"]["images"] == []
+        assert payload["data"]["total_size_bytes"] == 0
+
+    def test_list_human_empty_names_pull(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture
+    ) -> None:
+        ret = main(["image", "list", "--image-dir", str(tmp_path)])
+
+        assert ret == 0
+        # Rich wraps the panel mid-word with box-drawing borders; strip
+        # everything but letters/digits so the recovery command is findable.
+        flattened = re.sub(r"[^a-z0-9]+", "", capsys.readouterr().out.lower())
+        assert "smolvmimagepull" in flattened
+
+    def test_list_env_var_default(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture
+    ) -> None:
+        _make_cache_dirs(tmp_path)
+        monkeypatch.setenv(IMAGE_DIR_ENV, str(tmp_path))
+
+        ret = main(["image", "list", "--json"])
+
+        assert ret == 0
+        payload = json.loads(capsys.readouterr().out)
+        assert payload["data"]["image_dir"] == str(tmp_path)
+        assert len(payload["data"]["images"]) == 6
+
+
+class TestImageRm:
+    def test_rm_exact_name(self, tmp_path: Path, capsys: pytest.CaptureFixture) -> None:
+        _make_cache_dirs(tmp_path)
+
+        ret = main(
+            [
+                "image",
+                "rm",
+                "codex-v0.0.1-amd64-firecracker",
+                "--image-dir",
+                str(tmp_path),
+                "--json",
+            ]
+        )
+
+        assert ret == 0
+        payload = json.loads(capsys.readouterr().out)
+        assert payload["command"] == "image.rm"
+        assert [e["name"] for e in payload["data"]["removed"]] == ["codex-v0.0.1-amd64-firecracker"]
+        assert payload["data"]["freed_bytes"] == 5
+        assert not (tmp_path / "codex-v0.0.1-amd64-firecracker").exists()
+        # The other codex version is untouched by an exact-name removal.
+        assert (tmp_path / f"codex-v{__version__}-arm64-qemu").exists()
+
+    def test_rm_by_preset_removes_all_versions(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture
+    ) -> None:
+        _make_cache_dirs(tmp_path)
+
+        ret = main(["image", "rm", "codex", "--image-dir", str(tmp_path), "--json"])
+
+        assert ret == 0
+        payload = json.loads(capsys.readouterr().out)
+        removed = {e["name"] for e in payload["data"]["removed"]}
+        assert removed == {
+            "codex-v0.0.1-amd64-firecracker",
+            f"codex-v{__version__}-arm64-qemu",
+        }
+        assert payload["data"]["freed_bytes"] == 12
+        # Unrelated entries survive preset-wide removal.
+        assert (tmp_path / "s3").exists()
+        assert (tmp_path / "_guest-agent").exists()
+        assert (tmp_path / "base-kernel-v0.0.1-amd64").exists()
+        assert (tmp_path / "claude-code-v0.0.1-arm64-qemu-alpine").exists()
+
+    def test_rm_claude_alias(self, tmp_path: Path, capsys: pytest.CaptureFixture) -> None:
+        _make_cache_dirs(tmp_path)
+
+        ret = main(["image", "rm", "claude", "--image-dir", str(tmp_path), "--json"])
+
+        assert ret == 0
+        payload = json.loads(capsys.readouterr().out)
+        assert [e["name"] for e in payload["data"]["removed"]] == [
+            "claude-code-v0.0.1-arm64-qemu-alpine"
+        ]
+
+    def test_rm_dry_run_removes_nothing(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture
+    ) -> None:
+        _make_cache_dirs(tmp_path)
+
+        ret = main(["image", "rm", "codex", "--dry-run", "--image-dir", str(tmp_path), "--json"])
+
+        assert ret == 0
+        payload = json.loads(capsys.readouterr().out)
+        assert payload["data"]["dry_run"] is True
+        assert payload["data"]["would_free_bytes"] == 12
+        assert (tmp_path / "codex-v0.0.1-amd64-firecracker").exists()
+
+    def test_rm_unknown_name_fails_with_recovery(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture
+    ) -> None:
+        _make_cache_dirs(tmp_path)
+
+        ret = main(["image", "rm", "nope", "--image-dir", str(tmp_path), "--json"])
+
+        assert ret == 1
+        payload = json.loads(capsys.readouterr().out)
+        assert payload["ok"] is False
+        assert "smolvm image list" in payload["error"]["recovery"]
+
+    @pytest.mark.parametrize("name", ["../evil", "a/b", "..", "."])
+    def test_rm_rejects_traversal_names(
+        self, name: str, tmp_path: Path, capsys: pytest.CaptureFixture
+    ) -> None:
+        (tmp_path / "evil").mkdir()
+
+        ret = main(["image", "rm", name, "--image-dir", str(tmp_path / "sub"), "--json"])
+
+        assert ret == 2
+        payload = json.loads(capsys.readouterr().out)
+        assert payload["error"]["code"] == "invalid_input"
+        assert (tmp_path / "evil").exists()
+
+    def test_rm_refuses_symlink_escaping_root(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture
+    ) -> None:
+        root = tmp_path / "images"
+        root.mkdir()
+        outside = tmp_path / "outside"
+        outside.mkdir()
+        (outside / "data").write_text("keep me")
+        (root / "escape").symlink_to(outside)
+
+        ret = main(["image", "rm", "escape", "--image-dir", str(root), "--json"])
+
+        assert ret == 1
+        payload = json.loads(capsys.readouterr().out)
+        assert payload["ok"] is False
+        assert (outside / "data").exists()
+
+
+class TestPruneAlias:
+    def test_top_level_prune_keeps_command_name(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture
+    ) -> None:
+        ret = main(["prune", "--cache-dir", str(tmp_path), "--json"])
+
+        assert ret == 0
+        payload = json.loads(capsys.readouterr().out)
+        assert payload["command"] == "prune"
+
+    def test_image_prune_uses_dotted_command_name(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture
+    ) -> None:
+        ret = main(["image", "prune", "--image-dir", str(tmp_path), "--json"])
+
+        assert ret == 0
+        payload = json.loads(capsys.readouterr().out)
+        assert payload["command"] == "image.prune"
+
+    def test_image_prune_removes_stale_dirs(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture
+    ) -> None:
+        _make_cache_dirs(tmp_path)
+
+        ret = main(["image", "prune", "--image-dir", str(tmp_path), "--json"])
+
+        assert ret == 0
+        payload = json.loads(capsys.readouterr().out)
+        assert payload["ok"] is True
+        # Stale-versioned dirs go; current-version and unversioned stay.
+        assert not (tmp_path / "codex-v0.0.1-amd64-firecracker").exists()
+        assert not (tmp_path / "base-kernel-v0.0.1-amd64").exists()
+        assert (tmp_path / f"codex-v{__version__}-arm64-qemu").exists()
+        assert (tmp_path / "s3").exists()

--- a/tests/test_image_cmd.py
+++ b/tests/test_image_cmd.py
@@ -20,6 +20,7 @@ import json
 import os
 import re
 from pathlib import Path
+from unittest.mock import MagicMock, patch
 
 import pytest
 
@@ -543,3 +544,318 @@ class TestChoiceListsMatchPublishedTypes:
         assert choices["arch"] == set(typing.get_args(Arch))
         assert choices["vmm"] == set(typing.get_args(Vmm))
         assert choices["os_name"] == set(typing.get_args(Os))
+
+
+class TestRelativeTime:
+    def test_buckets(self) -> None:
+        from datetime import datetime, timezone
+
+        from smolvm.cli.image import _relative_time
+
+        now = datetime(2026, 7, 17, 12, 0, 0, tzinfo=timezone.utc)
+
+        def at(seconds_ago: int) -> str:
+            from datetime import timedelta
+
+            return (now - timedelta(seconds=seconds_ago)).isoformat()
+
+        assert _relative_time(at(0), now=now) == "0 seconds ago"
+        assert _relative_time(at(1), now=now) == "1 second ago"
+        assert _relative_time(at(90), now=now) == "1 minute ago"
+        assert _relative_time(at(7200), now=now) == "2 hours ago"
+        assert _relative_time(at(86400 * 3), now=now) == "3 days ago"
+        assert _relative_time(at(86400 * 8), now=now) == "1 week ago"
+        assert _relative_time(at(86400 * 40), now=now) == "1 month ago"
+        assert _relative_time(at(86400 * 400), now=now) == "1 year ago"
+        assert _relative_time(None, now=now) == "-"
+        assert _relative_time("not-a-date", now=now) == "-"
+
+    def test_list_rows_carry_parseable_created(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture
+    ) -> None:
+        from datetime import datetime
+
+        _make_cache_dirs(tmp_path)
+        ret = main(["image", "list", "--image-dir", str(tmp_path), "--json"])
+        assert ret == 0
+        payload = json.loads(capsys.readouterr().out)
+        for row in payload["data"]["images"]:
+            assert row["created"] is not None
+            datetime.fromisoformat(row["created"])
+
+
+class TestAliases:
+    def test_top_level_images_envelope(self, tmp_path: Path, capsys: pytest.CaptureFixture) -> None:
+        _make_cache_dirs(tmp_path)
+        ret = main(["images", "--image-dir", str(tmp_path), "--json"])
+        assert ret == 0
+        payload = json.loads(capsys.readouterr().out)
+        assert payload["command"] == "images"
+        assert len(payload["data"]["images"]) == 6
+
+    def test_image_ls_keeps_list_envelope(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture
+    ) -> None:
+        _make_cache_dirs(tmp_path)
+        ret = main(["image", "ls", "--image-dir", str(tmp_path), "--json"])
+        assert ret == 0
+        payload = json.loads(capsys.readouterr().out)
+        assert payload["command"] == "image.list"
+
+
+def _make_published_entry(root: Path, name: str) -> Path:
+    """A realistic published cache dir: kernel, zst, sparse rootfs, sidecar."""
+    import hashlib
+
+    import zstandard
+
+    d = root / name
+    d.mkdir(parents=True)
+    raw = b"\x00" * (1 << 20) + b"REAL-DATA" + b"\x00" * (1 << 20)
+    (d / "rootfs.ext4.zst").write_bytes(zstandard.compress(raw))
+    sha = hashlib.sha256((d / "rootfs.ext4.zst").read_bytes()).hexdigest()
+    (d / "rootfs.ext4.from-sha256").write_text(f"sparse-v1:{sha}")
+    (d / "vmlinux.bin").write_bytes(b"kernel-bytes")
+    with open(d / "rootfs.ext4", "wb") as f:
+        f.truncate(len(raw))
+        f.seek(1 << 20)
+        f.write(b"REAL-DATA")
+    return d
+
+
+class TestImageInspect:
+    def test_inspect_exact_name_returns_array(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture
+    ) -> None:
+        _make_published_entry(tmp_path, "codex-v0.0.1-amd64-firecracker")
+
+        ret = main(
+            [
+                "image",
+                "inspect",
+                "codex-v0.0.1-amd64-firecracker",
+                "--image-dir",
+                str(tmp_path),
+                "--json",
+            ]
+        )
+
+        assert ret == 0
+        payload = json.loads(capsys.readouterr().out)
+        assert payload["command"] == "image.inspect"
+        assert isinstance(payload["data"], list) and len(payload["data"]) == 1
+        entry = payload["data"][0]
+        assert entry["kind"] == "image"
+        assert entry["rootfs_sidecar"].startswith("sparse-v1:")
+        files = {f["name"]: f for f in entry["files"]}
+        assert set(files) == {
+            "rootfs.ext4",
+            "rootfs.ext4.from-sha256",
+            "rootfs.ext4.zst",
+            "vmlinux.bin",
+        }
+        rootfs = files["rootfs.ext4"]
+        if os.name == "posix":
+            assert rootfs["size_on_disk_bytes"] < rootfs["size_bytes"]
+        # Stale version: no manifest section.
+        assert entry["manifest"] is None
+
+    def test_inspect_current_version_gets_manifest(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture
+    ) -> None:
+        from smolvm.images.published import IMAGES_RELEASE_TAG, cache_name
+
+        _make_published_entry(tmp_path, cache_name("codex", "amd64", "firecracker"))
+
+        ret = main(["image", "inspect", "codex", "--image-dir", str(tmp_path), "--json"])
+
+        assert ret == 0
+        payload = json.loads(capsys.readouterr().out)
+        entry = payload["data"][0]
+        assert entry["current"] is True
+        manifest = entry["manifest"]
+        assert manifest is not None
+        assert manifest["images_release_tag"] == IMAGES_RELEASE_TAG
+        assert len(manifest["rootfs_sha256"]) == 64
+        assert manifest["kernel_url"].startswith("https://")
+
+    def test_inspect_preset_matches_all_variants(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture
+    ) -> None:
+        _make_cache_dirs(tmp_path)
+
+        ret = main(["image", "inspect", "codex", "--image-dir", str(tmp_path), "--json"])
+
+        assert ret == 0
+        payload = json.loads(capsys.readouterr().out)
+        assert len(payload["data"]) == 2
+
+    def test_inspect_unknown_name(self, tmp_path: Path, capsys: pytest.CaptureFixture) -> None:
+        ret = main(["image", "inspect", "nope", "--image-dir", str(tmp_path), "--json"])
+
+        assert ret == 1
+        payload = json.loads(capsys.readouterr().out)
+        assert "smolvm image list" in payload["error"]["recovery"]
+
+
+class TestImagePullAll:
+    @pytest.mark.parametrize("argv", [["image", "pull"], ["image", "pull", "codex", "--all"]])
+    def test_mutual_exclusion(self, argv: list[str], capsys: pytest.CaptureFixture) -> None:
+        ret = main([*argv, "--json"])
+
+        assert ret == 2
+        payload = json.loads(capsys.readouterr().out)
+        assert "Choose one target" in payload["error"]["message"]
+
+    @patch("smolvm.images.published.ensure_published_image")
+    @patch("smolvm.cli.main._vmm_for_host", return_value="firecracker")
+    @patch("smolvm.cli.main._host_arch_for_published", return_value="amd64")
+    def test_pull_all_covers_manifest(
+        self,
+        mock_arch: MagicMock,
+        mock_vmm: MagicMock,
+        mock_ensure: MagicMock,
+        tmp_path: Path,
+        capsys: pytest.CaptureFixture,
+    ) -> None:
+        from smolvm.images.manager import LocalImage
+        from smolvm.images.published import MANIFEST
+
+        kernel = tmp_path / "vmlinux.bin"
+        rootfs = tmp_path / "rootfs.ext4"
+        kernel.touch()
+        rootfs.touch()
+        mock_ensure.return_value = LocalImage(name="x", kernel_path=kernel, rootfs_path=rootfs)
+
+        ret = main(["image", "pull", "--all", "--image-dir", str(tmp_path), "--json"])
+
+        assert ret == 0
+        payload = json.loads(capsys.readouterr().out)
+        assert payload["command"] == "image.pull"
+        expected = sorted(
+            {(p, o) for (p, a, v, o) in MANIFEST if a == "amd64" and v == "firecracker"}
+        )
+        assert len(payload["data"]["pulled"]) == len(expected)
+        assert payload["data"]["failed"] == []
+        called = sorted((c.args[0], c.args[3]) for c in mock_ensure.call_args_list)
+        assert called == expected
+
+    @patch("smolvm.images.published.ensure_published_image")
+    @patch("smolvm.cli.main._vmm_for_host", return_value="firecracker")
+    @patch("smolvm.cli.main._host_arch_for_published", return_value="amd64")
+    def test_pull_all_isolates_failures(
+        self,
+        mock_arch: MagicMock,
+        mock_vmm: MagicMock,
+        mock_ensure: MagicMock,
+        tmp_path: Path,
+        capsys: pytest.CaptureFixture,
+    ) -> None:
+        from smolvm.exceptions import ImageError
+        from smolvm.images.manager import LocalImage
+
+        kernel = tmp_path / "vmlinux.bin"
+        rootfs = tmp_path / "rootfs.ext4"
+        kernel.touch()
+        rootfs.touch()
+
+        def flaky(preset: str, *args: object, **kwargs: object) -> LocalImage:
+            if preset == "codex":
+                raise ImageError("boom")
+            return LocalImage(name="x", kernel_path=kernel, rootfs_path=rootfs)
+
+        mock_ensure.side_effect = flaky
+
+        ret = main(["image", "pull", "--all", "--image-dir", str(tmp_path), "--json"])
+
+        assert ret == 1
+        payload = json.loads(capsys.readouterr().out)
+        assert payload["ok"] is False
+        details = payload["error"]["details"]
+        assert {f["preset"] for f in details["failed"]} == {"codex"}
+        assert details["pulled"]  # other presets still downloaded
+        assert "smolvm image pull --all" in payload["error"]["recovery"]
+
+    @patch("smolvm.images.published.ensure_published_image")
+    @patch("smolvm.cli.main._vmm_for_host", return_value="firecracker")
+    @patch("smolvm.cli.main._host_arch_for_published", return_value="amd64")
+    def test_pull_all_os_filter(
+        self,
+        mock_arch: MagicMock,
+        mock_vmm: MagicMock,
+        mock_ensure: MagicMock,
+        tmp_path: Path,
+        capsys: pytest.CaptureFixture,
+    ) -> None:
+        from smolvm.images.manager import LocalImage
+
+        kernel = tmp_path / "vmlinux.bin"
+        rootfs = tmp_path / "rootfs.ext4"
+        kernel.touch()
+        rootfs.touch()
+        mock_ensure.return_value = LocalImage(name="x", kernel_path=kernel, rootfs_path=rootfs)
+
+        ret = main(
+            ["image", "pull", "--all", "--os", "alpine", "--image-dir", str(tmp_path), "--json"]
+        )
+
+        assert ret == 0
+        capsys.readouterr()
+        assert all(c.args[3] == "alpine" for c in mock_ensure.call_args_list)
+
+
+class TestCustomImages:
+    def _make_custom(self, root: Path, name: str = "myimg") -> Path:
+        fp = root / "custom" / name / "abc123def4567890"
+        fp.mkdir(parents=True)
+        (fp / "metadata.json").write_text(json.dumps({"name": name, "arch": "amd64"}))
+        (fp / "rootfs.ext4").write_bytes(b"rootfs")
+        return fp
+
+    def test_list_shows_custom_rows(self, tmp_path: Path, capsys: pytest.CaptureFixture) -> None:
+        self._make_custom(tmp_path)
+
+        ret = main(["image", "list", "--image-dir", str(tmp_path), "--json"])
+
+        assert ret == 0
+        rows = json.loads(capsys.readouterr().out)["data"]["images"]
+        assert len(rows) == 1
+        row = rows[0]
+        assert row["kind"] == "custom"
+        assert row["name"] == "custom/myimg"
+        assert row["version"] == "abc123def456"
+        assert row["arch"] == "amd64"
+
+    def test_rm_custom_name_removes_tree(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture
+    ) -> None:
+        self._make_custom(tmp_path)
+
+        ret = main(["image", "rm", "custom/myimg", "--image-dir", str(tmp_path), "--json"])
+
+        assert ret == 0
+        payload = json.loads(capsys.readouterr().out)
+        assert [e["name"] for e in payload["data"]["removed"]] == ["custom/myimg"]
+        assert not (tmp_path / "custom" / "myimg").exists()
+
+    def test_rm_custom_fingerprint(self, tmp_path: Path, capsys: pytest.CaptureFixture) -> None:
+        fp = self._make_custom(tmp_path)
+
+        ret = main(
+            ["image", "rm", f"custom/myimg/{fp.name}", "--image-dir", str(tmp_path), "--json"]
+        )
+
+        assert ret == 0
+        capsys.readouterr()
+        assert not fp.exists()
+        assert (tmp_path / "custom" / "myimg").exists()
+
+    @pytest.mark.parametrize("bad", ["custom/../x", "custom//x", "custom/a/b/c", "other/x"])
+    def test_rm_rejects_bad_custom_names(
+        self, bad: str, tmp_path: Path, capsys: pytest.CaptureFixture
+    ) -> None:
+        ret = main(["image", "rm", bad, "--image-dir", str(tmp_path), "--json"])
+
+        assert ret == 2
+        payload = json.loads(capsys.readouterr().out)
+        assert payload["error"]["code"] == "invalid_input"

--- a/tests/test_image_cmd.py
+++ b/tests/test_image_cmd.py
@@ -17,14 +17,16 @@
 from __future__ import annotations
 
 import json
+import os
 import re
 from pathlib import Path
 
 import pytest
 
 from smolvm import __version__
+from smolvm.cli.image import _IMAGE_DIR_NAME_RE, _KERNEL_DIR_NAME_RE
 from smolvm.cli.main import main
-from smolvm.cli.prune import find_stale_caches
+from smolvm.cli.prune import _format_bytes, _total_size, find_stale_caches
 from smolvm.images.manager import IMAGE_DIR_ENV, ImageManager, resolve_image_dir
 
 
@@ -66,6 +68,24 @@ class TestResolveImageDir:
     def test_blank_env_var_falls_through(self, monkeypatch: pytest.MonkeyPatch) -> None:
         monkeypatch.setenv(IMAGE_DIR_ENV, "  ")
         assert resolve_image_dir() == Path.home() / ".smolvm" / "images"
+
+    def test_blank_explicit_arg_falls_through(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """`--image-dir "$UNSET"` must never target the current directory."""
+        monkeypatch.delenv(IMAGE_DIR_ENV, raising=False)
+        assert resolve_image_dir("") == Path.home() / ".smolvm" / "images"
+        assert resolve_image_dir("   ") == Path.home() / ".smolvm" / "images"
+        monkeypatch.setenv(IMAGE_DIR_ENV, str(tmp_path / "env"))
+        assert resolve_image_dir("") == tmp_path / "env"
+
+    def test_unknown_user_tilde_does_not_crash(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """expanduser failures fall back to the path as written (regression:
+        a '~typo/...' value used to escape as a raw RuntimeError)."""
+        monkeypatch.delenv(IMAGE_DIR_ENV, raising=False)
+        assert resolve_image_dir("~nosuchuser-xyz/dir") == Path("~nosuchuser-xyz/dir")
+        monkeypatch.setenv(IMAGE_DIR_ENV, "~nosuchuser-xyz/dir")
+        assert resolve_image_dir() == Path("~nosuchuser-xyz/dir")
 
     def test_does_not_create_the_directory(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
@@ -113,6 +133,57 @@ class TestResolveImageDir:
         assert find_stale_caches(current_version="9.9.9") == [stale]
 
 
+class TestSizeHelpers:
+    def test_format_bytes_keeps_fractions(self) -> None:
+        assert _format_bytes(0) == "0.0 B"
+        assert _format_bytes(1536) == "1.5 KiB"
+        assert _format_bytes(2_040_109_465) == "1.9 GiB"
+
+    def test_total_size_is_sparse_aware(self, tmp_path: Path) -> None:
+        sparse = tmp_path / "rootfs.ext4"
+        with sparse.open("wb") as f:
+            f.truncate(64 * 1024 * 1024)  # 64 MiB apparent, ~0 allocated
+            f.write(b"x")
+        apparent = sparse.stat().st_size
+        on_disk = _total_size(tmp_path)
+        assert apparent >= 64 * 1024 * 1024
+        if getattr(os.stat(sparse), "st_blocks", None) is not None:
+            assert on_disk < apparent
+
+    def test_total_size_tolerates_missing_path(self, tmp_path: Path) -> None:
+        assert _total_size(tmp_path / "gone") == 0
+
+
+class TestCacheNameParsing:
+    def test_round_trips_every_manifest_entry(self) -> None:
+        """The list/rm parser must recognize everything cache_name() emits."""
+        from smolvm.images.published import MANIFEST, cache_name
+
+        for preset, arch, vmm, os_name in MANIFEST:
+            for version in ("0.0.26", "0.0.14a0", "0.0.24.post3", "1.2.3.dev1"):
+                name = cache_name(preset, arch, vmm, version, os=os_name)
+                match = _IMAGE_DIR_NAME_RE.match(name)
+                assert match is not None, f"unparsed cache name: {name}"
+                assert match["preset"] == preset
+                assert match["version"] == version
+                assert match["arch"] == arch
+                assert match["vmm"] == vmm
+                assert (match["os"] or "ubuntu") == os_name
+
+    def test_kernel_names_round_trip(self) -> None:
+        for version in ("0.0.26", "0.0.24.post3"):
+            name = f"base-kernel-v{version}-amd64"
+            match = _KERNEL_DIR_NAME_RE.match(name)
+            assert match is not None
+            assert match["version"] == version
+
+    def test_prune_matches_dotted_suffix_versions(self, tmp_path: Path) -> None:
+        """Shipped 0.0.24.postN caches must be prunable (regression)."""
+        stale = tmp_path / "codex-v0.0.24.post3-amd64-firecracker"
+        stale.mkdir()
+        assert find_stale_caches(cache_dir=tmp_path, current_version="9.9.9") == [stale]
+
+
 class TestImageList:
     def test_list_json_classifies_entries(
         self, tmp_path: Path, capsys: pytest.CaptureFixture
@@ -137,7 +208,8 @@ class TestImageList:
         assert codex["vmm"] == "firecracker"
         assert codex["os"] == "ubuntu"
         assert codex["current"] is False
-        assert codex["size_bytes"] == 5
+        assert codex["size_bytes"] == _total_size(tmp_path / "codex-v0.0.1-amd64-firecracker")
+        assert codex["size_bytes"] > 0
 
         # Non-greedy preset parse: hyphenated preset with alpine suffix.
         claude = rows["claude-code-v0.0.1-arm64-qemu-alpine"]
@@ -157,7 +229,25 @@ class TestImageList:
         assert rows["s3"]["current"] is None
         assert rows["_guest-agent"]["kind"] == "other"
 
-        assert payload["data"]["total_size_bytes"] == 17
+        assert payload["data"]["total_size_bytes"] == sum(
+            row["size_bytes"] for row in payload["data"]["images"]
+        )
+
+    def test_list_classifies_dotted_suffix_versions(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture
+    ) -> None:
+        """Shipped 0.0.24.postN caches parse as images, not 'other' (regression)."""
+        (tmp_path / "codex-v0.0.24.post3-amd64-firecracker").mkdir(parents=True)
+
+        ret = main(["image", "list", "--image-dir", str(tmp_path), "--json"])
+
+        assert ret == 0
+        payload = json.loads(capsys.readouterr().out)
+        row = payload["data"]["images"][0]
+        assert row["kind"] == "image"
+        assert row["preset"] == "codex"
+        assert row["version"] == "0.0.24.post3"
+        assert row["current"] is False
 
     def test_list_missing_dir_is_empty(self, tmp_path: Path, capsys: pytest.CaptureFixture) -> None:
         ret = main(["image", "list", "--image-dir", str(tmp_path / "missing"), "--json"])
@@ -176,7 +266,7 @@ class TestImageList:
         # Rich wraps the panel mid-word with box-drawing borders; strip
         # everything but letters/digits so the recovery command is findable.
         flattened = re.sub(r"[^a-z0-9]+", "", capsys.readouterr().out.lower())
-        assert "smolvmimagepull" in flattened
+        assert "smolvmimagepullcodex" in flattened
 
     def test_list_env_var_default(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture
@@ -191,10 +281,28 @@ class TestImageList:
         assert payload["data"]["image_dir"] == str(tmp_path)
         assert len(payload["data"]["images"]) == 6
 
+    def test_list_unreadable_dir_reports_error_envelope(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Permission failures produce the JSON envelope, not a traceback."""
+
+        def boom(self: Path) -> None:
+            raise PermissionError(13, "Permission denied", str(self))
+
+        monkeypatch.setattr(Path, "iterdir", boom)
+
+        ret = main(["image", "list", "--image-dir", str(tmp_path), "--json"])
+
+        assert ret == 1
+        payload = json.loads(capsys.readouterr().out)
+        assert payload["ok"] is False
+        assert "permission" in payload["error"]["recovery"].lower()
+
 
 class TestImageRm:
     def test_rm_exact_name(self, tmp_path: Path, capsys: pytest.CaptureFixture) -> None:
         _make_cache_dirs(tmp_path)
+        expected_freed = _total_size(tmp_path / "codex-v0.0.1-amd64-firecracker")
 
         ret = main(
             [
@@ -211,15 +319,43 @@ class TestImageRm:
         payload = json.loads(capsys.readouterr().out)
         assert payload["command"] == "image.rm"
         assert [e["name"] for e in payload["data"]["removed"]] == ["codex-v0.0.1-amd64-firecracker"]
-        assert payload["data"]["freed_bytes"] == 5
+        assert payload["data"]["freed_bytes"] == expected_freed
+        assert expected_freed > 0
         assert not (tmp_path / "codex-v0.0.1-amd64-firecracker").exists()
         # The other codex version is untouched by an exact-name removal.
         assert (tmp_path / f"codex-v{__version__}-arm64-qemu").exists()
+
+    def test_rm_accepts_trailing_slash_and_list_path(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture
+    ) -> None:
+        """Tab-completed names and the path `image list` prints both work."""
+        _make_cache_dirs(tmp_path)
+
+        ret = main(
+            [
+                "image",
+                "rm",
+                "codex-v0.0.1-amd64-firecracker/",
+                "--image-dir",
+                str(tmp_path),
+                "--json",
+            ]
+        )
+        assert ret == 0
+        capsys.readouterr()
+        assert not (tmp_path / "codex-v0.0.1-amd64-firecracker").exists()
+
+        full_path = str(tmp_path / "base-kernel-v0.0.1-amd64")
+        ret = main(["image", "rm", full_path, "--image-dir", str(tmp_path), "--json"])
+        assert ret == 0
+        payload = json.loads(capsys.readouterr().out)
+        assert [e["name"] for e in payload["data"]["removed"]] == ["base-kernel-v0.0.1-amd64"]
 
     def test_rm_by_preset_removes_all_versions(
         self, tmp_path: Path, capsys: pytest.CaptureFixture
     ) -> None:
         _make_cache_dirs(tmp_path)
+        (tmp_path / "codex-v0.0.24.post3-amd64-firecracker").mkdir()
 
         ret = main(["image", "rm", "codex", "--image-dir", str(tmp_path), "--json"])
 
@@ -229,24 +365,34 @@ class TestImageRm:
         assert removed == {
             "codex-v0.0.1-amd64-firecracker",
             f"codex-v{__version__}-arm64-qemu",
+            "codex-v0.0.24.post3-amd64-firecracker",
         }
-        assert payload["data"]["freed_bytes"] == 12
+        assert payload["data"]["freed_bytes"] > 0
         # Unrelated entries survive preset-wide removal.
         assert (tmp_path / "s3").exists()
         assert (tmp_path / "_guest-agent").exists()
         assert (tmp_path / "base-kernel-v0.0.1-amd64").exists()
         assert (tmp_path / "claude-code-v0.0.1-arm64-qemu-alpine").exists()
 
-    def test_rm_claude_alias(self, tmp_path: Path, capsys: pytest.CaptureFixture) -> None:
+    @pytest.mark.parametrize(
+        ("alias", "expected"),
+        [
+            ("claude", "claude-code-v0.0.1-arm64-qemu-alpine"),
+            ("claw", "openclaw-v0.0.1-amd64-firecracker"),
+        ],
+    )
+    def test_rm_preset_aliases(
+        self, alias: str, expected: str, tmp_path: Path, capsys: pytest.CaptureFixture
+    ) -> None:
+        """Aliases come from the presets registry, not a hardcoded map."""
         _make_cache_dirs(tmp_path)
+        (tmp_path / "openclaw-v0.0.1-amd64-firecracker").mkdir()
 
-        ret = main(["image", "rm", "claude", "--image-dir", str(tmp_path), "--json"])
+        ret = main(["image", "rm", alias, "--image-dir", str(tmp_path), "--json"])
 
         assert ret == 0
         payload = json.loads(capsys.readouterr().out)
-        assert [e["name"] for e in payload["data"]["removed"]] == [
-            "claude-code-v0.0.1-arm64-qemu-alpine"
-        ]
+        assert [e["name"] for e in payload["data"]["removed"]] == [expected]
 
     def test_rm_dry_run_removes_nothing(
         self, tmp_path: Path, capsys: pytest.CaptureFixture
@@ -258,7 +404,7 @@ class TestImageRm:
         assert ret == 0
         payload = json.loads(capsys.readouterr().out)
         assert payload["data"]["dry_run"] is True
-        assert payload["data"]["would_free_bytes"] == 12
+        assert payload["data"]["would_free_bytes"] > 0
         assert (tmp_path / "codex-v0.0.1-amd64-firecracker").exists()
 
     def test_rm_unknown_name_fails_with_recovery(
@@ -273,7 +419,7 @@ class TestImageRm:
         assert payload["ok"] is False
         assert "smolvm image list" in payload["error"]["recovery"]
 
-    @pytest.mark.parametrize("name", ["../evil", "a/b", "..", "."])
+    @pytest.mark.parametrize("name", ["../evil", "a/b", "..", ".", "/somewhere/else/evil"])
     def test_rm_rejects_traversal_names(
         self, name: str, tmp_path: Path, capsys: pytest.CaptureFixture
     ) -> None:
@@ -286,7 +432,28 @@ class TestImageRm:
         assert payload["error"]["code"] == "invalid_input"
         assert (tmp_path / "evil").exists()
 
-    def test_rm_refuses_symlink_escaping_root(
+    def test_rm_symlink_unlinks_without_touching_target(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture
+    ) -> None:
+        """Symlink entries are unlinked in place — never followed, never
+        rmtree'd (regression: rmtree on a symlink used to crash)."""
+        root = tmp_path / "images"
+        root.mkdir()
+        real = root / "codex-v0.0.1-amd64-firecracker"
+        real.mkdir()
+        (real / "rootfs.ext4").write_text("data")
+        (root / "old-codex").symlink_to(real)
+
+        ret = main(["image", "rm", "old-codex", "--image-dir", str(root), "--json"])
+
+        assert ret == 0
+        payload = json.loads(capsys.readouterr().out)
+        assert [e["name"] for e in payload["data"]["removed"]] == ["old-codex"]
+        assert payload["data"]["freed_bytes"] == 0
+        assert not (root / "old-codex").exists()
+        assert (real / "rootfs.ext4").exists()
+
+    def test_rm_symlink_outside_root_only_removes_link(
         self, tmp_path: Path, capsys: pytest.CaptureFixture
     ) -> None:
         root = tmp_path / "images"
@@ -298,9 +465,10 @@ class TestImageRm:
 
         ret = main(["image", "rm", "escape", "--image-dir", str(root), "--json"])
 
-        assert ret == 1
+        assert ret == 0
         payload = json.loads(capsys.readouterr().out)
-        assert payload["ok"] is False
+        assert [e["name"] for e in payload["data"]["removed"]] == ["escape"]
+        assert not (root / "escape").exists()
         assert (outside / "data").exists()
 
 
@@ -313,6 +481,20 @@ class TestPruneAlias:
         assert ret == 0
         payload = json.loads(capsys.readouterr().out)
         assert payload["command"] == "prune"
+
+    def test_top_level_prune_accepts_image_dir(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture
+    ) -> None:
+        """The documented alias takes the same --image-dir flag as the group."""
+        stale = tmp_path / "codex-v0.0.1-amd64-firecracker"
+        stale.mkdir()
+
+        ret = main(["prune", "--image-dir", str(tmp_path), "--dry-run", "--json"])
+
+        assert ret == 0
+        payload = json.loads(capsys.readouterr().out)
+        assert payload["command"] == "prune"
+        assert payload["data"]["would_remove"]
 
     def test_image_prune_uses_dotted_command_name(
         self, tmp_path: Path, capsys: pytest.CaptureFixture
@@ -338,3 +520,26 @@ class TestPruneAlias:
         assert not (tmp_path / "base-kernel-v0.0.1-amd64").exists()
         assert (tmp_path / f"codex-v{__version__}-arm64-qemu").exists()
         assert (tmp_path / "s3").exists()
+
+
+class TestChoiceListsMatchPublishedTypes:
+    def test_pull_option_choices_track_published_literals(self) -> None:
+        """The hardcoded click.Choice lists must not drift from the manifest
+        type literals (they are hardcoded to keep published.py off the CLI
+        import path)."""
+        import typing
+
+        import click
+
+        from smolvm.cli.main import build_cli
+        from smolvm.images.published import Arch, Os, Vmm
+
+        pull = build_cli().commands["image"].commands["pull"]  # type: ignore[attr-defined]
+        choices = {
+            param.name: set(param.type.choices)
+            for param in pull.params
+            if isinstance(param.type, click.Choice)
+        }
+        assert choices["arch"] == set(typing.get_args(Arch))
+        assert choices["vmm"] == set(typing.get_args(Vmm))
+        assert choices["os_name"] == set(typing.get_args(Os))

--- a/tests/test_image_cmd.py
+++ b/tests/test_image_cmd.py
@@ -1011,3 +1011,51 @@ class TestPullAllRecovery:
         recovery = payload["error"]["recovery"]
         assert "smolvm image pull --all" in recovery
         assert "--os" not in recovery
+
+
+class TestUpstreamReviewRegressions:
+    def test_image_ls_parse_error_reports_list_envelope(
+        self, capsys: pytest.CaptureFixture
+    ) -> None:
+        """Usage errors on the ls alias must report the canonical
+        image.list command (regression: argv fallback said image.ls)."""
+        ret = main(["image", "ls", "--not-a-flag", "--json"])
+
+        assert ret == 2
+        payload = json.loads(capsys.readouterr().out)
+        assert payload["command"] == "image.list"
+
+    def test_prune_unlinks_symlinked_stale_entries(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture
+    ) -> None:
+        """Prune must unlink symlinked entries, not crash rmtree, and must
+        never follow the link (regression)."""
+        real = tmp_path / "real-data"
+        real.mkdir()
+        (real / "keep").write_text("keep")
+        (tmp_path / "codex-v0.0.1-amd64-firecracker").symlink_to(real)
+
+        ret = main(["prune", "--image-dir", str(tmp_path), "--json"])
+
+        assert ret == 0
+        capsys.readouterr()
+        assert not (tmp_path / "codex-v0.0.1-amd64-firecracker").exists()
+        assert (real / "keep").exists()
+
+    def test_guest_agent_cache_dir_honors_explicit_cache_dir(self, tmp_path: Path) -> None:
+        """An explicit builder cache_dir must reach the guest-agent cache
+        (regression: it always used the global default)."""
+        from smolvm.images.builder import _guest_agent_binary_cache_dir
+
+        assert _guest_agent_binary_cache_dir(tmp_path) == tmp_path / "_guest-agent"
+
+    @pytest.mark.parametrize("name", ["custom/.hidden", "custom/web/.fp"])
+    def test_dot_prefixed_custom_segments_rejected(
+        self, name: str, tmp_path: Path, capsys: pytest.CaptureFixture
+    ) -> None:
+        """Dot-prefixed custom names would be invisible to image list."""
+        ret = main(["image", "rm", name, "--image-dir", str(tmp_path), "--json"])
+
+        assert ret == 2
+        payload = json.loads(capsys.readouterr().out)
+        assert payload["error"]["code"] == "invalid_input"

--- a/tests/test_image_transfer.py
+++ b/tests/test_image_transfer.py
@@ -1,0 +1,303 @@
+# Copyright 2026 Celesto AI
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for `smolvm image save` / `smolvm image load`."""
+
+from __future__ import annotations
+
+import hashlib
+import io
+import json
+import os
+import tarfile
+from pathlib import Path
+from typing import Any
+
+import pytest
+import zstandard
+
+from smolvm.cli.main import main
+
+_SPARSE_PAYLOAD = b"\x00" * (1 << 20) + b"REAL-DATA" + b"\x00" * (1 << 20)
+
+
+def _make_published_entry(root: Path, name: str) -> Path:
+    d = root / name
+    d.mkdir(parents=True)
+    (d / "rootfs.ext4.zst").write_bytes(zstandard.compress(_SPARSE_PAYLOAD))
+    sha = hashlib.sha256((d / "rootfs.ext4.zst").read_bytes()).hexdigest()
+    (d / "rootfs.ext4.from-sha256").write_text(f"sparse-v1:{sha}")
+    (d / "vmlinux.bin").write_bytes(b"kernel-bytes")
+    with open(d / "rootfs.ext4", "wb") as f:
+        f.truncate(len(_SPARSE_PAYLOAD))
+        f.seek(1 << 20)
+        f.write(b"REAL-DATA")
+    return d
+
+
+def _write_archive(
+    path: Path, manifest: dict[str, Any], members: list[tarfile.TarInfo | tuple[str, bytes]]
+) -> None:
+    with tarfile.open(path, "w") as tar:
+        blob = json.dumps(manifest).encode()
+        info = tarfile.TarInfo("manifest.json")
+        info.size = len(blob)
+        tar.addfile(info, io.BytesIO(blob))
+        for member in members:
+            if isinstance(member, tuple):
+                name, data = member
+                info = tarfile.TarInfo(name)
+                info.size = len(data)
+                tar.addfile(info, io.BytesIO(data))
+            else:
+                tar.addfile(member)
+
+
+class TestSaveLoadRoundTrip:
+    def test_published_entry_round_trips(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture
+    ) -> None:
+        src = tmp_path / "src"
+        entry = _make_published_entry(src, "codex-v0.0.1-amd64-firecracker")
+        archive = tmp_path / "codex.tar"
+
+        ret = main(
+            ["image", "save", "codex", "--image-dir", str(src), "-o", str(archive), "--json"]
+        )
+        assert ret == 0
+        payload = json.loads(capsys.readouterr().out)
+        assert payload["command"] == "image.save"
+        assert payload["data"]["excluded_decompressed_rootfs"] is True
+
+        # The multi-MB decompressed rootfs never travels.
+        with tarfile.open(archive) as tar:
+            names = tar.getnames()
+        assert names[0] == "manifest.json"
+        assert "files/rootfs.ext4" not in names
+        assert "files/rootfs.ext4.zst" in names
+        assert archive.stat().st_size < 64 * 1024
+
+        dest = tmp_path / "dest"
+        ret = main(["image", "load", "-i", str(archive), "--image-dir", str(dest), "--json"])
+        assert ret == 0
+        payload = json.loads(capsys.readouterr().out)
+        assert payload["command"] == "image.load"
+
+        loaded = dest / "codex-v0.0.1-amd64-firecracker"
+        assert sorted(p.name for p in loaded.iterdir()) == [
+            "rootfs.ext4",
+            "rootfs.ext4.from-sha256",
+            "rootfs.ext4.zst",
+            "vmlinux.bin",
+        ]
+        # Sidecar reproduced exactly, so ensure_published_image accepts it.
+        assert (loaded / "rootfs.ext4.from-sha256").read_text() == (
+            entry / "rootfs.ext4.from-sha256"
+        ).read_text()
+        # Rootfs content intact and holes restored.
+        with open(loaded / "rootfs.ext4", "rb") as f:
+            f.seek(1 << 20)
+            assert f.read(9) == b"REAL-DATA"
+        st = os.stat(loaded / "rootfs.ext4")
+        if getattr(st, "st_blocks", None) is not None:
+            assert st.st_blocks * 512 < st.st_size
+
+    def test_custom_entry_round_trips(self, tmp_path: Path, capsys: pytest.CaptureFixture) -> None:
+        src = tmp_path / "src"
+        fp = src / "custom" / "myimg" / "abc123def4567890"
+        fp.mkdir(parents=True)
+        (fp / "metadata.json").write_text(json.dumps({"name": "myimg", "arch": "amd64"}))
+        (fp / "rootfs.ext4").write_bytes(b"custom-rootfs")
+        (fp / ".build.lock").write_text("")
+        archive = tmp_path / "myimg.tar"
+
+        ret = main(
+            [
+                "image",
+                "save",
+                "custom/myimg",
+                "--image-dir",
+                str(src),
+                "-o",
+                str(archive),
+                "--json",
+            ]
+        )
+        assert ret == 0
+        capsys.readouterr()
+
+        with tarfile.open(archive) as tar:
+            names = tar.getnames()
+        assert "files/.build.lock" not in names and "files/.build.lock.zst" not in names
+
+        dest = tmp_path / "dest"
+        ret = main(["image", "load", "-i", str(archive), "--image-dir", str(dest), "--json"])
+        assert ret == 0
+        capsys.readouterr()
+        loaded = dest / "custom" / "myimg" / "abc123def4567890"
+        assert (loaded / "rootfs.ext4").read_bytes() == b"custom-rootfs"
+        assert json.loads((loaded / "metadata.json").read_text())["arch"] == "amd64"
+
+    def test_load_refuses_overwrite_without_force(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture
+    ) -> None:
+        src = tmp_path / "src"
+        _make_published_entry(src, "codex-v0.0.1-amd64-firecracker")
+        archive = tmp_path / "codex.tar"
+        assert main(["image", "save", "codex", "--image-dir", str(src), "-o", str(archive)]) == 0
+        capsys.readouterr()
+
+        dest = tmp_path / "dest"
+        assert main(["image", "load", "-i", str(archive), "--image-dir", str(dest)]) == 0
+        capsys.readouterr()
+
+        ret = main(["image", "load", "-i", str(archive), "--image-dir", str(dest), "--json"])
+        assert ret == 1
+        payload = json.loads(capsys.readouterr().out)
+        assert "--force" in payload["error"]["recovery"]
+
+        ret = main(
+            ["image", "load", "-i", str(archive), "--image-dir", str(dest), "--force", "--json"]
+        )
+        assert ret == 0
+
+    def test_save_ambiguous_preset_lists_options(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture
+    ) -> None:
+        src = tmp_path / "src"
+        _make_published_entry(src, "codex-v0.0.1-amd64-firecracker")
+        _make_published_entry(src, "codex-v0.0.2-amd64-qemu")
+
+        ret = main(
+            [
+                "image",
+                "save",
+                "codex",
+                "--image-dir",
+                str(src),
+                "-o",
+                str(tmp_path / "x.tar"),
+                "--json",
+            ]
+        )
+        assert ret == 2
+        payload = json.loads(capsys.readouterr().out)
+        assert "codex-v0.0.1-amd64-firecracker" in payload["error"]["message"]
+        assert "codex-v0.0.2-amd64-qemu" in payload["error"]["message"]
+
+
+class TestLoadRejectsMaliciousArchives:
+    def _assert_rejected(
+        self, archive: Path, dest: Path, capsys: pytest.CaptureFixture
+    ) -> dict[str, Any]:
+        ret = main(["image", "load", "-i", str(archive), "--image-dir", str(dest), "--json"])
+        assert ret == 2
+        payload = json.loads(capsys.readouterr().out)
+        assert payload["ok"] is False
+        # Nothing may be written outside (or inside) the destination.
+        assert not dest.exists() or not any(dest.iterdir())
+        return dict(payload)
+
+    def test_traversal_path_in_manifest(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture
+    ) -> None:
+        archive = tmp_path / "evil.tar"
+        _write_archive(
+            archive,
+            {
+                "schema_version": 1,
+                "name": "evil",
+                "rootfs_sidecar": None,
+                "files": [{"path": "../../escape", "encoding": "raw", "size": 4}],
+            },
+            [("files/../../escape", b"boom")],
+        )
+        self._assert_rejected(archive, tmp_path / "dest", capsys)
+        assert not (tmp_path / "escape").exists()
+
+    def test_absolute_member_name(self, tmp_path: Path, capsys: pytest.CaptureFixture) -> None:
+        archive = tmp_path / "evil.tar"
+        _write_archive(
+            archive,
+            {
+                "schema_version": 1,
+                "name": "evil",
+                "rootfs_sidecar": None,
+                "files": [{"path": "/etc/passwd", "encoding": "raw", "size": 4}],
+            },
+            [("files//etc/passwd", b"boom")],
+        )
+        self._assert_rejected(archive, tmp_path / "dest", capsys)
+
+    def test_symlink_member_rejected(self, tmp_path: Path, capsys: pytest.CaptureFixture) -> None:
+        archive = tmp_path / "evil.tar"
+        link = tarfile.TarInfo("files/link")
+        link.type = tarfile.SYMTYPE
+        link.linkname = "/etc/passwd"
+        _write_archive(
+            archive,
+            {
+                "schema_version": 1,
+                "name": "evil",
+                "rootfs_sidecar": None,
+                "files": [{"path": "link", "encoding": "raw", "size": 0}],
+            },
+            [link],
+        )
+        self._assert_rejected(archive, tmp_path / "dest", capsys)
+
+    def test_undeclared_member_rejected(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture
+    ) -> None:
+        archive = tmp_path / "evil.tar"
+        _write_archive(
+            archive,
+            {"schema_version": 1, "name": "ok-name", "rootfs_sidecar": None, "files": []},
+            [("files/surprise", b"boom")],
+        )
+        self._assert_rejected(archive, tmp_path / "dest", capsys)
+
+    def test_bad_entry_name_rejected(self, tmp_path: Path, capsys: pytest.CaptureFixture) -> None:
+        archive = tmp_path / "evil.tar"
+        _write_archive(
+            archive,
+            {"schema_version": 1, "name": "../outside", "rootfs_sidecar": None, "files": []},
+            [],
+        )
+        self._assert_rejected(archive, tmp_path / "dest", capsys)
+
+    def test_newer_schema_names_update(self, tmp_path: Path, capsys: pytest.CaptureFixture) -> None:
+        archive = tmp_path / "future.tar"
+        _write_archive(
+            archive,
+            {"schema_version": 99, "name": "x", "rootfs_sidecar": None, "files": []},
+            [],
+        )
+        ret = main(
+            ["image", "load", "-i", str(archive), "--image-dir", str(tmp_path / "dest"), "--json"]
+        )
+        assert ret == 2
+        payload = json.loads(capsys.readouterr().out)
+        assert "smolvm update" in payload["error"]["recovery"]
+
+    def test_not_a_tar(self, tmp_path: Path, capsys: pytest.CaptureFixture) -> None:
+        bogus = tmp_path / "bogus.tar"
+        bogus.write_bytes(b"not a tar at all")
+
+        ret = main(
+            ["image", "load", "-i", str(bogus), "--image-dir", str(tmp_path / "dest"), "--json"]
+        )
+        assert ret == 2
+        payload = json.loads(capsys.readouterr().out)
+        assert "smolvm image save" in payload["error"]["recovery"]

--- a/tests/test_image_transfer.py
+++ b/tests/test_image_transfer.py
@@ -83,7 +83,7 @@ class TestSaveLoadRoundTrip:
         # The multi-MB decompressed rootfs never travels.
         with tarfile.open(archive) as tar:
             names = tar.getnames()
-        assert names[0] == "manifest.json"
+        assert "manifest.json" in names
         assert "files/rootfs.ext4" not in names
         assert "files/rootfs.ext4.zst" in names
         assert archive.stat().st_size < 64 * 1024
@@ -301,3 +301,204 @@ class TestLoadRejectsMaliciousArchives:
         assert ret == 2
         payload = json.loads(capsys.readouterr().out)
         assert "smolvm image save" in payload["error"]["recovery"]
+
+
+class TestArchiveRobustness:
+    def test_sibling_zst_pair_round_trips(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture
+    ) -> None:
+        """x and x.zst in one entry must both survive (regression: member
+        name collision silently dropped one)."""
+        src = tmp_path / "src"
+        entry = src / "oddball"
+        entry.mkdir(parents=True)
+        (entry / "data.txt").write_bytes(b"plain")
+        (entry / "data.txt.zst").write_bytes(zstandard.compress(b"compressed"))
+        archive = tmp_path / "odd.tar"
+
+        assert (
+            main(
+                ["image", "save", "oddball", "--image-dir", str(src), "-o", str(archive), "--json"]
+            )
+            == 0
+        )
+        capsys.readouterr()
+        dest = tmp_path / "dest"
+        assert main(["image", "load", "-i", str(archive), "--image-dir", str(dest), "--json"]) == 0
+        capsys.readouterr()
+
+        loaded = dest / "oddball"
+        assert (loaded / "data.txt").read_bytes() == b"plain"
+        assert (loaded / "data.txt.zst").read_bytes() == zstandard.compress(b"compressed")
+
+    def test_truncated_archive_gets_clean_envelope(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture
+    ) -> None:
+        """A cut-off transfer must produce the error envelope, not a
+        traceback (regression)."""
+        src = tmp_path / "src"
+        _make_published_entry(src, "codex-v0.0.1-amd64-firecracker")
+        archive = tmp_path / "codex.tar"
+        assert main(["image", "save", "codex", "--image-dir", str(src), "-o", str(archive)]) == 0
+        capsys.readouterr()
+        # Cut into the first member's data (small archives are mostly
+        # zero padding, so a percentage cut may remove nothing real).
+        data = archive.read_bytes()
+        archive.write_bytes(data[:700])
+
+        ret = main(
+            ["image", "load", "-i", str(archive), "--image-dir", str(tmp_path / "dest"), "--json"]
+        )
+
+        assert ret == 2
+        payload = json.loads(capsys.readouterr().out)
+        assert payload["error"]["code"] == "invalid_input"
+
+    def test_archive_missing_declared_member_is_rejected(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture
+    ) -> None:
+        """An archive whose manifest promises files it doesn't carry must
+        not load as success (regression)."""
+        archive = tmp_path / "short.tar"
+        _write_archive(
+            archive,
+            {
+                "schema_version": 1,
+                "name": "codex-v0.0.1-amd64-firecracker",
+                "rootfs_sidecar": None,
+                "files": [
+                    {"path": "vmlinux.bin", "encoding": "raw", "size": 4},
+                    {"path": "rootfs.ext4.zst", "encoding": "raw", "size": 4},
+                ],
+            },
+            [("files/vmlinux.bin", b"kern")],
+        )
+
+        ret = main(
+            ["image", "load", "-i", str(archive), "--image-dir", str(tmp_path / "dest"), "--json"]
+        )
+
+        assert ret == 2
+        payload = json.loads(capsys.readouterr().out)
+        assert "incomplete" in payload["error"]["message"]
+        assert not (tmp_path / "dest" / "codex-v0.0.1-amd64-firecracker").exists()
+
+    def test_size_mismatch_is_rejected(self, tmp_path: Path, capsys: pytest.CaptureFixture) -> None:
+        archive = tmp_path / "lying.tar"
+        _write_archive(
+            archive,
+            {
+                "schema_version": 1,
+                "name": "entry",
+                "rootfs_sidecar": None,
+                "files": [{"path": "blob", "encoding": "raw", "size": 3}],
+            },
+            [("files/blob", b"0123456789")],
+        )
+
+        ret = main(
+            ["image", "load", "-i", str(archive), "--image-dir", str(tmp_path / "dest"), "--json"]
+        )
+
+        assert ret == 2
+        payload = json.loads(capsys.readouterr().out)
+        assert "damaged" in payload["error"]["message"]
+        assert not (tmp_path / "dest" / "entry").exists()
+
+    def test_load_force_replaces_symlinked_entry(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture
+    ) -> None:
+        """--force onto a symlinked entry must replace the link, not crash
+        (regression: rmtree refused symlinks)."""
+        src = tmp_path / "src"
+        _make_published_entry(src, "codex-v0.0.1-amd64-firecracker")
+        archive = tmp_path / "codex.tar"
+        assert main(["image", "save", "codex", "--image-dir", str(src), "-o", str(archive)]) == 0
+        capsys.readouterr()
+
+        dest = tmp_path / "dest"
+        dest.mkdir()
+        outside = tmp_path / "outside"
+        outside.mkdir()
+        (outside / "keep").write_text("keep")
+        (dest / "codex-v0.0.1-amd64-firecracker").symlink_to(outside)
+
+        ret = main(
+            ["image", "load", "-i", str(archive), "--image-dir", str(dest), "--force", "--json"]
+        )
+
+        assert ret == 0
+        capsys.readouterr()
+        loaded = dest / "codex-v0.0.1-amd64-firecracker"
+        assert not loaded.is_symlink()
+        assert (loaded / "vmlinux.bin").is_file()
+        assert (outside / "keep").exists()
+
+    def test_save_to_directory_gets_clean_envelope(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture
+    ) -> None:
+        """-o pointing at a folder must error cleanly, not traceback in
+        cleanup (regression)."""
+        src = tmp_path / "src"
+        _make_published_entry(src, "codex-v0.0.1-amd64-firecracker")
+
+        ret = main(
+            ["image", "save", "codex", "--image-dir", str(src), "-o", str(tmp_path), "--json"]
+        )
+
+        assert ret == 2
+        payload = json.loads(capsys.readouterr().out)
+        assert payload["error"]["code"] == "invalid_input"
+        assert "-o" in payload["error"]["message"]
+
+    def test_failed_save_preserves_existing_archive(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture
+    ) -> None:
+        """A failing save must never destroy a pre-existing file at -o
+        (regression: cleanup unlinked it)."""
+        from unittest.mock import patch
+
+        src = tmp_path / "src"
+        entry = src / "entry"
+        entry.mkdir(parents=True)
+        (entry / "blob").write_bytes(b"x")
+        archive = tmp_path / "precious.tar"
+        archive.write_bytes(b"OLD ARCHIVE")
+
+        with patch("zstandard.ZstdCompressor") as mock_compressor:
+            mock_compressor.return_value.copy_stream.side_effect = OSError(28, "No space left")
+            ret = main(
+                ["image", "save", "entry", "--image-dir", str(src), "-o", str(archive), "--json"]
+            )
+
+        assert ret == 1
+        payload = json.loads(capsys.readouterr().out)
+        assert payload["ok"] is False
+        assert archive.read_bytes() == b"OLD ARCHIVE"
+        assert not archive.with_name("precious.tar.partial").exists()
+
+    def test_save_warns_about_skipped_links(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture
+    ) -> None:
+        src = tmp_path / "src"
+        entry = src / "entry"
+        entry.mkdir(parents=True)
+        (entry / "blob").write_bytes(b"x")
+        (entry / "link").symlink_to(entry / "blob")
+
+        ret = main(
+            [
+                "image",
+                "save",
+                "entry",
+                "--image-dir",
+                str(src),
+                "-o",
+                str(tmp_path / "e.tar"),
+                "--json",
+            ]
+        )
+
+        assert ret == 0
+        payload = json.loads(capsys.readouterr().out)
+        assert any("link" in w for w in payload["data"]["warnings"])

--- a/tests/test_image_transfer.py
+++ b/tests/test_image_transfer.py
@@ -367,8 +367,18 @@ class TestArchiveRobustness:
                 "name": "codex-v0.0.1-amd64-firecracker",
                 "rootfs_sidecar": None,
                 "files": [
-                    {"path": "vmlinux.bin", "encoding": "raw", "size": 4},
-                    {"path": "rootfs.ext4.zst", "encoding": "raw", "size": 4},
+                    {
+                        "path": "vmlinux.bin",
+                        "encoding": "raw",
+                        "size": 4,
+                        "sha256": hashlib.sha256(b"kern").hexdigest(),
+                    },
+                    {
+                        "path": "rootfs.ext4.zst",
+                        "encoding": "raw",
+                        "size": 4,
+                        "sha256": hashlib.sha256(b"zstd").hexdigest(),
+                    },
                 ],
             },
             [("files/vmlinux.bin", b"kern")],
@@ -391,7 +401,14 @@ class TestArchiveRobustness:
                 "schema_version": 1,
                 "name": "entry",
                 "rootfs_sidecar": None,
-                "files": [{"path": "blob", "encoding": "raw", "size": 3}],
+                "files": [
+                    {
+                        "path": "blob",
+                        "encoding": "raw",
+                        "size": 3,
+                        "sha256": hashlib.sha256(b"0123456789").hexdigest(),
+                    }
+                ],
             },
             [("files/blob", b"0123456789")],
         )
@@ -475,7 +492,7 @@ class TestArchiveRobustness:
         payload = json.loads(capsys.readouterr().out)
         assert payload["ok"] is False
         assert archive.read_bytes() == b"OLD ARCHIVE"
-        assert not archive.with_name("precious.tar.partial").exists()
+        assert not list(archive.parent.glob("precious.tar.partial*"))
 
     def test_save_warns_about_skipped_links(
         self, tmp_path: Path, capsys: pytest.CaptureFixture
@@ -502,3 +519,92 @@ class TestArchiveRobustness:
         assert ret == 0
         payload = json.loads(capsys.readouterr().out)
         assert any("link" in w for w in payload["data"]["warnings"])
+
+
+class TestUpstreamReviewRegressions:
+    def test_symlinked_zst_is_treated_as_absent(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture
+    ) -> None:
+        """A symlinked wire file must not produce an archive with no rootfs
+        (regression: is_file() followed the link, excluding the real one)."""
+        src = tmp_path / "src"
+        entry = src / "entry"
+        entry.mkdir(parents=True)
+        real_zst = tmp_path / "elsewhere.zst"
+        real_zst.write_bytes(zstandard.compress(b"data"))
+        (entry / "rootfs.ext4.zst").symlink_to(real_zst)
+        (entry / "rootfs.ext4").write_bytes(b"decompressed")
+        archive = tmp_path / "e.tar"
+
+        ret = main(
+            ["image", "save", "entry", "--image-dir", str(src), "-o", str(archive), "--json"]
+        )
+
+        assert ret == 0
+        payload = json.loads(capsys.readouterr().out)
+        assert payload["data"]["excluded_decompressed_rootfs"] is False
+        with tarfile.open(archive) as tar:
+            names = tar.getnames()
+        # The real decompressed rootfs travels (zstd-encoded, suffix-free).
+        assert "files/rootfs.ext4" in names
+
+        dest = tmp_path / "dest"
+        assert main(["image", "load", "-i", str(archive), "--image-dir", str(dest), "--json"]) == 0
+        capsys.readouterr()
+        assert (dest / "entry" / "rootfs.ext4").read_bytes() == b"decompressed"
+
+    def test_corrupted_member_bytes_are_rejected(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture
+    ) -> None:
+        """Same-length corruption must fail the per-file digest check
+        (regression: size-only validation let it load)."""
+        archive = tmp_path / "tampered.tar"
+        _write_archive(
+            archive,
+            {
+                "schema_version": 1,
+                "name": "entry",
+                "rootfs_sidecar": None,
+                "files": [
+                    {
+                        "path": "blob",
+                        "encoding": "raw",
+                        "size": 10,
+                        "sha256": hashlib.sha256(b"0123456789").hexdigest(),
+                    }
+                ],
+            },
+            [("files/blob", b"0123456780")],  # same length, one byte off
+        )
+
+        ret = main(
+            ["image", "load", "-i", str(archive), "--image-dir", str(tmp_path / "dest"), "--json"]
+        )
+
+        assert ret == 2
+        payload = json.loads(capsys.readouterr().out)
+        assert "damaged" in payload["error"]["message"]
+        assert not (tmp_path / "dest" / "entry").exists()
+
+    def test_manifest_without_sha256_is_rejected(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture
+    ) -> None:
+        archive = tmp_path / "nosha.tar"
+        _write_archive(
+            archive,
+            {
+                "schema_version": 1,
+                "name": "entry",
+                "rootfs_sidecar": None,
+                "files": [{"path": "blob", "encoding": "raw", "size": 4}],
+            },
+            [("files/blob", b"data")],
+        )
+
+        ret = main(
+            ["image", "load", "-i", str(archive), "--image-dir", str(tmp_path / "dest"), "--json"]
+        )
+
+        assert ret == 2
+        payload = json.loads(capsys.readouterr().out)
+        assert payload["error"]["code"] == "invalid_input"

--- a/tests/test_image_transfer.py
+++ b/tests/test_image_transfer.py
@@ -331,6 +331,44 @@ class TestArchiveRobustness:
         assert (loaded / "data.txt").read_bytes() == b"plain"
         assert (loaded / "data.txt.zst").read_bytes() == zstandard.compress(b"compressed")
 
+    def test_zstd_encoded_rootfs_member_regenerates_matching_sidecar(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture
+    ) -> None:
+        """A hand-built archive may ship rootfs.ext4.zst as a zstd stream;
+        the regenerated sidecar must hash the installed file, not the
+        archive stream (regression)."""
+        zst_file = zstandard.compress(_SPARSE_PAYLOAD)
+        stored = zstandard.compress(zst_file)
+        archive = tmp_path / "in.tar"
+        _write_archive(
+            archive,
+            {
+                "schema_version": 1,
+                "name": "oddball",
+                "rootfs_sidecar": None,
+                "files": [
+                    {
+                        "path": "rootfs.ext4.zst",
+                        "encoding": "zstd",
+                        "size": len(zst_file),
+                        "sha256": hashlib.sha256(stored).hexdigest(),
+                    }
+                ],
+            },
+            [("files/rootfs.ext4.zst", stored)],
+        )
+
+        dest = tmp_path / "dest"
+        assert main(["image", "load", "-i", str(archive), "--image-dir", str(dest), "--json"]) == 0
+        capsys.readouterr()
+
+        loaded = dest / "oddball"
+        installed_sha = hashlib.sha256((loaded / "rootfs.ext4.zst").read_bytes()).hexdigest()
+        assert (loaded / "rootfs.ext4.from-sha256").read_text() == f"sparse-v1:{installed_sha}"
+        with open(loaded / "rootfs.ext4", "rb") as f:
+            f.seek(1 << 20)
+            assert f.read(9) == b"REAL-DATA"
+
     def test_truncated_archive_gets_clean_envelope(
         self, tmp_path: Path, capsys: pytest.CaptureFixture
     ) -> None:
@@ -344,6 +382,7 @@ class TestArchiveRobustness:
         # Cut into the first member's data (small archives are mostly
         # zero padding, so a percentage cut may remove nothing real).
         data = archive.read_bytes()
+        assert len(data) > 700, "test needs an archive large enough to truncate"
         archive.write_bytes(data[:700])
 
         ret = main(

--- a/tests/test_image_transfer.py
+++ b/tests/test_image_transfer.py
@@ -331,12 +331,12 @@ class TestArchiveRobustness:
         assert (loaded / "data.txt").read_bytes() == b"plain"
         assert (loaded / "data.txt.zst").read_bytes() == zstandard.compress(b"compressed")
 
-    def test_zstd_encoded_rootfs_member_regenerates_matching_sidecar(
+    def test_zstd_encoded_zst_member_is_rejected(
         self, tmp_path: Path, capsys: pytest.CaptureFixture
     ) -> None:
-        """A hand-built archive may ship rootfs.ext4.zst as a zstd stream;
-        the regenerated sidecar must hash the installed file, not the
-        archive stream (regression)."""
+        """.zst files always travel raw; a re-compressed rootfs.ext4.zst
+        would install bytes whose digest differs from what the manifest and
+        the regenerated sidecar describe, so load refuses the archive."""
         zst_file = zstandard.compress(_SPARSE_PAYLOAD)
         stored = zstandard.compress(zst_file)
         archive = tmp_path / "in.tar"
@@ -359,15 +359,74 @@ class TestArchiveRobustness:
         )
 
         dest = tmp_path / "dest"
-        assert main(["image", "load", "-i", str(archive), "--image-dir", str(dest), "--json"]) == 0
+        ret = main(["image", "load", "-i", str(archive), "--image-dir", str(dest), "--json"])
+        assert ret == 2
+        payload = json.loads(capsys.readouterr().out)
+        assert payload["error"]["code"] == "invalid_input"
+        assert not (dest / "oddball").exists()
+
+    def test_save_skips_build_temp_artifacts(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture
+    ) -> None:
+        """Dot-prefixed lock files and builders' in-progress artifacts must
+        not travel; archiving them would install a half-written rootfs on
+        the target machine."""
+        src = tmp_path / "src"
+        entry = _make_published_entry(src, "codex-v0.0.1-amd64-firecracker")
+        (entry / ".rootfs.tmp.ext4").write_bytes(b"half-written")
+        context_dir = entry / ".build-abc123"
+        context_dir.mkdir()
+        (context_dir / "Dockerfile").write_text("FROM scratch")
+        archive = tmp_path / "codex.tar"
+
+        assert main(["image", "save", "codex", "--image-dir", str(src), "-o", str(archive)]) == 0
         capsys.readouterr()
 
-        loaded = dest / "oddball"
-        installed_sha = hashlib.sha256((loaded / "rootfs.ext4.zst").read_bytes()).hexdigest()
-        assert (loaded / "rootfs.ext4.from-sha256").read_text() == f"sparse-v1:{installed_sha}"
-        with open(loaded / "rootfs.ext4", "rb") as f:
-            f.seek(1 << 20)
-            assert f.read(9) == b"REAL-DATA"
+        with tarfile.open(archive) as tar:
+            names = tar.getnames()
+        assert names, "archive must not be empty"
+        assert not any(".rootfs.tmp.ext4" in n or ".build-abc123" in n for n in names)
+
+    def test_save_reports_busy_while_entry_is_being_built(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture
+    ) -> None:
+        """While a builder holds the entry's build lock, save must fail
+        with a clear message instead of archiving a mix of two builds."""
+        fcntl = pytest.importorskip("fcntl")
+        src = tmp_path / "src"
+        entry = _make_published_entry(src, "codex-v0.0.1-amd64-firecracker")
+        archive = tmp_path / "codex.tar"
+
+        with (entry / ".build.lock").open("w") as lock:
+            fcntl.flock(lock.fileno(), fcntl.LOCK_EX)
+            ret = main(
+                ["image", "save", "codex", "--image-dir", str(src), "-o", str(archive), "--json"]
+            )
+
+        assert ret == 1
+        payload = json.loads(capsys.readouterr().out)
+        assert "being built" in payload["error"]["message"]
+        assert "retry" in payload["error"]["recovery"]
+        assert not archive.exists()
+
+    def test_raw_zst_member_keeps_source_metadata(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture
+    ) -> None:
+        """Raw members are streamed from an open fd; the tar header must
+        still carry the source file's mtime, like every other member."""
+        src = tmp_path / "src"
+        entry = _make_published_entry(src, "codex-v0.0.1-amd64-firecracker")
+        stamp = 1_700_000_000
+        os.utime(entry / "rootfs.ext4.zst", (stamp, stamp))
+        archive = tmp_path / "codex.tar"
+
+        assert main(["image", "save", "codex", "--image-dir", str(src), "-o", str(archive)]) == 0
+        capsys.readouterr()
+
+        with tarfile.open(archive) as tar:
+            member = tar.getmember("files/rootfs.ext4.zst")
+        assert member.isreg()
+        assert member.mtime == stamp
 
     def test_truncated_archive_gets_clean_envelope(
         self, tmp_path: Path, capsys: pytest.CaptureFixture

--- a/tests/test_kvm_session.py
+++ b/tests/test_kvm_session.py
@@ -118,6 +118,7 @@ class TestShouldAttemptReexec:
             ["image", "list"],
             ["image", "rm", "codex"],
             ["image", "prune"],
+            ["images"],
         ]
         for argv in skipped:
             assert _kvm_session._should_attempt_reexec(argv) is False, (

--- a/tests/test_kvm_session.py
+++ b/tests/test_kvm_session.py
@@ -114,6 +114,10 @@ class TestShouldAttemptReexec:
             ["sandbox", "file"],
             ["sandbox", "snapshot", "list"],
             ["sandbox", "port"],
+            ["image", "pull", "codex"],
+            ["image", "list"],
+            ["image", "rm", "codex"],
+            ["image", "prune"],
         ]
         for argv in skipped:
             assert _kvm_session._should_attempt_reexec(argv) is False, (


### PR DESCRIPTION
## Summary

SmolVM downloads base images (kernel + rootfs) lazily the first time a sandbox starts, the cache location was hardcoded to `~/.smolvm/images`, and there was no way to see, prefetch, or remove what's cached. This PR adds a full `smolvm image` command group modeled on `docker image`, plus configurable storage.

**New commands** (all support `--json` and `--image-dir`):

| Command | What it does |
| --- | --- |
| `smolvm image pull <preset>` / `pull --all` | Prefetch one published image or everything for this machine (offline prep, CI warm-up), with the existing Rich download progress |
| `smolvm images` / `image list` / `image ls` | Show cached images with kind, platform, version (stale-marked), docker-style CREATED ages, and sparse-aware sizes |
| `smolvm image inspect <name-or-preset>` | Docker-style JSON array with per-file sizes, checksums, and the manifest's expected SHAs/URLs/release tag for current published entries |
| `smolvm image build -t NAME [PATH]` | Build a custom image from a Dockerfile via the existing SDK `DockerRootfsBuilder`; built images appear in `list` as `custom/<name>` and are removable by name or unique fingerprint prefix |
| `smolvm image save <name> -o FILE` / `image load -i FILE` | Air-gapped transfer: manifest-driven tar with zstd members; the multi-GB decompressed rootfs is omitted and regenerated on load (sparse, with the exact integrity sidecar the boot path expects) |
| `smolvm image rm <name-or-preset>` | Remove one entry, all variants of a preset, or a custom build |
| `smolvm image prune` | Canonical home for prune; top-level `smolvm prune` remains a working alias |

**Configurable storage:** new `SMOLVM_IMAGE_DIR` env var (read by sandbox starts too) resolved at call time by `images/manager.py::resolve_image_dir`, honored by every cache consumer (ImageManager, ImageBuilder, guest-agent cache, prune). The `--image-dir` flag targets a single command; `pull` warns when downloading somewhere boots won't read. The import-time `ImageManager.DEFAULT_CACHE_DIR` class attribute is removed (breaking for external SDK callers that read it).

**Notable design decisions:**
- `image build` prints a runnable `SmolVM.from_image()` Python snippet as the boot path — the CLI can't boot local Linux images yet (facade limit; follow-up flagged). Same precedent as `windows build-image`.
- Archive loads are manifest-allowlisted: only declared, regular-file, validated-relative-path members are written; completeness and declared sizes are verified; symlink/device members, traversal paths, and newer schema versions are refused with clean error envelopes.
- Deletion safety: names are validated per segment, symlinked path components are refused, symlinked entries are unlinked (never followed), and the bare `custom` namespace is not a removable entry.
- Two adversarial review passes ran over this branch; all confirmed findings were fixed in the two "Fix review findings" commits (empty `--image-dir` resolving to CWD, archive member-name collisions, symlink-traversal deletes, truncated-archive handling, `_format_bytes` truncation, `.postN` version parsing, and ~40 more).
- `docker history`/`tag`/`push` intentionally have no equivalent (no layers, no registry).

## Related Issues

None.

## Testing

- `uv run pytest tests/ --ignore=tests/e2e --ignore=tests/test_facade.py` — 1454 passed, 10 skipped (~180 tests added by this PR). `test_facade.py` fails in the dev container for lack of `ssh-keygen`; verified identical on `main`.
- `uv run ruff check .` and `uv run ruff format --check .` — clean.
- `uv run mypy src/smolvm/cli/image.py src/smolvm/cli/image_transfer.py` — clean; full `mypy src` unchanged at the pre-existing 148-error baseline (identical count on `main`).
- Live CLI smoke: list/inspect/rm/save/load round-trip (sparse rootfs restored hole-for-hole, sidecar byte-identical), alias envelopes, fingerprint-prefix rm, malicious-archive rejection, `prune`/`image prune` parity. Real network pulls could not complete in the sandbox (egress proxy returns 403 for GitHub release assets) — the download path itself is the pre-existing SHA-pinned `ensure_published_image`; one `smolvm image pull codex` on a normal machine is recommended before merge.

## Checklist

- [x] Scope is focused and limited to this change
- [x] Tests added/updated for behavior changes
- [x] Docs updated for user-visible changes
- [x] No secrets or sensitive data included

🤖 Generated with [Claude Code Fable 5](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `smolvm image` command group: `pull` (supports `--all`), `list`/`ls`, `inspect`, `rm`, `build`, `save`, `load`, and `prune`.
  * Added image transfer: `smolvm image save` / `smolvm image load` via a single tar archive (supports `--force`).
  * Added configurable image storage via `--image-dir`, `SMOLVM_IMAGE_DIR`, or the default directory.
* **Improvements / Bug Fixes**
  * Improved stale-cache pruning accuracy and safer deletion.
  * Improved JSON error command naming and prevented unnecessary re-exec for image-cache commands.
* **Documentation**
  * Updated CLI reference and alias policy notes.
* **Tests**
  * Added extensive end-to-end and safety regression coverage for image commands and transfer.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->