### PR TITLE
feat(cli): add sandbox exec / sandbox logs commands and shell completion

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -43,6 +43,9 @@ SmolVM is specifically designed to provide a secure "sandbox" for AI agents to e
   aliases exist for muscle memory (`images` mirrors `docker images`); both
   delegate to their NOUN-VERB homes (`image prune`, `image list`). Do not
   add further top-level aliases without discussion.
+- `smolvm completion <shell>` is an accepted top-level meta-command (like
+  `git`/`gh` completion): it acts on the CLI itself rather than a sandbox
+  resource, so it sits outside the NOUN-VERB rule by design.
 
 
 ### Core writing principles

--- a/README.md
+++ b/README.md
@@ -144,6 +144,20 @@ smolvm sandbox shell my-sandbox
 
 Use `smolvm sandbox ssh my-sandbox` when you specifically need an SSH session.
 
+Run a single command without opening a shell — useful in scripts. Put the command after `--`:
+
+```bash
+smolvm sandbox exec my-sandbox -- python --version
+```
+
+If something goes wrong, read the sandbox's logs (add `--follow` to watch them live):
+
+```bash
+smolvm sandbox logs my-sandbox
+```
+
+Tip: turn on tab completion so your shell can finish commands and sandbox names for you — add `eval "$(smolvm completion bash)"` (or `zsh`) to your shell startup file. See the [CLI reference](docs/reference/cli.md#shell-completion) for fish and other details.
+
 ## Windows sandbox
 
 SmolVM can boot a Windows 11 guest as well as Linux. Hand it a Windows image and you get the same Python and CLI you use for Linux — run PowerShell, upload files, set environment variables, and run many sandboxes in parallel from one baseline image.

--- a/README.md
+++ b/README.md
@@ -156,7 +156,7 @@ If something goes wrong, read the sandbox's logs (add `--follow` to watch them l
 smolvm sandbox logs my-sandbox
 ```
 
-Tip: turn on tab completion so your shell can finish commands and sandbox names for you — add `eval "$(smolvm completion bash)"` (or `zsh`) to your shell startup file. See the [CLI reference](docs/reference/cli.md#shell-completion) for fish and other details.
+Tip: turn on tab completion so your shell can finish commands and sandbox names for you — run `smolvm completion bash --install` (or `zsh`, `fish`) once. See the [CLI reference](docs/reference/cli.md#shell-completion) for details.
 
 ## Windows sandbox
 

--- a/README.md
+++ b/README.md
@@ -144,7 +144,7 @@ smolvm sandbox shell my-sandbox
 
 Use `smolvm sandbox ssh my-sandbox` when you specifically need an SSH session.
 
-Run a single command without opening a shell — useful in scripts. Put the command after `--`:
+Run a single command in a running sandbox without opening a shell — useful in scripts. Put the command after `--`, and add `--start` if you want a stopped sandbox started first:
 
 ```bash
 smolvm sandbox exec my-sandbox -- python --version

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -68,7 +68,15 @@ Images are stored in `~/.smolvm/images`. To keep them somewhere else, set the `S
 
 ## Shell completion
 
-Turn on tab completion so your shell can finish `smolvm` commands, options, and the names of your existing sandboxes as you type. Pick the line for your shell:
+Turn on tab completion so your shell can finish `smolvm` commands, options, and the names of your existing sandboxes as you type. One command sets it up:
+
+```bash
+smolvm completion bash --install   # also works with: zsh, fish
+```
+
+Open a new shell afterward, then type `smolvm sandbox ssh` followed by a space and press Tab to complete a sandbox name.
+
+Prefer to wire it up yourself? Run the same command without `--install` to print the script, then load it your own way:
 
 ```bash
 # bash — add to ~/.bashrc
@@ -81,8 +89,6 @@ eval "$(smolvm completion zsh)"
 mkdir -p ~/.config/fish/completions
 smolvm completion fish > ~/.config/fish/completions/smolvm.fish
 ```
-
-Open a new shell afterward, then type `smolvm sandbox ssh` followed by a space and press Tab to complete a sandbox name.
 
 ## Common options
 

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -21,6 +21,8 @@ Run these in the order you need them:
 | `smolvm sandbox create` | Create a sandbox. Add `--network bridge --bridge BRIDGE` only when the sandbox should appear as a separate computer on that network. |
 | `smolvm sandbox list` / `info` | Find or inspect sandboxes. |
 | `smolvm sandbox shell` / `ssh` | Open a shell. `shell` uses SmolVM's fast control channel when available; `ssh` explicitly uses SSH. |
+| `smolvm sandbox exec` | Run one command inside a sandbox and print its output — handy for scripts and agents. Put the command after `--`, e.g. `smolvm sandbox exec my-sandbox -- ls -la`. |
+| `smolvm sandbox logs` | Show a sandbox's boot and console logs. Add `--follow` to keep printing new lines. |
 | `smolvm sandbox start` / `stop` | Start or stop a sandbox. |
 | `smolvm sandbox pause` / `resume` | Temporarily freeze and continue a running sandbox. |
 | `smolvm sandbox delete` | Remove one or more sandboxes. |
@@ -63,6 +65,23 @@ Images are stored in `~/.smolvm/images`. To keep them somewhere else, set the `S
 | `smolvm ui` | Start the local dashboard. |
 | `smolvm server start` | Start the local HTTP API. |
 | `smolvm windows build-image` | Build a Windows qcow2 image. |
+
+## Shell completion
+
+Turn on tab completion so your shell can finish `smolvm` commands, options, and the names of your existing sandboxes as you type. Pick the line for your shell:
+
+```bash
+# bash — add to ~/.bashrc
+eval "$(smolvm completion bash)"
+
+# zsh — add to ~/.zshrc
+eval "$(smolvm completion zsh)"
+
+# fish — write once to the completions folder
+smolvm completion fish > ~/.config/fish/completions/smolvm.fish
+```
+
+Open a new shell afterward, then type `smolvm sandbox ssh ` and press Tab to complete a sandbox name.
 
 ## Common options
 

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -77,7 +77,8 @@ eval "$(smolvm completion bash)"
 # zsh — add to ~/.zshrc
 eval "$(smolvm completion zsh)"
 
-# fish — write once to the completions folder
+# fish — create the folder once, then write the completion file
+mkdir -p ~/.config/fish/completions
 smolvm completion fish > ~/.config/fish/completions/smolvm.fish
 ```
 

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -21,7 +21,7 @@ Run these in the order you need them:
 | `smolvm sandbox create` | Create a sandbox. Add `--network bridge --bridge BRIDGE` only when the sandbox should appear as a separate computer on that network. |
 | `smolvm sandbox list` / `info` | Find or inspect sandboxes. |
 | `smolvm sandbox shell` / `ssh` | Open a shell. `shell` uses SmolVM's fast control channel when available; `ssh` explicitly uses SSH. |
-| `smolvm sandbox exec` | Run one command inside a sandbox and print its output — handy for scripts and agents. Put the command after `--`, e.g. `smolvm sandbox exec my-sandbox -- ls -la`. |
+| `smolvm sandbox exec` | Run one command inside a running sandbox and print its output — handy for scripts and agents. Put the command after `--`, e.g. `smolvm sandbox exec my-sandbox -- ls -la`. Add `--start` to start the sandbox first if it isn't running. |
 | `smolvm sandbox logs` | Show a sandbox's boot and console logs. Add `--follow` to keep printing new lines. |
 | `smolvm sandbox start` / `stop` | Start or stop a sandbox. |
 | `smolvm sandbox pause` / `resume` | Temporarily freeze and continue a running sandbox. |

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -81,7 +81,7 @@ eval "$(smolvm completion zsh)"
 smolvm completion fish > ~/.config/fish/completions/smolvm.fish
 ```
 
-Open a new shell afterward, then type `smolvm sandbox ssh ` and press Tab to complete a sandbox name.
+Open a new shell afterward, then type `smolvm sandbox ssh` followed by a space and press Tab to complete a sandbox name.
 
 ## Common options
 

--- a/src/smolvm/browser.py
+++ b/src/smolvm/browser.py
@@ -750,13 +750,13 @@ class _BrowserSandbox:
 
     @staticmethod
     def _tail_local_file(path: Path, line_count: int) -> str:
+        from smolvm.utils import tail_file
+
         try:
-            lines = path.read_text(encoding="utf-8", errors="replace").splitlines()
+            lines, _, _ = tail_file(path, line_count)
         except OSError as e:
             return f"<failed to read {path}: {e}>"
-        if line_count <= 0:
-            return ""
-        return "\n".join(lines[-line_count:])
+        return "\n".join(lines)
 
 
 class _DesktopSandbox(_BrowserSandbox):

--- a/src/smolvm/cli/commands/app.py
+++ b/src/smolvm/cli/commands/app.py
@@ -13,6 +13,7 @@ from smolvm.cli.commands.options import (
     backend_option,
     boot_timeout_option,
     comm_channel_option,
+    complete_sandbox_names,
     image_dir_option,
     json_option,
     positive_float_type,
@@ -165,7 +166,7 @@ def sandbox_list(include_all: bool, status_filter: str | None, json_output: bool
 
 
 @sandbox.command("info")
-@click.argument("vm_id", metavar="sandbox")
+@click.argument("vm_id", metavar="sandbox", shell_complete=complete_sandbox_names)
 @json_option
 def sandbox_info(vm_id: str, json_output: bool) -> Any:
     """Show details about a sandbox."""
@@ -178,7 +179,7 @@ def sandbox_info(vm_id: str, json_output: bool) -> Any:
 
 
 @sandbox.command("start")
-@click.argument("vm_id", metavar="sandbox")
+@click.argument("vm_id", metavar="sandbox", shell_complete=complete_sandbox_names)
 @boot_timeout_option
 @json_option
 def sandbox_start(vm_id: str, boot_timeout: float, json_output: bool) -> Any:
@@ -190,7 +191,7 @@ def sandbox_start(vm_id: str, boot_timeout: float, json_output: bool) -> Any:
 
 
 @sandbox.command("stop")
-@click.argument("vm_id", metavar="sandbox")
+@click.argument("vm_id", metavar="sandbox", shell_complete=complete_sandbox_names)
 @click.option(
     "--timeout",
     type=positive_float_type(),
@@ -208,7 +209,7 @@ def sandbox_stop(vm_id: str, timeout: float, json_output: bool) -> Any:
 
 
 @sandbox.command("pause")
-@click.argument("vm_id", metavar="sandbox")
+@click.argument("vm_id", metavar="sandbox", shell_complete=complete_sandbox_names)
 @json_option
 def sandbox_pause(vm_id: str, json_output: bool) -> Any:
     """Pause a running sandbox."""
@@ -217,7 +218,7 @@ def sandbox_pause(vm_id: str, json_output: bool) -> Any:
 
 
 @sandbox.command("resume")
-@click.argument("vm_id", metavar="sandbox")
+@click.argument("vm_id", metavar="sandbox", shell_complete=complete_sandbox_names)
 @json_option
 def sandbox_resume(vm_id: str, json_output: bool) -> Any:
     """Resume a paused sandbox."""
@@ -228,7 +229,7 @@ def sandbox_resume(vm_id: str, json_output: bool) -> Any:
 
 
 @sandbox.command("shell")
-@click.argument("vm_id", metavar="sandbox")
+@click.argument("vm_id", metavar="sandbox", shell_complete=complete_sandbox_names)
 @boot_timeout_option
 def sandbox_shell(vm_id: str, boot_timeout: float) -> Any:
     """Open a fast shell in a sandbox."""
@@ -243,7 +244,7 @@ def sandbox_shell(vm_id: str, boot_timeout: float) -> Any:
 
 
 @sandbox.command("ssh")
-@click.argument("vm_id", metavar="sandbox")
+@click.argument("vm_id", metavar="sandbox", shell_complete=complete_sandbox_names)
 @ssh_auth_options
 @boot_timeout_option
 def sandbox_ssh(vm_id: str, ssh_key: str | None, ssh_user: str, boot_timeout: float) -> Any:
@@ -260,8 +261,75 @@ def sandbox_ssh(vm_id: str, ssh_key: str | None, ssh_user: str, boot_timeout: fl
     )
 
 
+@sandbox.command(
+    "exec",
+    short_help="Run a command in a sandbox and print its output.",
+    context_settings={"ignore_unknown_options": True},
+)
+@click.argument("vm_id", metavar="sandbox", shell_complete=complete_sandbox_names)
+@click.argument("command", nargs=-1, required=True, metavar="-- COMMAND ...")
+@click.option(
+    "--timeout",
+    type=positive_int_type(),
+    default=30,
+    show_default=True,
+    help="Seconds to wait for the command to finish.",
+)
+@boot_timeout_option
+@json_option
+def sandbox_exec(
+    vm_id: str,
+    command: tuple[str, ...],
+    timeout: int,
+    boot_timeout: float,
+    json_output: bool,
+) -> Any:
+    """Run a command in a sandbox and print its output.
+
+    \b
+    Example:
+      smolvm sandbox exec my-sandbox -- ls -la /root
+    """
+    _before_command(json_output=json_output)
+    return _handlers()._run_exec(
+        _ns(
+            command_name="sandbox.exec",
+            vm_id=vm_id,
+            command=command,
+            timeout=timeout,
+            boot_timeout=boot_timeout,
+            json=json_output,
+        )
+    )
+
+
+@sandbox.command("logs")
+@click.argument("vm_id", metavar="sandbox", shell_complete=complete_sandbox_names)
+@click.option(
+    "--tail",
+    type=positive_int_type(),
+    default=200,
+    show_default=True,
+    help="Number of lines to show from the end of the log.",
+)
+@click.option("-f", "--follow", is_flag=True, help="Keep printing new log lines as they arrive.")
+@json_option
+def sandbox_logs(vm_id: str, tail: int, follow: bool, json_output: bool) -> Any:
+    """Show a sandbox's boot and console logs."""
+    _before_command(json_output=json_output)
+    return _handlers()._run_logs(
+        _ns(
+            command_name="sandbox.logs",
+            vm_id=vm_id,
+            tail=tail,
+            follow=follow,
+            json=json_output,
+        )
+    )
+
+
 @sandbox.command("delete")
-@click.argument("vm_ids", nargs=-1, metavar="sandbox...")
+@click.argument("vm_ids", nargs=-1, metavar="sandbox...", shell_complete=complete_sandbox_names)
 @click.option("--all", "all_sandboxes", is_flag=True, help="Delete every sandbox.")
 @click.option("--force", is_flag=True, help="Skip the confirmation prompt for --all.")
 @click.option("--dry-run", is_flag=True, help="Show what would be deleted.")
@@ -372,6 +440,33 @@ def update(check_only: bool, json_output: bool) -> Any:
     from smolvm.cli.update import run_update
 
     return run_update(check=check_only, json_output=json_output)
+
+
+@cli.command("completion", short_help="Print a shell tab-completion script.")
+@click.argument("shell", type=click.Choice(["bash", "zsh", "fish"]))
+def completion(shell: str) -> int:
+    """Print a shell tab-completion script for smolvm.
+
+    Completion suggests subcommands, options, and the names of your existing
+    sandboxes. Load it in your current shell, or install it permanently:
+
+    \b
+    bash:  eval "$(smolvm completion bash)"
+           # or persist: smolvm completion bash > ~/.smolvm-completion.bash
+           #             echo 'source ~/.smolvm-completion.bash' >> ~/.bashrc
+    zsh:   eval "$(smolvm completion zsh)"
+           # or persist: smolvm completion zsh > ~/.smolvm-completion.zsh
+           #             echo 'source ~/.smolvm-completion.zsh' >> ~/.zshrc
+    fish:  smolvm completion fish > ~/.config/fish/completions/smolvm.fish
+    """
+    from click.shell_completion import get_completion_class
+
+    completion_cls = get_completion_class(shell)
+    if completion_cls is None:  # pragma: no cover - guarded by click.Choice
+        raise click.UsageError(f"Shell completion is not supported for '{shell}'.")
+    comp = completion_cls(cli, {}, "smolvm", "_SMOLVM_COMPLETE")
+    click.echo(comp.source())
+    return 0
 
 
 @cli.command("prune", help="Remove stale image-cache entries (alias for 'smolvm image prune').")
@@ -647,7 +742,7 @@ def snapshot() -> None:
 
 
 @snapshot.command("create")
-@click.argument("vm_id", metavar="sandbox")
+@click.argument("vm_id", metavar="sandbox", shell_complete=complete_sandbox_names)
 @click.option("--snapshot-id", default=None)
 @click.option(
     "--snapshot-type",
@@ -756,7 +851,7 @@ def file() -> None:
 
 
 @file.command("upload")
-@click.argument("vm_id", metavar="sandbox")
+@click.argument("vm_id", metavar="sandbox", shell_complete=complete_sandbox_names)
 @click.argument("local_path", metavar="local-path")
 @click.argument("guest_path", metavar="guest-path")
 @click.option("--no-create-dirs", is_flag=True)
@@ -792,7 +887,7 @@ def file_upload(
 
 
 @file.command("download")
-@click.argument("vm_id", metavar="sandbox")
+@click.argument("vm_id", metavar="sandbox", shell_complete=complete_sandbox_names)
 @click.argument("guest_path", metavar="guest-path")
 @click.argument("local_path", metavar="local-path")
 @click.option("--no-create-dirs", is_flag=True)
@@ -833,7 +928,7 @@ def env() -> None:
 
 
 @env.command("set")
-@click.argument("vm_id", metavar="sandbox")
+@click.argument("vm_id", metavar="sandbox", shell_complete=complete_sandbox_names)
 @click.argument("pairs", nargs=-1, required=True, metavar="KEY=VALUE...")
 @ssh_auth_options
 @comm_channel_option
@@ -863,7 +958,7 @@ def env_set(
 
 
 @env.command("unset")
-@click.argument("vm_id", metavar="sandbox")
+@click.argument("vm_id", metavar="sandbox", shell_complete=complete_sandbox_names)
 @click.argument("keys", nargs=-1, required=True, metavar="KEY...")
 @ssh_auth_options
 @comm_channel_option
@@ -893,7 +988,7 @@ def env_unset(
 
 
 @env.command("list")
-@click.argument("vm_id", metavar="sandbox")
+@click.argument("vm_id", metavar="sandbox", shell_complete=complete_sandbox_names)
 @click.option("--show-values", is_flag=True)
 @ssh_auth_options
 @comm_channel_option
@@ -928,7 +1023,7 @@ def port() -> None:
 
 
 @port.command("expose")
-@click.argument("vm_id", metavar="sandbox")
+@click.argument("vm_id", metavar="sandbox", shell_complete=complete_sandbox_names)
 @click.argument("mapping", metavar="[host-port:]sandbox-port")
 @ssh_auth_options
 @comm_channel_option
@@ -957,7 +1052,7 @@ def port_expose(
 
 
 @port.command("close")
-@click.argument("vm_id", metavar="sandbox")
+@click.argument("vm_id", metavar="sandbox", shell_complete=complete_sandbox_names)
 @click.argument("mapping", metavar="host-port:sandbox-port")
 @ssh_auth_options
 @comm_channel_option
@@ -986,7 +1081,7 @@ def port_close(
 
 
 @port.command("list")
-@click.argument("vm_id", metavar="sandbox")
+@click.argument("vm_id", metavar="sandbox", shell_complete=complete_sandbox_names)
 @ssh_auth_options
 @comm_channel_option
 @json_option
@@ -1137,7 +1232,9 @@ def browser_start(
 
 
 @browser.command("stop")
-@click.argument("session_id", required=False, metavar="sandbox")
+@click.argument(
+    "session_id", required=False, metavar="sandbox", shell_complete=complete_sandbox_names
+)
 @click.option("--all", "all_sessions", is_flag=True)
 def browser_stop(session_id: str | None, all_sessions: bool) -> Any:
     """Stop a browser sandbox."""
@@ -1166,7 +1263,7 @@ def browser_list(status: str | None, json_output: bool) -> Any:
 
 
 @browser.command("open")
-@click.argument("session_id", metavar="sandbox")
+@click.argument("session_id", metavar="sandbox", shell_complete=complete_sandbox_names)
 def browser_open(session_id: str) -> Any:
     """Open a browser view."""
     _before_command()
@@ -1174,7 +1271,7 @@ def browser_open(session_id: str) -> Any:
 
 
 @browser.command("logs")
-@click.argument("session_id", metavar="sandbox")
+@click.argument("session_id", metavar="sandbox", shell_complete=complete_sandbox_names)
 @click.option("--tail", type=int, default=100, show_default=True)
 def browser_logs(session_id: str, tail: int) -> Any:
     """Show recent browser output."""

--- a/src/smolvm/cli/commands/app.py
+++ b/src/smolvm/cli/commands/app.py
@@ -453,21 +453,28 @@ def update(check_only: bool, json_output: bool) -> Any:
     return run_update(check=check_only, json_output=json_output)
 
 
-@cli.command("completion", short_help="Print a shell tab-completion script.")
+@cli.command("completion", short_help="Print or install a shell tab-completion script.")
 @click.argument("shell", type=click.Choice(["bash", "zsh", "fish"]))
-def completion(shell: str) -> int:
-    """Print a shell tab-completion script for smolvm.
+@click.option(
+    "--install",
+    "install",
+    is_flag=True,
+    help="Set up completion for the shell in one step instead of printing the script.",
+)
+def completion(shell: str, install: bool) -> int:
+    """Print or install a shell tab-completion script for smolvm.
 
     Completion suggests subcommands, options, and the names of your existing
-    sandboxes. Load it in your current shell, or install it permanently:
+    sandboxes. The quickest setup is one command:
+
+    \b
+      smolvm completion bash --install   # also: zsh, fish
+
+    Without --install the script is printed so you can wire it up yourself:
 
     \b
     bash:  eval "$(smolvm completion bash)"
-           # or persist: smolvm completion bash > ~/.smolvm-completion.bash
-           #             echo 'source ~/.smolvm-completion.bash' >> ~/.bashrc
     zsh:   eval "$(smolvm completion zsh)"
-           # or persist: smolvm completion zsh > ~/.smolvm-completion.zsh
-           #             echo 'source ~/.smolvm-completion.zsh' >> ~/.zshrc
     fish:  smolvm completion fish > ~/.config/fish/completions/smolvm.fish
     """
     from click.shell_completion import get_completion_class
@@ -476,7 +483,12 @@ def completion(shell: str) -> int:
     if completion_cls is None:  # pragma: no cover - guarded by click.Choice
         raise click.UsageError(f"Shell completion is not supported for '{shell}'.")
     comp = completion_cls(cli, {}, "smolvm", "_SMOLVM_COMPLETE")
-    click.echo(comp.source())
+    script = comp.source()
+    if install:
+        from smolvm.cli.completion import run_completion_install
+
+        return run_completion_install(shell, script)
+    click.echo(script)
     return 0
 
 

--- a/src/smolvm/cli/commands/app.py
+++ b/src/smolvm/cli/commands/app.py
@@ -275,16 +275,25 @@ def sandbox_ssh(vm_id: str, ssh_key: str | None, ssh_user: str, boot_timeout: fl
     show_default=True,
     help="Seconds to wait for the command to finish.",
 )
+@click.option(
+    "--start",
+    is_flag=True,
+    help="Start the sandbox first if it is not already running.",
+)
 @boot_timeout_option
 @json_option
 def sandbox_exec(
     vm_id: str,
     command: tuple[str, ...],
     timeout: int,
+    start: bool,
     boot_timeout: float,
     json_output: bool,
 ) -> Any:
     """Run a command in a sandbox and print its output.
+
+    The sandbox must already be running. Pass --start to have it started
+    automatically first.
 
     \b
     Example:
@@ -297,6 +306,7 @@ def sandbox_exec(
             vm_id=vm_id,
             command=command,
             timeout=timeout,
+            start=start,
             boot_timeout=boot_timeout,
             json=json_output,
         )

--- a/src/smolvm/cli/commands/app.py
+++ b/src/smolvm/cli/commands/app.py
@@ -1244,7 +1244,7 @@ def browser_start(
 
 @browser.command("stop")
 @click.argument(
-    "session_id", required=False, metavar="sandbox", shell_complete=complete_browser_session_names
+    "session_id", required=False, metavar="session", shell_complete=complete_browser_session_names
 )
 @click.option("--all", "all_sessions", is_flag=True)
 def browser_stop(session_id: str | None, all_sessions: bool) -> Any:
@@ -1274,7 +1274,7 @@ def browser_list(status: str | None, json_output: bool) -> Any:
 
 
 @browser.command("open")
-@click.argument("session_id", metavar="sandbox", shell_complete=complete_browser_session_names)
+@click.argument("session_id", metavar="session", shell_complete=complete_browser_session_names)
 def browser_open(session_id: str) -> Any:
     """Open a browser view."""
     _before_command()
@@ -1282,7 +1282,7 @@ def browser_open(session_id: str) -> Any:
 
 
 @browser.command("logs")
-@click.argument("session_id", metavar="sandbox", shell_complete=complete_browser_session_names)
+@click.argument("session_id", metavar="session", shell_complete=complete_browser_session_names)
 @click.option("--tail", type=int, default=100, show_default=True)
 def browser_logs(session_id: str, tail: int) -> Any:
     """Show recent browser output."""

--- a/src/smolvm/cli/commands/app.py
+++ b/src/smolvm/cli/commands/app.py
@@ -13,6 +13,7 @@ from smolvm.cli.commands.options import (
     backend_option,
     boot_timeout_option,
     comm_channel_option,
+    complete_browser_session_names,
     complete_sandbox_names,
     image_dir_option,
     json_option,
@@ -1243,7 +1244,7 @@ def browser_start(
 
 @browser.command("stop")
 @click.argument(
-    "session_id", required=False, metavar="sandbox", shell_complete=complete_sandbox_names
+    "session_id", required=False, metavar="sandbox", shell_complete=complete_browser_session_names
 )
 @click.option("--all", "all_sessions", is_flag=True)
 def browser_stop(session_id: str | None, all_sessions: bool) -> Any:
@@ -1273,7 +1274,7 @@ def browser_list(status: str | None, json_output: bool) -> Any:
 
 
 @browser.command("open")
-@click.argument("session_id", metavar="sandbox", shell_complete=complete_sandbox_names)
+@click.argument("session_id", metavar="sandbox", shell_complete=complete_browser_session_names)
 def browser_open(session_id: str) -> Any:
     """Open a browser view."""
     _before_command()
@@ -1281,7 +1282,7 @@ def browser_open(session_id: str) -> Any:
 
 
 @browser.command("logs")
-@click.argument("session_id", metavar="sandbox", shell_complete=complete_sandbox_names)
+@click.argument("session_id", metavar="sandbox", shell_complete=complete_browser_session_names)
 @click.option("--tail", type=int, default=100, show_default=True)
 def browser_logs(session_id: str, tail: int) -> Any:
     """Show recent browser output."""

--- a/src/smolvm/cli/commands/options.py
+++ b/src/smolvm/cli/commands/options.py
@@ -119,17 +119,14 @@ def positive_float_type() -> click.FloatRange:
     return click.FloatRange(min=0, min_open=True)
 
 
-def complete_sandbox_names(
-    ctx: click.Context,
-    param: click.Parameter,
-    incomplete: str,
-) -> list[Any]:
-    """Complete a sandbox-name argument with the user's existing sandboxes.
+def _complete_from_state(select: Callable[[Any], Any], incomplete: str) -> list[Any]:
+    """Return prefix-matched CompletionItems from the state store.
 
-    Used as a ``shell_complete`` callback. Completion runs in the user's
-    shell on every ``<TAB>``, so it must never raise and must stay cheap:
-    any failure (no state DB yet, backend import error) yields no
-    suggestions rather than a traceback.
+    Opens the state store directly (not SmolVMManager, which would create
+    disk/snapshot subdirectories just to list names on ``<TAB>``), calls
+    ``select(state)`` to get an iterable of ids, and closes the store.
+    Completion runs in the user's shell on every ``<TAB>``, so this must
+    never raise: any failure yields no suggestions rather than a traceback.
     """
     from click.shell_completion import CompletionItem
 
@@ -138,10 +135,8 @@ def complete_sandbox_names(
         from smolvm.storage import create_state_manager
         from smolvm.vm import resolve_data_dir
 
-        # Use the state store directly rather than SmolVMManager, which would
-        # create disk/snapshot subdirectories just to list names on <TAB>.
         state = create_state_manager(db_path=resolve_data_dir() / "smolvm.db")
-        names = [vm.vm_id for vm in state.list_vms()]
+        ids = list(select(state))
     except Exception:
         return []
     finally:
@@ -149,7 +144,16 @@ def complete_sandbox_names(
             with contextlib.suppress(Exception):
                 state.close()
 
-    return [CompletionItem(name) for name in names if name.startswith(incomplete)]
+    return [CompletionItem(i) for i in ids if i.startswith(incomplete)]
+
+
+def complete_sandbox_names(
+    ctx: click.Context,
+    param: click.Parameter,
+    incomplete: str,
+) -> list[Any]:
+    """Complete a sandbox-name argument with the user's existing sandboxes."""
+    return _complete_from_state(lambda state: [vm.vm_id for vm in state.list_vms()], incomplete)
 
 
 def complete_browser_session_names(
@@ -160,24 +164,10 @@ def complete_browser_session_names(
     """Complete a browser session-id argument with existing browser sessions.
 
     Browser sandboxes live in their own session-id namespace (distinct from
-    sandbox names), so ``browser`` commands need this rather than
-    :func:`complete_sandbox_names`. Like that helper it must never raise and
-    yields no suggestions on any failure.
+    sandbox names), so ``browser`` commands use this rather than
+    :func:`complete_sandbox_names`.
     """
-    from click.shell_completion import CompletionItem
-
-    state = None
-    try:
-        from smolvm.storage import create_state_manager
-        from smolvm.vm import resolve_data_dir
-
-        state = create_state_manager(db_path=resolve_data_dir() / "smolvm.db")
-        ids = [session.session_id for session in state.list_browser_sessions()]
-    except Exception:
-        return []
-    finally:
-        if state is not None:
-            with contextlib.suppress(Exception):
-                state.close()
-
-    return [CompletionItem(sid) for sid in ids if sid.startswith(incomplete)]
+    return _complete_from_state(
+        lambda state: [session.session_id for session in state.list_browser_sessions()],
+        incomplete,
+    )

--- a/src/smolvm/cli/commands/options.py
+++ b/src/smolvm/cli/commands/options.py
@@ -133,13 +133,21 @@ def complete_sandbox_names(
     """
     from click.shell_completion import CompletionItem
 
+    state = None
     try:
-        from smolvm.vm import SmolVMManager
+        from smolvm.storage import create_state_manager
+        from smolvm.vm import resolve_data_dir
 
-        with SmolVMManager() as sdk:
-            names = [vm.vm_id for vm in sdk.list_vms()]
+        # Use the state store directly rather than SmolVMManager, which would
+        # create disk/snapshot subdirectories just to list names on <TAB>.
+        state = create_state_manager(db_path=resolve_data_dir() / "smolvm.db")
+        names = [vm.vm_id for vm in state.list_vms()]
     except Exception:
         return []
+    finally:
+        if state is not None:
+            with contextlib.suppress(Exception):
+                state.close()
 
     return [CompletionItem(name) for name in names if name.startswith(incomplete)]
 

--- a/src/smolvm/cli/commands/options.py
+++ b/src/smolvm/cli/commands/options.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import contextlib
 import platform
 from collections.abc import Callable, Mapping
 from functools import wraps
@@ -141,3 +142,34 @@ def complete_sandbox_names(
         return []
 
     return [CompletionItem(name) for name in names if name.startswith(incomplete)]
+
+
+def complete_browser_session_names(
+    ctx: click.Context,
+    param: click.Parameter,
+    incomplete: str,
+) -> list[Any]:
+    """Complete a browser session-id argument with existing browser sessions.
+
+    Browser sandboxes live in their own session-id namespace (distinct from
+    sandbox names), so ``browser`` commands need this rather than
+    :func:`complete_sandbox_names`. Like that helper it must never raise and
+    yields no suggestions on any failure.
+    """
+    from click.shell_completion import CompletionItem
+
+    state = None
+    try:
+        from smolvm.storage import create_state_manager
+        from smolvm.vm import resolve_data_dir
+
+        state = create_state_manager(db_path=resolve_data_dir() / "smolvm.db")
+        ids = [session.session_id for session in state.list_browser_sessions()]
+    except Exception:
+        return []
+    finally:
+        if state is not None:
+            with contextlib.suppress(Exception):
+                state.close()
+
+    return [CompletionItem(sid) for sid in ids if sid.startswith(incomplete)]

--- a/src/smolvm/cli/commands/options.py
+++ b/src/smolvm/cli/commands/options.py
@@ -116,3 +116,28 @@ def positive_int_type() -> click.IntRange:
 
 def positive_float_type() -> click.FloatRange:
     return click.FloatRange(min=0, min_open=True)
+
+
+def complete_sandbox_names(
+    ctx: click.Context,
+    param: click.Parameter,
+    incomplete: str,
+) -> list[Any]:
+    """Complete a sandbox-name argument with the user's existing sandboxes.
+
+    Used as a ``shell_complete`` callback. Completion runs in the user's
+    shell on every ``<TAB>``, so it must never raise and must stay cheap:
+    any failure (no state DB yet, backend import error) yields no
+    suggestions rather than a traceback.
+    """
+    from click.shell_completion import CompletionItem
+
+    try:
+        from smolvm.vm import SmolVMManager
+
+        with SmolVMManager() as sdk:
+            names = [vm.vm_id for vm in sdk.list_vms()]
+    except Exception:
+        return []
+
+    return [CompletionItem(name) for name in names if name.startswith(incomplete)]

--- a/src/smolvm/cli/completion.py
+++ b/src/smolvm/cli/completion.py
@@ -64,6 +64,23 @@ def _user_home() -> Path:
     return Path.home()
 
 
+def _with_ancestors_below(path: Path, stop: Path) -> list[Path]:
+    """Return ``path`` plus every ancestor strictly below ``stop``.
+
+    ``mkdir(parents=True)`` may create a whole chain of directories (a
+    custom ``XDG_CONFIG_HOME`` or ``ZDOTDIR`` several levels deep), so
+    ownership fixes must cover the full chain, not a fixed number of
+    parent levels. For a path outside ``stop`` only the path itself is
+    returned.
+    """
+    targets = [path]
+    current = path.parent
+    while current != stop and current != current.parent and current.is_relative_to(stop):
+        targets.append(current)
+        current = current.parent
+    return targets
+
+
 def _chown_to_sudo_user(paths: list[Path]) -> None:
     """Give files created while running under sudo back to the real user."""
     from smolvm.vm import _get_sudo_user_info
@@ -133,20 +150,21 @@ def _install_rc_line(shell: str, rc_path: Path, script_path: Path) -> str:
 
     kept = [line for line in lines if _MARKER not in line]
     marker_lines = [line for line in lines if _MARKER in line]
-    active = managed_line in marker_lines
-    stale = [line for line in marker_lines if line != managed_line]
     user_written = any(
         f"completions/smolvm.{shell}" in line and not line.lstrip().startswith("#") for line in kept
     )
 
-    if active and not stale:
+    # Exact-list comparison so duplicated copies of the current line still
+    # fall through to the rewrite below and get collapsed to one.
+    if marker_lines == [managed_line]:
         return (
             f"Tab completion for {shell} is already set up in '{rc_path}'. "
             "Open a new shell if it isn't active."
         )
 
     if user_written:
-        if stale:
+        if marker_lines:
+            # The user's own line loads the script; ours are redundant.
             _write_rc(rc_path, kept)
         return (
             f"Tab completion for {shell} is already loaded by a line you added "
@@ -182,11 +200,12 @@ def run_completion_install(shell: str, script: str) -> int:
     """
     console = console_stdout()
     try:
+        home = _user_home()
         if shell == "fish":
             target = _fish_completions_dir() / "smolvm.fish"
             target.parent.mkdir(parents=True, exist_ok=True)
             target.write_text(script, encoding="utf-8")
-            _chown_to_sudo_user([target.parent.parent, target.parent, target])
+            _chown_to_sudo_user(_with_ancestors_below(target, home))
             console.print(
                 f"Tab completion for fish is set up at '{target}'. Open a new shell to use it."
             )
@@ -195,7 +214,7 @@ def run_completion_install(shell: str, script: str) -> int:
         if shell == "zsh":
             script = _ZSH_COMPINIT_GUARD + script
 
-        script_path = _user_home() / ".smolvm" / "completions" / f"smolvm.{shell}"
+        script_path = home / ".smolvm" / "completions" / f"smolvm.{shell}"
         script_path.parent.mkdir(parents=True, exist_ok=True)
         script_path.write_text(script, encoding="utf-8")
 
@@ -203,9 +222,9 @@ def run_completion_install(shell: str, script: str) -> int:
         rc_existed = rc_path.exists()
         message = _install_rc_line(shell, rc_path, script_path)
 
-        chown_targets = [script_path.parent.parent, script_path.parent, script_path]
+        chown_targets = _with_ancestors_below(script_path, home)
         if not rc_existed and rc_path.exists():
-            chown_targets.append(rc_path)
+            chown_targets.extend(_with_ancestors_below(rc_path, home))
         _chown_to_sudo_user(chown_targets)
 
         console.print(message)

--- a/src/smolvm/cli/completion.py
+++ b/src/smolvm/cli/completion.py
@@ -12,78 +12,212 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""One-shot installation of shell tab-completion for the smolvm CLI."""
+"""One-shot installation of shell tab-completion for the smolvm CLI.
+
+fish autoloads per-command completion files from its completions
+directory, so a single file write is enough there. bash and zsh do have
+autoload mechanisms too (bash-completion's drop-in directory, zsh's
+``fpath``), but both only work when the machine has them set up, so for
+a setup that works everywhere we write the script under
+``~/.smolvm/completions`` and manage one marker-tagged ``source`` line
+in the shell's startup file instead.
+"""
 
 from __future__ import annotations
 
 import os
+import platform
+import shlex
+from contextlib import suppress
 from pathlib import Path
 
 from smolvm.cli.output import console_stdout, render_error
 
+# Trailing tag on the rc line this tool manages. Install looks for this
+# marker to find (and replace) its own line without touching lines the
+# user wrote themselves.
+_MARKER = "# smolvm tab completion"
+
+# zsh's `compdef` only exists after `compinit` has run; a minimal .zshrc
+# never runs it, so the installed script initializes completion first.
+_ZSH_COMPINIT_GUARD = (
+    "# Ensure zsh's completion system is initialized before compdef is used.\n"
+    "if ! command -v compdef > /dev/null 2>&1; then\n"
+    "  autoload -Uz compinit\n"
+    "  compinit\n"
+    "fi\n"
+    "\n"
+)
+
+
+def _user_home() -> Path:
+    """Return the invoking user's home, resolving through sudo.
+
+    Under ``sudo`` a bare ``Path.home()`` is root's home, which would
+    install completion where the real user's shell never sees it.
+    """
+    from smolvm.vm import _get_sudo_user_info
+
+    sudo_user = _get_sudo_user_info()
+    if sudo_user is not None:
+        return Path(sudo_user.pw_dir)
+    return Path.home()
+
+
+def _chown_to_sudo_user(paths: list[Path]) -> None:
+    """Give files created while running under sudo back to the real user."""
+    from smolvm.vm import _get_sudo_user_info
+
+    sudo_user = _get_sudo_user_info()
+    if sudo_user is None:
+        return
+    for path in paths:
+        with suppress(OSError):
+            os.chown(path, sudo_user.pw_uid, sudo_user.pw_gid)
+
 
 def _rc_path(shell: str) -> Path:
     """Return the shell startup file completion should be sourced from."""
+    home = _user_home()
     if shell == "zsh":
         zdotdir = os.environ.get("ZDOTDIR")
-        base = Path(zdotdir).expanduser() if zdotdir else Path.home()
+        base = Path(zdotdir).expanduser() if zdotdir else home
         return base / ".zshrc"
-    return Path.home() / ".bashrc"
+    if platform.system() == "Darwin":
+        # macOS terminals start login shells, which read ~/.bash_profile
+        # (never ~/.bashrc). Prefer an existing file, else create the
+        # login-shell one.
+        for name in (".bash_profile", ".bashrc"):
+            candidate = home / name
+            if candidate.exists():
+                return candidate
+        return home / ".bash_profile"
+    return home / ".bashrc"
 
 
 def _fish_completions_dir() -> Path:
     """Return fish's user completions directory (autoloaded by fish)."""
     xdg = os.environ.get("XDG_CONFIG_HOME")
-    config_home = Path(xdg).expanduser() if xdg else Path.home() / ".config"
+    config_home = Path(xdg).expanduser() if xdg else _user_home() / ".config"
     return config_home / "fish" / "completions"
+
+
+def _read_rc(rc_path: Path) -> str:
+    """Read a startup file, round-tripping non-UTF-8 bytes losslessly."""
+    if not rc_path.exists():
+        return ""
+    return rc_path.read_text(encoding="utf-8", errors="surrogateescape")
+
+
+def _write_rc(rc_path: Path, lines: list[str]) -> None:
+    """Write a startup file back, preserving undecodable bytes."""
+    while lines and lines[-1] == "":
+        lines = lines[:-1]
+    text = "\n".join(lines)
+    if text and not text.endswith("\n"):
+        text += "\n"
+    rc_path.write_text(text, encoding="utf-8", errors="surrogateescape")
+
+
+def _install_rc_line(shell: str, rc_path: Path, script_path: Path) -> str:
+    """Ensure exactly one active managed source line in ``rc_path``.
+
+    Returns a short human message describing what happened. Marker-tagged
+    lines from previous installs (stale paths, duplicates, commented-out
+    copies) are replaced by one fresh line; lines the user wrote
+    themselves are never modified.
+    """
+    managed_line = f"source {shlex.quote(str(script_path))}  {_MARKER}"
+    rc_content = _read_rc(rc_path)
+    lines = rc_content.split("\n") if rc_content else []
+
+    kept = [line for line in lines if _MARKER not in line]
+    marker_lines = [line for line in lines if _MARKER in line]
+    active = managed_line in marker_lines
+    stale = [line for line in marker_lines if line != managed_line]
+    user_written = any(
+        f"completions/smolvm.{shell}" in line and not line.lstrip().startswith("#") for line in kept
+    )
+
+    if active and not stale:
+        return (
+            f"Tab completion for {shell} is already set up in '{rc_path}'. "
+            "Open a new shell if it isn't active."
+        )
+
+    if user_written:
+        if stale:
+            _write_rc(rc_path, kept)
+        return (
+            f"Tab completion for {shell} is already loaded by a line you added "
+            f"to '{rc_path}'. Open a new shell if it isn't active."
+        )
+
+    if not marker_lines:
+        # Nothing of ours in the file: append without rewriting it.
+        rc_path.parent.mkdir(parents=True, exist_ok=True)
+        with rc_path.open("a", encoding="utf-8", errors="surrogateescape") as handle:
+            if rc_content and not rc_content.endswith("\n"):
+                handle.write("\n")
+            handle.write(f"{managed_line}\n")
+        return (
+            f"Tab completion for {shell} is set up: added one line to '{rc_path}'. "
+            "Open a new shell to use it."
+        )
+
+    # Stale, duplicated, or commented-out managed lines: replace them all
+    # with one fresh line.
+    _write_rc(rc_path, [*kept, managed_line])
+    return (
+        f"Tab completion for {shell} is set up: updated the smolvm line in "
+        f"'{rc_path}'. Open a new shell to use it."
+    )
 
 
 def run_completion_install(shell: str, script: str) -> int:
     """Install the completion ``script`` for ``shell`` so new shells load it.
 
-    fish autoloads per-command files from its completions directory, so a
-    single file write is enough. bash and zsh have no autoload directory,
-    so the script is written under ``~/.smolvm/completions`` and one
-    ``source`` line is added to the shell's startup file (idempotently:
-    re-running refreshes the script without duplicating the line).
+    Idempotent: re-running refreshes the script file and repairs the
+    managed startup-file line without duplicating it.
     """
     console = console_stdout()
     try:
         if shell == "fish":
             target = _fish_completions_dir() / "smolvm.fish"
             target.parent.mkdir(parents=True, exist_ok=True)
-            target.write_text(script)
+            target.write_text(script, encoding="utf-8")
+            _chown_to_sudo_user([target.parent.parent, target.parent, target])
             console.print(
                 f"Tab completion for fish is set up at '{target}'. Open a new shell to use it."
             )
             return 0
 
-        script_path = Path.home() / ".smolvm" / "completions" / f"smolvm.{shell}"
+        if shell == "zsh":
+            script = _ZSH_COMPINIT_GUARD + script
+
+        script_path = _user_home() / ".smolvm" / "completions" / f"smolvm.{shell}"
         script_path.parent.mkdir(parents=True, exist_ok=True)
-        script_path.write_text(script)
+        script_path.write_text(script, encoding="utf-8")
 
         rc_path = _rc_path(shell)
-        rc_content = rc_path.read_text() if rc_path.exists() else ""
-        if str(script_path) in rc_content:
-            console.print(
-                f"Tab completion for {shell} is already set up in '{rc_path}'. "
-                "Open a new shell if it isn't active."
-            )
-            return 0
+        rc_existed = rc_path.exists()
+        message = _install_rc_line(shell, rc_path, script_path)
 
-        source_line = f"source '{script_path}'  # smolvm tab completion"
-        with rc_path.open("a") as handle:
-            if rc_content and not rc_content.endswith("\n"):
-                handle.write("\n")
-            handle.write(f"{source_line}\n")
-        console.print(
-            f"Tab completion for {shell} is set up: added one line to '{rc_path}'. "
-            "Open a new shell to use it."
-        )
+        chown_targets = [script_path.parent.parent, script_path.parent, script_path]
+        if not rc_existed and rc_path.exists():
+            chown_targets.append(rc_path)
+        _chown_to_sudo_user(chown_targets)
+
+        console.print(message)
         return 0
-    except OSError as exc:
+    except (OSError, UnicodeError) as exc:
+        detail = str(exc)
+        if isinstance(exc, OSError) and exc.strerror:
+            detail = exc.strerror.lower()
+            if exc.filename:
+                detail += f" for '{exc.filename}'"
         render_error(
-            f"Could not set up tab completion: {exc}. "
+            f"Could not set up tab completion: {detail}. "
             f"Run 'smolvm completion {shell}' and add the printed script "
             "to your shell yourself."
         )

--- a/src/smolvm/cli/completion.py
+++ b/src/smolvm/cli/completion.py
@@ -1,0 +1,90 @@
+# Copyright 2026 Celesto AI
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""One-shot installation of shell tab-completion for the smolvm CLI."""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+from smolvm.cli.output import console_stdout, render_error
+
+
+def _rc_path(shell: str) -> Path:
+    """Return the shell startup file completion should be sourced from."""
+    if shell == "zsh":
+        zdotdir = os.environ.get("ZDOTDIR")
+        base = Path(zdotdir).expanduser() if zdotdir else Path.home()
+        return base / ".zshrc"
+    return Path.home() / ".bashrc"
+
+
+def _fish_completions_dir() -> Path:
+    """Return fish's user completions directory (autoloaded by fish)."""
+    xdg = os.environ.get("XDG_CONFIG_HOME")
+    config_home = Path(xdg).expanduser() if xdg else Path.home() / ".config"
+    return config_home / "fish" / "completions"
+
+
+def run_completion_install(shell: str, script: str) -> int:
+    """Install the completion ``script`` for ``shell`` so new shells load it.
+
+    fish autoloads per-command files from its completions directory, so a
+    single file write is enough. bash and zsh have no autoload directory,
+    so the script is written under ``~/.smolvm/completions`` and one
+    ``source`` line is added to the shell's startup file (idempotently:
+    re-running refreshes the script without duplicating the line).
+    """
+    console = console_stdout()
+    try:
+        if shell == "fish":
+            target = _fish_completions_dir() / "smolvm.fish"
+            target.parent.mkdir(parents=True, exist_ok=True)
+            target.write_text(script)
+            console.print(
+                f"Tab completion for fish is set up at '{target}'. Open a new shell to use it."
+            )
+            return 0
+
+        script_path = Path.home() / ".smolvm" / "completions" / f"smolvm.{shell}"
+        script_path.parent.mkdir(parents=True, exist_ok=True)
+        script_path.write_text(script)
+
+        rc_path = _rc_path(shell)
+        rc_content = rc_path.read_text() if rc_path.exists() else ""
+        if str(script_path) in rc_content:
+            console.print(
+                f"Tab completion for {shell} is already set up in '{rc_path}'. "
+                "Open a new shell if it isn't active."
+            )
+            return 0
+
+        source_line = f"source '{script_path}'  # smolvm tab completion"
+        with rc_path.open("a") as handle:
+            if rc_content and not rc_content.endswith("\n"):
+                handle.write("\n")
+            handle.write(f"{source_line}\n")
+        console.print(
+            f"Tab completion for {shell} is set up: added one line to '{rc_path}'. "
+            "Open a new shell to use it."
+        )
+        return 0
+    except OSError as exc:
+        render_error(
+            f"Could not set up tab completion: {exc}. "
+            f"Run 'smolvm completion {shell}' and add the printed script "
+            "to your shell yourself."
+        )
+        return 1

--- a/src/smolvm/cli/main.py
+++ b/src/smolvm/cli/main.py
@@ -2493,7 +2493,10 @@ def _suppress_broken_pipe() -> None:
     """
     with suppress(Exception):
         devnull = os.open(os.devnull, os.O_WRONLY)
-        os.dup2(devnull, sys.stdout.fileno())
+        try:
+            os.dup2(devnull, sys.stdout.fileno())
+        finally:
+            os.close(devnull)
 
 
 def _bring_sandbox_up(
@@ -2571,17 +2574,17 @@ def _run_exec(args: SimpleNamespace) -> int:
         cmd_str = shlex.join(args.command)
         result = vm.run(cmd_str, timeout=args.timeout)
 
-        try:
-            if json_output:
-                error = None
-                if result.exit_code != 0:
-                    # Keep the envelope's ok<->error invariant: a non-zero guest
-                    # exit is a failure, so populate error while still returning
-                    # the command's stdout/stderr in data.
-                    error = {
-                        "code": "command_failed",
-                        "message": f"Command exited with status {result.exit_code}.",
-                    }
+        if json_output:
+            error = None
+            if result.exit_code != 0:
+                # Keep the envelope's ok<->error invariant: a non-zero guest
+                # exit is a failure, so populate error while still returning
+                # the command's stdout/stderr in data.
+                error = {
+                    "code": "command_failed",
+                    "message": f"Command exited with status {result.exit_code}.",
+                }
+            with suppress(BrokenPipeError):
                 emit_json(
                     command_name,
                     result.exit_code,
@@ -2592,16 +2595,20 @@ def _run_exec(args: SimpleNamespace) -> int:
                     },
                     error=error,
                 )
-                return result.exit_code
+            return result.exit_code
 
-            if result.stdout:
+        # Write each stream under its own guard so a closed stdout pipe does
+        # not swallow the command's stderr (which may still reach a terminal).
+        if result.stdout:
+            try:
                 sys.stdout.write(result.stdout)
                 sys.stdout.flush()
-            if result.stderr:
+            except BrokenPipeError:
+                _suppress_broken_pipe()
+        if result.stderr:
+            with suppress(BrokenPipeError):
                 sys.stderr.write(result.stderr)
                 sys.stderr.flush()
-        except BrokenPipeError:
-            _suppress_broken_pipe()
         return result.exit_code
     except Exception as exc:
         return _emit_cli_error(command_name, 1, exc, json_output=json_output)

--- a/src/smolvm/cli/main.py
+++ b/src/smolvm/cli/main.py
@@ -2432,29 +2432,13 @@ def _run_ssh(args: SimpleNamespace) -> int:
             ssh_key_path=args.ssh_key,
         )
 
-        console = console_stdout()
-        if vm.status in {VMState.CREATED, VMState.STOPPED}:
-            with console.status(f"Starting sandbox '{args.vm_id}'...", spinner="dots") as status:
-                vm.start(boot_timeout=args.boot_timeout)
-                status.update("Waiting for SSH...")
-                vm.wait_for_ssh(timeout=args.boot_timeout)
-        elif vm.status == VMState.PAUSED:
-            with console.status(f"Resuming sandbox '{args.vm_id}'...", spinner="dots") as status:
-                vm.resume()
-                status.update("Waiting for SSH...")
-                vm.wait_for_ssh(timeout=args.boot_timeout)
-        elif vm.status == VMState.ERROR:
-            raise RuntimeError(
-                f"VM '{args.vm_id}' is in error state. Recreate it or inspect the VM logs "
-                "before attaching."
-            )
-        else:
-            with console.status("Waiting for SSH...", spinner="dots"):
-                vm.wait_for_ssh(timeout=args.boot_timeout)
-            completed = subprocess.run(vm._ssh_attach_command(), check=False)
-            if completed.returncode != 0:
-                _hint_if_vm_crashed(vm)
-            return completed.returncode
+        _bring_sandbox_up(
+            vm,
+            args.boot_timeout,
+            status_console=console_stdout(),
+            ready_message="Waiting for SSH...",
+            wait=lambda: vm.wait_for_ssh(timeout=args.boot_timeout),
+        )
         completed = subprocess.run(vm._ssh_attach_command(), check=False)
         if completed.returncode != 0:
             _hint_if_vm_crashed(vm)
@@ -2483,28 +2467,13 @@ def _run_shell(args: SimpleNamespace) -> int:
         vm = SmolVM.from_id(args.vm_id)
         vm.ensure_shell_supported()
 
-        console = console_stdout()
-        if vm.status in {VMState.CREATED, VMState.STOPPED}:
-            with console.status(f"Starting sandbox '{args.vm_id}'...", spinner="dots") as status:
-                vm.start(boot_timeout=args.boot_timeout)
-                status.update("Opening shell...")
-                vm.wait_for_shell(timeout=args.boot_timeout)
-            return vm.attach_shell(timeout=args.boot_timeout)
-        if vm.status == VMState.PAUSED:
-            with console.status(f"Resuming sandbox '{args.vm_id}'...", spinner="dots") as status:
-                vm.resume()
-                status.update("Opening shell...")
-                vm.wait_for_shell(timeout=args.boot_timeout)
-            return vm.attach_shell(timeout=args.boot_timeout)
-        if vm.status == VMState.ERROR:
-            raise RuntimeError(
-                f"Sandbox '{args.vm_id}' is in error state; inspect the sandbox logs, or run "
-                f"'smolvm sandbox delete {args.vm_id}' then "
-                f"'smolvm sandbox create --name {args.vm_id}' to recreate it."
-            )
-
-        with console.status("Opening shell...", spinner="dots"):
-            vm.wait_for_shell(timeout=args.boot_timeout)
+        _bring_sandbox_up(
+            vm,
+            args.boot_timeout,
+            status_console=console_stdout(),
+            ready_message="Opening shell...",
+            wait=lambda: vm.wait_for_shell(timeout=args.boot_timeout),
+        )
         return vm.attach_shell(timeout=args.boot_timeout)
     except Exception as exc:
         return _emit_cli_error(command_name, 1, exc, json_output=False)
@@ -2513,20 +2482,51 @@ def _run_shell(args: SimpleNamespace) -> int:
             vm.close()
 
 
-def _bring_sandbox_up(vm: Any, boot_timeout: float, *, status_console: Any) -> None:
-    """Start or resume a sandbox so a command can run in it.
+def _suppress_broken_pipe() -> None:
+    """Silence the interpreter's exit-time flush after a reader closed.
 
-    Mirrors the connect-command convention used by ``shell``/``ssh``:
-    a stopped sandbox is started and a paused one resumed; an errored
-    sandbox raises with a recovery path. Progress is shown on stderr so
-    it never mixes into captured command output.
+    When output is piped into a consumer that exits early (``| head``),
+    the next write to stdout raises ``BrokenPipeError`` and Python would
+    also re-raise it while flushing at shutdown. Pointing stdout at
+    ``os.devnull`` makes the shutdown flush a no-op so the command exits
+    quietly, matching how standard tools behave under a closed pipe.
+    """
+    with suppress(Exception):
+        devnull = os.open(os.devnull, os.O_WRONLY)
+        os.dup2(devnull, sys.stdout.fileno())
+
+
+def _bring_sandbox_up(
+    vm: Any,
+    boot_timeout: float,
+    *,
+    status_console: Any,
+    ready_message: str | None = None,
+    wait: Callable[[], Any] | None = None,
+) -> None:
+    """Start or resume a sandbox so it can be used.
+
+    A stopped sandbox is started and a paused one resumed; an errored
+    sandbox raises with a recovery path. When ``wait`` is given it is
+    called once the sandbox is up (and for an already-running sandbox) to
+    block until it is reachable, showing ``ready_message`` on the spinner.
+    Progress renders on ``status_console`` so callers that need a clean
+    stdout can direct it to stderr.
     """
     if vm.status in {VMState.CREATED, VMState.STOPPED}:
-        with status_console.status(f"Starting sandbox '{vm.vm_id}'...", spinner="dots"):
+        with status_console.status(f"Starting sandbox '{vm.vm_id}'...", spinner="dots") as spinner:
             vm.start(boot_timeout=boot_timeout)
+            if wait is not None:
+                if ready_message:
+                    spinner.update(ready_message)
+                wait()
     elif vm.status == VMState.PAUSED:
-        with status_console.status(f"Resuming sandbox '{vm.vm_id}'...", spinner="dots"):
+        with status_console.status(f"Resuming sandbox '{vm.vm_id}'...", spinner="dots") as spinner:
             vm.resume()
+            if wait is not None:
+                if ready_message:
+                    spinner.update(ready_message)
+                wait()
     elif vm.status == VMState.ERROR:
         raise RuntimeError(
             f"Sandbox '{vm.vm_id}' is in error state; inspect its logs with "
@@ -2534,6 +2534,9 @@ def _bring_sandbox_up(vm: Any, boot_timeout: float, *, status_console: Any) -> N
             f"'smolvm sandbox delete {vm.vm_id}' then "
             f"'smolvm sandbox create --name {vm.vm_id}' to recreate it."
         )
+    elif wait is not None:
+        with status_console.status(ready_message or "Connecting...", spinner="dots"):
+            wait()
 
 
 def _run_exec(args: SimpleNamespace) -> int:
@@ -2547,6 +2550,10 @@ def _run_exec(args: SimpleNamespace) -> int:
     json_output = bool(getattr(args, "json", False))
     try:
         vm = SmolVM.from_id(args.vm_id)
+        # Pull the latest persisted state so the running check below and the
+        # --start decision don't act on a status cached at from_id() time.
+        with suppress(Exception):
+            vm.refresh()
 
         if args.start:
             _bring_sandbox_up(vm, args.boot_timeout, status_console=console_stderr())
@@ -2564,24 +2571,37 @@ def _run_exec(args: SimpleNamespace) -> int:
         cmd_str = shlex.join(args.command)
         result = vm.run(cmd_str, timeout=args.timeout)
 
-        if json_output:
-            emit_json(
-                command_name,
-                result.exit_code,
-                data={
-                    "exit_code": result.exit_code,
-                    "stdout": result.stdout,
-                    "stderr": result.stderr,
-                },
-            )
-            return result.exit_code
+        try:
+            if json_output:
+                error = None
+                if result.exit_code != 0:
+                    # Keep the envelope's ok<->error invariant: a non-zero guest
+                    # exit is a failure, so populate error while still returning
+                    # the command's stdout/stderr in data.
+                    error = {
+                        "code": "command_failed",
+                        "message": f"Command exited with status {result.exit_code}.",
+                    }
+                emit_json(
+                    command_name,
+                    result.exit_code,
+                    data={
+                        "exit_code": result.exit_code,
+                        "stdout": result.stdout,
+                        "stderr": result.stderr,
+                    },
+                    error=error,
+                )
+                return result.exit_code
 
-        if result.stdout:
-            sys.stdout.write(result.stdout)
-            sys.stdout.flush()
-        if result.stderr:
-            sys.stderr.write(result.stderr)
-            sys.stderr.flush()
+            if result.stdout:
+                sys.stdout.write(result.stdout)
+                sys.stdout.flush()
+            if result.stderr:
+                sys.stderr.write(result.stderr)
+                sys.stderr.flush()
+        except BrokenPipeError:
+            _suppress_broken_pipe()
         return result.exit_code
     except Exception as exc:
         return _emit_cli_error(command_name, 1, exc, json_output=json_output)
@@ -2590,23 +2610,13 @@ def _run_exec(args: SimpleNamespace) -> int:
             vm.close()
 
 
-def _tail_file(path: Path, lines: int) -> tuple[list[str], int]:
-    """Return the last ``lines`` lines of ``path`` and the current byte size.
-
-    The byte size lets ``--follow`` resume reading from where the tail
-    ended without re-printing what was already shown.
-    """
-    data = path.read_bytes()
-    text = data.decode("utf-8", errors="replace")
-    all_lines = text.splitlines()
-    return all_lines[-lines:], len(data)
-
-
 def _run_logs(args: SimpleNamespace) -> int:
     """Handle ``smolvm sandbox logs``."""
+    import codecs
     import time
 
     from smolvm.facade import SmolVM
+    from smolvm.utils import tail_file
 
     command_name = getattr(args, "command_name", "sandbox.logs")
     json_output = bool(getattr(args, "json", False))
@@ -2623,7 +2633,7 @@ def _run_logs(args: SimpleNamespace) -> int:
             render_error(message)
             return 1
 
-        tail_lines, offset = _tail_file(log_path, args.tail)
+        tail_lines, offset, ends_with_newline = tail_file(log_path, args.tail)
 
         if json_output:
             if args.follow:
@@ -2641,28 +2651,41 @@ def _run_logs(args: SimpleNamespace) -> int:
             )
             return 0
 
-        for line in tail_lines:
-            sys.stdout.write(line + "\n")
-        sys.stdout.flush()
-
-        if not args.follow:
-            return 0
-
         try:
+            body = "\n".join(tail_lines)
+            if body:
+                sys.stdout.write(body)
+                # Terminate the last line unless we are about to --follow a file
+                # whose final line had no newline yet; adding one there would
+                # split a line the guest is still writing.
+                if ends_with_newline or not args.follow:
+                    sys.stdout.write("\n")
+            sys.stdout.flush()
+
+            if not args.follow:
+                return 0
+
+            # Decode incrementally so a multi-byte UTF-8 character split across
+            # a read boundary is buffered rather than mangled.
+            decoder = codecs.getincrementaldecoder("utf-8")("replace")
             while True:
                 time.sleep(0.5)
                 size = log_path.stat().st_size
                 if size < offset:
                     # File was truncated/rotated; restart from the top.
                     offset = 0
+                    decoder = codecs.getincrementaldecoder("utf-8")("replace")
                 if size > offset:
                     with log_path.open("rb") as handle:
                         handle.seek(offset)
                         chunk = handle.read()
                         offset += len(chunk)
-                    sys.stdout.write(chunk.decode("utf-8", errors="replace"))
+                    sys.stdout.write(decoder.decode(chunk))
                     sys.stdout.flush()
         except KeyboardInterrupt:
+            return 0
+        except BrokenPipeError:
+            _suppress_broken_pipe()
             return 0
     except Exception as exc:
         return _emit_cli_error(command_name, 1, exc, json_output=json_output)

--- a/src/smolvm/cli/main.py
+++ b/src/smolvm/cli/main.py
@@ -2547,7 +2547,19 @@ def _run_exec(args: SimpleNamespace) -> int:
     json_output = bool(getattr(args, "json", False))
     try:
         vm = SmolVM.from_id(args.vm_id)
-        _bring_sandbox_up(vm, args.boot_timeout, status_console=console_stderr())
+
+        if args.start:
+            _bring_sandbox_up(vm, args.boot_timeout, status_console=console_stderr())
+        elif vm.status != VMState.RUNNING:
+            recovery = (
+                f"Run 'smolvm sandbox start {args.vm_id}' first, or add --start to "
+                "start it automatically."
+            )
+            message = f"Sandbox '{args.vm_id}' is not running ({vm.status.value}). {recovery}"
+            if json_output:
+                return emit_error(command_name, "not_running", message, recovery=recovery)
+            render_error(message)
+            return 1
 
         cmd_str = shlex.join(args.command)
         result = vm.run(cmd_str, timeout=args.timeout)

--- a/src/smolvm/cli/main.py
+++ b/src/smolvm/cli/main.py
@@ -47,6 +47,7 @@ from rich.text import Text
 
 from smolvm.cli._kvm_session import maybe_reexec_for_kvm_group
 from smolvm.cli.output import (
+    console_stderr,
     console_stdout,
     emit_error,
     emit_json,
@@ -2507,6 +2508,152 @@ def _run_shell(args: SimpleNamespace) -> int:
         return vm.attach_shell(timeout=args.boot_timeout)
     except Exception as exc:
         return _emit_cli_error(command_name, 1, exc, json_output=False)
+    finally:
+        if vm is not None:
+            vm.close()
+
+
+def _bring_sandbox_up(vm: Any, boot_timeout: float, *, status_console: Any) -> None:
+    """Start or resume a sandbox so a command can run in it.
+
+    Mirrors the connect-command convention used by ``shell``/``ssh``:
+    a stopped sandbox is started and a paused one resumed; an errored
+    sandbox raises with a recovery path. Progress is shown on stderr so
+    it never mixes into captured command output.
+    """
+    if vm.status in {VMState.CREATED, VMState.STOPPED}:
+        with status_console.status(f"Starting sandbox '{vm.vm_id}'...", spinner="dots"):
+            vm.start(boot_timeout=boot_timeout)
+    elif vm.status == VMState.PAUSED:
+        with status_console.status(f"Resuming sandbox '{vm.vm_id}'...", spinner="dots"):
+            vm.resume()
+    elif vm.status == VMState.ERROR:
+        raise RuntimeError(
+            f"Sandbox '{vm.vm_id}' is in error state; inspect its logs with "
+            f"'smolvm sandbox logs {vm.vm_id}', or run "
+            f"'smolvm sandbox delete {vm.vm_id}' then "
+            f"'smolvm sandbox create --name {vm.vm_id}' to recreate it."
+        )
+
+
+def _run_exec(args: SimpleNamespace) -> int:
+    """Handle ``smolvm sandbox exec``."""
+    import shlex
+
+    from smolvm.facade import SmolVM
+
+    vm: SmolVM | None = None
+    command_name = getattr(args, "command_name", "sandbox.exec")
+    json_output = bool(getattr(args, "json", False))
+    try:
+        vm = SmolVM.from_id(args.vm_id)
+        _bring_sandbox_up(vm, args.boot_timeout, status_console=console_stderr())
+
+        cmd_str = shlex.join(args.command)
+        result = vm.run(cmd_str, timeout=args.timeout)
+
+        if json_output:
+            emit_json(
+                command_name,
+                result.exit_code,
+                data={
+                    "exit_code": result.exit_code,
+                    "stdout": result.stdout,
+                    "stderr": result.stderr,
+                },
+            )
+            return result.exit_code
+
+        if result.stdout:
+            sys.stdout.write(result.stdout)
+            sys.stdout.flush()
+        if result.stderr:
+            sys.stderr.write(result.stderr)
+            sys.stderr.flush()
+        return result.exit_code
+    except Exception as exc:
+        return _emit_cli_error(command_name, 1, exc, json_output=json_output)
+    finally:
+        if vm is not None:
+            vm.close()
+
+
+def _tail_file(path: Path, lines: int) -> tuple[list[str], int]:
+    """Return the last ``lines`` lines of ``path`` and the current byte size.
+
+    The byte size lets ``--follow`` resume reading from where the tail
+    ended without re-printing what was already shown.
+    """
+    data = path.read_bytes()
+    text = data.decode("utf-8", errors="replace")
+    all_lines = text.splitlines()
+    return all_lines[-lines:], len(data)
+
+
+def _run_logs(args: SimpleNamespace) -> int:
+    """Handle ``smolvm sandbox logs``."""
+    import time
+
+    from smolvm.facade import SmolVM
+
+    command_name = getattr(args, "command_name", "sandbox.logs")
+    json_output = bool(getattr(args, "json", False))
+    vm: SmolVM | None = None
+    try:
+        vm = SmolVM.from_id(args.vm_id)
+        log_path = vm.data_dir / f"{args.vm_id}.log"
+
+        if not log_path.exists():
+            recovery = f"Start it with 'smolvm sandbox start {args.vm_id}' to generate logs."
+            message = f"No logs found for sandbox '{args.vm_id}'. {recovery}"
+            if json_output:
+                return emit_error(command_name, "not_found", message, recovery=recovery)
+            render_error(message)
+            return 1
+
+        tail_lines, offset = _tail_file(log_path, args.tail)
+
+        if json_output:
+            if args.follow:
+                return emit_error(
+                    command_name,
+                    "invalid_input",
+                    "Cannot combine --follow with --json. Run "
+                    f"'smolvm sandbox logs {args.vm_id} --json' without --follow.",
+                    recovery=f"Run 'smolvm sandbox logs {args.vm_id} --json' without --follow.",
+                )
+            emit_json(
+                command_name,
+                0,
+                data={"path": str(log_path), "lines": tail_lines},
+            )
+            return 0
+
+        for line in tail_lines:
+            sys.stdout.write(line + "\n")
+        sys.stdout.flush()
+
+        if not args.follow:
+            return 0
+
+        try:
+            while True:
+                time.sleep(0.5)
+                size = log_path.stat().st_size
+                if size < offset:
+                    # File was truncated/rotated; restart from the top.
+                    offset = 0
+                if size > offset:
+                    with log_path.open("rb") as handle:
+                        handle.seek(offset)
+                        chunk = handle.read()
+                        offset += len(chunk)
+                    sys.stdout.write(chunk.decode("utf-8", errors="replace"))
+                    sys.stdout.flush()
+        except KeyboardInterrupt:
+            return 0
+    except Exception as exc:
+        return _emit_cli_error(command_name, 1, exc, json_output=json_output)
     finally:
         if vm is not None:
             vm.close()

--- a/src/smolvm/cli/main.py
+++ b/src/smolvm/cli/main.py
@@ -2584,7 +2584,7 @@ def _run_exec(args: SimpleNamespace) -> int:
                     "code": "command_failed",
                     "message": f"Command exited with status {result.exit_code}.",
                 }
-            with suppress(BrokenPipeError):
+            try:
                 emit_json(
                     command_name,
                     result.exit_code,
@@ -2595,6 +2595,8 @@ def _run_exec(args: SimpleNamespace) -> int:
                     },
                     error=error,
                 )
+            except BrokenPipeError:
+                _suppress_broken_pipe()
             return result.exit_code
 
         # Write each stream under its own guard so a closed stdout pipe does
@@ -2651,11 +2653,14 @@ def _run_logs(args: SimpleNamespace) -> int:
                     f"'smolvm sandbox logs {args.vm_id} --json' without --follow.",
                     recovery=f"Run 'smolvm sandbox logs {args.vm_id} --json' without --follow.",
                 )
-            emit_json(
-                command_name,
-                0,
-                data={"path": str(log_path), "lines": tail_lines},
-            )
+            try:
+                emit_json(
+                    command_name,
+                    0,
+                    data={"path": str(log_path), "lines": tail_lines},
+                )
+            except BrokenPipeError:
+                _suppress_broken_pipe()
             return 0
 
         try:

--- a/src/smolvm/utils.py
+++ b/src/smolvm/utils.py
@@ -175,6 +175,25 @@ async def async_run_command(
     )
 
 
+def tail_file(path: Path, line_count: int) -> tuple[list[str], int, bool]:
+    """Return the tail of a UTF-8 text file.
+
+    Reads ``path`` and returns ``(lines, size, ends_with_newline)`` where
+    ``lines`` is the last ``line_count`` lines (all lines if the file is
+    shorter, empty if ``line_count <= 0``), ``size`` is the file's byte
+    length, and ``ends_with_newline`` says whether the content ends with a
+    line break. ``size`` lets a caller that streams later appends resume
+    from exactly where these lines end, and ``ends_with_newline`` lets it
+    avoid inserting a spurious break mid-line.
+    """
+    data = path.read_bytes()
+    text = data.decode("utf-8", errors="replace")
+    ends_with_newline = text.endswith(("\n", "\r"))
+    if line_count <= 0:
+        return [], len(data), ends_with_newline
+    return text.splitlines()[-line_count:], len(data), ends_with_newline
+
+
 def which(binary: str) -> Path | None:
     """Find a binary on the system PATH.
 

--- a/src/smolvm/utils.py
+++ b/src/smolvm/utils.py
@@ -191,7 +191,14 @@ def tail_file(path: Path, line_count: int) -> tuple[list[str], int, bool]:
     ends_with_newline = text.endswith(("\n", "\r"))
     if line_count <= 0:
         return [], len(data), ends_with_newline
-    return text.splitlines()[-line_count:], len(data), ends_with_newline
+    # Split only on newlines. str.splitlines() also breaks on other Unicode
+    # and control separators (\v, \f, \x1c-\x1e, \x85,  ,  ), which
+    # would inflate the line count for logs that legitimately contain them.
+    normalized = text.replace("\r\n", "\n").replace("\r", "\n")
+    if normalized.endswith("\n"):
+        normalized = normalized[:-1]  # no trailing empty line, matching splitlines
+    lines = normalized.split("\n") if normalized else []
+    return lines[-line_count:], len(data), ends_with_newline
 
 
 def which(binary: str) -> Path | None:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -4990,6 +4990,22 @@ class TestCliExec:
         # stderr is still delivered even though the stdout write broke.
         assert capsys.readouterr().err == "err\n"
 
+    def test_exec_json_broken_pipe_suppressed(self, mock_vm_cls: MagicMock) -> None:
+        """A closed pipe during the JSON emit is handled, not left to noise at exit."""
+        from smolvm.types import CommandResult
+
+        vm = self._setup_vm(mock_vm_cls)
+        vm.run.return_value = CommandResult(exit_code=0, stdout="x", stderr="")
+
+        with (
+            patch("smolvm.cli.main.emit_json", side_effect=BrokenPipeError),
+            patch("smolvm.cli.main._suppress_broken_pipe") as suppress_pipe,
+        ):
+            ret = main(["sandbox", "exec", "vm001", "--json", "--", "echo", "x"])
+
+        assert ret == 0
+        suppress_pipe.assert_called_once()
+
 
 class TestCliLogs:
     """Tests for `smolvm sandbox logs`."""
@@ -5120,6 +5136,24 @@ class TestCliLogs:
             patch("smolvm.cli.main._suppress_broken_pipe") as suppress_pipe,
         ):
             ret = main(["sandbox", "logs", "vm001"])
+
+        assert ret == 0
+        suppress_pipe.assert_called_once()
+
+    def test_logs_json_broken_pipe_suppressed(
+        self,
+        mock_vm_cls: MagicMock,
+        tmp_path: Path,
+    ) -> None:
+        """A closed pipe during the JSON emit does not re-raise via the outer handler."""
+        self._setup_vm(mock_vm_cls, tmp_path)
+        (tmp_path / "vm001.log").write_text("a\nb\n")
+
+        with (
+            patch("smolvm.cli.main.emit_json", side_effect=BrokenPipeError),
+            patch("smolvm.cli.main._suppress_broken_pipe") as suppress_pipe,
+        ):
+            ret = main(["sandbox", "logs", "vm001", "--json"])
 
         assert ret == 0
         suppress_pipe.assert_called_once()

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -4770,3 +4770,256 @@ class TestCliImage:
         payload = json.loads(capsys.readouterr().out)
         assert payload["command"] == "image.pull"
         assert "smolvm image pull --help" in payload["error"]["recovery"]
+
+
+class TestCliExec:
+    """Tests for `smolvm sandbox exec`."""
+
+    @pytest.fixture
+    def mock_vm_cls(self) -> MagicMock:
+        with patch("smolvm.facade.SmolVM") as m:
+            yield m
+
+    def _setup_vm(self, mock_vm_cls: MagicMock) -> MagicMock:
+        vm = MagicMock()
+        vm.vm_id = "vm001"
+        vm.status = VMState.RUNNING
+        mock_vm_cls.from_id.return_value = vm
+        return vm
+
+    def test_exec_prints_stdout_and_returns_exit_code(
+        self,
+        mock_vm_cls: MagicMock,
+        capsys: pytest.CaptureFixture,
+    ) -> None:
+        """`sandbox exec` runs the command and passes output/exit code through."""
+        from smolvm.types import CommandResult
+
+        vm = self._setup_vm(mock_vm_cls)
+        vm.run.return_value = CommandResult(exit_code=0, stdout="hi\n", stderr="")
+
+        ret = main(["sandbox", "exec", "vm001", "--", "echo", "hi"])
+
+        assert ret == 0
+        vm.run.assert_called_once_with("echo hi", timeout=30)
+        captured = capsys.readouterr()
+        assert captured.out == "hi\n"
+        vm.close.assert_called_once()
+
+    def test_exec_preserves_quoting(self, mock_vm_cls: MagicMock) -> None:
+        """Command tokens are re-joined with shell quoting preserved."""
+        from smolvm.types import CommandResult
+
+        vm = self._setup_vm(mock_vm_cls)
+        vm.run.return_value = CommandResult(exit_code=0, stdout="", stderr="")
+
+        main(["sandbox", "exec", "vm001", "--", "echo", "hello world"])
+
+        vm.run.assert_called_once_with("echo 'hello world'", timeout=30)
+
+    def test_exec_nonzero_exit_code_propagates(
+        self,
+        mock_vm_cls: MagicMock,
+        capsys: pytest.CaptureFixture,
+    ) -> None:
+        """A failing guest command surfaces its exit code and stderr."""
+        from smolvm.types import CommandResult
+
+        vm = self._setup_vm(mock_vm_cls)
+        vm.run.return_value = CommandResult(exit_code=3, stdout="", stderr="boom\n")
+
+        ret = main(["sandbox", "exec", "vm001", "--", "false"])
+
+        assert ret == 3
+        assert capsys.readouterr().err == "boom\n"
+
+    def test_exec_json_envelope(
+        self,
+        mock_vm_cls: MagicMock,
+        capsys: pytest.CaptureFixture,
+    ) -> None:
+        """`--json` emits the command result as a JSON envelope."""
+        from smolvm.types import CommandResult
+
+        vm = self._setup_vm(mock_vm_cls)
+        vm.run.return_value = CommandResult(exit_code=0, stdout="out", stderr="err")
+
+        ret = main(["sandbox", "exec", "vm001", "--json", "--", "echo", "out"])
+
+        assert ret == 0
+        payload = json.loads(capsys.readouterr().out)
+        assert payload["command"] == "sandbox.exec"
+        assert payload["data"] == {"exit_code": 0, "stdout": "out", "stderr": "err"}
+
+    def test_exec_custom_timeout(self, mock_vm_cls: MagicMock) -> None:
+        """`--timeout` is forwarded to the facade run call."""
+        from smolvm.types import CommandResult
+
+        vm = self._setup_vm(mock_vm_cls)
+        vm.run.return_value = CommandResult(exit_code=0, stdout="", stderr="")
+
+        main(["sandbox", "exec", "vm001", "--timeout", "5", "--", "sleep", "1"])
+
+        vm.run.assert_called_once_with("sleep 1", timeout=5)
+
+    def test_exec_lookup_failure_prints_error(
+        self,
+        mock_vm_cls: MagicMock,
+        capsys: pytest.CaptureFixture,
+    ) -> None:
+        """A missing sandbox surfaces a human-facing error."""
+        mock_vm_cls.from_id.side_effect = Exception("VM 'missing' not found")
+
+        ret = main(["sandbox", "exec", "missing", "--", "ls"])
+
+        assert ret == 1
+        assert "not found" in capsys.readouterr().err
+
+
+class TestCliLogs:
+    """Tests for `smolvm sandbox logs`."""
+
+    @pytest.fixture
+    def mock_vm_cls(self) -> MagicMock:
+        with patch("smolvm.facade.SmolVM") as m:
+            yield m
+
+    def _setup_vm(self, mock_vm_cls: MagicMock, data_dir: Path) -> MagicMock:
+        vm = MagicMock()
+        vm.vm_id = "vm001"
+        vm.data_dir = data_dir
+        mock_vm_cls.from_id.return_value = vm
+        return vm
+
+    def test_logs_prints_tail(
+        self,
+        mock_vm_cls: MagicMock,
+        tmp_path: Path,
+        capsys: pytest.CaptureFixture,
+    ) -> None:
+        """`sandbox logs` prints the last N lines of the host log."""
+        self._setup_vm(mock_vm_cls, tmp_path)
+        (tmp_path / "vm001.log").write_text("line1\nline2\nline3\n")
+
+        ret = main(["sandbox", "logs", "vm001", "--tail", "2"])
+
+        assert ret == 0
+        assert capsys.readouterr().out == "line2\nline3\n"
+
+    def test_logs_json_payload(
+        self,
+        mock_vm_cls: MagicMock,
+        tmp_path: Path,
+        capsys: pytest.CaptureFixture,
+    ) -> None:
+        """`--json` returns the log path and the tailed lines."""
+        self._setup_vm(mock_vm_cls, tmp_path)
+        (tmp_path / "vm001.log").write_text("a\nb\nc\n")
+
+        ret = main(["sandbox", "logs", "vm001", "--tail", "2", "--json"])
+
+        assert ret == 0
+        payload = json.loads(capsys.readouterr().out)
+        assert payload["command"] == "sandbox.logs"
+        assert payload["data"]["lines"] == ["b", "c"]
+        assert payload["data"]["path"].endswith("vm001.log")
+
+    def test_logs_missing_file_errors(
+        self,
+        mock_vm_cls: MagicMock,
+        tmp_path: Path,
+        capsys: pytest.CaptureFixture,
+    ) -> None:
+        """A sandbox with no log file yields an actionable error."""
+        self._setup_vm(mock_vm_cls, tmp_path)
+
+        ret = main(["sandbox", "logs", "vm001"])
+
+        assert ret == 1
+        assert "No logs found" in capsys.readouterr().err
+
+    def test_logs_missing_file_json(
+        self,
+        mock_vm_cls: MagicMock,
+        tmp_path: Path,
+        capsys: pytest.CaptureFixture,
+    ) -> None:
+        """Missing-log error is also emitted as a JSON envelope with recovery."""
+        self._setup_vm(mock_vm_cls, tmp_path)
+
+        ret = main(["sandbox", "logs", "vm001", "--json"])
+
+        assert ret == 1
+        payload = json.loads(capsys.readouterr().out)
+        assert payload["ok"] is False
+        assert payload["error"]["code"] == "not_found"
+        assert "smolvm sandbox start vm001" in payload["error"]["recovery"]
+
+    def test_logs_follow_rejected_in_json(
+        self,
+        mock_vm_cls: MagicMock,
+        tmp_path: Path,
+        capsys: pytest.CaptureFixture,
+    ) -> None:
+        """`--follow --json` is refused because streaming has no envelope."""
+        self._setup_vm(mock_vm_cls, tmp_path)
+        (tmp_path / "vm001.log").write_text("x\n")
+
+        ret = main(["sandbox", "logs", "vm001", "--follow", "--json"])
+
+        assert ret == 1
+        payload = json.loads(capsys.readouterr().out)
+        assert payload["error"]["code"] == "invalid_input"
+
+
+class TestCliCompletion:
+    """Tests for `smolvm completion` and dynamic sandbox-name completion."""
+
+    def test_completion_bash_emits_script(self, capsys: pytest.CaptureFixture) -> None:
+        """`smolvm completion bash` prints a sourceable completion script."""
+        ret = main(["completion", "bash"])
+
+        assert ret == 0
+        assert "_SMOLVM_COMPLETE" in capsys.readouterr().out
+
+    @pytest.mark.parametrize("shell", ["bash", "zsh", "fish"])
+    def test_completion_supported_shells(
+        self,
+        shell: str,
+        capsys: pytest.CaptureFixture,
+    ) -> None:
+        """Every advertised shell produces a non-empty script."""
+        ret = main(["completion", shell])
+
+        assert ret == 0
+        assert capsys.readouterr().out.strip()
+
+    def test_completion_invalid_shell(self) -> None:
+        """An unsupported shell is a usage error."""
+        from click.testing import CliRunner
+
+        result = CliRunner().invoke(build_cli(), ["completion", "powershell"])
+        assert result.exit_code == 2
+
+    def test_complete_sandbox_names_filters_by_prefix(self) -> None:
+        """The completion callback returns matching sandbox names."""
+        from smolvm.cli.commands.options import complete_sandbox_names
+
+        sdk = MagicMock()
+        sdk.__enter__.return_value = sdk
+        sdk.__exit__.return_value = False
+        sdk.list_vms.return_value = [_make_vm_info("web-1"), _make_vm_info("api-2")]
+
+        with patch("smolvm.vm.SmolVMManager", return_value=sdk):
+            items = complete_sandbox_names(MagicMock(), MagicMock(), "web")
+
+        assert [item.value for item in items] == ["web-1"]
+
+    def test_complete_sandbox_names_never_raises(self) -> None:
+        """A backend failure yields no suggestions instead of a traceback."""
+        from smolvm.cli.commands.options import complete_sandbox_names
+
+        with patch("smolvm.vm.SmolVMManager", side_effect=Exception("no db")):
+            items = complete_sandbox_names(MagicMock(), MagicMock(), "")
+
+        assert items == []

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -5188,6 +5188,82 @@ class TestCliCompletion:
         result = CliRunner().invoke(build_cli(), ["completion", "powershell"])
         assert result.exit_code == 2
 
+    @pytest.fixture
+    def fake_home(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+        monkeypatch.setenv("HOME", str(tmp_path))
+        monkeypatch.delenv("ZDOTDIR", raising=False)
+        monkeypatch.delenv("XDG_CONFIG_HOME", raising=False)
+        return tmp_path
+
+    def test_completion_install_bash_writes_script_and_rc_line(
+        self,
+        fake_home: Path,
+        capsys: pytest.CaptureFixture,
+    ) -> None:
+        """`completion bash --install` persists the script and sources it from ~/.bashrc."""
+        ret = main(["completion", "bash", "--install"])
+
+        assert ret == 0
+        script_path = fake_home / ".smolvm" / "completions" / "smolvm.bash"
+        assert "_SMOLVM_COMPLETE" in script_path.read_text()
+        bashrc = (fake_home / ".bashrc").read_text()
+        assert str(script_path) in bashrc
+        out = " ".join(capsys.readouterr().out.split())
+        assert "Open a new shell" in out
+
+    def test_completion_install_is_idempotent(self, fake_home: Path) -> None:
+        """Re-running --install refreshes the script without duplicating the rc line."""
+        main(["completion", "bash", "--install"])
+        ret = main(["completion", "bash", "--install"])
+
+        assert ret == 0
+        script_path = fake_home / ".smolvm" / "completions" / "smolvm.bash"
+        bashrc = (fake_home / ".bashrc").read_text()
+        assert bashrc.count(str(script_path)) == 1
+
+    def test_completion_install_zsh_respects_zdotdir(
+        self,
+        fake_home: Path,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """`completion zsh --install` writes the source line to $ZDOTDIR/.zshrc."""
+        zdotdir = tmp_path / "zdot"
+        zdotdir.mkdir()
+        monkeypatch.setenv("ZDOTDIR", str(zdotdir))
+
+        ret = main(["completion", "zsh", "--install"])
+
+        assert ret == 0
+        script_path = fake_home / ".smolvm" / "completions" / "smolvm.zsh"
+        assert str(script_path) in (zdotdir / ".zshrc").read_text()
+
+    def test_completion_install_fish_writes_autoload_file(self, fake_home: Path) -> None:
+        """`completion fish --install` creates the autoloaded completions file."""
+        ret = main(["completion", "fish", "--install"])
+
+        assert ret == 0
+        target = fake_home / ".config" / "fish" / "completions" / "smolvm.fish"
+        assert "smolvm" in target.read_text()
+        # fish autoloads the directory; no startup-file edit should happen.
+        assert not (fake_home / ".bashrc").exists()
+
+    def test_completion_install_failure_names_recovery(
+        self,
+        fake_home: Path,
+        monkeypatch: pytest.MonkeyPatch,
+        capsys: pytest.CaptureFixture,
+    ) -> None:
+        """A write failure yields an actionable error, not a traceback."""
+        blocker = fake_home / "not-a-dir"
+        blocker.write_text("")
+        monkeypatch.setenv("HOME", str(blocker))
+
+        ret = main(["completion", "bash", "--install"])
+
+        assert ret == 1
+        assert "Could not set up tab completion" in capsys.readouterr().err
+
     def test_complete_sandbox_names_filters_by_prefix(self) -> None:
         """The completion callback returns matching sandbox names."""
         from smolvm.cli.commands.options import complete_sandbox_names

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -5193,6 +5193,9 @@ class TestCliCompletion:
         monkeypatch.setenv("HOME", str(tmp_path))
         monkeypatch.delenv("ZDOTDIR", raising=False)
         monkeypatch.delenv("XDG_CONFIG_HOME", raising=False)
+        # The suite may run as root (containers); without this the sudo-aware
+        # home resolution would ignore the monkeypatched HOME.
+        monkeypatch.delenv("SUDO_USER", raising=False)
         return tmp_path
 
     def test_completion_install_bash_writes_script_and_rc_line(
@@ -5262,7 +5265,141 @@ class TestCliCompletion:
         ret = main(["completion", "bash", "--install"])
 
         assert ret == 1
-        assert "Could not set up tab completion" in capsys.readouterr().err
+        err = " ".join(capsys.readouterr().err.split())
+        assert "Could not set up tab completion" in err
+        # Plain English, not a raw exception repr with errno codes.
+        assert "Errno" not in err
+
+    def test_completion_install_quotes_path_with_apostrophe(self, fake_home: Path) -> None:
+        """A home path containing a single quote yields a shell-safe source line."""
+        import shlex
+
+        quirky_home = fake_home / "o'brien"
+        quirky_home.mkdir()
+        with pytest.MonkeyPatch.context() as mp:
+            mp.setenv("HOME", str(quirky_home))
+            ret = main(["completion", "bash", "--install"])
+
+        assert ret == 0
+        script_path = quirky_home / ".smolvm" / "completions" / "smolvm.bash"
+        bashrc = (quirky_home / ".bashrc").read_text()
+        assert f"source {shlex.quote(str(script_path))}" in bashrc
+
+    def test_completion_install_reenables_commented_line(self, fake_home: Path) -> None:
+        """A commented-out managed line is replaced by an active one, not kept."""
+        script_path = fake_home / ".smolvm" / "completions" / "smolvm.bash"
+        bashrc = fake_home / ".bashrc"
+        bashrc.write_text(f"# source {script_path}  # smolvm tab completion\nalias ll='ls -la'\n")
+
+        ret = main(["completion", "bash", "--install"])
+
+        assert ret == 0
+        content = bashrc.read_text()
+        assert f"source {script_path}  # smolvm tab completion" in content
+        assert f"# source {script_path}" not in content
+        # User content is untouched.
+        assert "alias ll='ls -la'" in content
+
+    def test_completion_install_replaces_stale_managed_line(self, fake_home: Path) -> None:
+        """A managed line pointing at an old path is replaced, not duplicated."""
+        bashrc = fake_home / ".bashrc"
+        bashrc.write_text(
+            "source /old/home/.smolvm/completions/smolvm.bash  # smolvm tab completion\n"
+        )
+
+        ret = main(["completion", "bash", "--install"])
+
+        assert ret == 0
+        content = bashrc.read_text()
+        assert "/old/home/" not in content
+        script_path = fake_home / ".smolvm" / "completions" / "smolvm.bash"
+        assert content.count("# smolvm tab completion") == 1
+        assert str(script_path) in content
+
+    def test_completion_install_respects_user_written_line(self, fake_home: Path) -> None:
+        """A source line the user wrote themselves is honored, not duplicated."""
+        bashrc = fake_home / ".bashrc"
+        bashrc.write_text("source ~/.smolvm/completions/smolvm.bash\n")
+
+        ret = main(["completion", "bash", "--install"])
+
+        assert ret == 0
+        content = bashrc.read_text()
+        # No managed line added; the user's own line is untouched.
+        assert "# smolvm tab completion" not in content
+        assert content == "source ~/.smolvm/completions/smolvm.bash\n"
+
+    def test_completion_install_preserves_non_utf8_rc(self, fake_home: Path) -> None:
+        """An rc file with undecodable bytes is appended to without corruption."""
+        bashrc = fake_home / ".bashrc"
+        bashrc.write_bytes(b"alias x='y'\n\xff\xfe raw bytes\n")
+
+        ret = main(["completion", "bash", "--install"])
+
+        assert ret == 0
+        raw = bashrc.read_bytes()
+        assert b"\xff\xfe raw bytes" in raw
+        assert b"# smolvm tab completion" in raw
+
+    def test_completion_install_creates_missing_zdotdir(
+        self,
+        fake_home: Path,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """ZDOTDIR pointing at a not-yet-existing directory is created, not an error."""
+        zdotdir = tmp_path / "zdot-missing"
+        monkeypatch.setenv("ZDOTDIR", str(zdotdir))
+
+        ret = main(["completion", "zsh", "--install"])
+
+        assert ret == 0
+        assert (zdotdir / ".zshrc").exists()
+
+    def test_completion_install_zsh_script_guards_compinit(self, fake_home: Path) -> None:
+        """The installed zsh script initializes compinit before compdef runs."""
+        ret = main(["completion", "zsh", "--install"])
+
+        assert ret == 0
+        script = (fake_home / ".smolvm" / "completions" / "smolvm.zsh").read_text()
+        # The compinit guard must run before click's `compdef` registration.
+        assert "autoload -Uz compinit" in script
+        assert script.index("autoload -Uz compinit") < script.index("compdef _smolvm_completion")
+
+    def test_completion_install_bash_on_macos_uses_bash_profile(
+        self,
+        fake_home: Path,
+    ) -> None:
+        """On macOS, bash login shells read ~/.bash_profile, so install targets it."""
+        with patch("smolvm.cli.completion.platform.system", return_value="Darwin"):
+            ret = main(["completion", "bash", "--install"])
+
+        assert ret == 0
+        assert (fake_home / ".bash_profile").exists()
+        assert not (fake_home / ".bashrc").exists()
+
+    def test_completion_install_under_sudo_targets_real_user_home(
+        self,
+        fake_home: Path,
+        tmp_path: Path,
+    ) -> None:
+        """Under sudo, files land in the invoking user's home, not root's."""
+        sudo_home = tmp_path / "real-user"
+        sudo_home.mkdir()
+        sudo_info = MagicMock()
+        sudo_info.pw_dir = str(sudo_home)
+        sudo_info.pw_uid = os.getuid()
+        sudo_info.pw_gid = os.getgid()
+
+        with patch("smolvm.vm._get_sudo_user_info", return_value=sudo_info):
+            ret = main(["completion", "bash", "--install"])
+
+        assert ret == 0
+        script_path = sudo_home / ".smolvm" / "completions" / "smolvm.bash"
+        assert script_path.exists()
+        assert str(script_path) in (sudo_home / ".bashrc").read_text()
+        # Nothing written into the (fake) root home.
+        assert not (fake_home / ".bashrc").exists()
 
     def test_complete_sandbox_names_filters_by_prefix(self) -> None:
         """The completion callback returns matching sandbox names."""

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -4967,6 +4967,29 @@ class TestCliExec:
         assert ret == 0
         suppress_pipe.assert_called_once()
 
+    def test_exec_stderr_survives_broken_stdout(
+        self,
+        mock_vm_cls: MagicMock,
+        capsys: pytest.CaptureFixture,
+    ) -> None:
+        """A closed stdout pipe must not swallow the command's stderr."""
+        from smolvm.types import CommandResult
+
+        vm = self._setup_vm(mock_vm_cls)
+        vm.run.return_value = CommandResult(exit_code=0, stdout="out", stderr="err\n")
+        fake_stdout = MagicMock()
+        fake_stdout.write.side_effect = BrokenPipeError()
+
+        with (
+            patch("smolvm.cli.main.sys.stdout", fake_stdout),
+            patch("smolvm.cli.main._suppress_broken_pipe"),
+        ):
+            ret = main(["sandbox", "exec", "vm001", "--", "x"])
+
+        assert ret == 0
+        # stderr is still delivered even though the stdout write broke.
+        assert capsys.readouterr().err == "err\n"
+
 
 class TestCliLogs:
     """Tests for `smolvm sandbox logs`."""
@@ -5135,21 +5158,25 @@ class TestCliCompletion:
         """The completion callback returns matching sandbox names."""
         from smolvm.cli.commands.options import complete_sandbox_names
 
-        sdk = MagicMock()
-        sdk.__enter__.return_value = sdk
-        sdk.__exit__.return_value = False
-        sdk.list_vms.return_value = [_make_vm_info("web-1"), _make_vm_info("api-2")]
+        state = MagicMock()
+        state.list_vms.return_value = [_make_vm_info("web-1"), _make_vm_info("api-2")]
 
-        with patch("smolvm.vm.SmolVMManager", return_value=sdk):
+        with (
+            patch("smolvm.storage.create_state_manager", return_value=state),
+            patch("smolvm.vm.resolve_data_dir", return_value=Path("/tmp")),
+        ):
             items = complete_sandbox_names(MagicMock(), MagicMock(), "web")
 
         assert [item.value for item in items] == ["web-1"]
+        # The lighter state store is used, not SmolVMManager (which would
+        # create disk/snapshot dirs just to complete a name).
+        state.close.assert_called_once()
 
     def test_complete_sandbox_names_never_raises(self) -> None:
         """A backend failure yields no suggestions instead of a traceback."""
         from smolvm.cli.commands.options import complete_sandbox_names
 
-        with patch("smolvm.vm.SmolVMManager", side_effect=Exception("no db")):
+        with patch("smolvm.storage.create_state_manager", side_effect=Exception("no db")):
             items = complete_sandbox_names(MagicMock(), MagicMock(), "")
 
         assert items == []

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -2153,6 +2153,7 @@ class TestCliShell:
         capsys: pytest.CaptureFixture,
     ) -> None:
         vm = MagicMock()
+        vm.vm_id = "vm001"
         vm.status = VMState.ERROR
         mock_vm_cls.from_id.return_value = vm
 
@@ -2165,7 +2166,7 @@ class TestCliShell:
         vm.close.assert_called_once()
         err = " ".join(capsys.readouterr().err.replace("│", "").split())
         assert "error state" in err
-        assert "inspect the sandbox logs" in err
+        assert "smolvm sandbox logs vm001" in err
         assert "smolvm sandbox delete vm001" in err
         assert "smolvm sandbox create --name vm001" in err
 
@@ -4927,6 +4928,45 @@ class TestCliExec:
         vm.start.assert_called_once()
         vm.run.assert_called_once_with("echo ok", timeout=30)
 
+    def test_exec_json_nonzero_populates_error(
+        self,
+        mock_vm_cls: MagicMock,
+        capsys: pytest.CaptureFixture,
+    ) -> None:
+        """A non-zero guest exit keeps the envelope's ok<->error invariant."""
+        from smolvm.types import CommandResult
+
+        vm = self._setup_vm(mock_vm_cls)
+        vm.run.return_value = CommandResult(exit_code=2, stdout="partial", stderr="nope")
+
+        ret = main(["sandbox", "exec", "vm001", "--json", "--", "false"])
+
+        assert ret == 2
+        payload = json.loads(capsys.readouterr().out)
+        assert payload["ok"] is False
+        assert payload["error"]["code"] == "command_failed"
+        assert "2" in payload["error"]["message"]
+        # stdout/stderr are still available to the consumer on failure.
+        assert payload["data"] == {"exit_code": 2, "stdout": "partial", "stderr": "nope"}
+
+    def test_exec_broken_pipe_exits_cleanly(self, mock_vm_cls: MagicMock) -> None:
+        """A reader closing the pipe (`| head`) does not surface as an error."""
+        from smolvm.types import CommandResult
+
+        vm = self._setup_vm(mock_vm_cls)
+        vm.run.return_value = CommandResult(exit_code=0, stdout="data", stderr="")
+        fake_stdout = MagicMock()
+        fake_stdout.write.side_effect = BrokenPipeError()
+
+        with (
+            patch("smolvm.cli.main.sys.stdout", fake_stdout),
+            patch("smolvm.cli.main._suppress_broken_pipe") as suppress_pipe,
+        ):
+            ret = main(["sandbox", "exec", "vm001", "--", "echo", "data"])
+
+        assert ret == 0
+        suppress_pipe.assert_called_once()
+
 
 class TestCliLogs:
     """Tests for `smolvm sandbox logs`."""
@@ -5023,6 +5063,44 @@ class TestCliLogs:
         payload = json.loads(capsys.readouterr().out)
         assert payload["error"]["code"] == "invalid_input"
 
+    def test_logs_follow_no_trailing_newline_keeps_line_intact(
+        self,
+        mock_vm_cls: MagicMock,
+        tmp_path: Path,
+        capsys: pytest.CaptureFixture,
+    ) -> None:
+        """--follow must not append a newline to a final line still being written."""
+        self._setup_vm(mock_vm_cls, tmp_path)
+        (tmp_path / "vm001.log").write_text("Booting")  # no trailing newline
+
+        # KeyboardInterrupt breaks out of the follow loop immediately after the
+        # initial tail is printed, so the test does not block.
+        with patch("time.sleep", side_effect=KeyboardInterrupt):
+            ret = main(["sandbox", "logs", "vm001", "--follow"])
+
+        assert ret == 0
+        assert capsys.readouterr().out == "Booting"
+
+    def test_logs_broken_pipe_exits_cleanly(
+        self,
+        mock_vm_cls: MagicMock,
+        tmp_path: Path,
+    ) -> None:
+        """A reader closing the pipe (`| head`) does not surface as an error."""
+        self._setup_vm(mock_vm_cls, tmp_path)
+        (tmp_path / "vm001.log").write_text("a\nb\n")
+        fake_stdout = MagicMock()
+        fake_stdout.write.side_effect = BrokenPipeError()
+
+        with (
+            patch("smolvm.cli.main.sys.stdout", fake_stdout),
+            patch("smolvm.cli.main._suppress_broken_pipe") as suppress_pipe,
+        ):
+            ret = main(["sandbox", "logs", "vm001"])
+
+        assert ret == 0
+        suppress_pipe.assert_called_once()
+
 
 class TestCliCompletion:
     """Tests for `smolvm completion` and dynamic sandbox-name completion."""
@@ -5073,5 +5151,34 @@ class TestCliCompletion:
 
         with patch("smolvm.vm.SmolVMManager", side_effect=Exception("no db")):
             items = complete_sandbox_names(MagicMock(), MagicMock(), "")
+
+        assert items == []
+
+    def test_complete_browser_session_names_uses_browser_namespace(self) -> None:
+        """Browser completion lists browser session ids, not sandbox vm_ids."""
+        from smolvm.cli.commands.options import complete_browser_session_names
+
+        state = MagicMock()
+        session_a = MagicMock()
+        session_a.session_id = "brs-alpha"
+        session_b = MagicMock()
+        session_b.session_id = "brs-beta"
+        state.list_browser_sessions.return_value = [session_a, session_b]
+
+        with (
+            patch("smolvm.storage.create_state_manager", return_value=state),
+            patch("smolvm.vm.resolve_data_dir", return_value=Path("/tmp")),
+        ):
+            items = complete_browser_session_names(MagicMock(), MagicMock(), "brs-a")
+
+        assert [item.value for item in items] == ["brs-alpha"]
+        state.close.assert_called_once()
+
+    def test_complete_browser_session_names_never_raises(self) -> None:
+        """A failure to open the state store yields no suggestions."""
+        from smolvm.cli.commands.options import complete_browser_session_names
+
+        with patch("smolvm.storage.create_state_manager", side_effect=Exception("no db")):
+            items = complete_browser_session_names(MagicMock(), MagicMock(), "")
 
         assert items == []

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -4875,6 +4875,58 @@ class TestCliExec:
         assert ret == 1
         assert "not found" in capsys.readouterr().err
 
+    def test_exec_fails_when_not_running(
+        self,
+        mock_vm_cls: MagicMock,
+        capsys: pytest.CaptureFixture,
+    ) -> None:
+        """A stopped sandbox is not started implicitly; exec errors out."""
+        vm = self._setup_vm(mock_vm_cls)
+        vm.status = VMState.STOPPED
+
+        ret = main(["sandbox", "exec", "vm001", "--", "ls"])
+
+        assert ret == 1
+        err = capsys.readouterr().err
+        assert "not running" in err
+        vm.run.assert_not_called()
+        vm.start.assert_not_called()
+        vm.close.assert_called_once()
+
+    def test_exec_not_running_json_recovery(
+        self,
+        mock_vm_cls: MagicMock,
+        capsys: pytest.CaptureFixture,
+    ) -> None:
+        """The not-running error carries a JSON recovery that mentions --start."""
+        vm = self._setup_vm(mock_vm_cls)
+        vm.status = VMState.STOPPED
+
+        ret = main(["sandbox", "exec", "vm001", "--json", "--", "ls"])
+
+        assert ret == 1
+        payload = json.loads(capsys.readouterr().out)
+        assert payload["error"]["code"] == "not_running"
+        assert "--start" in payload["error"]["recovery"]
+        vm.run.assert_not_called()
+
+    def test_exec_start_flag_boots_stopped_sandbox(
+        self,
+        mock_vm_cls: MagicMock,
+    ) -> None:
+        """`--start` starts a stopped sandbox before running the command."""
+        from smolvm.types import CommandResult
+
+        vm = self._setup_vm(mock_vm_cls)
+        vm.status = VMState.STOPPED
+        vm.run.return_value = CommandResult(exit_code=0, stdout="ok\n", stderr="")
+
+        ret = main(["sandbox", "exec", "vm001", "--start", "--", "echo", "ok"])
+
+        assert ret == 0
+        vm.start.assert_called_once()
+        vm.run.assert_called_once_with("echo ok", timeout=30)
+
 
 class TestCliLogs:
     """Tests for `smolvm sandbox logs`."""

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -5401,6 +5401,58 @@ class TestCliCompletion:
         # Nothing written into the (fake) root home.
         assert not (fake_home / ".bashrc").exists()
 
+    def test_completion_install_collapses_duplicate_managed_lines(
+        self,
+        fake_home: Path,
+    ) -> None:
+        """Two identical managed lines (e.g. concurrent installs) collapse to one."""
+        script_path = fake_home / ".smolvm" / "completions" / "smolvm.bash"
+        line = f"source {script_path}  # smolvm tab completion"
+        bashrc = fake_home / ".bashrc"
+        bashrc.write_text(f"{line}\n{line}\n")
+
+        ret = main(["completion", "bash", "--install"])
+
+        assert ret == 0
+        assert bashrc.read_text().count("# smolvm tab completion") == 1
+
+    def test_completion_install_sudo_chowns_created_ancestors(
+        self,
+        fake_home: Path,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Every directory created below the user's home is chowned, however deep."""
+        sudo_home = tmp_path / "real-user"
+        sudo_home.mkdir()
+        # A custom fish config dir several levels deep inside the user's home.
+        monkeypatch.setenv("XDG_CONFIG_HOME", str(sudo_home / "nested" / "cfg"))
+        sudo_info = MagicMock()
+        sudo_info.pw_dir = str(sudo_home)
+        sudo_info.pw_uid = os.getuid()
+        sudo_info.pw_gid = os.getgid()
+
+        chowned: list[str] = []
+        with (
+            patch("smolvm.vm._get_sudo_user_info", return_value=sudo_info),
+            patch(
+                "smolvm.cli.completion.os.chown",
+                side_effect=lambda p, *_: chowned.append(str(p)),
+            ),
+        ):
+            ret = main(["completion", "fish", "--install"])
+
+        assert ret == 0
+        base = sudo_home / "nested" / "cfg" / "fish" / "completions"
+        for expected in (
+            base / "smolvm.fish",
+            base,
+            base.parent,
+            sudo_home / "nested" / "cfg",
+            sudo_home / "nested",
+        ):
+            assert str(expected) in chowned
+
     def test_complete_sandbox_names_filters_by_prefix(self) -> None:
         """The completion callback returns matching sandbox names."""
         from smolvm.cli.commands.options import complete_sandbox_names

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -20,7 +20,55 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 from smolvm.exceptions import SmolVMError
-from smolvm.utils import ensure_ssh_key, run_command, which
+from smolvm.utils import ensure_ssh_key, run_command, tail_file, which
+
+
+class TestTailFile:
+    """Tests for ``tail_file``."""
+
+    def test_returns_last_n_lines_and_size(self, tmp_path) -> None:
+        p = tmp_path / "log.txt"
+        p.write_text("a\nb\nc\nd\n")
+        lines, size, ends_with_newline = tail_file(p, 2)
+        assert lines == ["c", "d"]
+        assert size == p.stat().st_size
+        assert ends_with_newline is True
+
+    def test_no_trailing_newline(self, tmp_path) -> None:
+        p = tmp_path / "log.txt"
+        p.write_text("a\nb")
+        lines, _, ends_with_newline = tail_file(p, 5)
+        assert lines == ["a", "b"]
+        assert ends_with_newline is False
+
+    def test_crlf_normalized_to_single_lines(self, tmp_path) -> None:
+        p = tmp_path / "log.txt"
+        p.write_text("a\r\nb\r\n")
+        lines, _, _ = tail_file(p, 5)
+        assert lines == ["a", "b"]
+
+    def test_does_not_split_on_non_newline_separators(self, tmp_path) -> None:
+        # \x0c (form feed) and \x85 (NEL) are line boundaries to str.splitlines()
+        # but must not inflate the line count for a log line that contains them.
+        p = tmp_path / "log.txt"
+        p.write_text("first\x0cstill-first\x85same\nsecond\n")
+        lines, _, _ = tail_file(p, 5)
+        assert lines == ["first\x0cstill-first\x85same", "second"]
+
+    def test_zero_or_negative_count_returns_no_lines(self, tmp_path) -> None:
+        p = tmp_path / "log.txt"
+        p.write_text("a\nb\n")
+        lines, size, _ = tail_file(p, 0)
+        assert lines == []
+        assert size == p.stat().st_size
+
+    def test_empty_file(self, tmp_path) -> None:
+        p = tmp_path / "log.txt"
+        p.write_text("")
+        lines, size, ends_with_newline = tail_file(p, 10)
+        assert lines == []
+        assert size == 0
+        assert ends_with_newline is False
 
 
 class TestRunCommand:

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -70,6 +70,16 @@ class TestTailFile:
         assert size == 0
         assert ends_with_newline is False
 
+    def test_invalid_utf8_replaced(self, tmp_path) -> None:
+        # A corrupt log (invalid UTF-8 bytes) must decode with replacement
+        # characters rather than raising.
+        p = tmp_path / "log.txt"
+        p.write_bytes(b"good\n\xff\xfe bad\n")
+        lines, size, _ = tail_file(p, 5)
+        assert lines[0] == "good"
+        assert "�" in lines[1]
+        assert size == p.stat().st_size
+
 
 class TestRunCommand:
     """Tests for run_command utility."""


### PR DESCRIPTION
## Summary

Adds three ergonomic CLI improvements, plus the hardening that came out of review.

**New commands & features**

- **`smolvm sandbox exec <sandbox> -- <cmd>`** — run one command in a sandbox and stream its output. Exit code is passed through; `--json` returns an envelope with `exit_code`/`stdout`/`stderr`. Requires the sandbox to be running and fails with an actionable message otherwise; pass **`--start`** to boot/resume it first (chosen over `--force`, which already means "skip confirmation" on `sandbox delete`).
- **`smolvm sandbox logs <sandbox>`** — show the host boot/console log, with `--tail N`, `-f/--follow`, and `--json`.
- **Shell completion** — `smolvm completion <bash|zsh|fish>` prints a sourceable script, and every sandbox-name argument now tab-completes existing sandboxes. Sandbox commands complete sandbox names; `browser` commands complete browser **session ids** (a separate namespace). The callbacks never raise and don't create state on `<TAB>`.

**Refactors / cleanup**

- Extracted a shared `_bring_sandbox_up` helper and refactored `sandbox ssh`/`sandbox shell` onto it, removing the triplicated start/resume/error state machine and unifying the error-state message.
- Extracted `utils.tail_file`, shared by `sandbox logs` and the browser log tail.
- Extracted `_complete_from_state` so the sandbox and browser completers share their open/list/close/never-raise logic.

**Correctness hardening (from three review passes)**

- JSON envelope: a non-zero guest exit from `exec --json` now populates `error` (`command_failed`) while keeping stdout/stderr in `data`, instead of emitting `{ok:false, error:null}`.
- Broken pipe: `exec` and `logs` (both human and `--json` output) exit cleanly when piped into a reader that closes early (e.g. `| head`) instead of raising a traceback or leaving an "Exception ignored" message; `exec` no longer drops the command's stderr when the stdout pipe closes.
- `logs --follow`: no longer splits the final line when the log lacks a trailing newline, and streams appended bytes through an incremental UTF-8 decoder so multi-byte characters spanning a read boundary aren't mangled.
- `exec` refreshes cached VM state before the not-running check.
- Completion no longer creates `disks/`/`snapshots/` directories as a side effect.

**Docs**

- `docs/reference/cli.md`: documents `exec`, `logs`, and a Shell completion section.
- `README.md`: `exec`/`logs` examples and a completion tip.
- `AGENTS.md`: records `completion` as an accepted top-level meta-command exception to the NOUN-VERB convention.

## Related Issues

- None.

## Testing

- `uv run pytest` — CLI + browser suites pass (262 tests). Full suite: 1737 passed, 18 skipped. The 7 failures in `tests/test_facade.py` are pre-existing and environmental (this host lacks `vhost_vsock`); they also fail on `main` and are untouched by this PR.
- `uv run ruff check .` — passes.
- `uv run ruff format --check .` — clean.
- `uv run mypy src` — not run.

## Checklist

- [x] Scope is focused and limited to this change
- [x] Tests added/updated for behavior changes
- [x] Docs updated for user-visible changes
- [x] No secrets or sensitive data included

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `smolvm sandbox exec` to run a single command in a sandbox (timeout, optional `--start`, and JSON output).
  * Added `smolvm sandbox logs` to view/tail sandbox logs with `--follow` and JSON output.
  * Added `smolvm completion <shell>` plus improved tab-completion for sandbox and browser session identifiers.
* **Documentation**
  * Updated Quickstart and CLI reference, including per-shell completion setup.
* **Bug Fixes**
  * More accurate log tailing for newline and encoding edge cases; cleaner behavior when output is piped.
* **Tests**
  * Expanded CLI and utility test coverage for exec, logs, completion, and tailing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->