### PR TITLE
Add QEMU dirty-bitmap incremental snapshot support

### DIFF
--- a/docs/deep-dive/qemu-incremental-snapshot-spike.md
+++ b/docs/deep-dive/qemu-incremental-snapshot-spike.md
@@ -1,6 +1,6 @@
 # QEMU incremental snapshot spike
 
-This spike proves that Celesto can capture small QEMU disk increments and rebuild bootable standalone disks without retaining source-host state. The local and production-image gates pass.
+Instead of copying an entire virtual disk every time, this feature can save only the disk areas that changed since the previous snapshot. These smaller files are called disk increments. To restore one, Celesto combines the original full copy with its ordered increments and produces a self-contained bootable disk, so the original virtual machine and host are not needed. The local and production-image tests passed.
 
 ## Test baseline
 
@@ -8,7 +8,7 @@ This spike proves that Celesto can capture small QEMU disk increments and rebuil
 - Local host: macOS arm64
 - Local QEMU and `qemu-img`: 11.0.0
 - Production image preflight: Ubuntu 24.04, QEMU 8.2.2 (`1:8.2.2+ds-0ubuntu1.17`), Linux 6.17 AWS x86_64
-- Bitmap granularity selected by QEMU: 64 KiB
+- Bitmap granularity (the smallest disk-change unit QEMU tracks): 64 KiB
 
 The production preflight found five running QEMU processes. No disk workload was run on that busy host. A diskless `-machine none` QMP check confirmed that QEMU 8.2.2 exposes every required bitmap, transaction, backup, job, and block-node command.
 
@@ -44,6 +44,16 @@ This idle marker workload demonstrates the artifact shape; the production-image 
 ## Compatibility finding
 
 Forced cancellation previously sent `force` to generic `job-cancel`. QEMU 11 rejects that argument. Forced block-backup cancellation now uses `block-job-cancel` with `device` and `force=true`; normal cancellation still uses generic `job-cancel`.
+
+## Interrupted capture recovery
+
+If SmolVM reports a recovered artifact, first adopt it into the remote snapshot chain using the `artifact_path` and metadata in the error details. Only after that succeeds, clear the retained local file and recovery record:
+
+```bash
+smolvm sandbox snapshot delete <recovered-snapshot-id>
+```
+
+Do not run the delete command before adoption because it removes the recovered artifact. If SmolVM reports that capture state is uncertain, discard that chain and run the fresh full-disk snapshot command included in the error.
 
 ## Commands
 

--- a/docs/deep-dive/qemu-incremental-snapshot-spike.md
+++ b/docs/deep-dive/qemu-incremental-snapshot-spike.md
@@ -1,0 +1,81 @@
+# QEMU incremental snapshot spike
+
+This spike proves that Celesto can capture small QEMU disk increments and rebuild bootable standalone disks without retaining source-host state. The local and production-image gates pass.
+
+## Test baseline
+
+- SmolVM source: `38c962f8afd89cc0fcbada5d437b3632eeba790b`
+- Local host: macOS arm64
+- Local QEMU and `qemu-img`: 11.0.0
+- Production image preflight: Ubuntu 24.04, QEMU 8.2.2 (`1:8.2.2+ds-0ubuntu1.17`), Linux 6.17 AWS x86_64
+- Bitmap granularity selected by QEMU: 64 KiB
+
+The production preflight found five running QEMU processes. No disk workload was run on that busy host. A diskless `-machine none` QMP check confirmed that QEMU 8.2.2 exposes every required bitmap, transaction, backup, job, and block-node command.
+
+## Proven locally
+
+`tests/test_qemu_incremental_spike.py` uses a real QEMU process and proves:
+
+- one transaction adds an enabled persistent bitmap and starts the full backup;
+- increment A contains only writes made after the base;
+- increment B contains writes made after increment A;
+- `qemu-img rebase -u` plus `qemu-img convert` produces a standalone qcow2;
+- a clean QEMU restart preserves the persistent bitmap;
+- forced cancellation leaves all 16 MiB of dirty writes in the bitmap;
+- the next successful increment contains the cancelled job's writes.
+
+`tests/e2e/test_qemu_incremental_snapshot.py` uses a disposable Ubuntu VM and proves:
+
+- base+A boots with marker A and without marker B;
+- base+A+B boots with both markers;
+- both restores work after the source VM, managed disk, QMP socket, and SmolVM state are deleted;
+- both materialized outputs are standalone qcow2 files.
+
+Local artifact allocation from the boot test:
+
+| Artifact | Virtual size | Allocated bytes |
+|---|---:|---:|
+| Base | 4 GiB | 479,985,664 |
+| Increment A | 4 GiB | 917,504 |
+| Increment B | 4 GiB | 983,040 |
+
+This idle marker workload demonstrates the artifact shape; the production-image benchmark below measures the byte-reduction target under active writes.
+
+## Compatibility finding
+
+Forced cancellation previously sent `force` to generic `job-cancel`. QEMU 11 rejects that argument. Forced block-backup cancellation now uses `block-job-cancel` with `device` and `force=true`; normal cancellation still uses generic `job-cancel`.
+
+## Commands
+
+```bash
+uv run pytest tests/test_qmp.py tests/test_qemu_incremental_spike.py tests/test_snapshot_qemu.py
+uv run pytest -m e2e tests/e2e/test_qemu_incremental_snapshot.py
+uv run python scripts/qemu_incremental_benchmark.py \
+  --output-dir /tmp/qemu-incremental-benchmark \
+  --intervals 12 \
+  --write-mib 32
+```
+
+## Production-image result
+
+The tests ran on an isolated `c5.metal` instance launched from the existing production AMI. No new AMI was created, no production user-data was supplied, and the host agent remained disabled. The instance and its root volume were terminated after the run.
+
+QEMU 8.2.2 with KVM passed:
+
+- the focused QMP, cancellation, and snapshot suite: 51 tests;
+- source-state deletion and boot of both materialized leaves;
+- 12 simulated five-minute intervals with 32 MiB of active guest writes per interval.
+
+Benchmark result:
+
+| Measurement | Result |
+|---|---:|
+| Repeated standalone full bytes | 6,188,171,264 |
+| Base plus 12 increments | 857,145,344 |
+| Byte reduction | **86.15%** |
+| Increment capture duration | 0.03–0.13 seconds |
+| Full capture duration | 2.65–3.74 seconds |
+| Baseline terminal latency, median | 45.12 ms |
+| During-capture terminal latency, median | 21.45 ms |
+
+The accelerated 12-interval run validates bytes and immediate latency. The 24-hour live canary in the rollout plan remains the long-duration operational test. Disk-heavy benchmarks must not run on a host serving customer VMs.

--- a/scripts/qemu_incremental_benchmark.py
+++ b/scripts/qemu_incremental_benchmark.py
@@ -19,13 +19,13 @@ from __future__ import annotations
 
 import argparse
 import json
+import logging
 import os
 import shutil
 import statistics
 import subprocess
 import tempfile
 import time
-from contextlib import suppress
 from pathlib import Path
 from typing import Any
 
@@ -33,6 +33,8 @@ from smolvm import SmolVM
 from smolvm.qmp import QMPClient
 
 _BITMAP_NAME = "celesto-phase0-benchmark"
+
+logger = logging.getLogger(__name__)
 
 
 def _run(*command: str) -> subprocess.CompletedProcess[str]:
@@ -244,10 +246,14 @@ def benchmark(output_dir: Path, *, intervals: int, write_mib: int) -> dict[str, 
             cpu_seconds = _process_cpu_seconds(pid) - cpu_before
             diskstats = _difference(_root_diskstats(), diskstats_before)
         finally:
-            with suppress(Exception):
+            try:
                 vm.stop(timeout=10)
-            with suppress(Exception):
+            except Exception:
+                logger.exception("Failed to stop benchmark VM %s", vm.vm_id)
+            try:
                 vm.delete()
+            except Exception:
+                logger.exception("Failed to delete benchmark VM %s", vm.vm_id)
 
     incremental_bytes = int(full_captures[0]["file_bytes"]) + sum(
         int(value["file_bytes"]) for value in increments

--- a/scripts/qemu_incremental_benchmark.py
+++ b/scripts/qemu_incremental_benchmark.py
@@ -1,0 +1,299 @@
+#!/usr/bin/env python3
+# Copyright 2026 Celesto AI
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Benchmark 12 QEMU incremental intervals against equivalent full backups."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import shutil
+import statistics
+import subprocess
+import tempfile
+import time
+from contextlib import suppress
+from pathlib import Path
+from typing import Any
+
+from smolvm import SmolVM
+from smolvm.qmp import QMPClient
+
+_BITMAP_NAME = "celesto-phase0-benchmark"
+
+
+def _run(*command: str) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(command, check=True, capture_output=True, text=True)
+
+
+def _qemu_img_info(qemu_img: str, path: Path) -> dict[str, Any]:
+    result = _run(qemu_img, "info", "--output=json", str(path))
+    value = json.loads(result.stdout)
+    if not isinstance(value, dict):
+        raise RuntimeError(f"qemu-img returned invalid metadata for {path}")
+    return value
+
+
+def _create_target(qemu_img: str, path: Path, virtual_size: int) -> None:
+    _run(qemu_img, "create", "-f", "qcow2", str(path), str(virtual_size))
+
+
+def _terminal_latency_ms(vm: SmolVM) -> float:
+    started = time.monotonic()
+    result = vm.run("true")
+    elapsed = (time.monotonic() - started) * 1000
+    if result.exit_code != 0:
+        raise RuntimeError("guest terminal latency probe failed")
+    return elapsed
+
+
+def _process_cpu_seconds(pid: int) -> float:
+    fields = Path(f"/proc/{pid}/stat").read_text().split()
+    ticks = int(fields[13]) + int(fields[14])
+    return ticks / os.sysconf("SC_CLK_TCK")
+
+
+def _root_diskstats() -> dict[str, int]:
+    device = os.stat("/").st_dev
+    major, minor = os.major(device), os.minor(device)
+    for line in Path("/proc/diskstats").read_text().splitlines():
+        fields = line.split()
+        if int(fields[0]) == major and int(fields[1]) == minor:
+            return {
+                "reads": int(fields[3]),
+                "sectors_read": int(fields[5]),
+                "writes": int(fields[7]),
+                "sectors_written": int(fields[9]),
+                "io_ticks_ms": int(fields[12]),
+            }
+    raise RuntimeError("root volume is missing from /proc/diskstats")
+
+
+def _difference(after: dict[str, int], before: dict[str, int]) -> dict[str, int]:
+    return {key: after[key] - before[key] for key in before}
+
+
+def _capture(
+    client: QMPClient,
+    vm: SmolVM,
+    qemu_img: str,
+    path: Path,
+    virtual_size: int,
+    *,
+    suffix: str,
+    mode: str,
+) -> dict[str, float | int]:
+    _create_target(qemu_img, path, virtual_size)
+    node_name = f"target-{suffix}"
+    job_id = f"job-{suffix}"
+    client.blockdev_add(node_name, path)
+    started = time.monotonic()
+    if mode == "base":
+        client.start_full_backup_with_dirty_bitmap(
+            job_id=job_id,
+            source_node="rootdisk0",
+            target_node=node_name,
+            bitmap_name=_BITMAP_NAME,
+        )
+    elif mode == "incremental":
+        client.blockdev_backup_incremental(
+            job_id=job_id,
+            source_node="rootdisk0",
+            target_node=node_name,
+            bitmap_name=_BITMAP_NAME,
+        )
+    elif mode == "full":
+        client.blockdev_backup(
+            job_id=job_id,
+            source_node="rootdisk0",
+            target_node=node_name,
+        )
+    else:
+        raise ValueError(f"unsupported capture mode: {mode}")
+    terminal_latency_ms = _terminal_latency_ms(vm)
+    client.wait_for_job(job_id, timeout=600)
+    duration_seconds = time.monotonic() - started
+    client.blockdev_del(node_name)
+    info = _qemu_img_info(qemu_img, path)
+    if info.get("backing-filename"):
+        raise RuntimeError(f"capture unexpectedly has a backing file: {path}")
+    return {
+        "duration_seconds": duration_seconds,
+        "terminal_latency_ms": terminal_latency_ms,
+        "file_bytes": path.stat().st_size,
+        "allocated_bytes": int(info["actual-size"]),
+    }
+
+
+def _summary(values: list[float]) -> dict[str, float]:
+    return {
+        "minimum": min(values),
+        "median": statistics.median(values),
+        "maximum": max(values),
+    }
+
+
+def benchmark(output_dir: Path, *, intervals: int, write_mib: int) -> dict[str, Any]:
+    qemu_img = shutil.which("qemu-img")
+    if qemu_img is None:
+        raise RuntimeError("qemu-img is required")
+
+    output_dir.mkdir(parents=True, exist_ok=False)
+    artifacts = output_dir / "artifacts"
+    artifacts.mkdir()
+    source_data = output_dir / "source-data"
+    terminal_baseline: list[float] = []
+    increments: list[dict[str, float | int]] = []
+    full_captures: list[dict[str, float | int]] = []
+    dirty_bytes: list[int] = []
+
+    with tempfile.TemporaryDirectory(prefix="qinc-bench-") as socket_raw:
+        vm = SmolVM(
+            backend="qemu",
+            os="ubuntu",
+            data_dir=source_data,
+            socket_dir=Path(socket_raw),
+            disk_size=4096,
+            comm_channel="ssh",
+        )
+        started = time.monotonic()
+        try:
+            vm.start(boot_timeout=180)
+            for _ in range(10):
+                terminal_baseline.append(_terminal_latency_ms(vm))
+
+            disk = vm._info.config.rootfs_path
+            control_socket = vm._info.control_socket_path
+            pid = vm._info.pid
+            if control_socket is None or pid is None:
+                raise RuntimeError("running QEMU VM did not expose runtime metadata")
+            virtual_size = int(
+                json.loads(_run(qemu_img, "info", "-U", "--output=json", str(disk)).stdout)[
+                    "virtual-size"
+                ]
+            )
+            diskstats_before = _root_diskstats()
+            cpu_before = _process_cpu_seconds(pid)
+
+            with QMPClient(control_socket) as client:
+                client.connect()
+                qemu_version = client.query_version()
+                base = _capture(
+                    client,
+                    vm,
+                    qemu_img,
+                    artifacts / "base.qcow2",
+                    virtual_size,
+                    suffix="base",
+                    mode="base",
+                )
+                full_captures.append(base)
+
+                for interval in range(1, intervals + 1):
+                    workload = vm.run(
+                        "dd if=/dev/urandom of=/root/qemu-incremental-benchmark.bin "
+                        f"bs=1M count={write_mib} conv=notrunc status=none && sync",
+                        timeout=120,
+                    )
+                    if workload.exit_code != 0:
+                        raise RuntimeError(f"guest workload failed at interval {interval}")
+                    bitmap = next(
+                        value
+                        for value in client.query_dirty_bitmaps("rootdisk0")
+                        if value.name == _BITMAP_NAME
+                    )
+                    dirty_bytes.append(bitmap.dirty_bytes)
+
+                    increment = _capture(
+                        client,
+                        vm,
+                        qemu_img,
+                        artifacts / f"increment-{interval:02d}.qcow2",
+                        virtual_size,
+                        suffix=f"inc-{interval:02d}",
+                        mode="incremental",
+                    )
+                    increments.append(increment)
+
+                    calibration = artifacts / f"full-{interval:02d}.qcow2"
+                    full_capture = _capture(
+                        client,
+                        vm,
+                        qemu_img,
+                        calibration,
+                        virtual_size,
+                        suffix=f"full-{interval:02d}",
+                        mode="full",
+                    )
+                    full_captures.append(full_capture)
+                    calibration.unlink()
+
+            cpu_seconds = _process_cpu_seconds(pid) - cpu_before
+            diskstats = _difference(_root_diskstats(), diskstats_before)
+        finally:
+            with suppress(Exception):
+                vm.stop(timeout=10)
+            with suppress(Exception):
+                vm.delete()
+
+    incremental_bytes = int(full_captures[0]["file_bytes"]) + sum(
+        int(value["file_bytes"]) for value in increments
+    )
+    repeated_full_bytes = sum(int(value["file_bytes"]) for value in full_captures)
+    reduction_ratio = 1 - (incremental_bytes / repeated_full_bytes)
+    capture_terminal = [
+        float(value["terminal_latency_ms"]) for value in [*increments, *full_captures]
+    ]
+    report: dict[str, Any] = {
+        "qemu_version": qemu_version,
+        "intervals": intervals,
+        "write_mib_per_interval": write_mib,
+        "virtual_size_bytes": virtual_size,
+        "elapsed_seconds": time.monotonic() - started,
+        "incremental_bytes": incremental_bytes,
+        "repeated_full_bytes": repeated_full_bytes,
+        "reduction_ratio": reduction_ratio,
+        "passes_80_percent_gate": reduction_ratio >= 0.8,
+        "dirty_bytes": dirty_bytes,
+        "base": full_captures[0],
+        "increments": increments,
+        "full_captures": full_captures,
+        "terminal_latency_ms": {
+            "baseline": _summary(terminal_baseline),
+            "during_capture": _summary(capture_terminal),
+        },
+        "qemu_cpu_seconds": cpu_seconds,
+        "root_volume_io": diskstats,
+    }
+    (output_dir / "benchmark.json").write_text(json.dumps(report, indent=2, sort_keys=True))
+    return report
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--output-dir", type=Path, required=True)
+    parser.add_argument("--intervals", type=int, default=12)
+    parser.add_argument("--write-mib", type=int, default=32)
+    args = parser.parse_args()
+    if args.intervals < 1 or args.write_mib < 1:
+        parser.error("--intervals and --write-mib must be positive")
+    report = benchmark(args.output_dir, intervals=args.intervals, write_mib=args.write_mib)
+    print(json.dumps(report, sort_keys=True))
+    return 0 if report["passes_80_percent_gate"] else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/smolvm/__init__.py
+++ b/src/smolvm/__init__.py
@@ -41,6 +41,7 @@ from smolvm.images.boot import BootImage, DirectKernelBoot, FirmwareBoot
 from smolvm.images.builder import SSH_BOOT_ARGS, DockerRootfsBuilder, ImageBuilder
 from smolvm.images.manager import ImageManager, ImageSource, LocalImage, S3ImageManifest, S3ImageRef
 from smolvm.kernels import ensure_base_kernel_for_backend
+from smolvm.runtime.base import QemuDirtyBitmapBackup
 from smolvm.ssh import SSHClient
 from smolvm.types import (
     BrowserViewport,
@@ -100,6 +101,7 @@ __all__ = [
     "VMState",
     "NetworkConfig",
     "QemuMachine",
+    "QemuDirtyBitmapBackup",
     "SnapshotArtifacts",
     "SnapshotCapturePolicy",
     "SnapshotInfo",

--- a/src/smolvm/cli/main.py
+++ b/src/smolvm/cli/main.py
@@ -2285,17 +2285,30 @@ def _run_snapshot(args: SimpleNamespace) -> int:
 
     if args.snapshot_action == "delete":
         try:
+            from smolvm.exceptions import SnapshotNotFoundError
+
+            existing_snapshot: SnapshotInfo | None
             with SmolVMManager() as sdk:
-                snapshot = sdk.get_snapshot(args.snapshot_id)
+                try:
+                    existing_snapshot = sdk.get_snapshot(args.snapshot_id)
+                except SnapshotNotFoundError:
+                    existing_snapshot = None
                 sdk.delete_snapshot(args.snapshot_id)
-            row = _snapshot_row(snapshot)
-            data: SnapshotPayload = {"snapshot": row}
+            if existing_snapshot is None:
+                delete_data: dict[str, object] = {
+                    "snapshot_id": args.snapshot_id,
+                    "recovery_record_cleared": True,
+                }
+                message = f"Cleared recovered snapshot '{args.snapshot_id}'."
+            else:
+                delete_data = {"snapshot": _snapshot_row(existing_snapshot)}
+                message = f"Deleted snapshot '{args.snapshot_id}'."
             if json_output:
-                emit_json(command_name, 0, data=data)
+                emit_json(command_name, 0, data=delete_data)
             else:
                 console_stdout().print(
                     Panel.fit(
-                        f"Deleted snapshot '{args.snapshot_id}'.",
+                        message,
                         title="Snapshot Deleted",
                         border_style="yellow",
                     )

--- a/src/smolvm/facade.py
+++ b/src/smolvm/facade.py
@@ -86,6 +86,7 @@ from smolvm.runtime.backends import (
     resolve_backend_for_guest,
     resolve_backend_status,
 )
+from smolvm.runtime.base import QemuDirtyBitmapBackup
 from smolvm.runtime.boot_profiles import (
     KernelBootProfile,
     get_boot_profile_spec,
@@ -1718,6 +1719,7 @@ class SmolVM:
         flush_policy: GuestFlushPolicy | str = GuestFlushPolicy.REQUIRED,
         timeout_seconds: float = 600.0,
         max_bytes_per_second: int | None = None,
+        qemu_dirty_bitmap_backup: QemuDirtyBitmapBackup | None = None,
     ) -> SnapshotInfo:
         """Create a snapshot for the VM.
 
@@ -1737,6 +1739,9 @@ class SmolVM:
                 flush to succeed, treats it as best-effort, or skips it.
             timeout_seconds: Maximum time for live disk capture.
             max_bytes_per_second: Optional generic bandwidth limit for live capture.
+            qemu_dirty_bitmap_backup: Start a new persistent QEMU bitmap chain or
+                capture its next incremental disk artifact. Requires a live-only
+                running QEMU disk snapshot.
         """
         try:
             resolved_snapshot_type = SnapshotType(snapshot_type)
@@ -1802,6 +1807,7 @@ class SmolVM:
             capture_policy=resolved_capture_policy,
             timeout_seconds=timeout_seconds,
             max_bytes_per_second=max_bytes_per_second,
+            qemu_dirty_bitmap_backup=qemu_dirty_bitmap_backup,
         )
         self._refresh_info()
         self._reset_runtime_state()

--- a/src/smolvm/qmp.py
+++ b/src/smolvm/qmp.py
@@ -18,7 +18,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Any
+from typing import Any, Literal
 
 from smolvm_core import errors as core_errors
 from smolvm_core import qmp as core_qmp
@@ -26,6 +26,14 @@ from smolvm_core import qmp as core_qmp
 from smolvm.exceptions import SmolVMError
 
 QMPJob = core_qmp.QMPJob
+
+
+class QMPJobFailedError(SmolVMError):
+    """A QMP job reached its terminal state with an error."""
+
+
+class QMPJobTimeoutError(SmolVMError):
+    """A QMP job did not finish before its wait deadline."""
 
 
 @dataclass(frozen=True)
@@ -49,6 +57,10 @@ def _core_error_to_smolvm(exc: Exception, socket_path: Path) -> SmolVMError:
         description = details.get("desc")
         if description and str(description) not in message:
             message = f"{message}: {description}"
+        if all(key in details for key in ("job_id", "job_type", "status", "error")):
+            return QMPJobFailedError(message, details)
+        if "job_id" in details and "last_status" in details:
+            return QMPJobTimeoutError(message, details)
         return SmolVMError(message, details)
     return SmolVMError(str(exc), {"socket_path": str(socket_path)})
 
@@ -157,6 +169,31 @@ class QMPClient:
             },
         )
 
+    @staticmethod
+    def _backup_arguments(
+        *,
+        job_id: str,
+        source_node: str,
+        target_node: str,
+        sync: Literal["full", "incremental"],
+        bitmap_name: str | None = None,
+        max_bytes_per_second: int | None = None,
+    ) -> dict[str, Any]:
+        """Build the shared blockdev-backup arguments."""
+        arguments: dict[str, Any] = {
+            "job-id": job_id,
+            "device": source_node,
+            "target": target_node,
+            "sync": sync,
+            "auto-finalize": True,
+            "auto-dismiss": False,
+        }
+        if bitmap_name is not None:
+            arguments["bitmap"] = bitmap_name
+        if max_bytes_per_second is not None:
+            arguments["speed"] = max_bytes_per_second
+        return arguments
+
     def blockdev_backup(
         self,
         *,
@@ -166,17 +203,16 @@ class QMPClient:
         max_bytes_per_second: int | None = None,
     ) -> None:
         """Start a full point-in-time block backup."""
-        arguments: dict[str, Any] = {
-            "job-id": job_id,
-            "device": source_node,
-            "target": target_node,
-            "sync": "full",
-            "auto-finalize": True,
-            "auto-dismiss": False,
-        }
-        if max_bytes_per_second is not None:
-            arguments["speed"] = max_bytes_per_second
-        self.execute("blockdev-backup", arguments)
+        self.execute(
+            "blockdev-backup",
+            self._backup_arguments(
+                job_id=job_id,
+                source_node=source_node,
+                target_node=target_node,
+                sync="full",
+                max_bytes_per_second=max_bytes_per_second,
+            ),
+        )
 
     def query_block_jobs(self) -> list[dict[str, Any]]:
         """Return active block jobs for progress reporting."""
@@ -191,6 +227,8 @@ class QMPClient:
     def cancel_job(self, job_id: str, *, force: bool = False) -> None:
         """Cancel a block job, forcing immediate cancellation when requested."""
         if force:
+            # Generic job-cancel has no force argument even on QEMU 11;
+            # block-job-cancel is still the supported immediate block-job path.
             self.execute("block-job-cancel", {"device": job_id, "force": True})
             return
         self.execute("job-cancel", {"id": job_id})
@@ -269,13 +307,6 @@ class QMPClient:
             )
         return bitmaps
 
-    def add_dirty_bitmap(self, source_node: str, bitmap_name: str) -> None:
-        """Add an enabled persistent dirty bitmap to a block node."""
-        self.execute(
-            "block-dirty-bitmap-add",
-            {"node": source_node, "name": bitmap_name, "persistent": True},
-        )
-
     def remove_dirty_bitmap(self, source_node: str, bitmap_name: str) -> None:
         """Remove a named dirty bitmap from a block node."""
         self.execute(
@@ -293,16 +324,13 @@ class QMPClient:
         max_bytes_per_second: int | None = None,
     ) -> None:
         """Atomically add a persistent bitmap and start its full base backup."""
-        backup: dict[str, Any] = {
-            "job-id": job_id,
-            "device": source_node,
-            "target": target_node,
-            "sync": "full",
-            "auto-finalize": True,
-            "auto-dismiss": False,
-        }
-        if max_bytes_per_second is not None:
-            backup["speed"] = max_bytes_per_second
+        backup = self._backup_arguments(
+            job_id=job_id,
+            source_node=source_node,
+            target_node=target_node,
+            sync="full",
+            max_bytes_per_second=max_bytes_per_second,
+        )
         self.execute(
             "transaction",
             {
@@ -330,18 +358,17 @@ class QMPClient:
         max_bytes_per_second: int | None = None,
     ) -> None:
         """Start an incremental backup using a named dirty bitmap."""
-        arguments: dict[str, Any] = {
-            "job-id": job_id,
-            "device": source_node,
-            "target": target_node,
-            "sync": "incremental",
-            "bitmap": bitmap_name,
-            "auto-finalize": True,
-            "auto-dismiss": False,
-        }
-        if max_bytes_per_second is not None:
-            arguments["speed"] = max_bytes_per_second
-        self.execute("blockdev-backup", arguments)
+        self.execute(
+            "blockdev-backup",
+            self._backup_arguments(
+                job_id=job_id,
+                source_node=source_node,
+                target_node=target_node,
+                sync="incremental",
+                bitmap_name=bitmap_name,
+                max_bytes_per_second=max_bytes_per_second,
+            ),
+        )
 
     def query_jobs(self) -> list[QMPJob]:
         """Return normalized job status rows."""
@@ -366,4 +393,10 @@ class QMPClient:
         self._core.close()
 
 
-__all__ = ["QMPClient", "QMPDirtyBitmap", "QMPJob"]
+__all__ = [
+    "QMPClient",
+    "QMPDirtyBitmap",
+    "QMPJob",
+    "QMPJobFailedError",
+    "QMPJobTimeoutError",
+]

--- a/src/smolvm/qmp.py
+++ b/src/smolvm/qmp.py
@@ -16,6 +16,7 @@
 
 from __future__ import annotations
 
+from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
 
@@ -25,6 +26,19 @@ from smolvm_core import qmp as core_qmp
 from smolvm.exceptions import SmolVMError
 
 QMPJob = core_qmp.QMPJob
+
+
+@dataclass(frozen=True)
+class QMPDirtyBitmap:
+    """Status for one named QEMU dirty bitmap."""
+
+    name: str
+    recording: bool
+    busy: bool
+    persistent: bool
+    inconsistent: bool
+    granularity: int
+    dirty_bytes: int
 
 
 def _core_error_to_smolvm(exc: Exception, socket_path: Path) -> SmolVMError:
@@ -175,8 +189,11 @@ class QMPClient:
         return [row for row in rows if isinstance(row, dict)]
 
     def cancel_job(self, job_id: str, *, force: bool = False) -> None:
-        """Cancel a generic QMP job."""
-        self.execute("job-cancel", {"id": job_id, "force": force})
+        """Cancel a block job, forcing immediate cancellation when requested."""
+        if force:
+            self.execute("block-job-cancel", {"device": job_id, "force": True})
+            return
+        self.execute("job-cancel", {"id": job_id})
 
     def blockdev_del(self, node_name: str) -> None:
         """Detach a named QEMU block node."""
@@ -191,6 +208,140 @@ class QMPClient:
                 {"socket_path": str(self.socket_path), "result": rows},
             )
         return [row for row in rows if isinstance(row, dict)]
+
+    def query_dirty_bitmaps(self, source_node: str) -> list[QMPDirtyBitmap]:
+        """Return named dirty bitmaps attached to a block node."""
+        nodes = self.query_named_block_nodes()
+        node = next((row for row in nodes if row.get("node-name") == source_node), None)
+        if node is None:
+            raise SmolVMError(
+                "QEMU did not report the source disk block node.",
+                {"socket_path": str(self.socket_path), "source_node": source_node},
+            )
+
+        rows = node.get("dirty-bitmaps", [])
+        if not isinstance(rows, list):
+            raise SmolVMError(
+                "QEMU returned invalid dirty bitmap status.",
+                {"socket_path": str(self.socket_path), "source_node": source_node},
+            )
+
+        bitmaps: list[QMPDirtyBitmap] = []
+        for row in rows:
+            if not isinstance(row, dict) or not isinstance(row.get("name"), str):
+                continue
+            recording = row.get("recording")
+            busy = row.get("busy")
+            persistent = row.get("persistent")
+            inconsistent = row.get("inconsistent", False)
+            granularity = row.get("granularity")
+            dirty_bytes = row.get("count")
+            if (
+                not isinstance(recording, bool)
+                or not isinstance(busy, bool)
+                or not isinstance(persistent, bool)
+                or not isinstance(inconsistent, bool)
+                or not isinstance(granularity, int)
+                or isinstance(granularity, bool)
+                or granularity < 0
+                or not isinstance(dirty_bytes, int)
+                or isinstance(dirty_bytes, bool)
+                or dirty_bytes < 0
+            ):
+                raise SmolVMError(
+                    "QEMU returned invalid dirty bitmap status.",
+                    {
+                        "socket_path": str(self.socket_path),
+                        "source_node": source_node,
+                        "bitmap": row,
+                    },
+                )
+            bitmaps.append(
+                QMPDirtyBitmap(
+                    name=row["name"],
+                    recording=recording,
+                    busy=busy,
+                    persistent=persistent,
+                    inconsistent=inconsistent,
+                    granularity=granularity,
+                    dirty_bytes=dirty_bytes,
+                )
+            )
+        return bitmaps
+
+    def add_dirty_bitmap(self, source_node: str, bitmap_name: str) -> None:
+        """Add an enabled persistent dirty bitmap to a block node."""
+        self.execute(
+            "block-dirty-bitmap-add",
+            {"node": source_node, "name": bitmap_name, "persistent": True},
+        )
+
+    def remove_dirty_bitmap(self, source_node: str, bitmap_name: str) -> None:
+        """Remove a named dirty bitmap from a block node."""
+        self.execute(
+            "block-dirty-bitmap-remove",
+            {"node": source_node, "name": bitmap_name},
+        )
+
+    def start_full_backup_with_dirty_bitmap(
+        self,
+        *,
+        job_id: str,
+        source_node: str,
+        target_node: str,
+        bitmap_name: str,
+        max_bytes_per_second: int | None = None,
+    ) -> None:
+        """Atomically add a persistent bitmap and start its full base backup."""
+        backup: dict[str, Any] = {
+            "job-id": job_id,
+            "device": source_node,
+            "target": target_node,
+            "sync": "full",
+            "auto-finalize": True,
+            "auto-dismiss": False,
+        }
+        if max_bytes_per_second is not None:
+            backup["speed"] = max_bytes_per_second
+        self.execute(
+            "transaction",
+            {
+                "actions": [
+                    {
+                        "type": "block-dirty-bitmap-add",
+                        "data": {
+                            "node": source_node,
+                            "name": bitmap_name,
+                            "persistent": True,
+                        },
+                    },
+                    {"type": "blockdev-backup", "data": backup},
+                ]
+            },
+        )
+
+    def blockdev_backup_incremental(
+        self,
+        *,
+        job_id: str,
+        source_node: str,
+        target_node: str,
+        bitmap_name: str,
+        max_bytes_per_second: int | None = None,
+    ) -> None:
+        """Start an incremental backup using a named dirty bitmap."""
+        arguments: dict[str, Any] = {
+            "job-id": job_id,
+            "device": source_node,
+            "target": target_node,
+            "sync": "incremental",
+            "bitmap": bitmap_name,
+            "auto-finalize": True,
+            "auto-dismiss": False,
+        }
+        if max_bytes_per_second is not None:
+            arguments["speed"] = max_bytes_per_second
+        self.execute("blockdev-backup", arguments)
 
     def query_jobs(self) -> list[QMPJob]:
         """Return normalized job status rows."""
@@ -215,4 +366,4 @@ class QMPClient:
         self._core.close()
 
 
-__all__ = ["QMPClient", "QMPJob"]
+__all__ = ["QMPClient", "QMPDirtyBitmap", "QMPJob"]

--- a/src/smolvm/runtime/base.py
+++ b/src/smolvm/runtime/base.py
@@ -49,6 +49,20 @@ class RuntimeLaunch:
 
 
 @dataclass(slots=True, frozen=True)
+class QemuDirtyBitmapBackup:
+    """Concrete dirty-bitmap mode for one running QEMU disk backup."""
+
+    mode: Literal["new-base", "incremental"]
+    bitmap_name: str
+
+    def __post_init__(self) -> None:
+        if self.mode not in {"new-base", "incremental"}:
+            raise ValueError("mode must be 'new-base' or 'incremental'")
+        if not self.bitmap_name:
+            raise ValueError("bitmap_name cannot be empty")
+
+
+@dataclass(slots=True, frozen=True)
 class SnapshotCreateRequest:
     """Runtime-specific snapshot creation inputs."""
 
@@ -62,6 +76,7 @@ class SnapshotCreateRequest:
     capture_policy: SnapshotCapturePolicy = SnapshotCapturePolicy.ALLOW_PAUSE
     timeout_seconds: float = 600.0
     max_bytes_per_second: int | None = None
+    qemu_dirty_bitmap_backup: QemuDirtyBitmapBackup | None = None
 
 
 @dataclass(slots=True, frozen=True)
@@ -73,6 +88,11 @@ class SnapshotCreateResult:
     captured_at: datetime = field(default_factory=lambda: datetime.now(timezone.utc))
     capture_method: Literal["paused", "live"] = "paused"
     operation_manifest_path: Path | None = None
+    artifact_kind: Literal["full", "incremental"] | None = None
+    virtual_size_bytes: int | None = None
+    changed_bytes: int | None = None
+    bitmap_granularity_bytes: int | None = None
+    bitmap_name: str | None = None
 
 
 @dataclass(slots=True, frozen=True)

--- a/src/smolvm/runtime/base.py
+++ b/src/smolvm/runtime/base.py
@@ -90,6 +90,7 @@ class SnapshotCreateResult:
     operation_manifest_path: Path | None = None
     artifact_kind: Literal["full", "incremental"] | None = None
     virtual_size_bytes: int | None = None
+    # Estimate sampled from QEMU immediately before an incremental backup starts.
     changed_bytes: int | None = None
     bitmap_granularity_bytes: int | None = None
     bitmap_name: str | None = None

--- a/src/smolvm/runtime/qemu.py
+++ b/src/smolvm/runtime/qemu.py
@@ -28,7 +28,7 @@ import time
 from contextlib import suppress
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import Any
+from typing import Any, Literal
 from uuid import uuid4
 
 from smolvm.exceptions import OperationTimeoutError, SmolVMError
@@ -77,6 +77,12 @@ _LIVE_BACKUP_REQUIRED_COMMANDS = {
     "job-dismiss",
     "query-jobs",
     "query-named-block-nodes",
+}
+_DIRTY_BITMAP_BACKUP_REQUIRED_COMMANDS = {
+    "block-dirty-bitmap-add",
+    "block-dirty-bitmap-remove",
+    "block-job-cancel",
+    "transaction",
 }
 
 
@@ -707,6 +713,7 @@ class QemuRuntimeAdapter(RuntimeAdapter):
         target_node: str,
         artifact_root: Path | None = None,
         trusted_snapshot_dir: Path | None = None,
+        artifact_filename: str = "disk.qcow2",
     ) -> bool:
         """Stop and detach a live backup, returning whether files are safe to remove."""
         # Journal fields must never be passed through to QMP or filesystem
@@ -751,9 +758,12 @@ class QemuRuntimeAdapter(RuntimeAdapter):
                 return False
             # Artifact names are fixed by the live-backup protocol.  In
             # particular, do not unlink paths read from a recovery journal.
+            if artifact_filename not in {"disk.qcow2", "increment.qcow2"}:
+                logger.warning("Refusing cleanup for an unknown live-backup artifact name")
+                return False
             artifact_paths = (
-                resolved_root / "disk.qcow2.partial",
-                resolved_root / "disk.qcow2",
+                resolved_root / f"{artifact_filename}.partial",
+                resolved_root / artifact_filename,
             )
 
         try:
@@ -783,6 +793,61 @@ class QemuRuntimeAdapter(RuntimeAdapter):
             with suppress(FileNotFoundError):
                 path.unlink()
         return True
+
+    @classmethod
+    def _publish_recovered_bitmap_artifact(
+        cls,
+        *,
+        manifest_path: Path,
+        payload: dict[str, Any],
+        partial_path: Path,
+        final_path: Path,
+    ) -> None:
+        """Validate and publish a QMP-successful bitmap artifact after interruption."""
+        if final_path.exists():
+            payload["phase"] = "artifact-published"
+            cls._write_live_backup_manifest(manifest_path, payload)
+            return
+        if not partial_path.exists():
+            raise SmolVMError(
+                "A completed QEMU bitmap backup has no local artifact.",
+                {"snapshot_id": payload.get("snapshot_id"), "capture_recovery_pending": True},
+            )
+        qemu_img = which("qemu-img")
+        if qemu_img is None:
+            raise SmolVMError(
+                "A completed QEMU bitmap backup cannot be verified because qemu-img is missing.",
+                {"snapshot_id": payload.get("snapshot_id"), "capture_recovery_pending": True},
+            )
+        check = subprocess.run(
+            [str(qemu_img), "check", str(partial_path)],
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        info = subprocess.run(
+            [str(qemu_img), "info", "--output=json", str(partial_path)],
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        try:
+            backing = json.loads(info.stdout).get("backing-filename")
+        except (AttributeError, TypeError, json.JSONDecodeError):
+            backing = "invalid"
+        if check.returncode != 0 or info.returncode != 0 or backing:
+            raise SmolVMError(
+                "A completed QEMU bitmap backup has an invalid local artifact.",
+                {
+                    "snapshot_id": payload.get("snapshot_id"),
+                    "capture_recovery_pending": True,
+                    "check_stderr": check.stderr.strip(),
+                    "info_stderr": info.stderr.strip(),
+                },
+            )
+        os.replace(partial_path, final_path)
+        payload["phase"] = "artifact-published"
+        cls._write_live_backup_manifest(manifest_path, payload)
 
     def reconcile_live_backups(
         self,
@@ -860,20 +925,37 @@ class QemuRuntimeAdapter(RuntimeAdapter):
                 continue
             job_id = payload.get("job_id")
             target_node = payload.get("target_node")
-            partial_path = artifact_root / "disk.qcow2.partial"
-            final_path = artifact_root / "disk.qcow2"
+            schema_version = payload.get("schema_version")
+            backup_mode = payload.get("backup_mode")
+            bitmap_capture = schema_version == 2 and backup_mode in {
+                "new-base",
+                "incremental",
+            }
+            artifact_filename = "increment.qcow2" if backup_mode == "incremental" else "disk.qcow2"
+            partial_path = artifact_root / f"{artifact_filename}.partial"
+            final_path = artifact_root / artifact_filename
             operation_id = (
                 _live_backup_operation_id(job_id, target_node)
                 if isinstance(job_id, str) and isinstance(target_node, str)
                 else None
             )
             valid = (
-                payload.get("schema_version") == 1
+                schema_version in {1, 2}
+                and (schema_version == 1 or bitmap_capture)
                 and payload.get("snapshot_id") == journal_snapshot_id
                 and payload.get("phase") in _LIVE_BACKUP_PHASES
                 and payload.get("partial_path") == str(partial_path)
                 and payload.get("final_path") == str(final_path)
                 and operation_id is not None
+                and (
+                    not bitmap_capture
+                    or (
+                        isinstance(payload.get("bitmap_name"), str)
+                        and bool(payload["bitmap_name"])
+                        and isinstance(payload.get("virtual_size_bytes"), int)
+                        and payload["virtual_size_bytes"] > 0
+                    )
+                )
             )
             if not valid:
                 # Do not let a malformed entry select QMP resources or files;
@@ -889,14 +971,89 @@ class QemuRuntimeAdapter(RuntimeAdapter):
             persisted = journal_snapshot_id in persisted_snapshot_ids
             assert operation_id is not None
             validated_job_id, validated_target_node = _live_backup_identifiers(operation_id)
+
+            if bitmap_capture and not persisted:
+                phase = str(payload["phase"])
+                jobs = {job.job_id: job for job in client.query_jobs()}
+                job = jobs.get(validated_job_id)
+                if phase in {"node-attached", "job-running"}:
+                    if job is None and phase == "job-running":
+                        raise SmolVMError(
+                            "A QEMU bitmap backup has ambiguous capture state; start a new base.",
+                            {
+                                "snapshot_id": journal_snapshot_id,
+                                "bitmap_name": payload["bitmap_name"],
+                                "bitmap_state_ambiguous": True,
+                            },
+                        )
+                    if job is not None and job.status == "concluded" and job.error is None:
+                        with suppress(Exception):
+                            client.dismiss_job(validated_job_id)
+                        payload["phase"] = "job-concluded"
+                        self._write_live_backup_manifest(manifest_path, payload)
+                        phase = "job-concluded"
+                    elif job is not None:
+                        cleaned = self._cleanup_live_backup(
+                            client,
+                            job_id=validated_job_id,
+                            target_node=validated_target_node,
+                            artifact_root=artifact_root,
+                            trusted_snapshot_dir=trusted_snapshot_dir,
+                            artifact_filename=artifact_filename,
+                        )
+                        if cleaned:
+                            if backup_mode == "new-base":
+                                with suppress(Exception):
+                                    client.remove_dirty_bitmap(
+                                        QEMU_ROOT_NODE_NAME,
+                                        str(payload["bitmap_name"]),
+                                    )
+                            with suppress(OSError):
+                                manifest_path.unlink()
+                            with suppress(OSError):
+                                manifest_path.parent.rmdir()
+                        continue
+
+                if phase in {"job-concluded", "node-detached", "artifact-published"}:
+                    if validated_target_node in self._node_names(client):
+                        client.blockdev_del(validated_target_node)
+                    payload["phase"] = "node-detached"
+                    self._write_live_backup_manifest(manifest_path, payload)
+                    self._publish_recovered_bitmap_artifact(
+                        manifest_path=manifest_path,
+                        payload=payload,
+                        partial_path=partial_path,
+                        final_path=final_path,
+                    )
+                    raise SmolVMError(
+                        "A completed QEMU bitmap backup is waiting for publication recovery.",
+                        {
+                            "snapshot_id": journal_snapshot_id,
+                            "bitmap_name": payload["bitmap_name"],
+                            "artifact_path": str(final_path),
+                            "artifact_kind": payload.get("artifact_kind"),
+                            "virtual_size_bytes": payload.get("virtual_size_bytes"),
+                            "changed_bytes": payload.get("changed_bytes"),
+                            "bitmap_granularity_bytes": payload.get("bitmap_granularity_bytes"),
+                            "capture_recovery_pending": True,
+                        },
+                    )
+
             cleaned = self._cleanup_live_backup(
                 client,
                 job_id=validated_job_id,
                 target_node=validated_target_node,
                 artifact_root=None if persisted else artifact_root,
                 trusted_snapshot_dir=trusted_snapshot_dir,
+                artifact_filename=artifact_filename,
             )
             if cleaned:
+                if bitmap_capture and backup_mode == "new-base":
+                    with suppress(Exception):
+                        client.remove_dirty_bitmap(
+                            QEMU_ROOT_NODE_NAME,
+                            str(payload["bitmap_name"]),
+                        )
                 with suppress(OSError):
                     manifest_path.unlink()
                 if not persisted:
@@ -947,7 +1104,11 @@ class QemuRuntimeAdapter(RuntimeAdapter):
                     "cause_details": getattr(exc, "details", {}),
                 },
             ) from exc
-        missing = sorted(_LIVE_BACKUP_REQUIRED_COMMANDS - commands)
+        required_commands = set(_LIVE_BACKUP_REQUIRED_COMMANDS)
+        bitmap_backup = request.qemu_dirty_bitmap_backup
+        if bitmap_backup is not None:
+            required_commands.update(_DIRTY_BITMAP_BACKUP_REQUIRED_COMMANDS)
+        missing = sorted(required_commands - commands)
         if missing:
             raise self._live_backup_error(
                 request,
@@ -963,6 +1124,53 @@ class QemuRuntimeAdapter(RuntimeAdapter):
             request=request,
             deadline=deadline,
         )
+        artifact_kind: Literal["full", "incremental"] | None = None
+        changed_bytes: int | None = None
+        bitmap_granularity: int | None = None
+        artifact_filename = "disk.qcow2"
+        if bitmap_backup is not None:
+            bitmaps = client.query_dirty_bitmaps(QEMU_ROOT_NODE_NAME)
+            existing_bitmap = next(
+                (bitmap for bitmap in bitmaps if bitmap.name == bitmap_backup.bitmap_name),
+                None,
+            )
+            if bitmap_backup.mode == "new-base":
+                if existing_bitmap is not None:
+                    raise self._live_backup_error(
+                        request,
+                        f"The dirty bitmap for sandbox '{request.vm_info.vm_id}' already exists",
+                        {"bitmap_name": bitmap_backup.bitmap_name},
+                    )
+                artifact_kind = "full"
+            else:
+                if existing_bitmap is None:
+                    raise self._live_backup_error(
+                        request,
+                        f"The dirty bitmap for sandbox '{request.vm_info.vm_id}' is missing",
+                        {"bitmap_name": bitmap_backup.bitmap_name},
+                    )
+                if (
+                    not existing_bitmap.recording
+                    or not existing_bitmap.persistent
+                    or existing_bitmap.busy
+                    or existing_bitmap.inconsistent
+                ):
+                    raise self._live_backup_error(
+                        request,
+                        f"The dirty bitmap for sandbox '{request.vm_info.vm_id}' is not usable",
+                        {
+                            "bitmap_name": bitmap_backup.bitmap_name,
+                            "recording": existing_bitmap.recording,
+                            "persistent": existing_bitmap.persistent,
+                            "busy": existing_bitmap.busy,
+                            "inconsistent": existing_bitmap.inconsistent,
+                        },
+                    )
+                artifact_kind = "incremental"
+                artifact_filename = "increment.qcow2"
+                changed_bytes = existing_bitmap.dirty_bytes
+                bitmap_granularity = existing_bitmap.granularity
+
         self._require_live_backup_space(
             qemu_img,
             request.managed_disk_path,
@@ -970,8 +1178,8 @@ class QemuRuntimeAdapter(RuntimeAdapter):
             request=request,
             deadline=deadline,
         )
-        partial_path = request.snapshot_root / "disk.qcow2.partial"
-        final_path = request.snapshot_root / "disk.qcow2"
+        partial_path = request.snapshot_root / f"{artifact_filename}.partial"
+        final_path = request.snapshot_root / artifact_filename
         create = self._run_live_backup_subprocess(
             [str(qemu_img), "create", "-f", "qcow2", str(partial_path), str(virtual_size)],
             request=request,
@@ -989,7 +1197,7 @@ class QemuRuntimeAdapter(RuntimeAdapter):
         job_id, target_node = _live_backup_identifiers(operation_id)
         manifest_path = request.snapshot_root / _LIVE_BACKUP_MANIFEST
         manifest: dict[str, Any] = {
-            "schema_version": 1,
+            "schema_version": 2 if bitmap_backup is not None else 1,
             "vm_id": request.vm_info.vm_id,
             "snapshot_id": request.snapshot_id,
             "job_id": job_id,
@@ -998,6 +1206,13 @@ class QemuRuntimeAdapter(RuntimeAdapter):
             "final_path": str(final_path),
             "phase": "target-created",
         }
+        if bitmap_backup is not None:
+            manifest["backup_mode"] = bitmap_backup.mode
+            manifest["bitmap_name"] = bitmap_backup.bitmap_name
+            manifest["artifact_kind"] = artifact_kind
+            manifest["virtual_size_bytes"] = virtual_size
+            manifest["changed_bytes"] = changed_bytes
+            manifest["bitmap_granularity_bytes"] = bitmap_granularity
         try:
             self._write_live_backup_manifest(manifest_path, manifest)
         except OSError as exc:
@@ -1009,17 +1224,36 @@ class QemuRuntimeAdapter(RuntimeAdapter):
                 {"error": str(exc)},
             ) from exc
 
+        bitmap_job_submitted = False
         try:
             client.blockdev_add(target_node, partial_path)
             manifest["phase"] = "node-attached"
             self._write_live_backup_manifest(manifest_path, manifest)
 
-            client.blockdev_backup(
-                job_id=job_id,
-                source_node=QEMU_ROOT_NODE_NAME,
-                target_node=target_node,
-                max_bytes_per_second=request.max_bytes_per_second,
-            )
+            if bitmap_backup is None:
+                client.blockdev_backup(
+                    job_id=job_id,
+                    source_node=QEMU_ROOT_NODE_NAME,
+                    target_node=target_node,
+                    max_bytes_per_second=request.max_bytes_per_second,
+                )
+            elif bitmap_backup.mode == "new-base":
+                client.start_full_backup_with_dirty_bitmap(
+                    job_id=job_id,
+                    source_node=QEMU_ROOT_NODE_NAME,
+                    target_node=target_node,
+                    bitmap_name=bitmap_backup.bitmap_name,
+                    max_bytes_per_second=request.max_bytes_per_second,
+                )
+            else:
+                client.blockdev_backup_incremental(
+                    job_id=job_id,
+                    source_node=QEMU_ROOT_NODE_NAME,
+                    target_node=target_node,
+                    bitmap_name=bitmap_backup.bitmap_name,
+                    max_bytes_per_second=request.max_bytes_per_second,
+                )
+            bitmap_job_submitted = bitmap_backup is not None
             captured_at = datetime.now(timezone.utc)
             logger.info(
                 "Live QEMU backup started vm_id=%s snapshot_id=%s job_id=%s "
@@ -1045,6 +1279,25 @@ class QemuRuntimeAdapter(RuntimeAdapter):
                 raise
             manifest["phase"] = "job-concluded"
             self._write_live_backup_manifest(manifest_path, manifest)
+
+            if bitmap_backup is not None and bitmap_backup.mode == "new-base":
+                created_bitmap = next(
+                    (
+                        bitmap
+                        for bitmap in client.query_dirty_bitmaps(QEMU_ROOT_NODE_NAME)
+                        if bitmap.name == bitmap_backup.bitmap_name
+                    ),
+                    None,
+                )
+                if created_bitmap is None:
+                    raise self._live_backup_error(
+                        request,
+                        f"The new dirty bitmap for sandbox '{request.vm_info.vm_id}' is missing",
+                        {"bitmap_name": bitmap_backup.bitmap_name},
+                    )
+                bitmap_granularity = created_bitmap.granularity
+                manifest["bitmap_granularity_bytes"] = bitmap_granularity
+                self._write_live_backup_manifest(manifest_path, manifest)
 
             client.blockdev_del(target_node)
             manifest["phase"] = "node-detached"
@@ -1074,6 +1327,11 @@ class QemuRuntimeAdapter(RuntimeAdapter):
                 captured_at=captured_at,
                 capture_method="live",
                 operation_manifest_path=manifest_path,
+                artifact_kind=artifact_kind,
+                virtual_size_bytes=virtual_size if bitmap_backup is not None else None,
+                changed_bytes=changed_bytes,
+                bitmap_granularity_bytes=bitmap_granularity,
+                bitmap_name=bitmap_backup.bitmap_name if bitmap_backup is not None else None,
             )
         except Exception as original_error:
             logger.warning(
@@ -1085,13 +1343,78 @@ class QemuRuntimeAdapter(RuntimeAdapter):
                 time.monotonic() - backup_started,
                 original_error,
             )
+            if bitmap_backup is not None:
+                phase = str(manifest["phase"])
+                if phase in {"job-concluded", "node-detached", "artifact-published"}:
+                    raise self._live_backup_error(
+                        request,
+                        "A completed QEMU bitmap backup requires publication recovery",
+                        {
+                            "snapshot_id": request.snapshot_id,
+                            "bitmap_name": bitmap_backup.bitmap_name,
+                            "capture_recovery_pending": True,
+                        },
+                    ) from original_error
+
+                try:
+                    jobs = {job.job_id: job for job in client.query_jobs()}
+                except Exception as query_error:
+                    if bitmap_job_submitted:
+                        raise self._live_backup_error(
+                            request,
+                            "A QEMU bitmap backup has ambiguous capture state; start a new base",
+                            {
+                                "snapshot_id": request.snapshot_id,
+                                "bitmap_name": bitmap_backup.bitmap_name,
+                                "bitmap_state_ambiguous": True,
+                                "job_query_error": str(query_error),
+                            },
+                        ) from original_error
+                else:
+                    job = jobs.get(job_id)
+                    if job is not None and job.status == "concluded" and job.error is None:
+                        with suppress(Exception):
+                            client.dismiss_job(job_id)
+                        manifest["phase"] = "job-concluded"
+                        self._write_live_backup_manifest(manifest_path, manifest)
+                        raise self._live_backup_error(
+                            request,
+                            "A completed QEMU bitmap backup requires publication recovery",
+                            {
+                                "snapshot_id": request.snapshot_id,
+                                "bitmap_name": bitmap_backup.bitmap_name,
+                                "capture_recovery_pending": True,
+                            },
+                        ) from original_error
+                    known_job_failure = (
+                        isinstance(original_error, OperationTimeoutError)
+                        or str(original_error) == "QMP job failed"
+                    )
+                    if job is None and bitmap_job_submitted and not known_job_failure:
+                        manifest["phase"] = "job-running"
+                        with suppress(OSError):
+                            self._write_live_backup_manifest(manifest_path, manifest)
+                        raise self._live_backup_error(
+                            request,
+                            "A QEMU bitmap backup has ambiguous capture state; start a new base",
+                            {
+                                "snapshot_id": request.snapshot_id,
+                                "bitmap_name": bitmap_backup.bitmap_name,
+                                "bitmap_state_ambiguous": True,
+                            },
+                        ) from original_error
+
             cleanup_safe = self._cleanup_live_backup(
                 client,
                 job_id=job_id,
                 target_node=target_node,
                 artifact_root=request.snapshot_root,
                 trusted_snapshot_dir=request.snapshot_root.parent,
+                artifact_filename=artifact_filename,
             )
+            if cleanup_safe and bitmap_backup is not None and bitmap_backup.mode == "new-base":
+                with suppress(Exception):
+                    client.remove_dirty_bitmap(QEMU_ROOT_NODE_NAME, bitmap_backup.bitmap_name)
             if cleanup_safe:
                 with suppress(OSError):
                     manifest_path.unlink()

--- a/src/smolvm/runtime/qemu.py
+++ b/src/smolvm/runtime/qemu.py
@@ -32,7 +32,7 @@ from typing import Any, Literal
 from uuid import uuid4
 
 from smolvm.exceptions import OperationTimeoutError, SmolVMError
-from smolvm.qmp import QMPClient
+from smolvm.qmp import QMPClient, QMPJobFailedError, QMPJobTimeoutError
 from smolvm.runtime.backends import BACKEND_QEMU
 from smolvm.runtime.base import (
     RuntimeAdapter,
@@ -472,6 +472,42 @@ class QemuRuntimeAdapter(RuntimeAdapter):
             f"--snapshot-id {request.snapshot_id} --snapshot-type disk --resume-source"
         )
 
+    @staticmethod
+    def _bitmap_snapshot_command(vm_id: str, snapshot_id: str) -> str:
+        """Return the exact command used to retry with a fresh disk capture."""
+        return (
+            f"smolvm sandbox snapshot create {vm_id} --snapshot-id {snapshot_id} "
+            "--snapshot-type disk --resume-source --live-only"
+        )
+
+    @staticmethod
+    def _bitmap_recovery_clear_command(snapshot_id: str) -> str:
+        """Return the command that clears an adopted recovered artifact."""
+        return f"smolvm sandbox snapshot delete {snapshot_id}"
+
+    @classmethod
+    def _bitmap_recovery_error(
+        cls,
+        *,
+        vm_id: str,
+        snapshot_id: str,
+        fact: str,
+        recovery: str,
+        recovery_command: str | None = None,
+        details: dict[str, Any] | None = None,
+    ) -> SmolVMError:
+        """Build a user-facing bitmap recovery error without a create request."""
+        error_details: dict[str, Any] = {
+            "vm_id": vm_id,
+            "snapshot_id": snapshot_id,
+            "capture_recovery_pending": True,
+        }
+        if recovery_command is not None:
+            error_details["recovery_command"] = recovery_command
+        if details:
+            error_details.update(details)
+        return SmolVMError(f"{fact} {recovery}", error_details)
+
     @classmethod
     def _live_backup_error(
         cls,
@@ -642,36 +678,40 @@ class QemuRuntimeAdapter(RuntimeAdapter):
         *,
         request: SnapshotCreateRequest,
         deadline: float,
+        required_bytes: int | None = None,
     ) -> None:
         """Reject a backup that is already likely to exhaust local storage."""
-        measure = cls._run_live_backup_subprocess(
-            [
-                str(qemu_img),
-                "measure",
-                "--output=json",
-                "--force-share",
-                "-O",
-                "qcow2",
-                str(source),
-            ],
-            request=request,
-            deadline=deadline,
-        )
-        if measure.returncode != 0:
-            raise cls._live_backup_error(
-                request,
-                f"The live snapshot size for sandbox '{request.vm_info.vm_id}' "
-                "could not be estimated",
-                {"disk_path": str(source), "stderr": measure.stderr.strip()},
+        if required_bytes is None:
+            measure = cls._run_live_backup_subprocess(
+                [
+                    str(qemu_img),
+                    "measure",
+                    "--output=json",
+                    "--force-share",
+                    "-O",
+                    "qcow2",
+                    str(source),
+                ],
+                request=request,
+                deadline=deadline,
             )
-        try:
-            required = int(json.loads(measure.stdout)["required"])
-        except (KeyError, TypeError, ValueError, json.JSONDecodeError) as exc:
-            raise cls._live_backup_error(
-                request,
-                f"The live snapshot size for sandbox '{request.vm_info.vm_id}' was invalid",
-                {"disk_path": str(source)},
-            ) from exc
+            if measure.returncode != 0:
+                raise cls._live_backup_error(
+                    request,
+                    f"The live snapshot size for sandbox '{request.vm_info.vm_id}' "
+                    "could not be estimated",
+                    {"disk_path": str(source), "stderr": measure.stderr.strip()},
+                )
+            try:
+                required = int(json.loads(measure.stdout)["required"])
+            except (KeyError, TypeError, ValueError, json.JSONDecodeError) as exc:
+                raise cls._live_backup_error(
+                    request,
+                    f"The live snapshot size for sandbox '{request.vm_info.vm_id}' was invalid",
+                    {"disk_path": str(source)},
+                ) from exc
+        else:
+            required = required_bytes
         headroom = max(256 * 1024 * 1024, required // 10)
         try:
             free = shutil.disk_usage(target_dir).free
@@ -798,49 +838,87 @@ class QemuRuntimeAdapter(RuntimeAdapter):
     def _publish_recovered_bitmap_artifact(
         cls,
         *,
+        vm_id: str,
+        retry_snapshot_id: str,
+        deadline: float,
         manifest_path: Path,
         payload: dict[str, Any],
         partial_path: Path,
         final_path: Path,
     ) -> None:
         """Validate and publish a QMP-successful bitmap artifact after interruption."""
+        snapshot_id = str(payload["snapshot_id"])
+        retry_command = cls._bitmap_snapshot_command(vm_id, retry_snapshot_id)
         if final_path.exists():
             payload["phase"] = "artifact-published"
             cls._write_live_backup_manifest(manifest_path, payload)
             return
         if not partial_path.exists():
-            raise SmolVMError(
-                "A completed QEMU bitmap backup has no local artifact.",
-                {"snapshot_id": payload.get("snapshot_id"), "capture_recovery_pending": True},
+            raise cls._bitmap_recovery_error(
+                vm_id=vm_id,
+                snapshot_id=snapshot_id,
+                fact=f"The completed disk capture for sandbox '{vm_id}' has no local file.",
+                recovery=f"Run '{retry_command}' to create a fresh disk capture.",
+                recovery_command=retry_command,
             )
         qemu_img = which("qemu-img")
         if qemu_img is None:
-            raise SmolVMError(
-                "A completed QEMU bitmap backup cannot be verified because qemu-img is missing.",
-                {"snapshot_id": payload.get("snapshot_id"), "capture_recovery_pending": True},
+            raise cls._bitmap_recovery_error(
+                vm_id=vm_id,
+                snapshot_id=snapshot_id,
+                fact=f"The recovered disk capture for sandbox '{vm_id}' cannot be checked.",
+                recovery=_qemu_img_install_hint(),
             )
-        check = subprocess.run(
-            [str(qemu_img), "check", str(partial_path)],
-            capture_output=True,
-            text=True,
-            check=False,
-        )
-        info = subprocess.run(
-            [str(qemu_img), "info", "--output=json", str(partial_path)],
-            capture_output=True,
-            text=True,
-            check=False,
-        )
+
+        def run_qemu_img(command: list[str]) -> subprocess.CompletedProcess[str]:
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                raise cls._bitmap_recovery_error(
+                    vm_id=vm_id,
+                    snapshot_id=snapshot_id,
+                    fact=f"Checking the recovered disk capture for sandbox '{vm_id}' timed out.",
+                    recovery=f"Retry with '{retry_command}'.",
+                    recovery_command=retry_command,
+                )
+            try:
+                return subprocess.run(
+                    command,
+                    capture_output=True,
+                    text=True,
+                    check=False,
+                    timeout=remaining,
+                )
+            except subprocess.TimeoutExpired as exc:
+                raise cls._bitmap_recovery_error(
+                    vm_id=vm_id,
+                    snapshot_id=snapshot_id,
+                    fact=f"Checking the recovered disk capture for sandbox '{vm_id}' timed out.",
+                    recovery=f"Retry with '{retry_command}'.",
+                    recovery_command=retry_command,
+                ) from exc
+            except OSError as exc:
+                raise cls._bitmap_recovery_error(
+                    vm_id=vm_id,
+                    snapshot_id=snapshot_id,
+                    fact=f"The recovered disk capture for sandbox '{vm_id}' could not be checked.",
+                    recovery=_qemu_img_install_hint(),
+                    details={"error": str(exc)},
+                ) from exc
+
+        check = run_qemu_img([str(qemu_img), "check", str(partial_path)])
+        info = run_qemu_img([str(qemu_img), "info", "--output=json", str(partial_path)])
         try:
             backing = json.loads(info.stdout).get("backing-filename")
         except (AttributeError, TypeError, json.JSONDecodeError):
             backing = "invalid"
         if check.returncode != 0 or info.returncode != 0 or backing:
-            raise SmolVMError(
-                "A completed QEMU bitmap backup has an invalid local artifact.",
-                {
-                    "snapshot_id": payload.get("snapshot_id"),
-                    "capture_recovery_pending": True,
+            raise cls._bitmap_recovery_error(
+                vm_id=vm_id,
+                snapshot_id=snapshot_id,
+                fact=f"The recovered disk capture for sandbox '{vm_id}' is invalid.",
+                recovery=f"Run '{retry_command}' to create a fresh disk capture.",
+                recovery_command=retry_command,
+                details={
                     "check_stderr": check.stderr.strip(),
                     "info_stderr": info.stderr.strip(),
                 },
@@ -856,6 +934,7 @@ class QemuRuntimeAdapter(RuntimeAdapter):
         snapshot_dir: Path,
         locked_snapshot_id: str,
         persisted_snapshot_ids: set[str],
+        timeout_seconds: float,
     ) -> None:
         """Reconcile journals after the caller has locked snapshot creation."""
         if not any(snapshot_dir.glob(f"*/{_LIVE_BACKUP_MANIFEST}")):
@@ -866,6 +945,7 @@ class QemuRuntimeAdapter(RuntimeAdapter):
                 snapshot_dir=snapshot_dir,
                 locked_snapshot_id=locked_snapshot_id,
                 persisted_snapshot_ids=persisted_snapshot_ids,
+                deadline=time.monotonic() + timeout_seconds,
                 client=client,
             )
 
@@ -876,6 +956,7 @@ class QemuRuntimeAdapter(RuntimeAdapter):
         snapshot_dir: Path,
         locked_snapshot_id: str,
         persisted_snapshot_ids: set[str],
+        deadline: float,
         client: QMPClient,
     ) -> None:
         """Clean stale jobs and nodes left by an interrupted Python process."""
@@ -978,10 +1059,14 @@ class QemuRuntimeAdapter(RuntimeAdapter):
                 job = jobs.get(validated_job_id)
                 if phase in {"node-attached", "job-running"}:
                     if job is None and phase == "job-running":
-                        raise SmolVMError(
-                            "A QEMU bitmap backup has ambiguous capture state; start a new base.",
-                            {
-                                "snapshot_id": journal_snapshot_id,
+                        retry_command = self._bitmap_snapshot_command(vm_id, locked_snapshot_id)
+                        raise self._bitmap_recovery_error(
+                            vm_id=vm_id,
+                            snapshot_id=journal_snapshot_id,
+                            fact=f"The last disk capture for sandbox '{vm_id}' may be incomplete.",
+                            recovery=f"Run '{retry_command}' to create a fresh disk capture.",
+                            recovery_command=retry_command,
+                            details={
                                 "bitmap_name": payload["bitmap_name"],
                                 "bitmap_state_ambiguous": True,
                             },
@@ -1020,22 +1105,33 @@ class QemuRuntimeAdapter(RuntimeAdapter):
                     payload["phase"] = "node-detached"
                     self._write_live_backup_manifest(manifest_path, payload)
                     self._publish_recovered_bitmap_artifact(
+                        vm_id=vm_id,
+                        retry_snapshot_id=locked_snapshot_id,
+                        deadline=deadline,
                         manifest_path=manifest_path,
                         payload=payload,
                         partial_path=partial_path,
                         final_path=final_path,
                     )
-                    raise SmolVMError(
-                        "A completed QEMU bitmap backup is waiting for publication recovery.",
-                        {
-                            "snapshot_id": journal_snapshot_id,
+                    clear_command = self._bitmap_recovery_clear_command(journal_snapshot_id)
+                    raise self._bitmap_recovery_error(
+                        vm_id=vm_id,
+                        snapshot_id=journal_snapshot_id,
+                        fact=(
+                            f"Recovered disk data for sandbox '{vm_id}' is ready at '{final_path}'."
+                        ),
+                        recovery=(
+                            f"After adopting that file, run '{clear_command}' to clear "
+                            "the recovery record."
+                        ),
+                        recovery_command=clear_command,
+                        details={
                             "bitmap_name": payload["bitmap_name"],
                             "artifact_path": str(final_path),
                             "artifact_kind": payload.get("artifact_kind"),
                             "virtual_size_bytes": payload.get("virtual_size_bytes"),
                             "changed_bytes": payload.get("changed_bytes"),
                             "bitmap_granularity_bytes": payload.get("bitmap_granularity_bytes"),
-                            "capture_recovery_pending": True,
                         },
                     )
 
@@ -1177,6 +1273,7 @@ class QemuRuntimeAdapter(RuntimeAdapter):
             request.snapshot_root,
             request=request,
             deadline=deadline,
+            required_bytes=changed_bytes if artifact_kind == "incremental" else None,
         )
         partial_path = request.snapshot_root / f"{artifact_filename}.partial"
         final_path = request.snapshot_root / artifact_filename
@@ -1273,10 +1370,8 @@ class QemuRuntimeAdapter(RuntimeAdapter):
                     job_id,
                     timeout=self._remaining_live_backup_timeout(request, deadline),
                 )
-            except SmolVMError as exc:
-                if str(exc) == "Timed out waiting for QMP job":
-                    raise self._live_backup_timeout_error(request) from exc
-                raise
+            except QMPJobTimeoutError as exc:
+                raise self._live_backup_timeout_error(request) from exc
             manifest["phase"] = "job-concluded"
             self._write_live_backup_manifest(manifest_path, manifest)
 
@@ -1346,25 +1441,38 @@ class QemuRuntimeAdapter(RuntimeAdapter):
             if bitmap_backup is not None:
                 phase = str(manifest["phase"])
                 if phase in {"job-concluded", "node-detached", "artifact-published"}:
-                    raise self._live_backup_error(
-                        request,
-                        "A completed QEMU bitmap backup requires publication recovery",
-                        {
-                            "snapshot_id": request.snapshot_id,
-                            "bitmap_name": bitmap_backup.bitmap_name,
-                            "capture_recovery_pending": True,
-                        },
+                    retry_command = self._bitmap_snapshot_command(
+                        request.vm_info.vm_id, request.snapshot_id
+                    )
+                    raise self._bitmap_recovery_error(
+                        vm_id=request.vm_info.vm_id,
+                        snapshot_id=request.snapshot_id,
+                        fact=(
+                            f"The completed disk capture for sandbox "
+                            f"'{request.vm_info.vm_id}' still needs to be published."
+                        ),
+                        recovery=f"Retry with '{retry_command}'.",
+                        recovery_command=retry_command,
+                        details={"bitmap_name": bitmap_backup.bitmap_name},
                     ) from original_error
 
                 try:
                     jobs = {job.job_id: job for job in client.query_jobs()}
                 except Exception as query_error:
                     if bitmap_job_submitted:
-                        raise self._live_backup_error(
-                            request,
-                            "A QEMU bitmap backup has ambiguous capture state; start a new base",
-                            {
-                                "snapshot_id": request.snapshot_id,
+                        retry_command = self._bitmap_snapshot_command(
+                            request.vm_info.vm_id, request.snapshot_id
+                        )
+                        raise self._bitmap_recovery_error(
+                            vm_id=request.vm_info.vm_id,
+                            snapshot_id=request.snapshot_id,
+                            fact=(
+                                f"The last disk capture for sandbox "
+                                f"'{request.vm_info.vm_id}' may be incomplete."
+                            ),
+                            recovery=(f"Run '{retry_command}' to create a fresh disk capture."),
+                            recovery_command=retry_command,
+                            details={
                                 "bitmap_name": bitmap_backup.bitmap_name,
                                 "bitmap_state_ambiguous": True,
                                 "job_query_error": str(query_error),
@@ -1377,28 +1485,40 @@ class QemuRuntimeAdapter(RuntimeAdapter):
                             client.dismiss_job(job_id)
                         manifest["phase"] = "job-concluded"
                         self._write_live_backup_manifest(manifest_path, manifest)
-                        raise self._live_backup_error(
-                            request,
-                            "A completed QEMU bitmap backup requires publication recovery",
-                            {
-                                "snapshot_id": request.snapshot_id,
-                                "bitmap_name": bitmap_backup.bitmap_name,
-                                "capture_recovery_pending": True,
-                            },
+                        retry_command = self._bitmap_snapshot_command(
+                            request.vm_info.vm_id, request.snapshot_id
+                        )
+                        raise self._bitmap_recovery_error(
+                            vm_id=request.vm_info.vm_id,
+                            snapshot_id=request.snapshot_id,
+                            fact=(
+                                f"The completed disk capture for sandbox "
+                                f"'{request.vm_info.vm_id}' still needs to be published."
+                            ),
+                            recovery=f"Retry with '{retry_command}'.",
+                            recovery_command=retry_command,
+                            details={"bitmap_name": bitmap_backup.bitmap_name},
                         ) from original_error
-                    known_job_failure = (
-                        isinstance(original_error, OperationTimeoutError)
-                        or str(original_error) == "QMP job failed"
+                    known_job_failure = isinstance(
+                        original_error, (OperationTimeoutError, QMPJobFailedError)
                     )
                     if job is None and bitmap_job_submitted and not known_job_failure:
                         manifest["phase"] = "job-running"
                         with suppress(OSError):
                             self._write_live_backup_manifest(manifest_path, manifest)
-                        raise self._live_backup_error(
-                            request,
-                            "A QEMU bitmap backup has ambiguous capture state; start a new base",
-                            {
-                                "snapshot_id": request.snapshot_id,
+                        retry_command = self._bitmap_snapshot_command(
+                            request.vm_info.vm_id, request.snapshot_id
+                        )
+                        raise self._bitmap_recovery_error(
+                            vm_id=request.vm_info.vm_id,
+                            snapshot_id=request.snapshot_id,
+                            fact=(
+                                f"The last disk capture for sandbox "
+                                f"'{request.vm_info.vm_id}' may be incomplete."
+                            ),
+                            recovery=(f"Run '{retry_command}' to create a fresh disk capture."),
+                            recovery_command=retry_command,
+                            details={
                                 "bitmap_name": bitmap_backup.bitmap_name,
                                 "bitmap_state_ambiguous": True,
                             },

--- a/src/smolvm/storage/_base.py
+++ b/src/smolvm/storage/_base.py
@@ -105,8 +105,27 @@ def snapshot_info_from_row(row: Any) -> SnapshotInfo:
         except (KeyError, IndexError):
             return None
 
+    def optional_int(name: str, *, positive: bool) -> int | None:
+        value = optional_value(name)
+        if isinstance(value, bool):
+            return None
+        try:
+            normalized = int(value)
+        except (TypeError, ValueError, OverflowError):
+            return None
+        if isinstance(value, float) and not value.is_integer():
+            return None
+        if normalized < (1 if positive else 0):
+            return None
+        return normalized
+
     raw_artifact_kind = optional_value("artifact_kind")
     artifact_kind = raw_artifact_kind if raw_artifact_kind in {"full", "incremental"} else None
+    raw_bitmap_name = optional_value("bitmap_name")
+    bitmap_name = raw_bitmap_name if isinstance(raw_bitmap_name, str) else None
+    virtual_size_bytes = optional_int("virtual_size_bytes", positive=True)
+    changed_bytes = optional_int("changed_bytes", positive=False)
+    bitmap_granularity_bytes = optional_int("bitmap_granularity_bytes", positive=True)
     return SnapshotInfo(
         snapshot_id=row["snapshot_id"],
         vm_id=row["vm_id"],
@@ -117,10 +136,10 @@ def snapshot_info_from_row(row: Any) -> SnapshotInfo:
         created_at=datetime.fromisoformat(row["created_at"]),
         snapshot_type=snapshot_type,
         artifact_kind=artifact_kind,
-        virtual_size_bytes=optional_value("virtual_size_bytes"),
-        changed_bytes=optional_value("changed_bytes"),
-        bitmap_granularity_bytes=optional_value("bitmap_granularity_bytes"),
-        bitmap_name=optional_value("bitmap_name"),
+        virtual_size_bytes=virtual_size_bytes,
+        changed_bytes=changed_bytes,
+        bitmap_granularity_bytes=bitmap_granularity_bytes,
+        bitmap_name=bitmap_name,
         restored=bool(row["restored"]),
         restored_vm_id=row["restored_vm_id"],
     )

--- a/src/smolvm/storage/_base.py
+++ b/src/smolvm/storage/_base.py
@@ -98,6 +98,15 @@ def snapshot_info_from_row(row: Any) -> SnapshotInfo:
     except ValueError:
         # Unknown value persisted by a newer/other writer — treat as full.
         snapshot_type = SnapshotType.FULL
+
+    def optional_value(name: str) -> Any:
+        try:
+            return row[name]
+        except (KeyError, IndexError):
+            return None
+
+    raw_artifact_kind = optional_value("artifact_kind")
+    artifact_kind = raw_artifact_kind if raw_artifact_kind in {"full", "incremental"} else None
     return SnapshotInfo(
         snapshot_id=row["snapshot_id"],
         vm_id=row["vm_id"],
@@ -107,6 +116,11 @@ def snapshot_info_from_row(row: Any) -> SnapshotInfo:
         network_config=NetworkConfig.model_validate_json(row["network_config"]),
         created_at=datetime.fromisoformat(row["created_at"]),
         snapshot_type=snapshot_type,
+        artifact_kind=artifact_kind,
+        virtual_size_bytes=optional_value("virtual_size_bytes"),
+        changed_bytes=optional_value("changed_bytes"),
+        bitmap_granularity_bytes=optional_value("bitmap_granularity_bytes"),
+        bitmap_name=optional_value("bitmap_name"),
         restored=bool(row["restored"]),
         restored_vm_id=row["restored_vm_id"],
     )

--- a/src/smolvm/storage/_postgres.py
+++ b/src/smolvm/storage/_postgres.py
@@ -201,6 +201,11 @@ class PostgresStateManager:
                     network_config TEXT NOT NULL,
                     created_at TEXT NOT NULL,
                     snapshot_type TEXT,
+                    artifact_kind TEXT,
+                    virtual_size_bytes BIGINT,
+                    changed_bytes BIGINT,
+                    bitmap_granularity_bytes BIGINT,
+                    bitmap_name TEXT,
                     restored BOOLEAN DEFAULT FALSE,
                     restored_vm_id TEXT
                 );
@@ -209,6 +214,11 @@ class PostgresStateManager:
 
                 ALTER TABLE vms ADD COLUMN IF NOT EXISTS display TEXT;
                 ALTER TABLE snapshots ADD COLUMN IF NOT EXISTS snapshot_type TEXT;
+                ALTER TABLE snapshots ADD COLUMN IF NOT EXISTS artifact_kind TEXT;
+                ALTER TABLE snapshots ADD COLUMN IF NOT EXISTS virtual_size_bytes BIGINT;
+                ALTER TABLE snapshots ADD COLUMN IF NOT EXISTS changed_bytes BIGINT;
+                ALTER TABLE snapshots ADD COLUMN IF NOT EXISTS bitmap_granularity_bytes BIGINT;
+                ALTER TABLE snapshots ADD COLUMN IF NOT EXISTS bitmap_name TEXT;
                 ALTER TABLE browser_sessions ADD COLUMN IF NOT EXISTS vnc_url TEXT;
                 ALTER TABLE browser_sessions ADD COLUMN IF NOT EXISTS vnc_port INTEGER;
                 """
@@ -724,9 +734,14 @@ class PostgresStateManager:
                 INSERT INTO snapshots (
                     snapshot_id, vm_id, snapshot_path, mem_file_path, disk_path,
                     backend, artifacts, vm_config, network_config,
-                    created_at, snapshot_type, restored, restored_vm_id
+                    created_at, snapshot_type, artifact_kind, virtual_size_bytes,
+                    changed_bytes, bitmap_granularity_bytes, bitmap_name,
+                    restored, restored_vm_id
                 )
-                VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s)
+                VALUES (
+                    %s, %s, %s, %s, %s, %s, %s, %s, %s,
+                    %s, %s, %s, %s, %s, %s, %s, %s, %s
+                )
                 """,
                 (
                     info.snapshot_id,
@@ -740,6 +755,11 @@ class PostgresStateManager:
                     info.network_config.model_dump_json(),
                     info.created_at.isoformat(),
                     info.snapshot_type.value,
+                    info.artifact_kind,
+                    info.virtual_size_bytes,
+                    info.changed_bytes,
+                    info.bitmap_granularity_bytes,
+                    info.bitmap_name,
                     info.restored,
                     info.restored_vm_id,
                 ),

--- a/src/smolvm/storage/_sqlite.py
+++ b/src/smolvm/storage/_sqlite.py
@@ -194,6 +194,11 @@ class SQLiteStateManager:
                     network_config TEXT NOT NULL,
                     created_at TEXT NOT NULL,
                     snapshot_type TEXT,
+                    artifact_kind TEXT,
+                    virtual_size_bytes INTEGER,
+                    changed_bytes INTEGER,
+                    bitmap_granularity_bytes INTEGER,
+                    bitmap_name TEXT,
                     restored INTEGER DEFAULT 0,
                     restored_vm_id TEXT
                 );
@@ -213,6 +218,16 @@ class SQLiteStateManager:
                 conn.execute("ALTER TABLE snapshots ADD COLUMN artifacts TEXT")
             if "snapshot_type" not in snapshot_columns:
                 conn.execute("ALTER TABLE snapshots ADD COLUMN snapshot_type TEXT")
+            if "artifact_kind" not in snapshot_columns:
+                conn.execute("ALTER TABLE snapshots ADD COLUMN artifact_kind TEXT")
+            if "virtual_size_bytes" not in snapshot_columns:
+                conn.execute("ALTER TABLE snapshots ADD COLUMN virtual_size_bytes INTEGER")
+            if "changed_bytes" not in snapshot_columns:
+                conn.execute("ALTER TABLE snapshots ADD COLUMN changed_bytes INTEGER")
+            if "bitmap_granularity_bytes" not in snapshot_columns:
+                conn.execute("ALTER TABLE snapshots ADD COLUMN bitmap_granularity_bytes INTEGER")
+            if "bitmap_name" not in snapshot_columns:
+                conn.execute("ALTER TABLE snapshots ADD COLUMN bitmap_name TEXT")
             browser_columns = {
                 row["name"]
                 for row in conn.execute("PRAGMA table_info(browser_sessions)").fetchall()
@@ -740,9 +755,11 @@ class SQLiteStateManager:
                 INSERT INTO snapshots (
                     snapshot_id, vm_id, snapshot_path, mem_file_path, disk_path,
                     backend, artifacts, vm_config, network_config,
-                    created_at, snapshot_type, restored, restored_vm_id
+                    created_at, snapshot_type, artifact_kind, virtual_size_bytes,
+                    changed_bytes, bitmap_granularity_bytes, bitmap_name,
+                    restored, restored_vm_id
                 )
-                VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
                 """,
                 (
                     info.snapshot_id,
@@ -756,6 +773,11 @@ class SQLiteStateManager:
                     info.network_config.model_dump_json(),
                     info.created_at.isoformat(),
                     info.snapshot_type.value,
+                    info.artifact_kind,
+                    info.virtual_size_bytes,
+                    info.changed_bytes,
+                    info.bitmap_granularity_bytes,
+                    info.bitmap_name,
                     int(info.restored),
                     info.restored_vm_id,
                 ),

--- a/src/smolvm/types.py
+++ b/src/smolvm/types.py
@@ -976,6 +976,7 @@ class SnapshotInfo(BaseModel):
     snapshot_type: SnapshotType = SnapshotType.FULL
     artifact_kind: Literal["full", "incremental"] | None = None
     virtual_size_bytes: int | None = None
+    # Estimate sampled from QEMU immediately before incremental capture begins.
     changed_bytes: int | None = None
     bitmap_granularity_bytes: int | None = None
     bitmap_name: str | None = None

--- a/src/smolvm/types.py
+++ b/src/smolvm/types.py
@@ -974,6 +974,11 @@ class SnapshotInfo(BaseModel):
     network_config: NetworkConfig
     created_at: datetime
     snapshot_type: SnapshotType = SnapshotType.FULL
+    artifact_kind: Literal["full", "incremental"] | None = None
+    virtual_size_bytes: int | None = None
+    changed_bytes: int | None = None
+    bitmap_granularity_bytes: int | None = None
+    bitmap_name: str | None = None
     restored: bool = False
     restored_vm_id: str | None = None
 

--- a/src/smolvm/vm.py
+++ b/src/smolvm/vm.py
@@ -2369,7 +2369,9 @@ class SmolVMManager:
         It requires a running QEMU VM, ``snapshot_type=DISK``, and
         ``resume_source=True``. ``timeout_seconds`` must be positive and bounds
         live disk capture; ``max_bytes_per_second`` may optionally apply a
-        positive bandwidth limit.
+        positive bandwidth limit. ``qemu_dirty_bitmap_backup`` starts a new
+        persistent QEMU bitmap chain or captures its next incremental disk
+        artifact; it requires a live-only running QEMU ``DISK`` snapshot.
         """
         if not vm_id:
             raise ValueError("vm_id cannot be empty")
@@ -2418,10 +2420,11 @@ class SmolVMManager:
 
         original_status = vm_info.status
         backend = self._backend_for_vm(vm_info)
-        live_command = (
+        disk_command = (
             f"smolvm sandbox snapshot create {vm_id} --snapshot-id {snapshot_id} "
-            "--snapshot-type disk --resume-source --live-only"
+            "--snapshot-type disk --resume-source"
         )
+        live_command = f"{disk_command} --live-only"
         if capture_policy == SnapshotCapturePolicy.LIVE_ONLY:
             if original_status != VMState.RUNNING:
                 raise SmolVMError(
@@ -2458,27 +2461,47 @@ class SmolVMManager:
         if qemu_dirty_bitmap_backup is not None:
             if backend != BACKEND_QEMU:
                 raise SmolVMError(
-                    "Dirty-bitmap backups require a running QEMU sandbox.",
-                    {"vm_id": vm_id, "backend": backend},
+                    f"Sandbox '{vm_id}' does not use QEMU; run '{disk_command}' "
+                    "to create a regular disk snapshot.",
+                    {
+                        "vm_id": vm_id,
+                        "backend": backend,
+                        "recovery_command": disk_command,
+                    },
                 )
             if (
                 original_status != VMState.RUNNING
                 or snapshot_type != SnapshotType.DISK
                 or capture_policy != SnapshotCapturePolicy.LIVE_ONLY
             ):
+                if original_status != VMState.RUNNING:
+                    start_command = f"smolvm sandbox start {vm_id}"
+                    fact = (
+                        f"Sandbox '{vm_id}' must be running for this disk capture; run "
+                        f"'{start_command}', then '{live_command}'."
+                    )
+                    recovery_command = start_command
+                else:
+                    fact = (
+                        f"This disk capture for sandbox '{vm_id}' must stay live; run "
+                        f"'{live_command}'."
+                    )
+                    recovery_command = live_command
                 raise SmolVMError(
-                    "Dirty-bitmap backups require a live-only running QEMU disk snapshot.",
+                    fact,
                     {
                         "vm_id": vm_id,
                         "current_status": original_status.value,
                         "snapshot_type": snapshot_type.value,
                         "capture_policy": capture_policy.value,
+                        "recovery_command": recovery_command,
                     },
                 )
             if not resume_source:
                 raise SmolVMError(
-                    "Dirty-bitmap backups must leave the source sandbox running.",
-                    {"vm_id": vm_id},
+                    f"This disk capture must leave sandbox '{vm_id}' running; run "
+                    f"'{live_command}'.",
+                    {"vm_id": vm_id, "recovery_command": live_command},
                 )
             if not qemu_dirty_bitmap_backup.bitmap_name:
                 raise ValueError("bitmap_name cannot be empty")
@@ -2488,8 +2511,13 @@ class SmolVMManager:
             raise SmolVMError("Snapshotting requires a managed isolated disk", {"vm_id": vm_id})
         if qemu_dirty_bitmap_backup is not None and managed_disk_path.suffix != ".qcow2":
             raise SmolVMError(
-                "Dirty-bitmap backups require a managed qcow2 disk.",
-                {"vm_id": vm_id, "disk_path": str(managed_disk_path)},
+                f"Sandbox '{vm_id}' does not use a compatible disk file; run "
+                f"'{disk_command}' to create a regular disk snapshot.",
+                {
+                    "vm_id": vm_id,
+                    "disk_path": str(managed_disk_path),
+                    "recovery_command": disk_command,
+                },
             )
 
         adapter = self._runtime_adapter_for_backend(backend)
@@ -2501,6 +2529,7 @@ class SmolVMManager:
                 persisted_snapshot_ids={
                     snapshot.snapshot_id for snapshot in self.state.list_snapshots(vm_id=vm_id)
                 },
+                timeout_seconds=timeout_seconds,
             )
 
         with suppress(SnapshotNotFoundError):
@@ -2877,10 +2906,32 @@ class SmolVMManager:
             raise
 
     def delete_snapshot(self, snapshot_id: str) -> None:
-        """Delete snapshot files and metadata."""
+        """Delete snapshot files and metadata, including adopted recovery artifacts."""
         snapshot_root = self._snapshot_root_for_id(snapshot_id)
 
-        snapshot = self.state.get_snapshot(snapshot_id)
+        try:
+            snapshot = self.state.get_snapshot(snapshot_id)
+        except SnapshotNotFoundError as missing_snapshot:
+            manifest_path = snapshot_root / "live-backup.json"
+            if manifest_path.is_symlink():
+                raise missing_snapshot
+            try:
+                manifest = json.loads(manifest_path.read_text())
+            except (OSError, UnicodeDecodeError, json.JSONDecodeError):
+                raise missing_snapshot from None
+            artifact_filename = (
+                "increment.qcow2" if manifest.get("backup_mode") == "incremental" else "disk.qcow2"
+            )
+            if (
+                manifest.get("schema_version") != 2
+                or manifest.get("snapshot_id") != snapshot_id
+                or manifest.get("phase") != "artifact-published"
+                or manifest.get("final_path") != str(snapshot_root / artifact_filename)
+                or not (snapshot_root / artifact_filename).is_file()
+            ):
+                raise missing_snapshot
+            shutil.rmtree(snapshot_root)
+            return
         if snapshot.restored and snapshot.restored_vm_id:
             with suppress(VMNotFoundError):
                 restored_vm = self.state.get_vm(snapshot.restored_vm_id)

--- a/src/smolvm/vm.py
+++ b/src/smolvm/vm.py
@@ -61,7 +61,12 @@ from smolvm.runtime.backends import (
     resolve_backend,
     resolve_backend_for_guest,
 )
-from smolvm.runtime.base import RuntimeContext, SnapshotCreateRequest, SnapshotRestoreRequest
+from smolvm.runtime.base import (
+    QemuDirtyBitmapBackup,
+    RuntimeContext,
+    SnapshotCreateRequest,
+    SnapshotRestoreRequest,
+)
 from smolvm.runtime.firecracker import FirecrackerRuntimeAdapter
 from smolvm.runtime.guest_platforms import get_guest_platform
 from smolvm.runtime.libkrun import LibkrunRuntimeAdapter
@@ -2348,6 +2353,7 @@ class SmolVMManager:
         capture_policy: SnapshotCapturePolicy = SnapshotCapturePolicy.ALLOW_PAUSE,
         timeout_seconds: float = 600.0,
         max_bytes_per_second: int | None = None,
+        qemu_dirty_bitmap_backup: QemuDirtyBitmapBackup | None = None,
     ) -> SnapshotInfo:
         """Create a snapshot for a paused or running VM.
 
@@ -2384,6 +2390,7 @@ class SmolVMManager:
                 capture_policy=capture_policy,
                 timeout_seconds=timeout_seconds,
                 max_bytes_per_second=max_bytes_per_second,
+                qemu_dirty_bitmap_backup=qemu_dirty_bitmap_backup,
             )
 
     def _create_snapshot_locked(
@@ -2397,6 +2404,7 @@ class SmolVMManager:
         capture_policy: SnapshotCapturePolicy,
         timeout_seconds: float,
         max_bytes_per_second: int | None,
+        qemu_dirty_bitmap_backup: QemuDirtyBitmapBackup | None,
     ) -> SnapshotInfo:
         """Create one snapshot while its VM and snapshot-ID locks are held."""
 
@@ -2447,9 +2455,42 @@ class SmolVMManager:
                     f"A live snapshot keeps sandbox '{vm_id}' running; run '{live_command}'.",
                     {"vm_id": vm_id},
                 )
+        if qemu_dirty_bitmap_backup is not None:
+            if backend != BACKEND_QEMU:
+                raise SmolVMError(
+                    "Dirty-bitmap backups require a running QEMU sandbox.",
+                    {"vm_id": vm_id, "backend": backend},
+                )
+            if (
+                original_status != VMState.RUNNING
+                or snapshot_type != SnapshotType.DISK
+                or capture_policy != SnapshotCapturePolicy.LIVE_ONLY
+            ):
+                raise SmolVMError(
+                    "Dirty-bitmap backups require a live-only running QEMU disk snapshot.",
+                    {
+                        "vm_id": vm_id,
+                        "current_status": original_status.value,
+                        "snapshot_type": snapshot_type.value,
+                        "capture_policy": capture_policy.value,
+                    },
+                )
+            if not resume_source:
+                raise SmolVMError(
+                    "Dirty-bitmap backups must leave the source sandbox running.",
+                    {"vm_id": vm_id},
+                )
+            if not qemu_dirty_bitmap_backup.bitmap_name:
+                raise ValueError("bitmap_name cannot be empty")
+
         managed_disk_path = self._managed_disk_for_vm(vm_info)
         if managed_disk_path is None:
             raise SmolVMError("Snapshotting requires a managed isolated disk", {"vm_id": vm_id})
+        if qemu_dirty_bitmap_backup is not None and managed_disk_path.suffix != ".qcow2":
+            raise SmolVMError(
+                "Dirty-bitmap backups require a managed qcow2 disk.",
+                {"vm_id": vm_id, "disk_path": str(managed_disk_path)},
+            )
 
         adapter = self._runtime_adapter_for_backend(backend)
         if isinstance(adapter, QemuRuntimeAdapter):
@@ -2504,6 +2545,7 @@ class SmolVMManager:
                     capture_policy=capture_policy,
                     timeout_seconds=timeout_seconds,
                     max_bytes_per_second=max_bytes_per_second,
+                    qemu_dirty_bitmap_backup=qemu_dirty_bitmap_backup,
                 )
             )
 
@@ -2516,6 +2558,11 @@ class SmolVMManager:
                 network_config=vm_info.network,
                 created_at=result.captured_at,
                 snapshot_type=snapshot_type,
+                artifact_kind=result.artifact_kind,
+                virtual_size_bytes=result.virtual_size_bytes,
+                changed_bytes=result.changed_bytes,
+                bitmap_granularity_bytes=result.bitmap_granularity_bytes,
+                bitmap_name=result.bitmap_name,
             )
             self.state.create_snapshot(snapshot_info)
             snapshot_persisted = True

--- a/tests/e2e/test_qemu_incremental_snapshot.py
+++ b/tests/e2e/test_qemu_incremental_snapshot.py
@@ -16,9 +16,7 @@
 
 from __future__ import annotations
 
-import json
 import shutil
-import subprocess
 import tempfile
 from contextlib import suppress
 from pathlib import Path
@@ -26,53 +24,9 @@ from pathlib import Path
 import pytest
 
 from smolvm import QemuDirtyBitmapBackup, SmolVM, SnapshotCapturePolicy, SnapshotType, VMConfig
+from tests.qemu_incremental import _materialize
 
 pytestmark = pytest.mark.e2e
-
-
-def _run(*command: str) -> subprocess.CompletedProcess[str]:
-    return subprocess.run(command, check=True, capture_output=True, text=True)
-
-
-def _materialize(qemu_img: str, root: Path, name: str, artifacts: list[Path]) -> Path:
-    staging = root / f"staging-{name}"
-    staging.mkdir()
-    local_chain: list[Path] = []
-    for depth, artifact in enumerate(artifacts):
-        local = staging / f"depth-{depth}.qcow2"
-        shutil.copy2(artifact, local)
-        local_chain.append(local)
-        if depth > 0:
-            _run(
-                qemu_img,
-                "rebase",
-                "-u",
-                "-f",
-                "qcow2",
-                "-F",
-                "qcow2",
-                "-b",
-                str(local_chain[depth - 1]),
-                str(local),
-            )
-
-    _run(qemu_img, "check", str(local_chain[-1]))
-    output = root / f"leaf-{name}.qcow2"
-    _run(
-        qemu_img,
-        "convert",
-        "-f",
-        "qcow2",
-        "-O",
-        "qcow2",
-        str(local_chain[-1]),
-        str(output),
-    )
-    info = json.loads(_run(qemu_img, "info", "--output=json", str(output)).stdout)
-    assert info["format"] == "qcow2"
-    assert not info.get("backing-filename")
-    _run(qemu_img, "check", str(output))
-    return output
 
 
 def _boot_and_read_markers(
@@ -101,7 +55,9 @@ def _boot_and_read_markers(
     )
     try:
         vm.start(boot_timeout=180)
-        marker_a = vm.run("cat /root/celesto-marker-a").stdout.strip()
+        marker_a_result = vm.run("cat /root/celesto-marker-a")
+        assert marker_a_result.exit_code == 0, marker_a_result.stderr
+        marker_a = marker_a_result.stdout.strip()
         marker_b_exists = vm.run("test -e /root/celesto-marker-b").exit_code == 0
         return marker_a, marker_b_exists
     finally:
@@ -193,8 +149,7 @@ def test_materialized_incremental_leaves_boot_after_source_state_is_deleted(
         finally:
             with suppress(Exception):
                 source.stop(timeout=10)
-            with suppress(Exception):
-                source.delete()
+            source.delete()
 
     assert source_disk is not None
     assert source_config is not None

--- a/tests/e2e/test_qemu_incremental_snapshot.py
+++ b/tests/e2e/test_qemu_incremental_snapshot.py
@@ -1,0 +1,227 @@
+# Copyright 2026 Celesto AI
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Boot proof for QEMU persistent dirty-bitmap incremental artifacts."""
+
+from __future__ import annotations
+
+import json
+import shutil
+import subprocess
+import tempfile
+from contextlib import suppress
+from pathlib import Path
+
+import pytest
+
+from smolvm import QemuDirtyBitmapBackup, SmolVM, SnapshotCapturePolicy, SnapshotType, VMConfig
+
+pytestmark = pytest.mark.e2e
+
+
+def _run(*command: str) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(command, check=True, capture_output=True, text=True)
+
+
+def _materialize(qemu_img: str, root: Path, name: str, artifacts: list[Path]) -> Path:
+    staging = root / f"staging-{name}"
+    staging.mkdir()
+    local_chain: list[Path] = []
+    for depth, artifact in enumerate(artifacts):
+        local = staging / f"depth-{depth}.qcow2"
+        shutil.copy2(artifact, local)
+        local_chain.append(local)
+        if depth > 0:
+            _run(
+                qemu_img,
+                "rebase",
+                "-u",
+                "-f",
+                "qcow2",
+                "-F",
+                "qcow2",
+                "-b",
+                str(local_chain[depth - 1]),
+                str(local),
+            )
+
+    _run(qemu_img, "check", str(local_chain[-1]))
+    output = root / f"leaf-{name}.qcow2"
+    _run(
+        qemu_img,
+        "convert",
+        "-f",
+        "qcow2",
+        "-O",
+        "qcow2",
+        str(local_chain[-1]),
+        str(output),
+    )
+    info = json.loads(_run(qemu_img, "info", "--output=json", str(output)).stdout)
+    assert info["format"] == "qcow2"
+    assert not info.get("backing-filename")
+    _run(qemu_img, "check", str(output))
+    return output
+
+
+def _boot_and_read_markers(
+    disk: Path,
+    root: Path,
+    socket_dir: Path,
+    source_config: VMConfig,
+    ssh_key_path: str | None,
+) -> tuple[str, bool]:
+    config = source_config.model_copy(
+        update={
+            "vm_id": f"sbx-phase0-{disk.stem}",
+            "rootfs_path": disk,
+            "disk_mode": "shared",
+            "disk_size_mib": None,
+        }
+    )
+    vm = SmolVM(
+        config=config,
+        data_dir=root,
+        socket_dir=socket_dir,
+        backend="qemu",
+        ssh_key_path=ssh_key_path,
+        comm_channel="ssh",
+        ssh_user="root",
+    )
+    try:
+        vm.start(boot_timeout=180)
+        marker_a = vm.run("cat /root/celesto-marker-a").stdout.strip()
+        marker_b_exists = vm.run("test -e /root/celesto-marker-b").exit_code == 0
+        return marker_a, marker_b_exists
+    finally:
+        with suppress(Exception):
+            vm.stop(timeout=10)
+        with suppress(Exception):
+            vm.delete()
+
+
+def test_materialized_incremental_leaves_boot_after_source_state_is_deleted(
+    tmp_path: Path,
+) -> None:
+    """Boot base+A and base+A+B after deleting the source VM and managed disk."""
+    qemu_img = shutil.which("qemu-img")
+    if qemu_img is None or (
+        shutil.which("qemu-system-x86_64") is None and shutil.which("qemu-system-aarch64") is None
+    ):
+        pytest.skip("qemu-system and qemu-img are required")
+
+    source_data = tmp_path / "source-data"
+    artifacts = tmp_path / "artifacts"
+    artifacts.mkdir()
+    bitmap_name = "celesto-phase0-boot"
+    base = artifacts / "base.qcow2"
+    increment_a = artifacts / "increment-a.qcow2"
+    increment_b = artifacts / "increment-b.qcow2"
+
+    with tempfile.TemporaryDirectory(prefix="qinc-src-") as source_socket_raw:
+        source_socket_dir = Path(source_socket_raw)
+        source = SmolVM(
+            backend="qemu",
+            os="ubuntu",
+            data_dir=source_data,
+            socket_dir=source_socket_dir,
+            disk_size=4096,
+            comm_channel="ssh",
+        )
+        source_disk: Path | None = None
+        source_config: VMConfig | None = None
+        ssh_key_path: str | None = None
+        try:
+            source.start(boot_timeout=180)
+            assert source.run("printf base > /root/celesto-marker-base && sync").exit_code == 0
+            source_disk = source._info.config.rootfs_path
+            source_config = source._info.config
+            ssh_key_path = source._ssh_key_path
+            base_snapshot = source.snapshot(
+                snapshot_id="snap-phase0-base",
+                snapshot_type=SnapshotType.DISK,
+                resume_source=True,
+                capture_policy=SnapshotCapturePolicy.LIVE_ONLY,
+                qemu_dirty_bitmap_backup=QemuDirtyBitmapBackup(
+                    mode="new-base",
+                    bitmap_name=bitmap_name,
+                ),
+            )
+            assert base_snapshot.artifact_kind == "full"
+            assert base_snapshot.bitmap_name == bitmap_name
+            shutil.copy2(base_snapshot.artifacts.disk_path, base)
+
+            assert source.run("printf marker-a > /root/celesto-marker-a && sync").exit_code == 0
+            snapshot_a = source.snapshot(
+                snapshot_id="snap-phase0-a",
+                snapshot_type=SnapshotType.DISK,
+                resume_source=True,
+                capture_policy=SnapshotCapturePolicy.LIVE_ONLY,
+                qemu_dirty_bitmap_backup=QemuDirtyBitmapBackup(
+                    mode="incremental",
+                    bitmap_name=bitmap_name,
+                ),
+            )
+            assert snapshot_a.artifact_kind == "incremental"
+            assert snapshot_a.changed_bytes is not None and snapshot_a.changed_bytes > 0
+            shutil.copy2(snapshot_a.artifacts.disk_path, increment_a)
+
+            assert source.run("printf marker-b > /root/celesto-marker-b && sync").exit_code == 0
+            snapshot_b = source.snapshot(
+                snapshot_id="snap-phase0-b",
+                snapshot_type=SnapshotType.DISK,
+                resume_source=True,
+                capture_policy=SnapshotCapturePolicy.LIVE_ONLY,
+                qemu_dirty_bitmap_backup=QemuDirtyBitmapBackup(
+                    mode="incremental",
+                    bitmap_name=bitmap_name,
+                ),
+            )
+            assert snapshot_b.artifact_kind == "incremental"
+            shutil.copy2(snapshot_b.artifacts.disk_path, increment_b)
+        finally:
+            with suppress(Exception):
+                source.stop(timeout=10)
+            with suppress(Exception):
+                source.delete()
+
+    assert source_disk is not None
+    assert source_config is not None
+    assert not source_disk.exists()
+    shutil.rmtree(source_data, ignore_errors=True)
+
+    leaf_a = _materialize(qemu_img, tmp_path, "a", [base, increment_a])
+    leaf_b = _materialize(qemu_img, tmp_path, "b", [base, increment_a, increment_b])
+
+    with tempfile.TemporaryDirectory(prefix="qinc-a-") as socket_a_raw:
+        marker_a, marker_b_exists = _boot_and_read_markers(
+            leaf_a,
+            tmp_path / "restore-a",
+            Path(socket_a_raw),
+            source_config,
+            ssh_key_path,
+        )
+    assert marker_a == "marker-a"
+    assert not marker_b_exists
+
+    with tempfile.TemporaryDirectory(prefix="qinc-b-") as socket_b_raw:
+        marker_a, marker_b_exists = _boot_and_read_markers(
+            leaf_b,
+            tmp_path / "restore-b",
+            Path(socket_b_raw),
+            source_config,
+            ssh_key_path,
+        )
+    assert marker_a == "marker-a"
+    assert marker_b_exists

--- a/tests/qemu_incremental.py
+++ b/tests/qemu_incremental.py
@@ -1,0 +1,74 @@
+# Copyright 2026 Celesto AI
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Shared helpers for QEMU incremental snapshot tests."""
+
+from __future__ import annotations
+
+import json
+import shutil
+import subprocess
+from pathlib import Path
+
+
+def _run(*command: str) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(command, check=True, capture_output=True, text=True)
+
+
+def _materialize(qemu_img: str, root: Path, name: str, artifacts: list[Path]) -> Path:
+    """Build and validate a standalone qcow2 from an ordered artifact chain."""
+    if not artifacts:
+        raise ValueError("artifacts cannot be empty")
+    expected_virtual_size = json.loads(
+        _run(qemu_img, "info", "--output=json", str(artifacts[0])).stdout
+    )["virtual-size"]
+    staging = root / f"materialize-{name}"
+    staging.mkdir()
+    local_artifacts: list[Path] = []
+    for depth, artifact in enumerate(artifacts):
+        local = staging / f"depth-{depth}.qcow2"
+        shutil.copy2(artifact, local)
+        local_artifacts.append(local)
+        if depth > 0:
+            _run(
+                qemu_img,
+                "rebase",
+                "-u",
+                "-f",
+                "qcow2",
+                "-F",
+                "qcow2",
+                "-b",
+                str(local_artifacts[depth - 1]),
+                str(local),
+            )
+
+    _run(qemu_img, "check", str(local_artifacts[-1]))
+    output = root / f"materialized-{name}.qcow2"
+    _run(
+        qemu_img,
+        "convert",
+        "-f",
+        "qcow2",
+        "-O",
+        "qcow2",
+        str(local_artifacts[-1]),
+        str(output),
+    )
+    info = json.loads(_run(qemu_img, "info", "--output=json", str(output)).stdout)
+    assert info["format"] == "qcow2"
+    assert info["virtual-size"] == expected_virtual_size
+    assert not info.get("backing-filename")
+    _run(qemu_img, "check", str(output))
+    return output

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1942,6 +1942,30 @@ class TestCliSnapshot:
         assert "Deleted snapshot 'snap-001'." in capsys.readouterr().out
 
     @patch("smolvm.vm.SmolVMManager")
+    def test_snapshot_delete_clears_recovered_artifact(
+        self,
+        mock_sdk_cls: MagicMock,
+        capsys: pytest.CaptureFixture,
+    ) -> None:
+        """Snapshot delete should expose the recovery-record cleanup action."""
+        from smolvm.exceptions import SnapshotNotFoundError
+
+        sdk = mock_sdk_cls.return_value
+        sdk.__enter__.return_value = sdk
+        sdk.__exit__.side_effect = lambda *args: sdk.close()
+        sdk.get_snapshot.side_effect = SnapshotNotFoundError("snap-recovered")
+
+        ret = main(["sandbox", "snapshot", "delete", "snap-recovered", "--json"])
+
+        assert ret == 0
+        sdk.delete_snapshot.assert_called_once_with("snap-recovered")
+        payload = json.loads(capsys.readouterr().out)
+        assert payload["data"] == {
+            "snapshot_id": "snap-recovered",
+            "recovery_record_cleared": True,
+        }
+
+    @patch("smolvm.vm.SmolVMManager")
     def test_snapshot_list_json(
         self,
         mock_sdk_cls: MagicMock,

--- a/tests/test_facade.py
+++ b/tests/test_facade.py
@@ -789,6 +789,7 @@ class TestSnapshot:
                 capture_policy=SnapshotCapturePolicy.ALLOW_PAUSE,
                 timeout_seconds=600.0,
                 max_bytes_per_second=None,
+                qemu_dirty_bitmap_backup=None,
             ),
         ]
 

--- a/tests/test_qemu_incremental_spike.py
+++ b/tests/test_qemu_incremental_spike.py
@@ -1,0 +1,345 @@
+# Copyright 2026 Celesto AI
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Real-QEMU proof for persistent dirty-bitmap incremental artifacts."""
+
+from __future__ import annotations
+
+import json
+import shutil
+import subprocess
+import tempfile
+import time
+from collections.abc import Iterator
+from pathlib import Path
+
+import pytest
+
+from smolvm.exceptions import SmolVMError
+from smolvm.qmp import QMPClient, QMPDirtyBitmap
+
+_VIRTUAL_SIZE = 64 * 1024 * 1024
+_BITMAP_NAME = "celesto-phase0"
+
+
+@pytest.fixture
+def short_socket_dir() -> Iterator[Path]:
+    """Keep QMP and NBD paths below platform AF_UNIX limits."""
+    with tempfile.TemporaryDirectory(prefix="qinc-") as socket_dir:
+        yield Path(socket_dir)
+
+
+def _run(*command: str) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(command, check=True, capture_output=True, text=True)
+
+
+def _start_qemu(qemu_system: str, source: Path, socket_path: Path) -> subprocess.Popen[str]:
+    process = subprocess.Popen(
+        [
+            qemu_system,
+            "-machine",
+            "none",
+            "-nodefaults",
+            "-display",
+            "none",
+            "-S",
+            "-qmp",
+            f"unix:{socket_path},server=on,wait=off",
+            "-blockdev",
+            f"driver=qcow2,node-name=rootdisk0,file.driver=file,file.filename={source}",
+        ],
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.PIPE,
+        text=True,
+    )
+    deadline = time.monotonic() + 5
+    while not socket_path.exists() and process.poll() is None and time.monotonic() < deadline:
+        time.sleep(0.05)
+    if not socket_path.exists():
+        if process.poll() is None:
+            process.terminate()
+        _, stderr = process.communicate(timeout=5)
+        pytest.fail(f"QEMU did not create its QMP socket: {stderr}")
+    return process
+
+
+def _stop_qemu(client: QMPClient, process: subprocess.Popen[str]) -> None:
+    client.execute("quit")
+    process.communicate(timeout=5)
+
+
+def _bitmap(client: QMPClient) -> QMPDirtyBitmap:
+    return next(
+        bitmap for bitmap in client.query_dirty_bitmaps("rootdisk0") if bitmap.name == _BITMAP_NAME
+    )
+
+
+def _create_target(qemu_img: str, root: Path, name: str) -> Path:
+    target = root / f"{name}.qcow2"
+    _run(qemu_img, "create", "-f", "qcow2", str(target), str(_VIRTUAL_SIZE))
+    return target
+
+
+def _attach_target(client: QMPClient, target: Path, name: str) -> str:
+    node_name = f"target-{name}"
+    client.blockdev_add(node_name, target)
+    return node_name
+
+
+def _write_pattern(qemu_io: str, nbd_socket: Path, pattern: str, offset: int, length: int) -> None:
+    _run(
+        qemu_io,
+        "-f",
+        "raw",
+        "-c",
+        f"write -P {pattern} {offset} {length}",
+        f"nbd+unix:///source?socket={nbd_socket}",
+    )
+
+
+def _assert_pattern(qemu_io: str, disk: Path, pattern: str, offset: int, length: int) -> None:
+    _run(qemu_io, "-f", "qcow2", "-c", f"read -P {pattern} {offset} {length}", str(disk))
+
+
+def _materialize(
+    qemu_img: str,
+    root: Path,
+    name: str,
+    artifacts: list[Path],
+) -> Path:
+    staging = root / f"materialize-{name}"
+    staging.mkdir()
+    local_artifacts: list[Path] = []
+    for depth, artifact in enumerate(artifacts):
+        local = staging / f"depth-{depth}.qcow2"
+        shutil.copy2(artifact, local)
+        local_artifacts.append(local)
+        if depth > 0:
+            _run(
+                qemu_img,
+                "rebase",
+                "-u",
+                "-f",
+                "qcow2",
+                "-F",
+                "qcow2",
+                "-b",
+                str(local_artifacts[depth - 1]),
+                str(local),
+            )
+
+    _run(qemu_img, "check", str(local_artifacts[-1]))
+    output = root / f"materialized-{name}.qcow2"
+    _run(qemu_img, "convert", "-f", "qcow2", "-O", "qcow2", str(local_artifacts[-1]), str(output))
+    info = json.loads(_run(qemu_img, "info", "--output=json", str(output)).stdout)
+    assert info["format"] == "qcow2"
+    assert info["virtual-size"] == _VIRTUAL_SIZE
+    assert not info.get("backing-filename")
+    _run(qemu_img, "check", str(output))
+    return output
+
+
+def test_incremental_chain_materializes_and_cancelled_backup_retains_dirty_bytes(
+    tmp_path: Path,
+    short_socket_dir: Path,
+) -> None:
+    """Prove base/A/B materialization, persistence, and cancellation safety."""
+    qemu_img = shutil.which("qemu-img")
+    qemu_io = shutil.which("qemu-io")
+    qemu_system = shutil.which("qemu-system-x86_64") or shutil.which("qemu-system-aarch64")
+    if qemu_img is None or qemu_io is None or qemu_system is None:
+        pytest.skip("qemu-system, qemu-img, and qemu-io are required")
+
+    source = tmp_path / "source.qcow2"
+    qmp_socket = short_socket_dir / "qmp.sock"
+    nbd_socket = short_socket_dir / "nbd.sock"
+    _run(qemu_img, "create", "-f", "qcow2", str(source), str(_VIRTUAL_SIZE))
+
+    artifacts: dict[str, Path] = {}
+    durations: dict[str, float] = {}
+    process = _start_qemu(qemu_system, source, qmp_socket)
+    try:
+        with QMPClient(qmp_socket) as client:
+            client.connect()
+            version = client.query_version()
+            client.execute(
+                "nbd-server-start",
+                {"addr": {"type": "unix", "data": {"path": str(nbd_socket)}}},
+            )
+            client.execute(
+                "block-export-add",
+                {
+                    "type": "nbd",
+                    "id": "source-export",
+                    "node-name": "rootdisk0",
+                    "name": "source",
+                    "writable": True,
+                },
+            )
+
+            artifacts["base"] = _create_target(qemu_img, tmp_path, "base")
+            target_node = _attach_target(client, artifacts["base"], "base")
+            started = time.monotonic()
+            client.start_full_backup_with_dirty_bitmap(
+                job_id="job-base",
+                source_node="rootdisk0",
+                target_node=target_node,
+                bitmap_name=_BITMAP_NAME,
+            )
+            client.wait_for_job("job-base", timeout=10)
+            durations["base"] = time.monotonic() - started
+            client.blockdev_del(target_node)
+            base_bitmap = _bitmap(client)
+            assert base_bitmap.recording
+            assert base_bitmap.persistent
+            assert not base_bitmap.busy
+            assert not base_bitmap.inconsistent
+            assert base_bitmap.dirty_bytes == 0
+
+            _write_pattern(qemu_io, nbd_socket, "0x41", 1024 * 1024, 65536)
+            assert _bitmap(client).dirty_bytes == 65536
+            artifacts["a"] = _create_target(qemu_img, tmp_path, "increment-a")
+            target_node = _attach_target(client, artifacts["a"], "a")
+            started = time.monotonic()
+            client.blockdev_backup_incremental(
+                job_id="job-a",
+                source_node="rootdisk0",
+                target_node=target_node,
+                bitmap_name=_BITMAP_NAME,
+            )
+            client.wait_for_job("job-a", timeout=10)
+            durations["a"] = time.monotonic() - started
+            client.blockdev_del(target_node)
+            assert _bitmap(client).dirty_bytes == 0
+
+            _write_pattern(qemu_io, nbd_socket, "0x42", 2 * 1024 * 1024, 65536)
+            artifacts["b"] = _create_target(qemu_img, tmp_path, "increment-b")
+            target_node = _attach_target(client, artifacts["b"], "b")
+            started = time.monotonic()
+            client.blockdev_backup_incremental(
+                job_id="job-b",
+                source_node="rootdisk0",
+                target_node=target_node,
+                bitmap_name=_BITMAP_NAME,
+            )
+            client.wait_for_job("job-b", timeout=10)
+            durations["b"] = time.monotonic() - started
+            client.blockdev_del(target_node)
+            assert _bitmap(client).dirty_bytes == 0
+
+            client.execute("block-export-del", {"id": "source-export", "mode": "hard"})
+            client.execute("nbd-server-stop")
+            _stop_qemu(client, process)
+    finally:
+        if process.poll() is None:
+            process.terminate()
+            process.communicate(timeout=5)
+
+    qmp_socket.unlink(missing_ok=True)
+    process = _start_qemu(qemu_system, source, qmp_socket)
+    try:
+        with QMPClient(qmp_socket) as client:
+            client.connect()
+            persisted = _bitmap(client)
+            assert persisted.recording
+            assert persisted.persistent
+            assert not persisted.inconsistent
+            assert persisted.dirty_bytes == 0
+            client.execute(
+                "nbd-server-start",
+                {"addr": {"type": "unix", "data": {"path": str(nbd_socket)}}},
+            )
+            client.execute(
+                "block-export-add",
+                {
+                    "type": "nbd",
+                    "id": "source-export",
+                    "node-name": "rootdisk0",
+                    "name": "source",
+                    "writable": True,
+                },
+            )
+
+            cancelled_bytes = 16 * 1024 * 1024
+            _write_pattern(qemu_io, nbd_socket, "0x43", 4 * 1024 * 1024, cancelled_bytes)
+            assert _bitmap(client).dirty_bytes == cancelled_bytes
+            cancelled = _create_target(qemu_img, tmp_path, "cancelled")
+            target_node = _attach_target(client, cancelled, "cancelled")
+            client.blockdev_backup_incremental(
+                job_id="job-cancelled",
+                source_node="rootdisk0",
+                target_node=target_node,
+                bitmap_name=_BITMAP_NAME,
+                max_bytes_per_second=1024 * 1024,
+            )
+            time.sleep(0.2)
+            client.cancel_job("job-cancelled", force=True)
+            with pytest.raises(SmolVMError, match="QMP job failed"):
+                client.wait_for_job("job-cancelled", timeout=10)
+            client.blockdev_del(target_node)
+            assert _bitmap(client).dirty_bytes == cancelled_bytes
+
+            artifacts["retry"] = _create_target(qemu_img, tmp_path, "increment-retry")
+            target_node = _attach_target(client, artifacts["retry"], "retry")
+            client.blockdev_backup_incremental(
+                job_id="job-retry",
+                source_node="rootdisk0",
+                target_node=target_node,
+                bitmap_name=_BITMAP_NAME,
+            )
+            client.wait_for_job("job-retry", timeout=10)
+            client.blockdev_del(target_node)
+            assert _bitmap(client).dirty_bytes == 0
+
+            client.execute("block-export-del", {"id": "source-export", "mode": "hard"})
+            client.execute("nbd-server-stop")
+            _stop_qemu(client, process)
+    finally:
+        if process.poll() is None:
+            process.terminate()
+            process.communicate(timeout=5)
+
+    leaf_a = _materialize(qemu_img, tmp_path, "a", [artifacts["base"], artifacts["a"]])
+    _assert_pattern(qemu_io, leaf_a, "0x41", 1024 * 1024, 65536)
+    _assert_pattern(qemu_io, leaf_a, "0x00", 2 * 1024 * 1024, 65536)
+
+    leaf_b = _materialize(
+        qemu_img,
+        tmp_path,
+        "b",
+        [artifacts["base"], artifacts["a"], artifacts["b"]],
+    )
+    _assert_pattern(qemu_io, leaf_b, "0x41", 1024 * 1024, 65536)
+    _assert_pattern(qemu_io, leaf_b, "0x42", 2 * 1024 * 1024, 65536)
+
+    retry_leaf = _materialize(
+        qemu_img,
+        tmp_path,
+        "retry",
+        [artifacts["base"], artifacts["a"], artifacts["b"], artifacts["retry"]],
+    )
+    _assert_pattern(qemu_io, retry_leaf, "0x43", 4 * 1024 * 1024, 16 * 1024 * 1024)
+
+    evidence = {
+        "qemu_version": version,
+        "bitmap_granularity": base_bitmap.granularity,
+        "capture_seconds": durations,
+        "artifact_actual_bytes": {
+            name: json.loads(_run(qemu_img, "info", "--output=json", str(path)).stdout)[
+                "actual-size"
+            ]
+            for name, path in artifacts.items()
+        },
+    }
+    print(json.dumps(evidence, sort_keys=True))

--- a/tests/test_qemu_incremental_spike.py
+++ b/tests/test_qemu_incremental_spike.py
@@ -28,6 +28,7 @@ import pytest
 
 from smolvm.exceptions import SmolVMError
 from smolvm.qmp import QMPClient, QMPDirtyBitmap
+from tests.qemu_incremental import _materialize
 
 _VIRTUAL_SIZE = 64 * 1024 * 1024
 _BITMAP_NAME = "celesto-phase0"
@@ -80,9 +81,13 @@ def _stop_qemu(client: QMPClient, process: subprocess.Popen[str]) -> None:
 
 
 def _bitmap(client: QMPClient) -> QMPDirtyBitmap:
-    return next(
-        bitmap for bitmap in client.query_dirty_bitmaps("rootdisk0") if bitmap.name == _BITMAP_NAME
+    bitmap = next(
+        (value for value in client.query_dirty_bitmaps("rootdisk0") if value.name == _BITMAP_NAME),
+        None,
     )
+    if bitmap is None:
+        pytest.fail(f"QEMU did not report dirty bitmap '{_BITMAP_NAME}'")
+    return bitmap
 
 
 def _create_target(qemu_img: str, root: Path, name: str) -> Path:
@@ -112,47 +117,10 @@ def _assert_pattern(qemu_io: str, disk: Path, pattern: str, offset: int, length:
     _run(qemu_io, "-f", "qcow2", "-c", f"read -P {pattern} {offset} {length}", str(disk))
 
 
-def _materialize(
-    qemu_img: str,
-    root: Path,
-    name: str,
-    artifacts: list[Path],
-) -> Path:
-    staging = root / f"materialize-{name}"
-    staging.mkdir()
-    local_artifacts: list[Path] = []
-    for depth, artifact in enumerate(artifacts):
-        local = staging / f"depth-{depth}.qcow2"
-        shutil.copy2(artifact, local)
-        local_artifacts.append(local)
-        if depth > 0:
-            _run(
-                qemu_img,
-                "rebase",
-                "-u",
-                "-f",
-                "qcow2",
-                "-F",
-                "qcow2",
-                "-b",
-                str(local_artifacts[depth - 1]),
-                str(local),
-            )
-
-    _run(qemu_img, "check", str(local_artifacts[-1]))
-    output = root / f"materialized-{name}.qcow2"
-    _run(qemu_img, "convert", "-f", "qcow2", "-O", "qcow2", str(local_artifacts[-1]), str(output))
-    info = json.loads(_run(qemu_img, "info", "--output=json", str(output)).stdout)
-    assert info["format"] == "qcow2"
-    assert info["virtual-size"] == _VIRTUAL_SIZE
-    assert not info.get("backing-filename")
-    _run(qemu_img, "check", str(output))
-    return output
-
-
 def test_incremental_chain_materializes_and_cancelled_backup_retains_dirty_bytes(
     tmp_path: Path,
     short_socket_dir: Path,
+    request: pytest.FixtureRequest,
 ) -> None:
     """Prove base/A/B materialization, persistence, and cancellation safety."""
     qemu_img = shutil.which("qemu-img")
@@ -206,6 +174,7 @@ def test_incremental_chain_materializes_and_cancelled_backup_retains_dirty_bytes
             assert not base_bitmap.busy
             assert not base_bitmap.inconsistent
             assert base_bitmap.dirty_bytes == 0
+            assert base_bitmap.granularity == 64 * 1024
 
             _write_pattern(qemu_io, nbd_socket, "0x41", 1024 * 1024, 65536)
             assert _bitmap(client).dirty_bytes == 65536
@@ -342,4 +311,6 @@ def test_incremental_chain_materializes_and_cancelled_backup_retains_dirty_bytes
             for name, path in artifacts.items()
         },
     }
-    print(json.dumps(evidence, sort_keys=True))
+    serialized_evidence = json.dumps(evidence, sort_keys=True)
+    request.node.user_properties.append(("qemu_incremental_evidence", serialized_evidence))
+    print(serialized_evidence)

--- a/tests/test_qmp.py
+++ b/tests/test_qmp.py
@@ -32,7 +32,7 @@ from smolvm_core import qmp as core_qmp
 
 import smolvm.qmp as qmp_module
 from smolvm.exceptions import SmolVMError
-from smolvm.qmp import QMPClient
+from smolvm.qmp import QMPClient, QMPDirtyBitmap
 from smolvm.runtime.qemu import _live_backup_identifiers
 
 
@@ -273,6 +273,7 @@ def test_qmp_live_block_backup_commands_round_trip(qmp_socket_path: Path) -> Non
         "blockdev-backup": [{"return": {}}],
         "query-block-jobs": [{"return": [{"device": "job-live", "offset": 5, "len": 10}]}],
         "job-cancel": [{"return": {}}],
+        "block-job-cancel": [{"return": {}}],
         "query-named-block-nodes": [{"return": [{"node-name": "target-live"}]}],
         "blockdev-del": [{"return": {}}],
     }
@@ -290,6 +291,7 @@ def test_qmp_live_block_backup_commands_round_trip(qmp_socket_path: Path) -> Non
             max_bytes_per_second=1024,
         )
         assert client.query_block_jobs()[0]["offset"] == 5
+        client.cancel_job("job-live")
         client.cancel_job("job-live", force=True)
         assert client.query_named_block_nodes()[0]["node-name"] == "target-live"
         client.blockdev_del("target-live")
@@ -309,7 +311,116 @@ def test_qmp_live_block_backup_commands_round_trip(qmp_socket_path: Path) -> Non
         "speed": 1024,
     }
     cancel = next(request for request in requests if request["execute"] == "job-cancel")
-    assert cancel["arguments"] == {"id": "job-live", "force": True}
+    assert cancel["arguments"] == {"id": "job-live"}
+    forced_cancel = next(
+        request for request in requests if request["execute"] == "block-job-cancel"
+    )
+    assert forced_cancel["arguments"] == {"device": "job-live", "force": True}
+
+
+def test_qmp_dirty_bitmap_and_incremental_backup_commands_round_trip(
+    qmp_socket_path: Path,
+) -> None:
+    """Dirty bitmap helpers should parse status and emit exact QMP payloads."""
+    requests: list[dict[str, object]] = []
+    responses: dict[str, list[dict[str, object] | list[dict[str, object]]]] = {
+        "qmp_capabilities": [{"return": {}}],
+        "query-named-block-nodes": [
+            {
+                "return": [
+                    {
+                        "node-name": "rootdisk0",
+                        "dirty-bitmaps": [
+                            {
+                                "name": "celesto-chain0",
+                                "count": 131072,
+                                "granularity": 65536,
+                                "recording": True,
+                                "busy": False,
+                                "persistent": True,
+                            }
+                        ],
+                    }
+                ]
+            }
+        ],
+        "transaction": [{"return": {}}],
+        "blockdev-backup": [{"return": {}}],
+        "block-dirty-bitmap-remove": [{"return": {}}],
+    }
+    thread = _start_qmp_server(qmp_socket_path, responses, requests)
+
+    with QMPClient(qmp_socket_path) as client:
+        client.connect()
+        assert client.query_dirty_bitmaps("rootdisk0") == [
+            QMPDirtyBitmap(
+                name="celesto-chain0",
+                recording=True,
+                busy=False,
+                persistent=True,
+                inconsistent=False,
+                granularity=65536,
+                dirty_bytes=131072,
+            )
+        ]
+        client.start_full_backup_with_dirty_bitmap(
+            job_id="job-base",
+            source_node="rootdisk0",
+            target_node="target-base",
+            bitmap_name="celesto-chain0",
+            max_bytes_per_second=1024,
+        )
+        client.blockdev_backup_incremental(
+            job_id="job-increment",
+            source_node="rootdisk0",
+            target_node="target-increment",
+            bitmap_name="celesto-chain0",
+            max_bytes_per_second=2048,
+        )
+        client.remove_dirty_bitmap("rootdisk0", "celesto-chain0")
+
+    thread.join(timeout=2.0)
+
+    transaction = next(request for request in requests if request["execute"] == "transaction")
+    assert transaction["arguments"] == {
+        "actions": [
+            {
+                "type": "block-dirty-bitmap-add",
+                "data": {
+                    "node": "rootdisk0",
+                    "name": "celesto-chain0",
+                    "persistent": True,
+                },
+            },
+            {
+                "type": "blockdev-backup",
+                "data": {
+                    "job-id": "job-base",
+                    "device": "rootdisk0",
+                    "target": "target-base",
+                    "sync": "full",
+                    "auto-finalize": True,
+                    "auto-dismiss": False,
+                    "speed": 1024,
+                },
+            },
+        ]
+    }
+    incremental = next(request for request in requests if request["execute"] == "blockdev-backup")
+    assert incremental["arguments"] == {
+        "job-id": "job-increment",
+        "device": "rootdisk0",
+        "target": "target-increment",
+        "sync": "incremental",
+        "bitmap": "celesto-chain0",
+        "auto-finalize": True,
+        "auto-dismiss": False,
+        "speed": 2048,
+    }
+    remove = next(
+        request for request in requests if request["execute"] == "block-dirty-bitmap-remove"
+    )
+    assert remove["arguments"] == {"node": "rootdisk0", "name": "celesto-chain0"}
 
 
 def test_qmp_command_error_includes_qemu_description(qmp_socket_path: Path) -> None:

--- a/tests/test_qmp.py
+++ b/tests/test_qmp.py
@@ -32,7 +32,7 @@ from smolvm_core import qmp as core_qmp
 
 import smolvm.qmp as qmp_module
 from smolvm.exceptions import SmolVMError
-from smolvm.qmp import QMPClient, QMPDirtyBitmap
+from smolvm.qmp import QMPClient, QMPDirtyBitmap, QMPJobFailedError
 from smolvm.runtime.qemu import _live_backup_identifiers
 
 
@@ -195,7 +195,7 @@ def test_qmp_wait_for_job_raises_on_job_error(qmp_socket_path: Path) -> None:
     with QMPClient(socket_path) as client:
         client.connect()
         client.snapshot_delete("job1", "snap0", ["disk0"])
-        with pytest.raises(SmolVMError, match="QMP job failed"):
+        with pytest.raises(QMPJobFailedError, match="QMP job failed"):
             client.wait_for_job("job1", poll_interval=0.01)
 
     thread.join(timeout=2.0)
@@ -421,6 +421,48 @@ def test_qmp_dirty_bitmap_and_incremental_backup_commands_round_trip(
         request for request in requests if request["execute"] == "block-dirty-bitmap-remove"
     )
     assert remove["arguments"] == {"node": "rootdisk0", "name": "celesto-chain0"}
+
+
+@pytest.mark.parametrize(
+    "invalid_field,invalid_value",
+    [
+        ("recording", 1),
+        ("busy", "false"),
+        ("persistent", 1),
+        ("inconsistent", "false"),
+        ("count", -1),
+    ],
+)
+def test_qmp_dirty_bitmap_rejects_malformed_status(
+    qmp_socket_path: Path,
+    invalid_field: str,
+    invalid_value: object,
+) -> None:
+    """Bitmap status flags must be booleans and dirty counts non-negative."""
+    row: dict[str, object] = {
+        "name": "celesto-chain0",
+        "count": 131072,
+        "granularity": 65536,
+        "recording": True,
+        "busy": False,
+        "persistent": True,
+    }
+    row[invalid_field] = invalid_value
+    requests: list[dict[str, object]] = []
+    responses: dict[str, list[dict[str, object] | list[dict[str, object]]]] = {
+        "qmp_capabilities": [{"return": {}}],
+        "query-named-block-nodes": [
+            {"return": [{"node-name": "rootdisk0", "dirty-bitmaps": [row]}]}
+        ],
+    }
+    thread = _start_qmp_server(qmp_socket_path, responses, requests)
+
+    with QMPClient(qmp_socket_path) as client:
+        client.connect()
+        with pytest.raises(SmolVMError, match="invalid dirty bitmap status"):
+            client.query_dirty_bitmaps("rootdisk0")
+
+    thread.join(timeout=2.0)
 
 
 def test_qmp_command_error_includes_qemu_description(qmp_socket_path: Path) -> None:

--- a/tests/test_snapshot_qemu.py
+++ b/tests/test_snapshot_qemu.py
@@ -26,6 +26,8 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 from smolvm.exceptions import OperationTimeoutError, SmolVMError, VMNotFoundError
+from smolvm.qmp import QMPDirtyBitmap
+from smolvm.runtime.base import QemuDirtyBitmapBackup
 from smolvm.runtime.qemu import (
     _QEMU_BLOCK_NODE_NAME_MAX,
     QemuRuntimeAdapter,
@@ -932,10 +934,14 @@ def _live_backup_commands() -> set[str]:
         "blockdev-add",
         "blockdev-backup",
         "blockdev-del",
+        "block-dirty-bitmap-add",
+        "block-dirty-bitmap-remove",
+        "block-job-cancel",
         "job-cancel",
         "job-dismiss",
         "query-jobs",
         "query-named-block-nodes",
+        "transaction",
     }
 
 
@@ -954,6 +960,31 @@ def test_live_backup_identifiers_fit_qemu_block_node_limit() -> None:
     assert target_node == "svmbn-0123456789abcdef"
     assert len(job_id) <= _QEMU_BLOCK_NODE_NAME_MAX
     assert len(target_node) <= _QEMU_BLOCK_NODE_NAME_MAX
+
+
+def test_qemu_dirty_bitmap_backup_rejects_empty_name() -> None:
+    with pytest.raises(ValueError, match="bitmap_name"):
+        QemuDirtyBitmapBackup(mode="new-base", bitmap_name="")
+
+
+def test_qemu_dirty_bitmap_backup_requires_live_only_capture(
+    qemu_smol_vm: SmolVMManager,
+    qemu_config: VMConfig,
+    tmp_path: Path,
+) -> None:
+    _running_qemu_vm(qemu_smol_vm, qemu_config, tmp_path)
+
+    with pytest.raises(SmolVMError, match="live-only"):
+        qemu_smol_vm.create_snapshot(
+            "vm001",
+            snapshot_id="snap-bitmap-pausing",
+            snapshot_type=SnapshotType.DISK,
+            resume_source=True,
+            qemu_dirty_bitmap_backup=QemuDirtyBitmapBackup(
+                mode="new-base",
+                bitmap_name="celesto-chain0",
+            ),
+        )
 
 
 def test_qemu_live_disk_snapshot_never_pauses_and_publishes_atomically(
@@ -1003,6 +1034,176 @@ def test_qemu_live_disk_snapshot_never_pauses_and_publishes_atomically(
     assert snapshot.artifacts.disk_path.exists()
     assert not (snapshot.artifacts.disk_path.parent / "disk.qcow2.partial").exists()
     assert qemu_smol_vm.get("vm001").status == VMState.RUNNING
+
+
+def test_qemu_dirty_bitmap_new_base_returns_capture_metadata(
+    qemu_smol_vm: SmolVMManager,
+    qemu_config: VMConfig,
+    tmp_path: Path,
+) -> None:
+    """A new base should atomically create its bitmap and return its metadata."""
+    _running_qemu_vm(qemu_smol_vm, qemu_config, tmp_path)
+    created_bitmap = QMPDirtyBitmap(
+        name="celesto-chain0",
+        recording=True,
+        busy=False,
+        persistent=True,
+        inconsistent=False,
+        granularity=65536,
+        dirty_bytes=0,
+    )
+
+    with (
+        patch("smolvm.runtime.qemu.QMPClient") as mock_client_cls,
+        patch.object(
+            QemuRuntimeAdapter,
+            "_qemu_img_virtual_size",
+            return_value=(Path("/usr/bin/qemu-img"), 10 * 1024 * 1024),
+        ),
+        patch.object(QemuRuntimeAdapter, "_require_live_backup_space"),
+        patch.object(QemuRuntimeAdapter, "_validate_live_backup_artifact"),
+        patch("smolvm.runtime.qemu.subprocess.run", side_effect=_fake_qemu_img_create),
+    ):
+        client = _mock_qmp_client()
+        client.query_commands.return_value = _live_backup_commands()
+        client.query_dirty_bitmaps.side_effect = [[], [created_bitmap]]
+        client.query_jobs.return_value = []
+        client.query_named_block_nodes.return_value = []
+        mock_client_cls.return_value = client
+
+        snapshot = qemu_smol_vm.create_snapshot(
+            "vm001",
+            snapshot_id="snap-bitmap-base",
+            snapshot_type=SnapshotType.DISK,
+            resume_source=True,
+            capture_policy=SnapshotCapturePolicy.LIVE_ONLY,
+            qemu_dirty_bitmap_backup=QemuDirtyBitmapBackup(
+                mode="new-base",
+                bitmap_name="celesto-chain0",
+            ),
+        )
+
+    client.start_full_backup_with_dirty_bitmap.assert_called_once()
+    client.blockdev_backup.assert_not_called()
+    assert snapshot.artifacts.disk_path.name == "disk.qcow2"
+    assert snapshot.artifact_kind == "full"
+    assert snapshot.virtual_size_bytes == 10 * 1024 * 1024
+    assert snapshot.changed_bytes is None
+    assert snapshot.bitmap_granularity_bytes == 65536
+    assert snapshot.bitmap_name == "celesto-chain0"
+
+
+def test_qemu_dirty_bitmap_increment_returns_sparse_capture_metadata(
+    qemu_smol_vm: SmolVMManager,
+    qemu_config: VMConfig,
+    tmp_path: Path,
+) -> None:
+    """An increment should require a usable bitmap and return dirty-byte metadata."""
+    _running_qemu_vm(qemu_smol_vm, qemu_config, tmp_path)
+    bitmap = QMPDirtyBitmap(
+        name="celesto-chain0",
+        recording=True,
+        busy=False,
+        persistent=True,
+        inconsistent=False,
+        granularity=65536,
+        dirty_bytes=131072,
+    )
+
+    with (
+        patch("smolvm.runtime.qemu.QMPClient") as mock_client_cls,
+        patch.object(
+            QemuRuntimeAdapter,
+            "_qemu_img_virtual_size",
+            return_value=(Path("/usr/bin/qemu-img"), 10 * 1024 * 1024),
+        ),
+        patch.object(QemuRuntimeAdapter, "_require_live_backup_space"),
+        patch.object(QemuRuntimeAdapter, "_validate_live_backup_artifact"),
+        patch("smolvm.runtime.qemu.subprocess.run", side_effect=_fake_qemu_img_create),
+    ):
+        client = _mock_qmp_client()
+        client.query_commands.return_value = _live_backup_commands()
+        client.query_dirty_bitmaps.return_value = [bitmap]
+        client.query_jobs.return_value = []
+        client.query_named_block_nodes.return_value = []
+        mock_client_cls.return_value = client
+
+        snapshot = qemu_smol_vm.create_snapshot(
+            "vm001",
+            snapshot_id="snap-bitmap-increment",
+            snapshot_type=SnapshotType.DISK,
+            resume_source=True,
+            capture_policy=SnapshotCapturePolicy.LIVE_ONLY,
+            qemu_dirty_bitmap_backup=QemuDirtyBitmapBackup(
+                mode="incremental",
+                bitmap_name="celesto-chain0",
+            ),
+        )
+
+    client.blockdev_backup_incremental.assert_called_once()
+    client.blockdev_backup.assert_not_called()
+    assert snapshot.artifacts.disk_path.name == "increment.qcow2"
+    assert snapshot.artifact_kind == "incremental"
+    assert snapshot.virtual_size_bytes == 10 * 1024 * 1024
+    assert snapshot.changed_bytes == 131072
+    assert snapshot.bitmap_granularity_bytes == 65536
+    assert snapshot.bitmap_name == "celesto-chain0"
+
+
+def test_qemu_dirty_bitmap_increment_failure_keeps_bitmap(
+    qemu_smol_vm: SmolVMManager,
+    qemu_config: VMConfig,
+    tmp_path: Path,
+) -> None:
+    """A failed increment must not remove or clear its dirty bitmap."""
+    _running_qemu_vm(qemu_smol_vm, qemu_config, tmp_path)
+    bitmap = QMPDirtyBitmap(
+        name="celesto-chain0",
+        recording=True,
+        busy=False,
+        persistent=True,
+        inconsistent=False,
+        granularity=65536,
+        dirty_bytes=131072,
+    )
+
+    with (
+        patch("smolvm.runtime.qemu.QMPClient") as mock_client_cls,
+        patch.object(
+            QemuRuntimeAdapter,
+            "_qemu_img_virtual_size",
+            return_value=(Path("/usr/bin/qemu-img"), 10 * 1024 * 1024),
+        ),
+        patch.object(QemuRuntimeAdapter, "_require_live_backup_space"),
+        patch("smolvm.runtime.qemu.subprocess.run", side_effect=_fake_qemu_img_create),
+    ):
+        client = _mock_qmp_client()
+        client.query_commands.return_value = _live_backup_commands()
+        client.query_dirty_bitmaps.return_value = [bitmap]
+        client.query_jobs.return_value = []
+        client.query_named_block_nodes.side_effect = lambda: (
+            [{"node-name": client.blockdev_add.call_args.args[0]}]
+            if client.blockdev_add.called
+            else []
+        )
+        client.wait_for_job.side_effect = SmolVMError("QMP job failed")
+        mock_client_cls.return_value = client
+
+        with pytest.raises(SmolVMError, match="could not complete"):
+            qemu_smol_vm.create_snapshot(
+                "vm001",
+                snapshot_id="snap-bitmap-failed",
+                snapshot_type=SnapshotType.DISK,
+                resume_source=True,
+                capture_policy=SnapshotCapturePolicy.LIVE_ONLY,
+                qemu_dirty_bitmap_backup=QemuDirtyBitmapBackup(
+                    mode="incremental",
+                    bitmap_name="celesto-chain0",
+                ),
+            )
+
+    client.remove_dirty_bitmap.assert_not_called()
+    assert not (qemu_smol_vm.snapshot_dir / "snap-bitmap-failed").exists()
 
 
 def test_qemu_live_disk_snapshot_timeout_cancels_without_resuming(
@@ -1166,6 +1367,179 @@ def test_qemu_live_only_rejects_conflicting_final_state_before_qmp(
         )
 
     assert not (qemu_smol_vm.snapshot_dir / "snap-conflict").exists()
+
+
+def test_qemu_bitmap_reconciliation_preserves_completed_unpublished_capture(
+    qemu_smol_vm: SmolVMManager,
+    qemu_config: VMConfig,
+    tmp_path: Path,
+) -> None:
+    """A successful bitmap capture must survive a process interruption."""
+    _running_qemu_vm(qemu_smol_vm, qemu_config, tmp_path)
+    job_id, target_node = _live_backup_identifiers("1111111111111111")
+    snapshot_root = qemu_smol_vm.snapshot_dir / "snap-pending-increment"
+    snapshot_root.mkdir()
+    final_path = snapshot_root / "increment.qcow2"
+    final_path.write_text("captured-delta")
+    manifest_path = snapshot_root / "live-backup.json"
+    manifest_path.write_text(
+        json.dumps(
+            {
+                "schema_version": 2,
+                "vm_id": "vm001",
+                "snapshot_id": "snap-pending-increment",
+                "job_id": job_id,
+                "target_node": target_node,
+                "partial_path": str(snapshot_root / "increment.qcow2.partial"),
+                "final_path": str(final_path),
+                "phase": "artifact-published",
+                "backup_mode": "incremental",
+                "bitmap_name": "celesto-chain0",
+                "virtual_size_bytes": 10 * 1024 * 1024,
+            }
+        )
+    )
+
+    with patch("smolvm.runtime.qemu.QMPClient") as mock_client_cls:
+        client = _mock_qmp_client()
+        client.query_jobs.return_value = []
+        client.query_named_block_nodes.return_value = []
+        mock_client_cls.return_value = client
+
+        with pytest.raises(SmolVMError) as exc_info:
+            qemu_smol_vm.create_snapshot(
+                "vm001",
+                snapshot_id="snap-next",
+                snapshot_type=SnapshotType.DISK,
+                resume_source=True,
+                capture_policy=SnapshotCapturePolicy.LIVE_ONLY,
+            )
+
+    assert exc_info.value.details["capture_recovery_pending"] is True
+    assert exc_info.value.details["artifact_path"] == str(final_path)
+    assert final_path.read_text() == "captured-delta"
+    assert manifest_path.exists()
+    client.blockdev_backup.assert_not_called()
+
+
+def test_qemu_bitmap_reconciliation_recovers_concluded_job_before_phase_write(
+    qemu_smol_vm: SmolVMManager,
+    qemu_config: VMConfig,
+    tmp_path: Path,
+) -> None:
+    """A crash after QMP submission must not discard a successful increment."""
+    _running_qemu_vm(qemu_smol_vm, qemu_config, tmp_path)
+    job_id, target_node = _live_backup_identifiers("3333333333333333")
+    snapshot_root = qemu_smol_vm.snapshot_dir / "snap-concluded-increment"
+    snapshot_root.mkdir()
+    partial_path = snapshot_root / "increment.qcow2.partial"
+    partial_path.write_text("completed-delta")
+    final_path = snapshot_root / "increment.qcow2"
+    manifest_path = snapshot_root / "live-backup.json"
+    manifest_path.write_text(
+        json.dumps(
+            {
+                "schema_version": 2,
+                "vm_id": "vm001",
+                "snapshot_id": "snap-concluded-increment",
+                "job_id": job_id,
+                "target_node": target_node,
+                "partial_path": str(partial_path),
+                "final_path": str(final_path),
+                "phase": "node-attached",
+                "backup_mode": "incremental",
+                "bitmap_name": "celesto-chain0",
+                "artifact_kind": "incremental",
+                "virtual_size_bytes": 10 * 1024 * 1024,
+                "changed_bytes": 131072,
+                "bitmap_granularity_bytes": 65536,
+            }
+        )
+    )
+
+    def qemu_img_result(command: list[str], **_kwargs: object) -> SimpleNamespace:
+        stdout = '{"backing-filename": null}' if "info" in command else ""
+        return SimpleNamespace(returncode=0, stdout=stdout, stderr="")
+
+    with (
+        patch("smolvm.runtime.qemu.QMPClient") as mock_client_cls,
+        patch("smolvm.runtime.qemu.which", return_value="/usr/bin/qemu-img"),
+        patch("smolvm.runtime.qemu.subprocess.run", side_effect=qemu_img_result),
+    ):
+        client = _mock_qmp_client()
+        client.query_jobs.return_value = [
+            SimpleNamespace(job_id=job_id, status="concluded", error=None)
+        ]
+        client.query_named_block_nodes.return_value = [{"node-name": target_node}]
+        mock_client_cls.return_value = client
+
+        with pytest.raises(SmolVMError) as exc_info:
+            qemu_smol_vm.create_snapshot(
+                "vm001",
+                snapshot_id="snap-next",
+                snapshot_type=SnapshotType.DISK,
+                resume_source=True,
+                capture_policy=SnapshotCapturePolicy.LIVE_ONLY,
+            )
+
+    assert exc_info.value.details["capture_recovery_pending"] is True
+    assert final_path.read_text() == "completed-delta"
+    assert not partial_path.exists()
+    assert json.loads(manifest_path.read_text())["phase"] == "artifact-published"
+    client.dismiss_job.assert_called_once_with(job_id)
+    client.blockdev_del.assert_called_once_with(target_node)
+
+
+def test_qemu_bitmap_reconciliation_rejects_ambiguous_missing_job(
+    qemu_smol_vm: SmolVMManager,
+    qemu_config: VMConfig,
+    tmp_path: Path,
+) -> None:
+    """A missing job at the capture boundary must force a new base instead of guessing."""
+    _running_qemu_vm(qemu_smol_vm, qemu_config, tmp_path)
+    job_id, target_node = _live_backup_identifiers("2222222222222222")
+    snapshot_root = qemu_smol_vm.snapshot_dir / "snap-ambiguous-increment"
+    snapshot_root.mkdir()
+    partial_path = snapshot_root / "increment.qcow2.partial"
+    partial_path.write_text("unknown-delta")
+    manifest_path = snapshot_root / "live-backup.json"
+    manifest_path.write_text(
+        json.dumps(
+            {
+                "schema_version": 2,
+                "vm_id": "vm001",
+                "snapshot_id": "snap-ambiguous-increment",
+                "job_id": job_id,
+                "target_node": target_node,
+                "partial_path": str(partial_path),
+                "final_path": str(snapshot_root / "increment.qcow2"),
+                "phase": "job-running",
+                "backup_mode": "incremental",
+                "bitmap_name": "celesto-chain0",
+                "virtual_size_bytes": 10 * 1024 * 1024,
+            }
+        )
+    )
+
+    with patch("smolvm.runtime.qemu.QMPClient") as mock_client_cls:
+        client = _mock_qmp_client()
+        client.query_jobs.return_value = []
+        client.query_named_block_nodes.return_value = []
+        mock_client_cls.return_value = client
+
+        with pytest.raises(SmolVMError) as exc_info:
+            qemu_smol_vm.create_snapshot(
+                "vm001",
+                snapshot_id="snap-next",
+                snapshot_type=SnapshotType.DISK,
+                resume_source=True,
+                capture_policy=SnapshotCapturePolicy.LIVE_ONLY,
+            )
+
+    assert exc_info.value.details["bitmap_state_ambiguous"] is True
+    assert partial_path.read_text() == "unknown-delta"
+    assert manifest_path.exists()
+    client.blockdev_backup.assert_not_called()
 
 
 def test_qemu_live_snapshot_reconciles_interrupted_backup(

--- a/tests/test_snapshot_qemu.py
+++ b/tests/test_snapshot_qemu.py
@@ -26,7 +26,7 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 from smolvm.exceptions import OperationTimeoutError, SmolVMError, VMNotFoundError
-from smolvm.qmp import QMPDirtyBitmap
+from smolvm.qmp import QMPDirtyBitmap, QMPJobFailedError, QMPJobTimeoutError
 from smolvm.runtime.base import QemuDirtyBitmapBackup
 from smolvm.runtime.qemu import (
     _QEMU_BLOCK_NODE_NAME_MAX,
@@ -974,7 +974,7 @@ def test_qemu_dirty_bitmap_backup_requires_live_only_capture(
 ) -> None:
     _running_qemu_vm(qemu_smol_vm, qemu_config, tmp_path)
 
-    with pytest.raises(SmolVMError, match="live-only"):
+    with pytest.raises(SmolVMError, match="live-only") as exc_info:
         qemu_smol_vm.create_snapshot(
             "vm001",
             snapshot_id="snap-bitmap-pausing",
@@ -985,6 +985,11 @@ def test_qemu_dirty_bitmap_backup_requires_live_only_capture(
                 bitmap_name="celesto-chain0",
             ),
         )
+
+    assert exc_info.value.details["recovery_command"] == (
+        "smolvm sandbox snapshot create vm001 --snapshot-id snap-bitmap-pausing "
+        "--snapshot-type disk --resume-source --live-only"
+    )
 
 
 def test_qemu_live_disk_snapshot_never_pauses_and_publishes_atomically(
@@ -1117,7 +1122,7 @@ def test_qemu_dirty_bitmap_increment_returns_sparse_capture_metadata(
             "_qemu_img_virtual_size",
             return_value=(Path("/usr/bin/qemu-img"), 10 * 1024 * 1024),
         ),
-        patch.object(QemuRuntimeAdapter, "_require_live_backup_space"),
+        patch.object(QemuRuntimeAdapter, "_require_live_backup_space") as require_live_backup_space,
         patch.object(QemuRuntimeAdapter, "_validate_live_backup_artifact"),
         patch("smolvm.runtime.qemu.subprocess.run", side_effect=_fake_qemu_img_create),
     ):
@@ -1142,6 +1147,7 @@ def test_qemu_dirty_bitmap_increment_returns_sparse_capture_metadata(
 
     client.blockdev_backup_incremental.assert_called_once()
     client.blockdev_backup.assert_not_called()
+    assert require_live_backup_space.call_args.kwargs["required_bytes"] == 131072
     assert snapshot.artifacts.disk_path.name == "increment.qcow2"
     assert snapshot.artifact_kind == "incremental"
     assert snapshot.virtual_size_bytes == 10 * 1024 * 1024
@@ -1186,7 +1192,9 @@ def test_qemu_dirty_bitmap_increment_failure_keeps_bitmap(
             if client.blockdev_add.called
             else []
         )
-        client.wait_for_job.side_effect = SmolVMError("QMP job failed")
+        client.wait_for_job.side_effect = QMPJobFailedError(
+            "QMP job failed", {"job_id": "job-increment", "error": "cancelled"}
+        )
         mock_client_cls.return_value = client
 
         with pytest.raises(SmolVMError, match="could not complete"):
@@ -1204,6 +1212,55 @@ def test_qemu_dirty_bitmap_increment_failure_keeps_bitmap(
 
     client.remove_dirty_bitmap.assert_not_called()
     assert not (qemu_smol_vm.snapshot_dir / "snap-bitmap-failed").exists()
+
+
+def test_qemu_dirty_bitmap_new_base_failure_removes_new_bitmap(
+    qemu_smol_vm: SmolVMManager,
+    qemu_config: VMConfig,
+    tmp_path: Path,
+) -> None:
+    """A failed new base should remove the bitmap created by its transaction."""
+    _running_qemu_vm(qemu_smol_vm, qemu_config, tmp_path)
+
+    with (
+        patch("smolvm.runtime.qemu.QMPClient") as mock_client_cls,
+        patch.object(
+            QemuRuntimeAdapter,
+            "_qemu_img_virtual_size",
+            return_value=(Path("/usr/bin/qemu-img"), 10 * 1024 * 1024),
+        ),
+        patch.object(QemuRuntimeAdapter, "_require_live_backup_space"),
+        patch("smolvm.runtime.qemu.subprocess.run", side_effect=_fake_qemu_img_create),
+    ):
+        client = _mock_qmp_client()
+        client.query_commands.return_value = _live_backup_commands()
+        client.query_dirty_bitmaps.return_value = []
+        client.query_jobs.return_value = []
+        client.query_named_block_nodes.side_effect = lambda: (
+            [{"node-name": client.blockdev_add.call_args.args[0]}]
+            if client.blockdev_add.called
+            else []
+        )
+        client.wait_for_job.side_effect = QMPJobFailedError(
+            "QMP job failed", {"job_id": "job-base", "error": "write failed"}
+        )
+        mock_client_cls.return_value = client
+
+        with pytest.raises(SmolVMError, match="could not complete"):
+            qemu_smol_vm.create_snapshot(
+                "vm001",
+                snapshot_id="snap-bitmap-base-failed",
+                snapshot_type=SnapshotType.DISK,
+                resume_source=True,
+                capture_policy=SnapshotCapturePolicy.LIVE_ONLY,
+                qemu_dirty_bitmap_backup=QemuDirtyBitmapBackup(
+                    mode="new-base",
+                    bitmap_name="celesto-chain0",
+                ),
+            )
+
+    client.remove_dirty_bitmap.assert_called_once_with("rootdisk0", "celesto-chain0")
+    assert not (qemu_smol_vm.snapshot_dir / "snap-bitmap-base-failed").exists()
 
 
 def test_qemu_live_disk_snapshot_timeout_cancels_without_resuming(
@@ -1240,7 +1297,10 @@ def test_qemu_live_disk_snapshot_timeout_cancels_without_resuming(
         client.query_jobs.side_effect = jobs
         client.query_named_block_nodes.side_effect = nodes
         client.wait_for_job.side_effect = [
-            SmolVMError("Timed out waiting for QMP job"),
+            QMPJobTimeoutError(
+                "Timed out waiting for QMP job",
+                {"job_id": "job-timeout", "last_status": "running"},
+            ),
             MagicMock(),
         ]
         mock_client_cls.return_value = client
@@ -1417,9 +1477,40 @@ def test_qemu_bitmap_reconciliation_preserves_completed_unpublished_capture(
 
     assert exc_info.value.details["capture_recovery_pending"] is True
     assert exc_info.value.details["artifact_path"] == str(final_path)
+    assert exc_info.value.details["recovery_command"] == (
+        "smolvm sandbox snapshot delete snap-pending-increment"
+    )
+    assert "vm001" in str(exc_info.value)
     assert final_path.read_text() == "captured-delta"
     assert manifest_path.exists()
     client.blockdev_backup.assert_not_called()
+
+
+def test_delete_snapshot_clears_adopted_bitmap_recovery_artifact(
+    qemu_smol_vm: SmolVMManager,
+) -> None:
+    """The documented delete command should clear an adopted recovery record."""
+    snapshot_id = "snap-adopted-increment"
+    snapshot_root = qemu_smol_vm.snapshot_dir / snapshot_id
+    snapshot_root.mkdir()
+    final_path = snapshot_root / "increment.qcow2"
+    final_path.write_text("adopted-delta")
+    (snapshot_root / "live-backup.json").write_text(
+        json.dumps(
+            {
+                "schema_version": 2,
+                "vm_id": "vm001",
+                "snapshot_id": snapshot_id,
+                "backup_mode": "incremental",
+                "phase": "artifact-published",
+                "final_path": str(final_path),
+            }
+        )
+    )
+
+    qemu_smol_vm.delete_snapshot(snapshot_id)
+
+    assert not snapshot_root.exists()
 
 
 def test_qemu_bitmap_reconciliation_recovers_concluded_job_before_phase_write(
@@ -1488,6 +1579,68 @@ def test_qemu_bitmap_reconciliation_recovers_concluded_job_before_phase_write(
     assert json.loads(manifest_path.read_text())["phase"] == "artifact-published"
     client.dismiss_job.assert_called_once_with(job_id)
     client.blockdev_del.assert_called_once_with(target_node)
+
+
+def test_qemu_bitmap_recovery_timeout_keeps_pending_artifact(
+    qemu_smol_vm: SmolVMManager,
+    qemu_config: VMConfig,
+    tmp_path: Path,
+) -> None:
+    """A slow qemu-img recovery check should remain pending and actionable."""
+    _running_qemu_vm(qemu_smol_vm, qemu_config, tmp_path)
+    job_id, target_node = _live_backup_identifiers("4444444444444444")
+    snapshot_root = qemu_smol_vm.snapshot_dir / "snap-slow-recovery"
+    snapshot_root.mkdir()
+    partial_path = snapshot_root / "increment.qcow2.partial"
+    partial_path.write_text("completed-delta")
+    manifest_path = snapshot_root / "live-backup.json"
+    manifest_path.write_text(
+        json.dumps(
+            {
+                "schema_version": 2,
+                "vm_id": "vm001",
+                "snapshot_id": "snap-slow-recovery",
+                "job_id": job_id,
+                "target_node": target_node,
+                "partial_path": str(partial_path),
+                "final_path": str(snapshot_root / "increment.qcow2"),
+                "phase": "job-concluded",
+                "backup_mode": "incremental",
+                "bitmap_name": "celesto-chain0",
+                "artifact_kind": "incremental",
+                "virtual_size_bytes": 10 * 1024 * 1024,
+            }
+        )
+    )
+
+    with (
+        patch("smolvm.runtime.qemu.QMPClient") as mock_client_cls,
+        patch("smolvm.runtime.qemu.which", return_value="/usr/bin/qemu-img"),
+        patch(
+            "smolvm.runtime.qemu.subprocess.run",
+            side_effect=subprocess.TimeoutExpired(["qemu-img", "check"], 1),
+        ),
+    ):
+        client = _mock_qmp_client()
+        client.query_jobs.return_value = []
+        client.query_named_block_nodes.return_value = []
+        mock_client_cls.return_value = client
+
+        with pytest.raises(SmolVMError) as exc_info:
+            qemu_smol_vm.create_snapshot(
+                "vm001",
+                snapshot_id="snap-retry-after-timeout",
+                snapshot_type=SnapshotType.DISK,
+                resume_source=True,
+                capture_policy=SnapshotCapturePolicy.LIVE_ONLY,
+                timeout_seconds=1,
+            )
+
+    assert exc_info.value.details["capture_recovery_pending"] is True
+    assert "vm001" in str(exc_info.value)
+    assert "smolvm sandbox snapshot create vm001" in exc_info.value.details["recovery_command"]
+    assert partial_path.read_text() == "completed-delta"
+    assert manifest_path.exists()
 
 
 def test_qemu_bitmap_reconciliation_rejects_ambiguous_missing_job(

--- a/tests/test_storage.py
+++ b/tests/test_storage.py
@@ -14,6 +14,7 @@
 
 """Tests for SmolVM storage module."""
 
+import sqlite3
 from datetime import datetime, timezone
 from pathlib import Path
 
@@ -471,6 +472,11 @@ class TestSnapshotStorage:
         assert fetched.vm_config.rootfs_path == sample_config.rootfs_path
         assert isinstance(fetched.vm_config.port_forwards[0], PortForwardConfig)
         assert fetched.network_config.tap_device == "tap2"
+        assert fetched.artifact_kind is None
+        assert fetched.virtual_size_bytes is None
+        assert fetched.changed_bytes is None
+        assert fetched.bitmap_granularity_bytes is None
+        assert fetched.bitmap_name is None
         assert [item.snapshot_id for item in listed] == ["snap-001"]
 
         restored = state_manager.mark_snapshot_restored("snap-001", "vm001")
@@ -543,6 +549,22 @@ class TestSnapshotStorage:
         assert fetched.changed_bytes == 131072
         assert fetched.bitmap_granularity_bytes == 65536
         assert fetched.bitmap_name == "celesto-chain0"
+
+        with sqlite3.connect(state_manager.db_path) as conn:
+            conn.execute(
+                """
+                UPDATE snapshots
+                SET virtual_size_bytes = ?, changed_bytes = ?,
+                    bitmap_granularity_bytes = ?, bitmap_name = ?
+                WHERE snapshot_id = ?
+                """,
+                ("invalid", -1, 0, sqlite3.Binary(b"not-text"), "snap-qemu"),
+            )
+        malformed = state_manager.get_snapshot("snap-qemu")
+        assert malformed.virtual_size_bytes is None
+        assert malformed.changed_bytes is None
+        assert malformed.bitmap_granularity_bytes is None
+        assert malformed.bitmap_name is None
 
 
 class TestReconciliation:

--- a/tests/test_storage.py
+++ b/tests/test_storage.py
@@ -514,7 +514,7 @@ class TestSnapshotStorage:
 
         snapshot_dir = tmp_path / "snapshots" / "snap-qemu"
         snapshot_dir.mkdir(parents=True)
-        disk_path = snapshot_dir / "disk.qcow2"
+        disk_path = snapshot_dir / "increment.qcow2"
         disk_path.write_bytes(b"")
         snapshot = SnapshotInfo(
             snapshot_id="snap-qemu",
@@ -524,6 +524,11 @@ class TestSnapshotStorage:
             vm_config=qemu_config,
             network_config=network,
             created_at=datetime.now(timezone.utc),
+            artifact_kind="incremental",
+            virtual_size_bytes=10 * 1024 * 1024,
+            changed_bytes=131072,
+            bitmap_granularity_bytes=65536,
+            bitmap_name="celesto-chain0",
         )
 
         state_manager.create_snapshot(snapshot)
@@ -533,6 +538,11 @@ class TestSnapshotStorage:
         assert fetched.artifacts.state_path is None
         assert fetched.artifacts.memory_path is None
         assert fetched.artifacts.disk_path == disk_path
+        assert fetched.artifact_kind == "incremental"
+        assert fetched.virtual_size_bytes == 10 * 1024 * 1024
+        assert fetched.changed_bytes == 131072
+        assert fetched.bitmap_granularity_bytes == 65536
+        assert fetched.bitmap_name == "celesto-chain0"
 
 
 class TestReconciliation:


### PR DESCRIPTION
## Summary

- add persistent QEMU dirty-bitmap discovery and backup commands to the QMP client
- expose explicit `new-base` and `incremental` live disk capture modes through the Python API
- persist artifact kind, virtual size, dirty bytes, bitmap granularity, and bitmap name with snapshot metadata
- preserve completed or ambiguous bitmap captures through live-backup journal reconciliation
- use `block-job-cancel` for forced block-job cancellation so cancelled increments retain dirty bytes
- add real-QEMU materialization, reboot-persistence, cancellation/retry, boot, and benchmark coverage

## Safety and artifact contract

A new base creates its persistent bitmap and starts the full backup in one QMP transaction. Incremental capture requires an existing healthy persistent bitmap. Failed or cancelled increments do not remove the bitmap, while completed or ambiguous captures are retained for explicit publication recovery rather than silently deleted.

Incremental snapshots are emitted as `increment.qcow2` and marked with `artifact_kind="incremental"`; callers must materialize the base and ordered increments into a standalone qcow2 before restore.

This PR adds the SmolVM capture primitive. It does not enable a scheduler, remote chain publication, retention policy, or restore materialization in a higher-level dataplane.

## Validation

- `uv run ruff check .`
- `uv run ruff format --check .`
- 158 focused snapshot/QMP/storage/facade tests passed
- `uv run pytest tests/test_qemu_incremental_spike.py -q` passed against real QEMU
- `uv run pytest -m e2e tests/e2e/test_qemu_incremental_snapshot.py -q` passed, including boot after deleting source VM state
- production-image validation passed on Ubuntu 24.04, QEMU 8.2.2, and KVM
- 12-interval benchmark: 857,145,344 bytes for base plus increments versus 6,188,171,264 bytes for repeated full captures (**86.15% reduction**)

A full local macOS run reached 1,841 passing tests. The remaining failures were existing platform/environment-sensitive Bash 3, vsock-device, and APFS sparse-file assertions; the one snapshot mock expectation affected by this API addition was updated and passed in the focused rerun.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added QEMU dirty-bitmap–driven live disk snapshots for both full base and incremental captures.
  * Snapshots now include additional artifact/bitmap metadata (e.g., sizes and bitmap details) and can be materialized into standalone bootable disks.
  * Added QEMU incremental benchmarking to compare incremental vs full backup size and timing.

* **Bug Fixes**
  * Improved recovery behavior for interrupted/cancelled incremental captures, including restart persistence.
  * Updated snapshot deletion to clear recovered-artifact records when the snapshot record is missing.

* **Documentation**
  * Added a deep-dive guide with compatibility notes, recovery scenarios, and benchmark findings.

* **Tests**
  * Added e2e boot-proof and real-QEMU integration coverage for incremental chains, recovery, and cancellation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->