### PR TITLE
Add QEMU dirty bitmap lifecycle API

### DIFF
--- a/src/smolvm/__init__.py
+++ b/src/smolvm/__init__.py
@@ -28,6 +28,7 @@ from smolvm.exceptions import (
     ImageError,
     NetworkError,
     OperationTimeoutError,
+    QemuDirtyBitmapStateError,
     SmolVMError,
     SnapshotAlreadyExistsError,
     SnapshotNotFoundError,
@@ -41,7 +42,7 @@ from smolvm.images.boot import BootImage, DirectKernelBoot, FirmwareBoot
 from smolvm.images.builder import SSH_BOOT_ARGS, DockerRootfsBuilder, ImageBuilder
 from smolvm.images.manager import ImageManager, ImageSource, LocalImage, S3ImageManifest, S3ImageRef
 from smolvm.kernels import ensure_base_kernel_for_backend
-from smolvm.runtime.base import QemuDirtyBitmapBackup
+from smolvm.runtime.base import QemuDirtyBitmapBackup, QemuDirtyBitmapStatus
 from smolvm.ssh import SSHClient
 from smolvm.types import (
     BrowserViewport,
@@ -102,6 +103,7 @@ __all__ = [
     "NetworkConfig",
     "QemuMachine",
     "QemuDirtyBitmapBackup",
+    "QemuDirtyBitmapStatus",
     "SnapshotArtifacts",
     "SnapshotCapturePolicy",
     "SnapshotInfo",
@@ -119,6 +121,7 @@ __all__ = [
     "CommandExecutionUnavailableError",
     "SnapshotAlreadyExistsError",
     "SnapshotNotFoundError",
+    "QemuDirtyBitmapStateError",
     "ValidationError",
     "VMAlreadyExistsError",
     "VMNotFoundError",

--- a/src/smolvm/exceptions.py
+++ b/src/smolvm/exceptions.py
@@ -87,13 +87,16 @@ class QemuDirtyBitmapStateError(SmolVMError):
         ],
         *,
         details: dict | None = None,
+        recovery_command: str | None = None,
     ) -> None:
         state_details = {
+            **(details or {}),
             "vm_id": vm_id,
             "bitmap_name": bitmap_name,
             "reason": reason,
-            **(details or {}),
         }
+        if recovery_command is not None:
+            state_details["recovery_command"] = recovery_command
         description = {
             "missing": "is missing",
             "exists": "already exists",
@@ -102,13 +105,14 @@ class QemuDirtyBitmapStateError(SmolVMError):
             "non-persistent": "is not persistent",
             "inconsistent": "is inconsistent",
         }[reason]
-        super().__init__(
-            f"The dirty bitmap for sandbox '{vm_id}' {description}",
-            state_details,
-        )
+        message = f"The dirty bitmap '{bitmap_name}' for sandbox '{vm_id}' {description}"
+        if recovery_command is not None:
+            message = f"{message}; recover with '{recovery_command}'."
+        super().__init__(message, state_details)
         self.vm_id = vm_id
         self.bitmap_name = bitmap_name
         self.reason = reason
+        self.recovery_command = recovery_command
 
 
 class BrowserSessionAlreadyExistsError(SmolVMError):

--- a/src/smolvm/exceptions.py
+++ b/src/smolvm/exceptions.py
@@ -14,6 +14,8 @@
 
 """Exception hierarchy for SmolVM SDK."""
 
+from typing import Literal
+
 
 class SmolVMError(Exception):
     """Base exception for all SmolVM errors."""
@@ -66,6 +68,47 @@ class SnapshotNotFoundError(SmolVMError):
             {"snapshot_id": snapshot_id},
         )
         self.snapshot_id = snapshot_id
+
+
+class QemuDirtyBitmapStateError(SmolVMError):
+    """Raised when a named QEMU dirty bitmap cannot serve its requested operation."""
+
+    def __init__(
+        self,
+        vm_id: str,
+        bitmap_name: str,
+        reason: Literal[
+            "missing",
+            "exists",
+            "busy",
+            "disabled",
+            "non-persistent",
+            "inconsistent",
+        ],
+        *,
+        details: dict | None = None,
+    ) -> None:
+        state_details = {
+            "vm_id": vm_id,
+            "bitmap_name": bitmap_name,
+            "reason": reason,
+            **(details or {}),
+        }
+        description = {
+            "missing": "is missing",
+            "exists": "already exists",
+            "busy": "is busy",
+            "disabled": "is disabled",
+            "non-persistent": "is not persistent",
+            "inconsistent": "is inconsistent",
+        }[reason]
+        super().__init__(
+            f"The dirty bitmap for sandbox '{vm_id}' {description}",
+            state_details,
+        )
+        self.vm_id = vm_id
+        self.bitmap_name = bitmap_name
+        self.reason = reason
 
 
 class BrowserSessionAlreadyExistsError(SmolVMError):

--- a/src/smolvm/facade.py
+++ b/src/smolvm/facade.py
@@ -86,7 +86,7 @@ from smolvm.runtime.backends import (
     resolve_backend_for_guest,
     resolve_backend_status,
 )
-from smolvm.runtime.base import QemuDirtyBitmapBackup
+from smolvm.runtime.base import QemuDirtyBitmapBackup, QemuDirtyBitmapStatus
 from smolvm.runtime.boot_profiles import (
     KernelBootProfile,
     get_boot_profile_spec,
@@ -1708,6 +1708,17 @@ class SmolVM:
         self._reset_runtime_state(close_ssh=False)
         logger.info("VM %s resumed", self._vm_id)
         return self
+
+    def get_qemu_dirty_bitmap(
+        self,
+        bitmap_name: str,
+    ) -> QemuDirtyBitmapStatus | None:
+        """Inspect one named persistent bitmap on this running QEMU disk."""
+        return self._sdk.get_qemu_dirty_bitmap(self._vm_id, bitmap_name)
+
+    def remove_qemu_dirty_bitmap(self, bitmap_name: str) -> bool:
+        """Remove one named persistent bitmap from this running QEMU disk."""
+        return self._sdk.remove_qemu_dirty_bitmap(self._vm_id, bitmap_name)
 
     def snapshot(
         self,

--- a/src/smolvm/runtime/base.py
+++ b/src/smolvm/runtime/base.py
@@ -63,6 +63,19 @@ class QemuDirtyBitmapBackup:
 
 
 @dataclass(slots=True, frozen=True)
+class QemuDirtyBitmapStatus:
+    """Public status for one persistent QEMU dirty bitmap."""
+
+    name: str
+    recording: bool
+    busy: bool
+    persistent: bool
+    inconsistent: bool
+    granularity_bytes: int
+    dirty_bytes: int
+
+
+@dataclass(slots=True, frozen=True)
 class SnapshotCreateRequest:
     """Runtime-specific snapshot creation inputs."""
 

--- a/src/smolvm/runtime/qemu.py
+++ b/src/smolvm/runtime/qemu.py
@@ -423,7 +423,13 @@ class QemuRuntimeAdapter(RuntimeAdapter):
                 details={"busy": True},
             )
         with self._client(vm_info.control_socket_path) as client:
-            client.remove_dirty_bitmap(QEMU_ROOT_NODE_NAME, bitmap_name)
+            try:
+                client.remove_dirty_bitmap(QEMU_ROOT_NODE_NAME, bitmap_name)
+            except SmolVMError as exc:
+                description = str(exc.details.get("desc", "")).lower()
+                if "dirty bitmap" in description and "not found" in description:
+                    return False
+                raise
         return True
 
     def resume(self, vm_info: VMInfo) -> None:
@@ -1284,6 +1290,7 @@ class QemuRuntimeAdapter(RuntimeAdapter):
                         request.vm_info.vm_id,
                         bitmap_backup.bitmap_name,
                         "exists",
+                        recovery_command=self._live_backup_fallback_command(request),
                     )
                 artifact_kind = "full"
             else:
@@ -1292,6 +1299,7 @@ class QemuRuntimeAdapter(RuntimeAdapter):
                         request.vm_info.vm_id,
                         bitmap_backup.bitmap_name,
                         "missing",
+                        recovery_command=self._live_backup_fallback_command(request),
                     )
                 invalid_reason: (
                     Literal[
@@ -1321,6 +1329,7 @@ class QemuRuntimeAdapter(RuntimeAdapter):
                             "busy": existing_bitmap.busy,
                             "inconsistent": existing_bitmap.inconsistent,
                         },
+                        recovery_command=self._live_backup_fallback_command(request),
                     )
                 artifact_kind = "incremental"
                 artifact_filename = "increment.qcow2"

--- a/src/smolvm/runtime/qemu.py
+++ b/src/smolvm/runtime/qemu.py
@@ -31,10 +31,15 @@ from pathlib import Path
 from typing import Any, Literal
 from uuid import uuid4
 
-from smolvm.exceptions import OperationTimeoutError, SmolVMError
+from smolvm.exceptions import (
+    OperationTimeoutError,
+    QemuDirtyBitmapStateError,
+    SmolVMError,
+)
 from smolvm.qmp import QMPClient, QMPJobFailedError, QMPJobTimeoutError
 from smolvm.runtime.backends import BACKEND_QEMU
 from smolvm.runtime.base import (
+    QemuDirtyBitmapStatus,
     RuntimeAdapter,
     RuntimeContext,
     RuntimeLaunch,
@@ -377,6 +382,49 @@ class QemuRuntimeAdapter(RuntimeAdapter):
         """Pause a running QEMU VM."""
         with self._client(vm_info.control_socket_path) as client:
             client.stop_vm()
+
+    def get_dirty_bitmap(
+        self,
+        vm_info: VMInfo,
+        bitmap_name: str,
+    ) -> QemuDirtyBitmapStatus | None:
+        """Return one named root-disk bitmap without changing it."""
+        with self._client(vm_info.control_socket_path) as client:
+            bitmap = next(
+                (
+                    candidate
+                    for candidate in client.query_dirty_bitmaps(QEMU_ROOT_NODE_NAME)
+                    if candidate.name == bitmap_name
+                ),
+                None,
+            )
+        if bitmap is None:
+            return None
+        return QemuDirtyBitmapStatus(
+            name=bitmap.name,
+            recording=bitmap.recording,
+            busy=bitmap.busy,
+            persistent=bitmap.persistent,
+            inconsistent=bitmap.inconsistent,
+            granularity_bytes=bitmap.granularity,
+            dirty_bytes=bitmap.dirty_bytes,
+        )
+
+    def remove_dirty_bitmap(self, vm_info: VMInfo, bitmap_name: str) -> bool:
+        """Remove one named root-disk bitmap, returning whether it existed."""
+        bitmap = self.get_dirty_bitmap(vm_info, bitmap_name)
+        if bitmap is None:
+            return False
+        if bitmap.busy:
+            raise QemuDirtyBitmapStateError(
+                vm_info.vm_id,
+                bitmap_name,
+                "busy",
+                details={"busy": True},
+            )
+        with self._client(vm_info.control_socket_path) as client:
+            client.remove_dirty_bitmap(QEMU_ROOT_NODE_NAME, bitmap_name)
+        return True
 
     def resume(self, vm_info: VMInfo) -> None:
         """Resume a paused QEMU VM."""
@@ -1232,30 +1280,42 @@ class QemuRuntimeAdapter(RuntimeAdapter):
             )
             if bitmap_backup.mode == "new-base":
                 if existing_bitmap is not None:
-                    raise self._live_backup_error(
-                        request,
-                        f"The dirty bitmap for sandbox '{request.vm_info.vm_id}' already exists",
-                        {"bitmap_name": bitmap_backup.bitmap_name},
+                    raise QemuDirtyBitmapStateError(
+                        request.vm_info.vm_id,
+                        bitmap_backup.bitmap_name,
+                        "exists",
                     )
                 artifact_kind = "full"
             else:
                 if existing_bitmap is None:
-                    raise self._live_backup_error(
-                        request,
-                        f"The dirty bitmap for sandbox '{request.vm_info.vm_id}' is missing",
-                        {"bitmap_name": bitmap_backup.bitmap_name},
+                    raise QemuDirtyBitmapStateError(
+                        request.vm_info.vm_id,
+                        bitmap_backup.bitmap_name,
+                        "missing",
                     )
-                if (
-                    not existing_bitmap.recording
-                    or not existing_bitmap.persistent
-                    or existing_bitmap.busy
-                    or existing_bitmap.inconsistent
-                ):
-                    raise self._live_backup_error(
-                        request,
-                        f"The dirty bitmap for sandbox '{request.vm_info.vm_id}' is not usable",
-                        {
-                            "bitmap_name": bitmap_backup.bitmap_name,
+                invalid_reason: (
+                    Literal[
+                        "busy",
+                        "disabled",
+                        "non-persistent",
+                        "inconsistent",
+                    ]
+                    | None
+                ) = None
+                if existing_bitmap.inconsistent:
+                    invalid_reason = "inconsistent"
+                elif existing_bitmap.busy:
+                    invalid_reason = "busy"
+                elif not existing_bitmap.persistent:
+                    invalid_reason = "non-persistent"
+                elif not existing_bitmap.recording:
+                    invalid_reason = "disabled"
+                if invalid_reason is not None:
+                    raise QemuDirtyBitmapStateError(
+                        request.vm_info.vm_id,
+                        bitmap_backup.bitmap_name,
+                        invalid_reason,
+                        details={
                             "recording": existing_bitmap.recording,
                             "persistent": existing_bitmap.persistent,
                             "busy": existing_bitmap.busy,

--- a/src/smolvm/vm.py
+++ b/src/smolvm/vm.py
@@ -2338,15 +2338,14 @@ class SmolVMManager:
                 f"Dirty bitmaps require a QEMU sandbox; '{vm_id}' uses {backend}",
                 {"vm_id": vm_id, "backend": backend},
             )
-        managed_disk = self._instance_disk_path(
-            vm_id,
-            BACKEND_QEMU,
-            vm_info.config.rootfs_format,
-        )
-        if managed_disk.suffix != ".qcow2":
+        managed_disk = self._managed_disk_for_vm(vm_info)
+        if managed_disk is None or managed_disk.suffix != ".qcow2":
             raise SmolVMError(
-                f"Dirty bitmaps require a qcow2 root disk for sandbox '{vm_id}'",
-                {"vm_id": vm_id, "disk_path": str(managed_disk)},
+                f"Dirty bitmaps require a managed qcow2 root disk for sandbox '{vm_id}'",
+                {
+                    "vm_id": vm_id,
+                    "disk_path": str(managed_disk) if managed_disk else None,
+                },
             )
         return vm_info, adapter
 

--- a/src/smolvm/vm.py
+++ b/src/smolvm/vm.py
@@ -63,6 +63,7 @@ from smolvm.runtime.backends import (
 )
 from smolvm.runtime.base import (
     QemuDirtyBitmapBackup,
+    QemuDirtyBitmapStatus,
     RuntimeContext,
     SnapshotCreateRequest,
     SnapshotRestoreRequest,
@@ -2303,6 +2304,51 @@ class SmolVMManager:
             self._raise_if_crashed(vm_info)
             raise
         return self.state.update_vm(vm_id, status=VMState.RUNNING)
+
+    def get_qemu_dirty_bitmap(
+        self,
+        vm_id: str,
+        bitmap_name: str,
+    ) -> QemuDirtyBitmapStatus | None:
+        """Inspect one named persistent bitmap on a running QEMU root disk."""
+        vm_info, adapter = self._qemu_bitmap_operation(vm_id, bitmap_name)
+        return adapter.get_dirty_bitmap(vm_info, bitmap_name)
+
+    def remove_qemu_dirty_bitmap(self, vm_id: str, bitmap_name: str) -> bool:
+        """Remove one named persistent bitmap from a running QEMU root disk."""
+        vm_info, adapter = self._qemu_bitmap_operation(vm_id, bitmap_name)
+        return adapter.remove_dirty_bitmap(vm_info, bitmap_name)
+
+    def _qemu_bitmap_operation(
+        self,
+        vm_id: str,
+        bitmap_name: str,
+    ) -> tuple[VMInfo, QemuRuntimeAdapter]:
+        if not vm_id:
+            raise ValueError("vm_id cannot be empty")
+        if not bitmap_name:
+            raise ValueError("bitmap_name cannot be empty")
+        vm_info = self.state.get_vm(vm_id)
+        if vm_info.status != VMState.RUNNING:
+            self._raise_crashed_or_state_error(vm_info, action="manage a dirty bitmap for")
+        adapter = self._runtime_adapter_for_vm(vm_info)
+        if not isinstance(adapter, QemuRuntimeAdapter):
+            backend = self._backend_for_vm(vm_info)
+            raise SmolVMError(
+                f"Dirty bitmaps require a QEMU sandbox; '{vm_id}' uses {backend}",
+                {"vm_id": vm_id, "backend": backend},
+            )
+        managed_disk = self._instance_disk_path(
+            vm_id,
+            BACKEND_QEMU,
+            vm_info.config.rootfs_format,
+        )
+        if managed_disk.suffix != ".qcow2":
+            raise SmolVMError(
+                f"Dirty bitmaps require a qcow2 root disk for sandbox '{vm_id}'",
+                {"vm_id": vm_id, "disk_path": str(managed_disk)},
+            )
+        return vm_info, adapter
 
     def _raise_crashed_or_state_error(self, vm_info: VMInfo, *, action: str) -> None:
         """Raise the state error, replacing it with a 'crashed' message if stale.

--- a/tests/test_snapshot_qemu.py
+++ b/tests/test_snapshot_qemu.py
@@ -236,6 +236,8 @@ def test_qemu_dirty_bitmap_removal_tolerates_already_removed_race(
     with patch("smolvm.runtime.qemu.QMPClient", return_value=client):
         assert qemu_smol_vm.remove_qemu_dirty_bitmap("vm001", "celesto-chain0") is False
 
+    client.remove_dirty_bitmap.assert_called_once_with("rootdisk0", "celesto-chain0")
+
 
 def test_dirty_bitmap_state_error_preserves_canonical_details_and_recovery() -> None:
     error = QemuDirtyBitmapStateError(
@@ -247,7 +249,11 @@ def test_dirty_bitmap_state_error_preserves_canonical_details_and_recovery() -> 
     )
 
     assert error.details["vm_id"] == "vm001"
+    assert error.details["bitmap_name"] == "celesto-chain0"
     assert error.details["reason"] == "missing"
+    assert error.details["recovery_command"] == (
+        "smolvm sandbox snapshot create vm001 --snapshot-type disk"
+    )
     assert "celesto-chain0" in str(error)
     assert "smolvm sandbox snapshot create vm001" in str(error)
 

--- a/tests/test_snapshot_qemu.py
+++ b/tests/test_snapshot_qemu.py
@@ -210,6 +210,48 @@ def test_qemu_dirty_bitmap_removal_rejects_busy_bitmap(
     client.remove_dirty_bitmap.assert_not_called()
 
 
+def test_qemu_dirty_bitmap_removal_tolerates_already_removed_race(
+    qemu_smol_vm: SmolVMManager,
+    qemu_config: VMConfig,
+    tmp_path: Path,
+) -> None:
+    _running_qemu_vm(qemu_smol_vm, qemu_config, tmp_path)
+    client = _mock_qmp_client()
+    client.query_dirty_bitmaps.return_value = [
+        QMPDirtyBitmap(
+            name="celesto-chain0",
+            recording=True,
+            busy=False,
+            persistent=True,
+            inconsistent=False,
+            granularity=65536,
+            dirty_bytes=0,
+        )
+    ]
+    client.remove_dirty_bitmap.side_effect = SmolVMError(
+        "bitmap not found",
+        {"desc": "Dirty bitmap 'celesto-chain0' not found"},
+    )
+
+    with patch("smolvm.runtime.qemu.QMPClient", return_value=client):
+        assert qemu_smol_vm.remove_qemu_dirty_bitmap("vm001", "celesto-chain0") is False
+
+
+def test_dirty_bitmap_state_error_preserves_canonical_details_and_recovery() -> None:
+    error = QemuDirtyBitmapStateError(
+        "vm001",
+        "celesto-chain0",
+        "missing",
+        details={"vm_id": "wrong", "reason": "busy"},
+        recovery_command="smolvm sandbox snapshot create vm001 --snapshot-type disk",
+    )
+
+    assert error.details["vm_id"] == "vm001"
+    assert error.details["reason"] == "missing"
+    assert "celesto-chain0" in str(error)
+    assert "smolvm sandbox snapshot create vm001" in str(error)
+
+
 def test_full_snapshot_copy_preserves_internal_snapshot_on_backed_overlay(
     tmp_path: Path,
 ) -> None:

--- a/tests/test_snapshot_qemu.py
+++ b/tests/test_snapshot_qemu.py
@@ -25,7 +25,12 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
-from smolvm.exceptions import OperationTimeoutError, SmolVMError, VMNotFoundError
+from smolvm.exceptions import (
+    OperationTimeoutError,
+    QemuDirtyBitmapStateError,
+    SmolVMError,
+    VMNotFoundError,
+)
 from smolvm.qmp import QMPDirtyBitmap, QMPJobFailedError, QMPJobTimeoutError
 from smolvm.runtime.base import QemuDirtyBitmapBackup
 from smolvm.runtime.qemu import (
@@ -127,6 +132,82 @@ def _mock_qmp_client() -> MagicMock:
     client.__enter__.return_value = client
     client.__exit__.return_value = False
     return client
+
+
+def test_qemu_dirty_bitmap_lifecycle_is_public_and_idempotent(
+    qemu_smol_vm: SmolVMManager,
+    qemu_config: VMConfig,
+    tmp_path: Path,
+) -> None:
+    _running_qemu_vm(qemu_smol_vm, qemu_config, tmp_path)
+    client = _mock_qmp_client()
+    client.query_dirty_bitmaps.side_effect = [
+        [
+            QMPDirtyBitmap(
+                name="celesto-chain0",
+                recording=True,
+                busy=False,
+                persistent=True,
+                inconsistent=False,
+                granularity=65536,
+                dirty_bytes=131072,
+            )
+        ],
+        [
+            QMPDirtyBitmap(
+                name="celesto-chain0",
+                recording=True,
+                busy=False,
+                persistent=True,
+                inconsistent=False,
+                granularity=65536,
+                dirty_bytes=131072,
+            )
+        ],
+        [],
+    ]
+
+    with patch("smolvm.runtime.qemu.QMPClient", return_value=client):
+        status = qemu_smol_vm.get_qemu_dirty_bitmap("vm001", "celesto-chain0")
+        removed = qemu_smol_vm.remove_qemu_dirty_bitmap("vm001", "celesto-chain0")
+        missing = qemu_smol_vm.remove_qemu_dirty_bitmap("vm001", "celesto-chain0")
+
+    assert status is not None
+    assert status.name == "celesto-chain0"
+    assert status.granularity_bytes == 65536
+    assert status.dirty_bytes == 131072
+    assert removed is True
+    assert missing is False
+    client.remove_dirty_bitmap.assert_called_once_with("rootdisk0", "celesto-chain0")
+
+
+def test_qemu_dirty_bitmap_removal_rejects_busy_bitmap(
+    qemu_smol_vm: SmolVMManager,
+    qemu_config: VMConfig,
+    tmp_path: Path,
+) -> None:
+    _running_qemu_vm(qemu_smol_vm, qemu_config, tmp_path)
+    client = _mock_qmp_client()
+    client.query_dirty_bitmaps.return_value = [
+        QMPDirtyBitmap(
+            name="celesto-chain0",
+            recording=True,
+            busy=True,
+            persistent=True,
+            inconsistent=False,
+            granularity=65536,
+            dirty_bytes=0,
+        )
+    ]
+
+    with (
+        patch("smolvm.runtime.qemu.QMPClient", return_value=client),
+        pytest.raises(QemuDirtyBitmapStateError) as exc_info,
+    ):
+        qemu_smol_vm.remove_qemu_dirty_bitmap("vm001", "celesto-chain0")
+
+    assert exc_info.value.reason == "busy"
+    client.remove_dirty_bitmap.assert_not_called()
 
 
 def test_full_snapshot_copy_preserves_internal_snapshot_on_backed_overlay(


### PR DESCRIPTION
## Summary
- expose typed QEMU dirty-bitmap status through the public SDK
- add idempotent bitmap removal for acknowledged chain rotation
- classify missing, busy, disabled, non-persistent, inconsistent, and existing bitmap states

## Validation
- Ruff passed
- 51 QEMU snapshot tests passed
- combined QMP/snapshot/facade run: 215 passed, 8 skipped; 3 unrelated host-vsock tests fail on this macOS host

Required by the dataplane incremental snapshot chain rollout.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added APIs to inspect and remove persistent QEMU dirty bitmaps on running virtual machines.
  - Added public dirty-bitmap status reporting (recording, busy, persistence, inconsistency, granularity, and dirty-byte metrics).
  - Exposed a structured dirty-bitmap state error for clearer client handling.

- **Bug Fixes**
  - Snapshot/backup flows now use explicit dirty-bitmap state errors (e.g., missing, exists, busy, disabled, inconsistent) and include recovery guidance where applicable.

- **Tests**
  - Added coverage for status retrieval, idempotent removal, busy-state rejection, already-removed race tolerance, and canonical error detail/recovery formatting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->