### PR TITLE
fix: sandbox backend auto-selection and add a fail-fast hypervisor preflight

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -39,6 +39,6 @@ After booting that image on the real runtime machine, run `smolvm doctor` before
 
 ## What SmolVM selects automatically
 
-When you do not choose a backend, SmolVM uses QEMU on macOS and Firecracker on other hosts. You can inspect a specific choice with `smolvm doctor --backend qemu` or `smolvm doctor --backend firecracker`.
+When you do not choose a backend, SmolVM picks the best one that is actually installed on your machine. It prefers Firecracker on Linux and QEMU on macOS, but if that one is missing it falls back to another installed backend, so it never picks something your machine cannot run. If nothing suitable is installed, `smolvm sandbox create` stops right away and tells you what to install — before downloading anything. You can inspect a specific choice with `smolvm doctor --backend qemu` or `smolvm doctor --backend firecracker`.
 
 **Implementation notes:** supported setup platforms and packaged setup scripts are defined in [`src/smolvm/host/setup.py`](../src/smolvm/host/setup.py); backend selection is in [`src/smolvm/runtime/backends.py`](../src/smolvm/runtime/backends.py) and is covered by [`tests/test_setup.py`](../tests/test_setup.py) and [`tests/test_backends.py`](../tests/test_backends.py).

--- a/src/smolvm/facade.py
+++ b/src/smolvm/facade.py
@@ -82,6 +82,7 @@ from smolvm.runtime.backends import (
     BACKEND_QEMU,
     ensure_backend_available,
     resolve_backend,
+    resolve_backend_status,
 )
 from smolvm.runtime.boot_profiles import (
     KernelBootProfile,
@@ -421,6 +422,11 @@ def _build_local_image_config(
                 f'backend={backend!r} or pass backend="qemu".'
             )
 
+    # Windows guests always run on QEMU; verify its tooling up front so a
+    # missing hypervisor fails fast instead of surfacing during disk overlay
+    # creation or VM start.
+    ensure_backend_available(BACKEND_QEMU)
+
     if ssh_key_path is None:
         from smolvm.utils import ensure_ssh_key
 
@@ -481,10 +487,11 @@ def _build_s3_image_config(
     Downloads the manifest and assets via :class:`ImageManager`, resolves
     boot arguments, and returns a ready-to-use config.
     """
-    resolved_backend = resolve_backend(backend)
+    resolved_backend, backend_status = resolve_backend_status(backend)
     # Verify the backend's tooling before pulling the S3 image, so a missing
-    # hypervisor fails fast instead of after the download.
-    ensure_backend_available(resolved_backend)
+    # hypervisor fails fast instead of after the download. Reuse the status the
+    # resolver already probed rather than probing the host again.
+    ensure_backend_available(resolved_backend, backend_status)
     resolved_ssh_key_path: str | None = ssh_key_path
 
     image_manager = ImageManager()
@@ -573,7 +580,7 @@ def _build_auto_config(
     on_download: Callable[[str, int, int | None], None] | None = None,
 ) -> tuple[VMConfig, str | None]:
     """Build the default SSH-ready VM config used by zero-config flows."""
-    resolved_backend = resolve_backend(backend)
+    resolved_backend, backend_status = resolve_backend_status(backend)
     resolved_os = _normalize_guest_os(os or _default_guest_os_for_backend(resolved_backend))
     if resolved_os is GuestOS.WINDOWS:
         # Auto-config builds a Linux SSH-ready VM from a built or downloaded
@@ -594,8 +601,8 @@ def _build_auto_config(
     # Gate the expensive work: verify the backend's hypervisor tooling is
     # installed before building or downloading a base image, so a missing
     # qemu/firecracker fails fast with an actionable message instead of after
-    # a multi-hundred-MB download.
-    ensure_backend_available(resolved_backend)
+    # a multi-hundred-MB download. Reuse the already-probed status.
+    ensure_backend_available(resolved_backend, backend_status)
 
     if resolved_os is GuestOS.UBUNTU:
         from smolvm.images.published import Vmm, ensure_published_image
@@ -1419,6 +1426,9 @@ class SmolVM:
         resolved_vm_id = _resolve_vm_name(vm_id, prefix=name_prefix)
 
         resolved_backend = _normalize_from_image_backend(image, backend, resolved_vm_id)
+        # Verify the backend's tooling before any kernel download or VM start,
+        # so a missing hypervisor fails fast with an actionable message.
+        ensure_backend_available(resolved_backend)
         resolved_arch = _normalize_from_image_arch(image, arch, resolved_vm_id)
         qemu_network = _normalize_from_image_network(
             backend=resolved_backend,

--- a/src/smolvm/facade.py
+++ b/src/smolvm/facade.py
@@ -491,7 +491,7 @@ def _build_s3_image_config(
     # Verify the backend's tooling before pulling the S3 image, so a missing
     # hypervisor fails fast instead of after the download. Reuse the status the
     # resolver already probed rather than probing the host again.
-    ensure_backend_available(resolved_backend, backend_status)
+    ensure_backend_available(resolved_backend, backend_status, vm_name=vm_name)
     resolved_ssh_key_path: str | None = ssh_key_path
 
     image_manager = ImageManager()
@@ -602,7 +602,7 @@ def _build_auto_config(
     # installed before building or downloading a base image, so a missing
     # qemu/firecracker fails fast with an actionable message instead of after
     # a multi-hundred-MB download. Reuse the already-probed status.
-    ensure_backend_available(resolved_backend, backend_status)
+    ensure_backend_available(resolved_backend, backend_status, vm_name=vm_name)
 
     if resolved_os is GuestOS.UBUNTU:
         from smolvm.images.published import Vmm, ensure_published_image
@@ -1428,7 +1428,7 @@ class SmolVM:
         resolved_backend = _normalize_from_image_backend(image, backend, resolved_vm_id)
         # Verify the backend's tooling before any kernel download or VM start,
         # so a missing hypervisor fails fast with an actionable message.
-        ensure_backend_available(resolved_backend)
+        ensure_backend_available(resolved_backend, vm_name=resolved_vm_id)
         resolved_arch = _normalize_from_image_arch(image, arch, resolved_vm_id)
         qemu_network = _normalize_from_image_network(
             backend=resolved_backend,

--- a/src/smolvm/facade.py
+++ b/src/smolvm/facade.py
@@ -80,6 +80,7 @@ from smolvm.runtime.backends import (
     BACKEND_FIRECRACKER,
     BACKEND_LIBKRUN,
     BACKEND_QEMU,
+    ensure_backend_available,
     resolve_backend,
 )
 from smolvm.runtime.boot_profiles import (
@@ -481,6 +482,9 @@ def _build_s3_image_config(
     boot arguments, and returns a ready-to-use config.
     """
     resolved_backend = resolve_backend(backend)
+    # Verify the backend's tooling before pulling the S3 image, so a missing
+    # hypervisor fails fast instead of after the download.
+    ensure_backend_available(resolved_backend)
     resolved_ssh_key_path: str | None = ssh_key_path
 
     image_manager = ImageManager()
@@ -586,6 +590,12 @@ def _build_auto_config(
     resolved_disk_size_mib = default_disk_size_mib if disk_size_mib is None else disk_size_mib
     if resolved_disk_size_mib < 64:
         raise ValueError("disk_size_mib must be >= 64")
+
+    # Gate the expensive work: verify the backend's hypervisor tooling is
+    # installed before building or downloading a base image, so a missing
+    # qemu/firecracker fails fast with an actionable message instead of after
+    # a multi-hundred-MB download.
+    ensure_backend_available(resolved_backend)
 
     if resolved_os is GuestOS.UBUNTU:
         from smolvm.images.published import Vmm, ensure_published_image

--- a/src/smolvm/runtime/backends.py
+++ b/src/smolvm/runtime/backends.py
@@ -19,6 +19,7 @@ from __future__ import annotations
 import logging
 import os
 import platform
+import shlex
 from pathlib import Path
 from typing import NamedTuple
 
@@ -189,9 +190,14 @@ def _auto_backend() -> tuple[str, BackendStatus | None]:
     system = platform.system().lower()
     preference = _AUTO_PREFERENCE.get(system, _AUTO_PREFERENCE["_default"])
     partial: tuple[str, BackendStatus] | None = None
-    for backend in preference:
+    fallback_status: BackendStatus | None = None
+    for index, backend in enumerate(preference):
         status = _backend_status(backend)
         assert status is not None  # preference lists only supported backends
+        if index == 0:
+            # preference[0] is the platform default and the final fallback;
+            # remember its status so we don't probe it a second time below.
+            fallback_status = status
         if status.available:
             logger.debug("auto backend selection chose %s", backend)
             return backend, status
@@ -206,7 +212,7 @@ def _auto_backend() -> tuple[str, BackendStatus | None]:
         return partial
     fallback = preference[0]
     logger.debug("auto backend selection found no installed backend; defaulting to %s", fallback)
-    return fallback, _backend_status(fallback)
+    return fallback, fallback_status
 
 
 def resolve_backend_status(requested: str | None = None) -> tuple[str, BackendStatus | None]:
@@ -256,24 +262,33 @@ def resolve_backend(requested: str | None = None) -> str:
     return resolve_backend_status(requested)[0]
 
 
-def _firecracker_missing_message() -> str:
+def _create_with_qemu_command(vm_name: str | None) -> str:
+    """Return the exact 'create with QEMU instead' recovery command.
+
+    Interpolates the sandbox name with ``--name`` when known so the suggested
+    command is runnable as-is rather than a generic placeholder.
+    """
+    if vm_name:
+        return f"smolvm sandbox create --name {shlex.quote(vm_name)} --backend qemu"
+    return "smolvm sandbox create --backend qemu"
+
+
+def _firecracker_missing_message(vm_name: str | None = None) -> str:
     """Plain-English recovery for a missing Firecracker binary."""
     return (
         "Firecracker isn't installed on this machine. Install it and make sure "
         "the 'firecracker' binary is on your PATH (or in ~/.smolvm/bin), or "
-        "create the sandbox with a different backend, e.g. "
-        "'smolvm sandbox create --backend qemu'."
+        f"create the sandbox with a different backend, e.g. '{_create_with_qemu_command(vm_name)}'."
     )
 
 
-def _firecracker_kvm_message() -> str:
+def _firecracker_kvm_message(vm_name: str | None = None) -> str:
     """Plain-English recovery for Firecracker present but KVM unusable."""
     return (
         "Firecracker needs hardware virtualization (/dev/kvm), which isn't "
         "available or accessible on this machine. Give your user access with "
         "'sudo usermod -aG kvm $USER' and start a new login session, or create "
-        "the sandbox with a different backend, e.g. "
-        "'smolvm sandbox create --backend qemu'."
+        f"the sandbox with a different backend, e.g. '{_create_with_qemu_command(vm_name)}'."
     )
 
 
@@ -317,7 +332,12 @@ def _libkrun_missing_message() -> str:
     )
 
 
-def ensure_backend_available(backend: str, status: BackendStatus | None = None) -> None:
+def ensure_backend_available(
+    backend: str,
+    status: BackendStatus | None = None,
+    *,
+    vm_name: str | None = None,
+) -> None:
     """Verify the tooling a resolved backend needs is installed.
 
     Call this before any slow work (such as downloading a base image) so a
@@ -329,11 +349,25 @@ def ensure_backend_available(backend: str, status: BackendStatus | None = None) 
         status: An already-probed :class:`BackendStatus` for *backend* (e.g. from
             :func:`resolve_backend_status`). Pass it to avoid re-probing the
             host; omit it to probe now.
+        vm_name: The sandbox name the caller is creating, if known. When set,
+            the Firecracker recovery command names it with ``--name`` so the
+            suggestion is exactly runnable.
 
     Raises:
         SmolVMError: If the backend's required tooling isn't present.
     """
     if status is None:
         status = _backend_status(backend)
-    if status is not None and not status.available:
-        raise SmolVMError(status.message or f"Backend '{backend}' is not available.")
+    if status is None or status.available:
+        return
+    message = status.message
+    if vm_name and backend == BACKEND_FIRECRACKER:
+        # Rebuild the Firecracker recovery with the real sandbox name.
+        # primary_present distinguishes a missing binary (False) from a present
+        # binary without usable KVM (True), matching firecracker_status().
+        message = (
+            _firecracker_kvm_message(vm_name)
+            if status.primary_present
+            else _firecracker_missing_message(vm_name)
+        )
+    raise SmolVMError(message or f"Backend '{backend}' is not available.")

--- a/src/smolvm/runtime/backends.py
+++ b/src/smolvm/runtime/backends.py
@@ -16,10 +16,15 @@
 
 from __future__ import annotations
 
+import logging
 import os
 import platform
+from pathlib import Path
 
+from smolvm.exceptions import SmolVMError
 from smolvm.utils import which  # noqa: F401 — imported for test patching
+
+logger = logging.getLogger(__name__)
 
 BACKEND_FIRECRACKER = "firecracker"
 BACKEND_QEMU = "qemu"
@@ -28,6 +33,84 @@ BACKEND_AUTO = "auto"
 
 SUPPORTED_BACKENDS = {BACKEND_FIRECRACKER, BACKEND_QEMU, BACKEND_LIBKRUN}
 
+# Where ``smolvm`` installs a private Firecracker binary when it isn't on PATH.
+# Kept in sync with ``smolvm.host.manager.HostManager.BIN_DIR``; duplicated here
+# so backend selection stays free of the heavier host-manager import.
+_LOCAL_BIN_DIR = Path.home() / ".smolvm" / "bin"
+
+
+def _qemu_system_candidates() -> tuple[str, ...]:
+    """Return host-arch-first ``qemu-system-*`` binary names to look for."""
+    arch = platform.machine().lower()
+    if arch in {"arm64", "aarch64"}:
+        return ("qemu-system-aarch64", "qemu-system-x86_64")
+    if arch in {"x86_64", "amd64"}:
+        return ("qemu-system-x86_64", "qemu-system-aarch64")
+    return ("qemu-system-aarch64", "qemu-system-x86_64")
+
+
+def firecracker_available() -> bool:
+    """Return whether a usable Firecracker binary is installed.
+
+    Looks on ``PATH`` first, then the private ``~/.smolvm/bin`` install dir.
+    """
+    if which("firecracker") is not None:
+        return True
+    local = _LOCAL_BIN_DIR / "firecracker"
+    return local.exists() and os.access(local, os.X_OK)
+
+
+def qemu_available() -> bool:
+    """Return whether QEMU (a system emulator plus ``qemu-img``) is installed."""
+    if which("qemu-img") is None:
+        return False
+    return any(which(candidate) is not None for candidate in _qemu_system_candidates())
+
+
+def libkrun_available() -> bool:
+    """Return whether the libkrun shared library can be loaded."""
+    try:
+        from smolvm.runtime._libkrun_ffi import is_available
+    except Exception:  # pragma: no cover - defensive import guard
+        return False
+    return is_available()
+
+
+# Auto-selection preference order per host, most-preferred first. Each entry
+# pairs a backend with the name of its probe (looked up on this module at call
+# time so tests can patch the probes). macOS has no KVM, so Firecracker is not
+# a candidate there.
+_AUTO_PREFERENCE: dict[str, tuple[tuple[str, str], ...]] = {
+    "darwin": (
+        (BACKEND_QEMU, "qemu_available"),
+        (BACKEND_LIBKRUN, "libkrun_available"),
+    ),
+    "_default": (
+        (BACKEND_FIRECRACKER, "firecracker_available"),
+        (BACKEND_QEMU, "qemu_available"),
+        (BACKEND_LIBKRUN, "libkrun_available"),
+    ),
+}
+
+
+def _auto_backend() -> str:
+    """Pick the best installed backend for this host.
+
+    Prefers Firecracker on Linux and QEMU on macOS, but falls through to the
+    next installed backend when the preferred one isn't present — so ``auto``
+    never resolves to a backend the host can't run. When nothing is detected,
+    returns the platform default and lets the preflight surface the fix.
+    """
+    system = platform.system().lower()
+    preference = _AUTO_PREFERENCE.get(system, _AUTO_PREFERENCE["_default"])
+    for backend, probe_name in preference:
+        if globals()[probe_name]():
+            logger.debug("auto backend selection chose %s", backend)
+            return backend
+    fallback = preference[0][0]
+    logger.debug("auto backend selection found no installed backend; defaulting to %s", fallback)
+    return fallback
+
 
 def resolve_backend(requested: str | None = None) -> str:
     """Resolve the effective backend name.
@@ -35,7 +118,9 @@ def resolve_backend(requested: str | None = None) -> str:
     Resolution order:
     1) Explicit ``requested`` argument.
     2) ``SMOLVM_BACKEND`` environment variable.
-    3) Platform-aware default (Darwin -> qemu; others -> firecracker).
+    3) ``auto``: the best backend actually installed on this host
+       (Firecracker preferred on Linux, QEMU on macOS), falling back to the
+       next installed backend when the preferred one is missing.
 
     Args:
         requested: Optional backend string.
@@ -49,13 +134,69 @@ def resolve_backend(requested: str | None = None) -> str:
     raw = (requested or os.environ.get("SMOLVM_BACKEND") or BACKEND_AUTO).strip().lower()
 
     if raw == BACKEND_AUTO:
-        system = platform.system().lower()
-        if system == "darwin":
-            return BACKEND_QEMU
-        return BACKEND_FIRECRACKER
+        return _auto_backend()
 
     if raw in SUPPORTED_BACKENDS:
         return raw
 
     supported = ", ".join(sorted((*SUPPORTED_BACKENDS, BACKEND_AUTO)))
     raise ValueError(f"Unsupported backend '{raw}'. Supported values: {supported}")
+
+
+def _firecracker_missing_message() -> str:
+    """Plain-English recovery for a missing Firecracker binary."""
+    return (
+        "Firecracker isn't installed on this machine. Install it and make sure "
+        "the 'firecracker' binary is on your PATH (or in ~/.smolvm/bin), or "
+        "create the sandbox with a different backend, e.g. "
+        "'smolvm sandbox create --backend qemu'."
+    )
+
+
+def _qemu_missing_message() -> str:
+    """Plain-English recovery for missing QEMU tooling."""
+    system = platform.system()
+    if system == "Darwin":
+        install = "Install it with 'brew install qemu'"
+    elif system == "Linux":
+        install = (
+            "Install it with 'sudo apt-get install -y qemu-system qemu-utils' on "
+            "Debian/Ubuntu, 'sudo dnf install -y qemu-system-x86 qemu-img' on "
+            "Fedora/RHEL, or your distro's QEMU package"
+        )
+    else:
+        install = "Install QEMU for this operating system"
+    return (
+        "QEMU isn't installed on this machine. "
+        f"{install}, then run 'smolvm doctor --backend qemu' to confirm."
+    )
+
+
+def _libkrun_missing_message() -> str:
+    """Plain-English recovery for a missing libkrun library."""
+    return (
+        "libkrun isn't installed on this machine. Install it with "
+        "'brew install libkrun/krun/libkrun' on macOS or 'sudo dnf install "
+        "libkrun' on Fedora, then run 'smolvm doctor --backend libkrun' to confirm."
+    )
+
+
+def ensure_backend_available(backend: str) -> None:
+    """Verify the tooling a resolved backend needs is installed.
+
+    Call this before any slow work (such as downloading a base image) so a
+    missing hypervisor fails fast with a clear, actionable message instead of
+    surfacing deep inside VM start after a download.
+
+    Args:
+        backend: A resolved backend name (not ``auto``).
+
+    Raises:
+        SmolVMError: If the backend's required tooling isn't present.
+    """
+    if backend == BACKEND_FIRECRACKER and not firecracker_available():
+        raise SmolVMError(_firecracker_missing_message())
+    if backend == BACKEND_QEMU and not qemu_available():
+        raise SmolVMError(_qemu_missing_message())
+    if backend == BACKEND_LIBKRUN and not libkrun_available():
+        raise SmolVMError(_libkrun_missing_message())

--- a/src/smolvm/runtime/backends.py
+++ b/src/smolvm/runtime/backends.py
@@ -354,11 +354,17 @@ def ensure_backend_available(
             suggestion is exactly runnable.
 
     Raises:
+        ValueError: If *backend* is not a recognized backend.
         SmolVMError: If the backend's required tooling isn't present.
     """
     if status is None:
         status = _backend_status(backend)
-    if status is None or status.available:
+    if status is None:
+        # An unrecognized backend has no tooling to verify; treat it as a usage
+        # error rather than silently reporting the backend as available.
+        supported = ", ".join(sorted(SUPPORTED_BACKENDS))
+        raise ValueError(f"Unsupported backend '{backend}'. Supported values: {supported}")
+    if status.available:
         return
     message = status.message
     if vm_name and backend == BACKEND_FIRECRACKER:

--- a/src/smolvm/runtime/backends.py
+++ b/src/smolvm/runtime/backends.py
@@ -20,6 +20,7 @@ import logging
 import os
 import platform
 from pathlib import Path
+from typing import NamedTuple
 
 from smolvm.exceptions import SmolVMError
 from smolvm.utils import which  # noqa: F401 — imported for test patching
@@ -37,6 +38,26 @@ SUPPORTED_BACKENDS = {BACKEND_FIRECRACKER, BACKEND_QEMU, BACKEND_LIBKRUN}
 # Kept in sync with ``smolvm.host.manager.HostManager.BIN_DIR``; duplicated here
 # so backend selection stays free of the heavier host-manager import.
 _LOCAL_BIN_DIR = Path.home() / ".smolvm" / "bin"
+_KVM_DEVICE = Path("/dev/kvm")
+
+
+class BackendStatus(NamedTuple):
+    """Result of probing one backend's host tooling.
+
+    Attributes:
+        available: The backend is fully installed and runnable here.
+        primary_present: The backend's main binary/library is present even if a
+            secondary requirement (KVM access, ``qemu-img``) is missing. Used to
+            pick the most-relevant backend to report when none is fully runnable.
+        message: Plain-English recovery when not ``available`` (else ``None``).
+    """
+
+    available: bool
+    primary_present: bool
+    message: str | None
+
+
+# --- low-level probes (patched directly in tests) --------------------------
 
 
 def _qemu_system_candidates() -> tuple[str, ...]:
@@ -49,22 +70,30 @@ def _qemu_system_candidates() -> tuple[str, ...]:
     return ("qemu-system-aarch64", "qemu-system-x86_64")
 
 
-def firecracker_available() -> bool:
-    """Return whether a usable Firecracker binary is installed.
-
-    Looks on ``PATH`` first, then the private ``~/.smolvm/bin`` install dir.
-    """
+def _firecracker_binary_present() -> bool:
+    """Return whether a Firecracker binary is on ``PATH`` or in ``~/.smolvm/bin``."""
     if which("firecracker") is not None:
         return True
     local = _LOCAL_BIN_DIR / "firecracker"
     return local.exists() and os.access(local, os.X_OK)
 
 
-def qemu_available() -> bool:
-    """Return whether QEMU (a system emulator plus ``qemu-img``) is installed."""
-    if which("qemu-img") is None:
-        return False
-    return any(which(candidate) is not None for candidate in _qemu_system_candidates())
+def _kvm_accessible() -> bool:
+    """Return whether ``/dev/kvm`` exists and the current user can read/write it."""
+    return _KVM_DEVICE.exists() and os.access(_KVM_DEVICE, os.R_OK | os.W_OK)
+
+
+def _qemu_system_binary() -> str | None:
+    """Return the first available ``qemu-system-*`` binary name, or ``None``."""
+    for candidate in _qemu_system_candidates():
+        if which(candidate) is not None:
+            return candidate
+    return None
+
+
+def _qemu_img_present() -> bool:
+    """Return whether ``qemu-img`` is on ``PATH``."""
+    return which("qemu-img") is not None
 
 
 def libkrun_available() -> bool:
@@ -76,40 +105,133 @@ def libkrun_available() -> bool:
     return is_available()
 
 
-# Auto-selection preference order per host, most-preferred first. Each entry
-# pairs a backend with the name of its probe (looked up on this module at call
-# time so tests can patch the probes). macOS has no KVM, so Firecracker is not
-# a candidate there.
-_AUTO_PREFERENCE: dict[str, tuple[tuple[str, str], ...]] = {
-    "darwin": (
-        (BACKEND_QEMU, "qemu_available"),
-        (BACKEND_LIBKRUN, "libkrun_available"),
-    ),
-    "_default": (
-        (BACKEND_FIRECRACKER, "firecracker_available"),
-        (BACKEND_QEMU, "qemu_available"),
-        (BACKEND_LIBKRUN, "libkrun_available"),
-    ),
+# --- per-backend status ----------------------------------------------------
+
+
+def firecracker_status() -> BackendStatus:
+    """Probe whether the Firecracker backend can run on this host.
+
+    Firecracker needs both its binary and hardware virtualization
+    (``/dev/kvm``); a binary without KVM access counts as installed-but-not-
+    runnable so selection can prefer a backend that actually works.
+    """
+    if not _firecracker_binary_present():
+        return BackendStatus(False, False, _firecracker_missing_message())
+    if not _kvm_accessible():
+        return BackendStatus(False, True, _firecracker_kvm_message())
+    return BackendStatus(True, True, None)
+
+
+def qemu_status() -> BackendStatus:
+    """Probe whether the QEMU backend can run on this host.
+
+    The QEMU backend needs a ``qemu-system-*`` emulator *and* ``qemu-img`` (for
+    the per-VM disk overlays and snapshots). A system emulator without
+    ``qemu-img`` counts as installed-but-not-runnable.
+    """
+    has_system = _qemu_system_binary() is not None
+    has_img = _qemu_img_present()
+    if has_system and has_img:
+        return BackendStatus(True, True, None)
+    return BackendStatus(
+        False,
+        has_system,
+        _qemu_missing_message(has_system=has_system, has_img=has_img),
+    )
+
+
+def libkrun_status() -> BackendStatus:
+    """Probe whether the libkrun backend can run on this host."""
+    if libkrun_available():
+        return BackendStatus(True, True, None)
+    return BackendStatus(False, False, _libkrun_missing_message())
+
+
+def firecracker_available() -> bool:
+    """Return whether the Firecracker backend is fully runnable here."""
+    return firecracker_status().available
+
+
+def qemu_available() -> bool:
+    """Return whether the QEMU backend is fully runnable here."""
+    return qemu_status().available
+
+
+def _backend_status(backend: str) -> BackendStatus | None:
+    """Return the availability status for a concrete backend, or ``None``."""
+    if backend == BACKEND_FIRECRACKER:
+        return firecracker_status()
+    if backend == BACKEND_QEMU:
+        return qemu_status()
+    if backend == BACKEND_LIBKRUN:
+        return libkrun_status()
+    return None
+
+
+# Auto-selection preference order per host, most-preferred first. macOS has no
+# KVM, so Firecracker is not a candidate there.
+_AUTO_PREFERENCE: dict[str, tuple[str, ...]] = {
+    "darwin": (BACKEND_QEMU, BACKEND_LIBKRUN),
+    "_default": (BACKEND_FIRECRACKER, BACKEND_QEMU, BACKEND_LIBKRUN),
 }
 
 
-def _auto_backend() -> str:
-    """Pick the best installed backend for this host.
+def _auto_backend() -> tuple[str, BackendStatus | None]:
+    """Pick the best backend for this host and return it with its status.
 
-    Prefers Firecracker on Linux and QEMU on macOS, but falls through to the
-    next installed backend when the preferred one isn't present — so ``auto``
-    never resolves to a backend the host can't run. When nothing is detected,
-    returns the platform default and lets the preflight surface the fix.
+    Prefers Firecracker on Linux and QEMU on macOS, and returns the first
+    backend that is fully runnable. When none is fully runnable, it returns the
+    one that is *closest* to runnable (its main binary is present but a
+    secondary requirement is missing) so the preflight can name the exact fix;
+    failing that, the platform default. Returning the status alongside the name
+    lets callers validate without probing a second time.
     """
     system = platform.system().lower()
     preference = _AUTO_PREFERENCE.get(system, _AUTO_PREFERENCE["_default"])
-    for backend, probe_name in preference:
-        if globals()[probe_name]():
+    partial: tuple[str, BackendStatus] | None = None
+    for backend in preference:
+        status = _backend_status(backend)
+        assert status is not None  # preference lists only supported backends
+        if status.available:
             logger.debug("auto backend selection chose %s", backend)
-            return backend
-    fallback = preference[0][0]
+            return backend, status
+        if partial is None and status.primary_present:
+            partial = (backend, status)
+    if partial is not None:
+        logger.debug(
+            "auto backend selection found no fully runnable backend; "
+            "reporting partially-installed %s",
+            partial[0],
+        )
+        return partial
+    fallback = preference[0]
     logger.debug("auto backend selection found no installed backend; defaulting to %s", fallback)
-    return fallback
+    return fallback, _backend_status(fallback)
+
+
+def resolve_backend_status(requested: str | None = None) -> tuple[str, BackendStatus | None]:
+    """Resolve a backend and return it with its availability status.
+
+    Like :func:`resolve_backend`, but also returns the probed
+    :class:`BackendStatus` so a caller can call
+    :func:`ensure_backend_available` without probing the host a second time.
+    For an explicitly-requested backend the status is ``None`` (unprobed) — the
+    check is deferred to :func:`ensure_backend_available`, keeping this cheap for
+    callers that only need the name.
+
+    Raises:
+        ValueError: If the requested backend is unknown.
+    """
+    raw = (requested or os.environ.get("SMOLVM_BACKEND") or BACKEND_AUTO).strip().lower()
+
+    if raw == BACKEND_AUTO:
+        return _auto_backend()
+
+    if raw in SUPPORTED_BACKENDS:
+        return raw, None
+
+    supported = ", ".join(sorted((*SUPPORTED_BACKENDS, BACKEND_AUTO)))
+    raise ValueError(f"Unsupported backend '{raw}'. Supported values: {supported}")
 
 
 def resolve_backend(requested: str | None = None) -> str:
@@ -120,7 +242,7 @@ def resolve_backend(requested: str | None = None) -> str:
     2) ``SMOLVM_BACKEND`` environment variable.
     3) ``auto``: the best backend actually installed on this host
        (Firecracker preferred on Linux, QEMU on macOS), falling back to the
-       next installed backend when the preferred one is missing.
+       next installed backend when the preferred one is missing or can't run.
 
     Args:
         requested: Optional backend string.
@@ -131,16 +253,7 @@ def resolve_backend(requested: str | None = None) -> str:
     Raises:
         ValueError: If backend is unknown.
     """
-    raw = (requested or os.environ.get("SMOLVM_BACKEND") or BACKEND_AUTO).strip().lower()
-
-    if raw == BACKEND_AUTO:
-        return _auto_backend()
-
-    if raw in SUPPORTED_BACKENDS:
-        return raw
-
-    supported = ", ".join(sorted((*SUPPORTED_BACKENDS, BACKEND_AUTO)))
-    raise ValueError(f"Unsupported backend '{raw}'. Supported values: {supported}")
+    return resolve_backend_status(requested)[0]
 
 
 def _firecracker_missing_message() -> str:
@@ -153,8 +266,31 @@ def _firecracker_missing_message() -> str:
     )
 
 
-def _qemu_missing_message() -> str:
-    """Plain-English recovery for missing QEMU tooling."""
+def _firecracker_kvm_message() -> str:
+    """Plain-English recovery for Firecracker present but KVM unusable."""
+    return (
+        "Firecracker needs hardware virtualization (/dev/kvm), which isn't "
+        "available or accessible on this machine. Give your user access with "
+        "'sudo usermod -aG kvm $USER' and start a new login session, or create "
+        "the sandbox with a different backend, e.g. "
+        "'smolvm sandbox create --backend qemu'."
+    )
+
+
+def _qemu_missing_message(*, has_system: bool, has_img: bool) -> str:
+    """Plain-English recovery for missing QEMU tooling.
+
+    Distinguishes a completely-absent QEMU from the case where the system
+    emulator is present but ``qemu-img`` is missing, so the message never
+    claims QEMU is uninstalled when it isn't.
+    """
+    if has_system and not has_img:
+        return (
+            "QEMU is installed but its 'qemu-img' disk tool is missing. Install "
+            "it with 'sudo apt-get install -y qemu-utils' on Debian/Ubuntu, "
+            "'sudo dnf install -y qemu-img' on Fedora/RHEL, or your distro's "
+            "qemu-img package, then run 'smolvm doctor --backend qemu' to confirm."
+        )
     system = platform.system()
     if system == "Darwin":
         install = "Install it with 'brew install qemu'"
@@ -181,7 +317,7 @@ def _libkrun_missing_message() -> str:
     )
 
 
-def ensure_backend_available(backend: str) -> None:
+def ensure_backend_available(backend: str, status: BackendStatus | None = None) -> None:
     """Verify the tooling a resolved backend needs is installed.
 
     Call this before any slow work (such as downloading a base image) so a
@@ -190,13 +326,14 @@ def ensure_backend_available(backend: str) -> None:
 
     Args:
         backend: A resolved backend name (not ``auto``).
+        status: An already-probed :class:`BackendStatus` for *backend* (e.g. from
+            :func:`resolve_backend_status`). Pass it to avoid re-probing the
+            host; omit it to probe now.
 
     Raises:
         SmolVMError: If the backend's required tooling isn't present.
     """
-    if backend == BACKEND_FIRECRACKER and not firecracker_available():
-        raise SmolVMError(_firecracker_missing_message())
-    if backend == BACKEND_QEMU and not qemu_available():
-        raise SmolVMError(_qemu_missing_message())
-    if backend == BACKEND_LIBKRUN and not libkrun_available():
-        raise SmolVMError(_libkrun_missing_message())
+    if status is None:
+        status = _backend_status(backend)
+    if status is not None and not status.available:
+        raise SmolVMError(status.message or f"Backend '{backend}' is not available.")

--- a/tests/test_backends.py
+++ b/tests/test_backends.py
@@ -193,6 +193,12 @@ def test_ensure_backend_available_raises_for_missing_libkrun() -> None:
         ensure_backend_available(BACKEND_LIBKRUN)
 
 
+def test_ensure_backend_available_rejects_unknown_backend() -> None:
+    # An unrecognized backend must not silently report success.
+    with pytest.raises(ValueError, match="Unsupported backend 'xen'"):
+        ensure_backend_available("xen")
+
+
 # --- probe details ---------------------------------------------------------
 
 

--- a/tests/test_backends.py
+++ b/tests/test_backends.py
@@ -91,6 +91,17 @@ def test_resolve_backend_auto_defaults_to_firecracker_when_nothing_installed() -
         assert resolve_backend("auto") == BACKEND_FIRECRACKER
 
 
+def test_auto_backend_does_not_reprobe_the_fallback() -> None:
+    # Nothing installed: each preferred backend is probed exactly once, and the
+    # platform-default fallback reuses the status probed in the first iteration
+    # instead of probing it again.
+    with _env(), patch("smolvm.runtime.backends._backend_status", wraps=b._backend_status) as spy:
+        backend, status = b._auto_backend()
+    assert backend == BACKEND_FIRECRACKER
+    assert status is not None
+    assert spy.call_count == len(b._AUTO_PREFERENCE["_default"])
+
+
 # --- status threading (single probe) ---------------------------------------
 
 
@@ -154,6 +165,27 @@ def test_ensure_backend_available_raises_for_missing_firecracker() -> None:
 def test_ensure_backend_available_firecracker_present_without_kvm_reports_kvm() -> None:
     with _env(fc_binary=True, kvm=False), pytest.raises(SmolVMError, match="/dev/kvm"):
         ensure_backend_available(BACKEND_FIRECRACKER)
+
+
+def test_firecracker_missing_message_interpolates_sandbox_name() -> None:
+    # The recovery command must name the sandbox with --name so it is runnable.
+    with _env(fc_binary=False), pytest.raises(SmolVMError) as excinfo:
+        ensure_backend_available(BACKEND_FIRECRACKER, vm_name="sbx-einstein")
+    assert "smolvm sandbox create --name sbx-einstein --backend qemu" in str(excinfo.value)
+
+
+def test_firecracker_kvm_message_interpolates_sandbox_name() -> None:
+    with _env(fc_binary=True, kvm=False), pytest.raises(SmolVMError) as excinfo:
+        ensure_backend_available(BACKEND_FIRECRACKER, vm_name="sbx-einstein")
+    assert "smolvm sandbox create --name sbx-einstein --backend qemu" in str(excinfo.value)
+
+
+def test_firecracker_recovery_command_omits_name_when_unknown() -> None:
+    with _env(fc_binary=False), pytest.raises(SmolVMError) as excinfo:
+        ensure_backend_available(BACKEND_FIRECRACKER)
+    message = str(excinfo.value)
+    assert "--name" not in message
+    assert "smolvm sandbox create --backend qemu" in message
 
 
 def test_ensure_backend_available_raises_for_missing_libkrun() -> None:

--- a/tests/test_backends.py
+++ b/tests/test_backends.py
@@ -1,10 +1,22 @@
 from unittest.mock import patch
 
-from smolvm.runtime.backends import BACKEND_LIBKRUN, BACKEND_QEMU, resolve_backend
+import pytest
+
+from smolvm.exceptions import SmolVMError
+from smolvm.runtime.backends import (
+    BACKEND_FIRECRACKER,
+    BACKEND_LIBKRUN,
+    BACKEND_QEMU,
+    ensure_backend_available,
+    resolve_backend,
+)
 
 
 def test_resolve_backend_auto_defaults_to_qemu_on_macos() -> None:
-    with patch("smolvm.runtime.backends.platform.system", return_value="Darwin"):
+    with (
+        patch("smolvm.runtime.backends.platform.system", return_value="Darwin"),
+        patch("smolvm.runtime.backends.qemu_available", return_value=True),
+    ):
         assert resolve_backend("auto") == BACKEND_QEMU
 
 
@@ -12,9 +24,96 @@ def test_resolve_backend_auto_defaults_to_qemu_on_macos_even_with_krunvm() -> No
     with (
         patch("smolvm.runtime.backends.platform.system", return_value="Darwin"),
         patch("smolvm.runtime.backends.which", return_value="/usr/local/bin/krunvm"),
+        patch("smolvm.runtime.backends.qemu_available", return_value=True),
     ):
         assert resolve_backend("auto") == BACKEND_QEMU
 
 
 def test_resolve_backend_accepts_libkrun_explicitly() -> None:
     assert resolve_backend(BACKEND_LIBKRUN) == BACKEND_LIBKRUN
+
+
+def test_resolve_backend_auto_prefers_firecracker_on_linux() -> None:
+    with (
+        patch("smolvm.runtime.backends.platform.system", return_value="Linux"),
+        patch("smolvm.runtime.backends.firecracker_available", return_value=True),
+        patch("smolvm.runtime.backends.qemu_available", return_value=True),
+    ):
+        assert resolve_backend("auto") == BACKEND_FIRECRACKER
+
+
+def test_resolve_backend_auto_falls_back_to_qemu_when_firecracker_missing() -> None:
+    # The reported bug: /dev/kvm is present but Firecracker isn't installed, so
+    # auto must not pick Firecracker when QEMU is the installed backend.
+    with (
+        patch("smolvm.runtime.backends.platform.system", return_value="Linux"),
+        patch("smolvm.runtime.backends.firecracker_available", return_value=False),
+        patch("smolvm.runtime.backends.qemu_available", return_value=True),
+    ):
+        assert resolve_backend("auto") == BACKEND_QEMU
+
+
+def test_resolve_backend_auto_falls_back_to_libkrun_when_only_libkrun_present() -> None:
+    with (
+        patch("smolvm.runtime.backends.platform.system", return_value="Linux"),
+        patch("smolvm.runtime.backends.firecracker_available", return_value=False),
+        patch("smolvm.runtime.backends.qemu_available", return_value=False),
+        patch("smolvm.runtime.backends.libkrun_available", return_value=True),
+    ):
+        assert resolve_backend("auto") == BACKEND_LIBKRUN
+
+
+def test_resolve_backend_auto_defaults_to_firecracker_when_nothing_installed() -> None:
+    # With nothing detected, auto keeps the platform default so the downstream
+    # preflight can surface an actionable "install Firecracker" message.
+    with (
+        patch("smolvm.runtime.backends.platform.system", return_value="Linux"),
+        patch("smolvm.runtime.backends.firecracker_available", return_value=False),
+        patch("smolvm.runtime.backends.qemu_available", return_value=False),
+        patch("smolvm.runtime.backends.libkrun_available", return_value=False),
+    ):
+        assert resolve_backend("auto") == BACKEND_FIRECRACKER
+
+
+def test_ensure_backend_available_passes_when_qemu_installed() -> None:
+    with patch("smolvm.runtime.backends.qemu_available", return_value=True):
+        ensure_backend_available(BACKEND_QEMU)  # does not raise
+
+
+def test_ensure_backend_available_raises_for_missing_qemu() -> None:
+    with (
+        patch("smolvm.runtime.backends.qemu_available", return_value=False),
+        pytest.raises(SmolVMError, match="QEMU isn't installed"),
+    ):
+        ensure_backend_available(BACKEND_QEMU)
+
+
+def test_ensure_backend_available_raises_for_missing_firecracker() -> None:
+    with (
+        patch("smolvm.runtime.backends.firecracker_available", return_value=False),
+        pytest.raises(SmolVMError, match="Firecracker isn't installed"),
+    ):
+        ensure_backend_available(BACKEND_FIRECRACKER)
+
+
+def test_ensure_backend_available_raises_for_missing_libkrun() -> None:
+    with (
+        patch("smolvm.runtime.backends.libkrun_available", return_value=False),
+        pytest.raises(SmolVMError, match="libkrun isn't installed"),
+    ):
+        ensure_backend_available(BACKEND_LIBKRUN)
+
+
+def test_qemu_available_needs_both_system_and_img() -> None:
+    from smolvm.runtime import backends
+
+    def only_qemu_img(binary: str):
+        return "/usr/bin/qemu-img" if binary == "qemu-img" else None
+
+    # qemu-img present but no system emulator -> not available.
+    with patch("smolvm.runtime.backends.which", side_effect=only_qemu_img):
+        assert backends.qemu_available() is False
+
+    # Both present -> available.
+    with patch("smolvm.runtime.backends.which", return_value="/usr/bin/qemu-x"):
+        assert backends.qemu_available() is True

--- a/tests/test_backends.py
+++ b/tests/test_backends.py
@@ -1,31 +1,58 @@
+import contextlib
 from unittest.mock import patch
 
 import pytest
 
 from smolvm.exceptions import SmolVMError
+from smolvm.runtime import backends as b
 from smolvm.runtime.backends import (
     BACKEND_FIRECRACKER,
     BACKEND_LIBKRUN,
     BACKEND_QEMU,
     ensure_backend_available,
     resolve_backend,
+    resolve_backend_status,
 )
 
 
+def _env(
+    *,
+    system="Linux",
+    fc_binary=False,
+    kvm=False,
+    qemu_system=False,
+    qemu_img=False,
+    libkrun=False,
+):
+    """Patch the low-level host probes so backend detection is deterministic."""
+    stack = contextlib.ExitStack()
+    stack.enter_context(patch("smolvm.runtime.backends.platform.system", return_value=system))
+    stack.enter_context(
+        patch("smolvm.runtime.backends._firecracker_binary_present", return_value=fc_binary)
+    )
+    stack.enter_context(patch("smolvm.runtime.backends._kvm_accessible", return_value=kvm))
+    stack.enter_context(
+        patch(
+            "smolvm.runtime.backends._qemu_system_binary",
+            return_value="qemu-system-x86_64" if qemu_system else None,
+        )
+    )
+    stack.enter_context(patch("smolvm.runtime.backends._qemu_img_present", return_value=qemu_img))
+    stack.enter_context(patch("smolvm.runtime.backends.libkrun_available", return_value=libkrun))
+    return stack
+
+
+# --- auto selection --------------------------------------------------------
+
+
 def test_resolve_backend_auto_defaults_to_qemu_on_macos() -> None:
-    with (
-        patch("smolvm.runtime.backends.platform.system", return_value="Darwin"),
-        patch("smolvm.runtime.backends.qemu_available", return_value=True),
-    ):
+    with _env(system="Darwin", qemu_system=True, qemu_img=True):
         assert resolve_backend("auto") == BACKEND_QEMU
 
 
-def test_resolve_backend_auto_defaults_to_qemu_on_macos_even_with_krunvm() -> None:
-    with (
-        patch("smolvm.runtime.backends.platform.system", return_value="Darwin"),
-        patch("smolvm.runtime.backends.which", return_value="/usr/local/bin/krunvm"),
-        patch("smolvm.runtime.backends.qemu_available", return_value=True),
-    ):
+def test_resolve_backend_auto_skips_firecracker_on_macos_even_if_binary_present() -> None:
+    # Firecracker is never a macOS candidate; QEMU wins.
+    with _env(system="Darwin", fc_binary=True, kvm=True, qemu_system=True, qemu_img=True):
         assert resolve_backend("auto") == BACKEND_QEMU
 
 
@@ -34,86 +61,118 @@ def test_resolve_backend_accepts_libkrun_explicitly() -> None:
 
 
 def test_resolve_backend_auto_prefers_firecracker_on_linux() -> None:
-    with (
-        patch("smolvm.runtime.backends.platform.system", return_value="Linux"),
-        patch("smolvm.runtime.backends.firecracker_available", return_value=True),
-        patch("smolvm.runtime.backends.qemu_available", return_value=True),
-    ):
+    with _env(fc_binary=True, kvm=True, qemu_system=True, qemu_img=True):
         assert resolve_backend("auto") == BACKEND_FIRECRACKER
 
 
 def test_resolve_backend_auto_falls_back_to_qemu_when_firecracker_missing() -> None:
     # The reported bug: /dev/kvm is present but Firecracker isn't installed, so
-    # auto must not pick Firecracker when QEMU is the installed backend.
-    with (
-        patch("smolvm.runtime.backends.platform.system", return_value="Linux"),
-        patch("smolvm.runtime.backends.firecracker_available", return_value=False),
-        patch("smolvm.runtime.backends.qemu_available", return_value=True),
-    ):
+    # auto must pick QEMU rather than the missing preferred backend.
+    with _env(fc_binary=False, kvm=True, qemu_system=True, qemu_img=True):
+        assert resolve_backend("auto") == BACKEND_QEMU
+
+
+def test_resolve_backend_auto_skips_firecracker_without_kvm_when_qemu_runs() -> None:
+    # Firecracker binary present but /dev/kvm inaccessible: auto must not pick a
+    # backend the host can't run when QEMU is fully usable.
+    with _env(fc_binary=True, kvm=False, qemu_system=True, qemu_img=True):
         assert resolve_backend("auto") == BACKEND_QEMU
 
 
 def test_resolve_backend_auto_falls_back_to_libkrun_when_only_libkrun_present() -> None:
-    with (
-        patch("smolvm.runtime.backends.platform.system", return_value="Linux"),
-        patch("smolvm.runtime.backends.firecracker_available", return_value=False),
-        patch("smolvm.runtime.backends.qemu_available", return_value=False),
-        patch("smolvm.runtime.backends.libkrun_available", return_value=True),
-    ):
+    with _env(fc_binary=False, kvm=False, qemu_system=False, qemu_img=False, libkrun=True):
         assert resolve_backend("auto") == BACKEND_LIBKRUN
 
 
 def test_resolve_backend_auto_defaults_to_firecracker_when_nothing_installed() -> None:
     # With nothing detected, auto keeps the platform default so the downstream
     # preflight can surface an actionable "install Firecracker" message.
-    with (
-        patch("smolvm.runtime.backends.platform.system", return_value="Linux"),
-        patch("smolvm.runtime.backends.firecracker_available", return_value=False),
-        patch("smolvm.runtime.backends.qemu_available", return_value=False),
-        patch("smolvm.runtime.backends.libkrun_available", return_value=False),
-    ):
+    with _env():
         assert resolve_backend("auto") == BACKEND_FIRECRACKER
 
 
+# --- status threading (single probe) ---------------------------------------
+
+
+def test_resolve_backend_status_returns_probed_status_for_auto() -> None:
+    with _env(fc_binary=True, kvm=True):
+        backend, status = resolve_backend_status("auto")
+    assert backend == BACKEND_FIRECRACKER
+    assert status is not None and status.available is True
+
+
+def test_resolve_backend_status_defers_probe_for_explicit_backend() -> None:
+    # Explicit backends are returned unprobed (status None); the check is
+    # deferred to ensure_backend_available so callers that only need the name
+    # stay cheap.
+    with _env():
+        backend, status = resolve_backend_status(BACKEND_QEMU)
+    assert backend == BACKEND_QEMU
+    assert status is None
+
+
+def test_ensure_backend_available_uses_supplied_status_without_reprobing() -> None:
+    from smolvm.runtime.backends import BackendStatus
+
+    good = BackendStatus(available=True, primary_present=True, message=None)
+    with patch("smolvm.runtime.backends._backend_status") as probe:
+        ensure_backend_available(BACKEND_QEMU, good)
+    probe.assert_not_called()
+
+
+# --- preflight messages ----------------------------------------------------
+
+
 def test_ensure_backend_available_passes_when_qemu_installed() -> None:
-    with patch("smolvm.runtime.backends.qemu_available", return_value=True):
+    with _env(qemu_system=True, qemu_img=True):
         ensure_backend_available(BACKEND_QEMU)  # does not raise
 
 
 def test_ensure_backend_available_raises_for_missing_qemu() -> None:
     with (
-        patch("smolvm.runtime.backends.qemu_available", return_value=False),
+        _env(qemu_system=False, qemu_img=False),
         pytest.raises(SmolVMError, match="QEMU isn't installed"),
     ):
         ensure_backend_available(BACKEND_QEMU)
 
 
-def test_ensure_backend_available_raises_for_missing_firecracker() -> None:
+def test_ensure_backend_available_qemu_img_only_missing_gives_accurate_message() -> None:
+    # qemu-system present but qemu-img absent must NOT claim QEMU is uninstalled.
     with (
-        patch("smolvm.runtime.backends.firecracker_available", return_value=False),
-        pytest.raises(SmolVMError, match="Firecracker isn't installed"),
+        _env(qemu_system=True, qemu_img=False),
+        pytest.raises(SmolVMError, match="qemu-img") as excinfo,
     ):
+        ensure_backend_available(BACKEND_QEMU)
+    assert "isn't installed" not in str(excinfo.value)
+
+
+def test_ensure_backend_available_raises_for_missing_firecracker() -> None:
+    with _env(fc_binary=False), pytest.raises(SmolVMError, match="Firecracker isn't installed"):
+        ensure_backend_available(BACKEND_FIRECRACKER)
+
+
+def test_ensure_backend_available_firecracker_present_without_kvm_reports_kvm() -> None:
+    with _env(fc_binary=True, kvm=False), pytest.raises(SmolVMError, match="/dev/kvm"):
         ensure_backend_available(BACKEND_FIRECRACKER)
 
 
 def test_ensure_backend_available_raises_for_missing_libkrun() -> None:
-    with (
-        patch("smolvm.runtime.backends.libkrun_available", return_value=False),
-        pytest.raises(SmolVMError, match="libkrun isn't installed"),
-    ):
+    with _env(libkrun=False), pytest.raises(SmolVMError, match="libkrun isn't installed"):
         ensure_backend_available(BACKEND_LIBKRUN)
 
 
+# --- probe details ---------------------------------------------------------
+
+
 def test_qemu_available_needs_both_system_and_img() -> None:
-    from smolvm.runtime import backends
+    with _env(qemu_system=True, qemu_img=False):
+        assert b.qemu_available() is False
+    with _env(qemu_system=True, qemu_img=True):
+        assert b.qemu_available() is True
 
-    def only_qemu_img(binary: str):
-        return "/usr/bin/qemu-img" if binary == "qemu-img" else None
 
-    # qemu-img present but no system emulator -> not available.
-    with patch("smolvm.runtime.backends.which", side_effect=only_qemu_img):
-        assert backends.qemu_available() is False
-
-    # Both present -> available.
-    with patch("smolvm.runtime.backends.which", return_value="/usr/bin/qemu-x"):
-        assert backends.qemu_available() is True
+def test_firecracker_available_needs_binary_and_kvm() -> None:
+    with _env(fc_binary=True, kvm=False):
+        assert b.firecracker_available() is False
+    with _env(fc_binary=True, kvm=True):
+        assert b.firecracker_available() is True

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1062,8 +1062,11 @@ class TestCliCreate:
         mock_vm_cls.return_value = vm
 
         # This test covers config building, not host hypervisor detection, so
-        # treat the QEMU backend as installed (preflight is covered elsewhere).
-        with patch("smolvm.facade.ensure_backend_available"):
+        # make QEMU look installed and let the real preflight pass through.
+        with (
+            patch("smolvm.runtime.backends._qemu_system_binary", return_value="qemu-system-x86_64"),
+            patch("smolvm.runtime.backends._qemu_img_present", return_value=True),
+        ):
             ret = main(
                 [
                     "sandbox",

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1061,19 +1061,22 @@ class TestCliCreate:
         vm.info.network.ssh_host_port = 2200
         mock_vm_cls.return_value = vm
 
-        ret = main(
-            [
-                "sandbox",
-                "create",
-                "--name",
-                "project-spacex",
-                "--os",
-                "ubuntu",
-                "--backend",
-                "qemu",
-                "--json",
-            ]
-        )
+        # This test covers config building, not host hypervisor detection, so
+        # treat the QEMU backend as installed (preflight is covered elsewhere).
+        with patch("smolvm.facade.ensure_backend_available"):
+            ret = main(
+                [
+                    "sandbox",
+                    "create",
+                    "--name",
+                    "project-spacex",
+                    "--os",
+                    "ubuntu",
+                    "--backend",
+                    "qemu",
+                    "--json",
+                ]
+            )
 
         assert ret == 0
         preset, arch, vmm, os_ = mock_ensure_published.call_args.args

--- a/tests/test_facade.py
+++ b/tests/test_facade.py
@@ -433,7 +433,7 @@ class TestVMInit:
     ) -> None:
         """The preflight must reject a missing backend before any image download.
 
-        The class-wide _assume_backend_installed fixture makes backends look
+        The module-wide _assume_backends_installed fixture makes backends look
         installed; here we override qemu to unavailable and assert the builder
         raises immediately without calling ensure_published_image.
         """
@@ -451,6 +451,27 @@ class TestVMInit:
             _build_auto_config(os="ubuntu", backend="qemu")
 
         mock_ensure_published.assert_not_called()
+
+    @patch("smolvm.utils.ensure_ssh_key")
+    def test_autoconfigure_missing_firecracker_names_sandbox_in_recovery(
+        self,
+        mock_ensure_ssh_key: MagicMock,
+        tmp_path: Path,
+    ) -> None:
+        """The Firecracker preflight recovery command names the sandbox."""
+        priv = tmp_path / "id_ed25519"
+        pub = tmp_path / "id_ed25519.pub"
+        priv.touch()
+        pub.write_text("ssh-ed25519 AAAAExampleKey test@host\n")
+        mock_ensure_ssh_key.return_value = (priv, pub)
+
+        with (
+            patch("smolvm.runtime.backends._firecracker_binary_present", return_value=False),
+            pytest.raises(SmolVMError) as excinfo,
+        ):
+            _build_auto_config(vm_name="sbx-einstein", backend="firecracker")
+
+        assert "smolvm sandbox create --name sbx-einstein --backend qemu" in str(excinfo.value)
 
     def test_firmware_boot_vmconfig_rejects_non_qemu_backend(
         self,

--- a/tests/test_facade.py
+++ b/tests/test_facade.py
@@ -40,6 +40,27 @@ from smolvm.types import (
 from smolvm.vm import SmolVMManager
 
 
+@pytest.fixture(autouse=True)
+def _assume_backends_installed():
+    """Make every backend look installed for the facade builder tests.
+
+    These tests exercise config building and image download/build, not host
+    hypervisor detection (covered in test_backends). Rather than stubbing the
+    preflight itself — which would mask a regression that removed it — patch the
+    low-level host probes so the *real* preflight runs and passes regardless of
+    what's installed on the test host. Individual tests can re-patch a probe to
+    False to assert the preflight fires.
+    """
+    with (
+        patch("smolvm.runtime.backends._firecracker_binary_present", return_value=True),
+        patch("smolvm.runtime.backends._kvm_accessible", return_value=True),
+        patch("smolvm.runtime.backends._qemu_system_binary", return_value="qemu-system-x86_64"),
+        patch("smolvm.runtime.backends._qemu_img_present", return_value=True),
+        patch("smolvm.runtime.backends.libkrun_available", return_value=True),
+    ):
+        yield
+
+
 @pytest.fixture
 def sample_config(tmp_path: Path) -> VMConfig:
     """Create a sample VMConfig."""
@@ -77,18 +98,6 @@ class TestDiskSizeHelpers:
 
 class TestVMInit:
     """Tests for VM initialization."""
-
-    @pytest.fixture(autouse=True)
-    def _assume_backend_installed(self):
-        """Treat the resolved backend as installed for builder tests.
-
-        These tests exercise config building and image download/build, not
-        host hypervisor detection (covered in test_backends). Auto-config now
-        preflights backend tooling before the download; stub it out so the
-        builder path runs regardless of what's installed on the test host.
-        """
-        with patch("smolvm.facade.ensure_backend_available"):
-            yield
 
     @patch("smolvm.facade.SmolVMManager")
     def test_create_with_config(
@@ -413,6 +422,35 @@ class TestVMInit:
         mock_ensure_published.side_effect = ImageError("rootfs SHA-256 mismatch")
         with pytest.raises(ImageError, match="SHA-256 mismatch"):
             _build_auto_config(os="ubuntu", backend="firecracker")
+
+    @patch("smolvm.images.published.ensure_published_image")
+    @patch("smolvm.utils.ensure_ssh_key")
+    def test_autoconfigure_missing_backend_fails_fast_before_download(
+        self,
+        mock_ensure_ssh_key: MagicMock,
+        mock_ensure_published: MagicMock,
+        tmp_path: Path,
+    ) -> None:
+        """The preflight must reject a missing backend before any image download.
+
+        The class-wide _assume_backend_installed fixture makes backends look
+        installed; here we override qemu to unavailable and assert the builder
+        raises immediately without calling ensure_published_image.
+        """
+        priv = tmp_path / "id_ed25519"
+        pub = tmp_path / "id_ed25519.pub"
+        priv.touch()
+        pub.write_text("ssh-ed25519 AAAAExampleKey test@host\n")
+        mock_ensure_ssh_key.return_value = (priv, pub)
+
+        with (
+            patch("smolvm.runtime.backends._qemu_system_binary", return_value=None),
+            patch("smolvm.runtime.backends._qemu_img_present", return_value=False),
+            pytest.raises(SmolVMError, match="QEMU isn't installed"),
+        ):
+            _build_auto_config(os="ubuntu", backend="qemu")
+
+        mock_ensure_published.assert_not_called()
 
     def test_firmware_boot_vmconfig_rejects_non_qemu_backend(
         self,

--- a/tests/test_facade.py
+++ b/tests/test_facade.py
@@ -78,6 +78,18 @@ class TestDiskSizeHelpers:
 class TestVMInit:
     """Tests for VM initialization."""
 
+    @pytest.fixture(autouse=True)
+    def _assume_backend_installed(self):
+        """Treat the resolved backend as installed for builder tests.
+
+        These tests exercise config building and image download/build, not
+        host hypervisor detection (covered in test_backends). Auto-config now
+        preflights backend tooling before the download; stub it out so the
+        builder path runs regardless of what's installed on the test host.
+        """
+        with patch("smolvm.facade.ensure_backend_available"):
+            yield
+
     @patch("smolvm.facade.SmolVMManager")
     def test_create_with_config(
         self,


### PR DESCRIPTION
## Summary

Fixes two problems in `smolvm sandbox create` and hardens the surrounding behavior.

**The bugs**

1. **`auto` picked a backend that wasn't installed.** `resolve_backend("auto")` always resolved to Firecracker on Linux (QEMU on macOS) regardless of what was actually on the host — so on a machine with `/dev/kvm` but no Firecracker it still chose Firecracker and failed, even when QEMU was installed and usable.
2. **`--backend qemu` downloaded before checking tooling.** The base image (hundreds of MB) was downloaded first, and the missing-hypervisor error only surfaced later at VM start.

**What changed**

- **Auto-selection now probes what's installed** and falls through `firecracker → qemu → libkrun` (macOS: `qemu → libkrun`), so `auto` never resolves to a backend the host can't run. Firecracker counts as runnable only when its binary **and** `/dev/kvm` are usable; QEMU only when a `qemu-system-*` emulator **and** `qemu-img` are present. When nothing is fully runnable, it reports the *partially-installed* backend so the error names the real fix, otherwise the platform default.
- **A `ensure_backend_available()` preflight** runs in the config builders **before** any image download or build, failing fast with a short, plain-English, recovery-oriented message. It guards all four create flows: auto-config, S3 image, Windows local-image, and `from_image`.
- **Accurate error messages.** Missing `qemu-img` (with `qemu-system` present) no longer claims "QEMU isn't installed"; a Firecracker binary without KVM reports the `/dev/kvm` fix, not "install Firecracker".
- **Single probe pass.** `resolve_backend_status()` returns the probed status so the builders validate without re-probing the host.

User-facing messages follow the repo's error-UX guidance in `CLAUDE.md` (state the fact plainly, name the recovery, stay short).

## Related Issues

- No linked issue.

## Testing

- `uv run --extra dev pytest` — **1701 passed**, 18 skipped. The only 7 failures are pre-existing and environment-specific (this container lacks `vhost_vsock`, plus the Windows-guest tests); they fail identically on a clean checkout of the base branch.
- `uv run --extra dev ruff check .` — clean on the changed files.
- `uv run --extra dev ruff format --check` — clean.
- `uv run --extra dev mypy src/smolvm/runtime/backends.py src/smolvm/facade.py` — `backends.py` clean; `facade.py` reports only pre-existing errors in untouched comm-channel/port-forward code (none in the changed lines).

New/updated tests: auto-selection preference and fallbacks (including the reported "kvm present, Firecracker missing → QEMU" case and the "Firecracker binary but no kvm → QEMU" case), the accurate `qemu-img`-only and kvm messages, status threading (no double probe), and a fail-fast-before-download assertion. Facade builder tests now drive the real preflight via low-level host probes instead of stubbing it.

## Checklist

- [x] Scope is focused and limited to this change
- [x] Tests added/updated for behavior changes
- [x] Docs updated for user-visible changes (error/warning copy per `CLAUDE.md` guidance; no doc pages affected)
- [x] No secrets or sensitive data included

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Enhanced automatic backend selection using detected host capabilities with OS-specific preferences.
  - Added backend availability/status reporting to support clearer guidance and diagnostics.
  - Added fail-fast backend validation before VM/image/kernel work begins.

- **Bug Fixes**
  - Sandbox creation now stops early (before downloads) when required backend tooling is missing.
  - Improved fallback to another suitable installed backend when the preferred one isn’t available.
  - Firecracker recovery guidance now includes the intended sandbox name when applicable.

- **Documentation**
  - Clarified auto backend selection, explicit fallback behavior, and early failure conditions.

- **Tests**
  - Expanded deterministic backend detection tests and fail-fast regression coverage.
  - Updated CLI/facade tests to stub backend preflight for reliable execution.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->