### PR TITLE
fix(runtime): detect unowned zombie VM processes

### DIFF
--- a/src/smolvm/vm.py
+++ b/src/smolvm/vm.py
@@ -3281,6 +3281,21 @@ class SmolVMManager:
                 handle.wait(timeout=0.1)
                 self._process_handles.pop(pid, None)
 
+    @staticmethod
+    def _is_zombie_process(pid: int) -> bool:
+        """Return whether an existing process has exited but is not yet reaped."""
+        try:
+            result = subprocess.run(
+                ["ps", "-o", "state=", "-p", str(pid)],
+                check=False,
+                capture_output=True,
+                text=True,
+                timeout=1.0,
+            )
+        except (OSError, subprocess.SubprocessError):
+            return False
+        return result.returncode == 0 and result.stdout.strip().startswith("Z")
+
     def _is_process_running(self, pid: int) -> bool:
         """Check if a process is running.
 
@@ -3298,11 +3313,11 @@ class SmolVMManager:
             return False
         try:
             os.kill(pid, 0)
-            return True
         except ProcessLookupError:
             return False
         except PermissionError:
-            return True  # Can't signal but exists
+            return not self._is_zombie_process(pid)
+        return not self._is_zombie_process(pid)
 
     def _wait_for_process(self, pid: int, timeout: float) -> None:
         """Wait for a process to exit.

--- a/tests/test_vm.py
+++ b/tests/test_vm.py
@@ -1566,6 +1566,27 @@ class TestProcessLifecycle:
         assert smol_vm._is_process_running(process.pid) is False
         assert process.pid not in smol_vm._process_handles
 
+    def test_is_process_running_rejects_zombie_without_handle(self, smol_vm: SmolVMManager) -> None:
+        """A zombie owned by another process must not be treated as running."""
+        with (
+            patch("smolvm.vm.os.kill"),
+            patch.object(smol_vm, "_is_zombie_process", return_value=True),
+        ):
+            assert smol_vm._is_process_running(12345) is False
+
+    def test_is_zombie_process_reads_ps_state(self, smol_vm: SmolVMManager) -> None:
+        """The portable fallback should recognize ps's zombie state marker."""
+        result = subprocess.CompletedProcess(args=["ps"], returncode=0, stdout="Z    \n", stderr="")
+        with patch("smolvm.vm.subprocess.run", return_value=result) as mock_run:
+            assert smol_vm._is_zombie_process(12345) is True
+        mock_run.assert_called_once_with(
+            ["ps", "-o", "state=", "-p", "12345"],
+            check=False,
+            capture_output=True,
+            text=True,
+            timeout=1.0,
+        )
+
     def test_kill_process_reaps_handle_so_followup_check_returns_false(
         self, smol_vm: SmolVMManager
     ) -> None:

--- a/tests/test_vm.py
+++ b/tests/test_vm.py
@@ -1569,10 +1569,11 @@ class TestProcessLifecycle:
     def test_is_process_running_rejects_zombie_without_handle(self, smol_vm: SmolVMManager) -> None:
         """A zombie owned by another process must not be treated as running."""
         with (
-            patch("smolvm.vm.os.kill"),
-            patch.object(smol_vm, "_is_zombie_process", return_value=True),
+            patch("smolvm.vm.os.kill", side_effect=PermissionError),
+            patch.object(smol_vm, "_is_zombie_process", return_value=True) as mock_is_zombie,
         ):
             assert smol_vm._is_process_running(12345) is False
+        mock_is_zombie.assert_called_once_with(12345)
 
     def test_is_zombie_process_reads_ps_state(self, smol_vm: SmolVMManager) -> None:
         """The portable fallback should recognize ps's zombie state marker."""


### PR DESCRIPTION
## Summary

- detect zombie VM processes even when the stopping manager does not own the original `Popen` handle
- prevent `os.kill(pid, 0)` from misclassifying an exited QEMU process as running
- add regression coverage for cross-process zombie detection and `ps` state parsing

This fixes `smolvm sandbox stop` reporting that QEMU did not exit after QEMU had already terminated and was waiting for its original long-running parent process to reap it.

## Related Issues

- Follow-up to #190

## Testing

- `uv run pytest tests/test_vm.py::TestProcessLifecycle tests/test_runtime_qemu.py -q`
- `uv run pytest tests/test_cli.py -q -k 'stop and not browser'`
- `uv run ruff check src/smolvm/vm.py tests/test_vm.py`
- `uv run ruff format --check src/smolvm/vm.py tests/test_vm.py`
- live reproduction: stopping the affected zombie-backed sandbox now succeeds and clears its persisted PID

Broader local runs reached unrelated macOS-specific failures in existing sparse-file and Bash completion tests.

## Checklist

- [x] Scope is focused and limited to this change
- [x] Tests added/updated for behavior changes
- [x] Docs not required; the user-visible command behavior is corrected without changing its interface
- [x] No secrets or sensitive data included


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved process-status handling when permission is denied, making results more reliable.
  * Zombie processes are now treated as not running to prevent inaccurate lifecycle reporting.

* **Tests**
  * Added unit tests covering zombie detection and portable process-state checks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->