### PR TITLE
Raise minimum Python to 3.11

### DIFF
--- a/.github/workflows/publish-core.yml
+++ b/.github/workflows/publish-core.yml
@@ -75,7 +75,6 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version: |
-            3.10
             3.11
             3.12
             3.13

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 [![CodeQL](https://github.com/CelestoAI/SmolVM/actions/workflows/github-code-scanning/codeql/badge.svg)](https://github.com/CelestoAI/SmolVM/actions/workflows/github-code-scanning/codeql)
 [![Run Tests](https://github.com/CelestoAI/SmolVM/actions/workflows/pytest.yml/badge.svg)](https://github.com/CelestoAI/SmolVM/actions/workflows/pytest.yml)
 [![License](https://img.shields.io/badge/License-Apache_2.0-orange.svg)](https://opensource.org/licenses/Apache-2.0)
-[![Python 3.10+](https://img.shields.io/badge/python-3.10+-orange.svg)](https://www.python.org/downloads/)
+[![Python 3.11+](https://img.shields.io/badge/python-3.11+-orange.svg)](https://www.python.org/downloads/)
 
 [Quick start](#quickstart) • [Examples](#examples) • [Features](https://docs.celesto.ai/smolvm/features) • [Performance](#performance) • [Docs](https://docs.celesto.ai) • [Discord](https://discord.gg/KNb5UkrAmm) 
 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -1,6 +1,6 @@
 # Install SmolVM
 
-Install SmolVM, prepare the machine that will run sandboxes, and confirm that it is ready. You need Python 3.10 or newer; supported host setup is Linux and macOS.
+Install SmolVM, prepare the machine that will run sandboxes, and confirm that it is ready. You need Python 3.11 or newer; supported host setup is Linux and macOS.
 
 ## Install the package
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ version = "0.0.30a0"
 description = "Open-source AI sandbox infrastructure with unified API for VMMs -- Firecracker, QEMU and libkrun."
 readme = "README.md"
 license = "Apache-2.0"
-requires-python = ">=3.10"
+requires-python = ">=3.11"
 authors = [
     { name = "Celesto AI", email = "hello@celesto.ai" }
 ]
@@ -19,7 +19,6 @@ classifiers = [
     "Operating System :: MacOS :: MacOS X",
     "Operating System :: POSIX :: Linux",
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
@@ -82,14 +81,17 @@ packages = ["src/smolvm"]
 exclude = ["/ui", "/smolvm-core"]
 
 [tool.ruff]
-target-version = "py310"
+target-version = "py311"
 line-length = 100
 
 [tool.ruff.lint]
 select = ["E", "F", "I", "N", "W", "UP", "B", "C4", "SIM"]
+# Migrating `(str, Enum)` to `StrEnum` changes `str()`/f-string output from
+# "VMState.RUNNING" to "running", which would alter CLI output and JSON payloads.
+ignore = ["UP042"]
 
 [tool.mypy]
-python_version = "3.10"
+python_version = "3.11"
 strict = true
 warn_return_any = true
 warn_unused_ignores = true

--- a/scripts/benchmarks/bench.py
+++ b/scripts/benchmarks/bench.py
@@ -42,7 +42,7 @@ import time
 import uuid
 from collections.abc import Callable
 from contextlib import suppress
-from datetime import datetime, timezone
+from datetime import UTC, datetime
 from pathlib import Path
 from typing import Any
 
@@ -520,7 +520,7 @@ def main() -> None:
     backend = _resolve_and_validate_backend(args.backend)
 
     started = time.monotonic()
-    started_at = datetime.now(timezone.utc).isoformat()
+    started_at = datetime.now(UTC).isoformat()
 
     results: dict[str, Any] = {}
     for name in selected:

--- a/scripts/benchmarks/reporting.py
+++ b/scripts/benchmarks/reporting.py
@@ -25,7 +25,7 @@ import subprocess
 import sys
 import time
 from dataclasses import dataclass
-from datetime import datetime, timezone
+from datetime import UTC, datetime
 from importlib.metadata import PackageNotFoundError, version
 from pathlib import Path
 from typing import Any, TextIO
@@ -59,7 +59,7 @@ class CommandPlan:
 def utc_now_iso() -> str:
     """Return an ISO-8601 UTC timestamp with second precision."""
 
-    return datetime.now(timezone.utc).replace(microsecond=0).isoformat()
+    return datetime.now(UTC).replace(microsecond=0).isoformat()
 
 
 def host_info() -> dict[str, str]:

--- a/scripts/benchmarks/ubuntu_transport.py
+++ b/scripts/benchmarks/ubuntu_transport.py
@@ -36,7 +36,7 @@ import sys
 import time
 import uuid
 from contextlib import suppress
-from datetime import datetime, timezone
+from datetime import UTC, datetime
 from pathlib import Path
 from typing import Any, Literal
 
@@ -649,7 +649,7 @@ def run_benchmark(
     snapshot_type: SnapshotChoice = "auto",
 ) -> dict[str, Any]:
     report: dict[str, Any] = {
-        "date": datetime.now(timezone.utc).isoformat(),
+        "date": datetime.now(UTC).isoformat(),
         "host": {
             "system": platform.system(),
             "machine": platform.machine(),

--- a/smolvm-core/pyproject.toml
+++ b/smolvm-core/pyproject.toml
@@ -8,7 +8,7 @@ dynamic = ["version"]
 description = "Rust-accelerated runtime and network operations for SmolVM"
 readme = "README.md"
 license = "Apache-2.0"
-requires-python = ">=3.10"
+requires-python = ">=3.11"
 authors = [
     { name = "Celesto AI", email = "hello@celesto.ai" }
 ]
@@ -19,7 +19,6 @@ classifiers = [
     "Operating System :: POSIX :: Linux",
     "Operating System :: MacOS :: MacOS X",
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",

--- a/src/smolvm/browser.py
+++ b/src/smolvm/browser.py
@@ -14,7 +14,7 @@ import uuid
 import webbrowser
 from collections.abc import Callable
 from contextlib import suppress
-from datetime import datetime, timedelta, timezone
+from datetime import UTC, datetime, timedelta
 from pathlib import Path
 from typing import Any
 
@@ -251,7 +251,7 @@ class _BrowserSandbox:
             config if config.session_id else config.model_copy(update={"session_id": session_id})
         )
         artifacts_dir = self._session_artifacts_dir(session_id)
-        expires_at = datetime.now(timezone.utc) + timedelta(minutes=session_config.timeout_minutes)
+        expires_at = datetime.now(UTC) + timedelta(minutes=session_config.timeout_minutes)
 
         vm: SmolVM | None = None
         try:

--- a/src/smolvm/cli/image.py
+++ b/src/smolvm/cli/image.py
@@ -30,9 +30,9 @@ import re
 import shlex
 import shutil
 from contextlib import AbstractContextManager, nullcontext
-from datetime import datetime, timezone
+from datetime import UTC, datetime
 from pathlib import Path
-from typing import Any, TypedDict, cast
+from typing import Any, NotRequired, TypedDict, cast
 
 from rich.progress import (
     BarColumn,
@@ -43,7 +43,6 @@ from rich.progress import (
     TimeElapsedColumn,
     TransferSpeedColumn,
 )
-from typing_extensions import NotRequired
 
 from smolvm import __version__
 from smolvm.cli.output import (
@@ -100,7 +99,7 @@ def _canonical_preset(name: str) -> str:
 def _created_iso(path: Path) -> str | None:
     """ISO 8601 UTC creation marker for a cache entry (its dir mtime)."""
     try:
-        return datetime.fromtimestamp(path.stat().st_mtime, tz=timezone.utc).isoformat()
+        return datetime.fromtimestamp(path.stat().st_mtime, tz=UTC).isoformat()
     except OSError:
         return None
 
@@ -117,7 +116,7 @@ def _relative_time(iso_ts: str | None, *, now: datetime | None = None) -> str:
         # A naive timestamp can't be compared to the aware clock; degrade
         # like any other unusable input instead of raising.
         return "-"
-    current = now if now is not None else datetime.now(timezone.utc)
+    current = now if now is not None else datetime.now(UTC)
     seconds = max(0, int((current - then).total_seconds()))
     for unit, span in (
         ("year", 31_536_000),

--- a/src/smolvm/cli/image_transfer.py
+++ b/src/smolvm/cli/image_transfer.py
@@ -40,7 +40,7 @@ import shutil
 import tarfile
 import tempfile
 from contextlib import suppress
-from datetime import datetime, timezone
+from datetime import UTC, datetime
 from pathlib import Path
 from typing import Any, TypedDict
 
@@ -316,7 +316,7 @@ def run_image_save(
             manifest = {
                 "schema_version": _SCHEMA_VERSION,
                 "saved_by": __version__,
-                "created": datetime.now(timezone.utc).isoformat(),
+                "created": datetime.now(UTC).isoformat(),
                 "name": archive_name,
                 "kind": _entry_kind(entry, root),
                 "rootfs_sidecar": sidecar_value,

--- a/src/smolvm/cli/main.py
+++ b/src/smolvm/cli/main.py
@@ -26,10 +26,10 @@ import subprocess
 import sys
 from collections.abc import Callable, Sequence
 from contextlib import suppress
-from datetime import datetime, timezone
+from datetime import UTC, datetime
 from pathlib import Path
 from types import SimpleNamespace
-from typing import TYPE_CHECKING, Any, TypedDict
+from typing import TYPE_CHECKING, Any, NotRequired, TypedDict
 
 import click
 from rich.markup import escape
@@ -45,7 +45,6 @@ from rich.progress import (
 )
 from rich.table import Table
 from rich.text import Text
-from typing_extensions import NotRequired
 
 from smolvm.cli._kvm_session import maybe_reexec_for_kvm_group
 from smolvm.cli.output import (
@@ -822,8 +821,8 @@ def _format_started_at(iso_ts: str) -> str:
     """Render an ISO timestamp as ``YYYY-MM-DD HH:MM:SS UTC``."""
     dt = datetime.fromisoformat(iso_ts)
     if dt.tzinfo is None:
-        dt = dt.replace(tzinfo=timezone.utc)
-    return dt.astimezone(timezone.utc).strftime("%Y-%m-%d %H:%M:%S UTC")
+        dt = dt.replace(tzinfo=UTC)
+    return dt.astimezone(UTC).strftime("%Y-%m-%d %H:%M:%S UTC")
 
 
 def _render_create_result(data: CreatePayload) -> None:
@@ -1345,7 +1344,7 @@ def _run_create(args: SimpleNamespace) -> int:
                     else VMState.RUNNING.value
                 ),
                 "os": os_label,
-                "started_at": datetime.now(timezone.utc).isoformat(),
+                "started_at": datetime.now(UTC).isoformat(),
             },
             "next": {
                 "shell_command": (None if is_macos else f"smolvm sandbox shell {vm.vm_id}"),

--- a/src/smolvm/macos/images.py
+++ b/src/smolvm/macos/images.py
@@ -22,7 +22,7 @@ import tempfile
 import zipfile
 from collections.abc import Callable, Iterator
 from contextlib import contextmanager, suppress
-from datetime import datetime, timezone
+from datetime import UTC, datetime
 from pathlib import Path
 from typing import Literal
 
@@ -230,7 +230,7 @@ class MacOSImageManager:
             allocated_size_bytes=details.disk_size.allocated,
             driver_version=self.driver.version(),
             host_arch=platform.machine(),
-            created_at=datetime.now(timezone.utc),
+            created_at=datetime.now(UTC),
         )
         manifest_path = self.manifest_path(name)
         manifest_path.parent.mkdir(parents=True, exist_ok=True)

--- a/src/smolvm/runtime/base.py
+++ b/src/smolvm/runtime/base.py
@@ -19,7 +19,7 @@ from __future__ import annotations
 import asyncio
 import subprocess
 from dataclasses import dataclass, field
-from datetime import datetime, timezone
+from datetime import UTC, datetime
 from pathlib import Path
 from typing import TYPE_CHECKING, Literal, Protocol, TextIO
 
@@ -98,7 +98,7 @@ class SnapshotCreateResult:
 
     artifacts: SnapshotArtifacts
     source_status: VMState
-    captured_at: datetime = field(default_factory=lambda: datetime.now(timezone.utc))
+    captured_at: datetime = field(default_factory=lambda: datetime.now(UTC))
     capture_method: Literal["paused", "live"] = "paused"
     operation_manifest_path: Path | None = None
     artifact_kind: Literal["full", "incremental"] | None = None

--- a/src/smolvm/runtime/firecracker.py
+++ b/src/smolvm/runtime/firecracker.py
@@ -20,7 +20,7 @@ import asyncio
 import logging
 import shutil
 from contextlib import suppress
-from datetime import datetime, timezone
+from datetime import UTC, datetime
 from pathlib import Path
 from typing import Any
 
@@ -184,7 +184,7 @@ class FirecrackerRuntimeAdapter(RuntimeAdapter):
 
             if request.original_status == VMState.RUNNING:
                 client.pause_vm()
-            captured_at = datetime.now(timezone.utc)
+            captured_at = datetime.now(UTC)
 
             if request.snapshot_type == SnapshotType.DISK:
                 shutil.copy2(request.managed_disk_path, disk_path)

--- a/src/smolvm/runtime/qemu.py
+++ b/src/smolvm/runtime/qemu.py
@@ -26,7 +26,7 @@ import signal
 import subprocess
 import time
 from contextlib import suppress
-from datetime import datetime, timezone
+from datetime import UTC, datetime
 from pathlib import Path
 from typing import Any, Literal
 from uuid import uuid4
@@ -466,7 +466,7 @@ class QemuRuntimeAdapter(RuntimeAdapter):
                     )
                     client.wait_for_job(save_job_id)
                 snapshot_saved = True
-                captured_at = datetime.now(timezone.utc)
+                captured_at = datetime.now(UTC)
 
                 disk_path = request.snapshot_root / "disk.qcow2"
                 if request.snapshot_type == SnapshotType.DIFF:
@@ -1420,7 +1420,7 @@ class QemuRuntimeAdapter(RuntimeAdapter):
                     max_bytes_per_second=request.max_bytes_per_second,
                 )
             bitmap_job_submitted = bitmap_backup is not None
-            captured_at = datetime.now(timezone.utc)
+            captured_at = datetime.now(UTC)
             logger.info(
                 "Live QEMU backup started vm_id=%s snapshot_id=%s job_id=%s "
                 "virtual_bytes=%d max_bytes_per_second=%s",

--- a/src/smolvm/storage/_base.py
+++ b/src/smolvm/storage/_base.py
@@ -16,7 +16,7 @@
 
 from __future__ import annotations
 
-from datetime import datetime, timezone
+from datetime import UTC, datetime
 from pathlib import Path
 from typing import Any
 
@@ -68,7 +68,7 @@ def ip_to_pool_index(ip: str) -> int:
 
 def now_iso() -> str:
     """Return the current UTC time as an ISO 8601 string."""
-    return datetime.now(timezone.utc).isoformat()
+    return datetime.now(UTC).isoformat()
 
 
 def vm_config_from_json(raw: str) -> VMConfig:

--- a/src/smolvm/utils.py
+++ b/src/smolvm/utils.py
@@ -144,7 +144,7 @@ async def async_run_command(
             proc.communicate(input=input.encode() if input else None),
             timeout=timeout,
         )
-    except asyncio.TimeoutError:
+    except TimeoutError:
         proc.kill()
         await proc.wait()
         raise SmolVMError(f"Command timed out: {' '.join(full_cmd)}") from None

--- a/tests/test_async_lifecycle.py
+++ b/tests/test_async_lifecycle.py
@@ -16,7 +16,6 @@
 
 from __future__ import annotations
 
-import asyncio
 from pathlib import Path
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -69,7 +68,7 @@ class TestAsyncRunCommand:
         from smolvm.utils import async_run_command
 
         mock_proc = AsyncMock()
-        mock_proc.communicate.side_effect = asyncio.TimeoutError()
+        mock_proc.communicate.side_effect = TimeoutError()
         mock_proc.kill = MagicMock()
         mock_proc.wait = AsyncMock()
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -17,7 +17,7 @@
 import ast
 import json
 import os
-from datetime import datetime, timezone
+from datetime import UTC, datetime
 from pathlib import Path
 from unittest.mock import ANY, MagicMock, patch
 
@@ -107,7 +107,7 @@ def _make_snapshot_info(
     snapshot.snapshot_type = SnapshotType.FULL
     snapshot.restored = restored
     snapshot.restored_vm_id = restored_vm_id
-    snapshot.created_at = datetime(2026, 4, 3, 12, 0, tzinfo=timezone.utc)
+    snapshot.created_at = datetime(2026, 4, 3, 12, 0, tzinfo=UTC)
     snapshot.artifacts = MagicMock()
     snapshot.artifacts.state_path = Path(f"/tmp/{snapshot_id}/vmstate.bin")
     snapshot.artifacts.memory_path = Path(f"/tmp/{snapshot_id}/mem.bin")

--- a/tests/test_image_cmd.py
+++ b/tests/test_image_cmd.py
@@ -19,6 +19,7 @@ from __future__ import annotations
 import json
 import os
 import re
+from datetime import UTC
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
@@ -548,11 +549,11 @@ class TestChoiceListsMatchPublishedTypes:
 
 class TestRelativeTime:
     def test_buckets(self) -> None:
-        from datetime import datetime, timezone
+        from datetime import datetime
 
         from smolvm.cli.image import _relative_time
 
-        now = datetime(2026, 7, 17, 12, 0, 0, tzinfo=timezone.utc)
+        now = datetime(2026, 7, 17, 12, 0, 0, tzinfo=UTC)
 
         def at(seconds_ago: int) -> str:
             from datetime import timedelta

--- a/tests/test_snapshot.py
+++ b/tests/test_snapshot.py
@@ -14,7 +14,7 @@
 
 """Tests for VM snapshot lifecycle management."""
 
-from datetime import datetime, timezone
+from datetime import UTC, datetime
 from pathlib import Path
 from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
@@ -284,7 +284,7 @@ def test_restore_snapshot_rehydrates_deleted_vm(
         ),
         vm_config=vm_info.config,
         network_config=vm_info.network,
-        created_at=datetime.now(timezone.utc),
+        created_at=datetime.now(UTC),
     )
     snapshot.artifacts.state_path.write_text("vmstate")
     snapshot.artifacts.memory_path.write_text("memory")
@@ -346,7 +346,7 @@ def test_restore_firecracker_full_snapshot_returns_vsock_uds_path(
             update={"vsock": VsockConfig(guest_cid=42, uds_path=str(uds_path))}
         ),
         network_config=vm_info.network,
-        created_at=datetime.now(timezone.utc),
+        created_at=datetime.now(UTC),
     )
     snapshot.artifacts.state_path.write_text("vmstate")
     snapshot.artifacts.memory_path.write_text("memory")
@@ -392,7 +392,7 @@ def test_restore_snapshot_rolls_back_new_vm_resources_on_failure(
         ),
         vm_config=vm_info.config,
         network_config=vm_info.network,
-        created_at=datetime.now(timezone.utc),
+        created_at=datetime.now(UTC),
     )
     snapshot.artifacts.state_path.write_text("vmstate")
     snapshot.artifacts.memory_path.write_text("memory")
@@ -446,7 +446,7 @@ def test_restore_snapshot_preserves_existing_managed_disk_on_failure(
         ),
         vm_config=vm_info.config,
         network_config=vm_info.network,
-        created_at=datetime.now(timezone.utc),
+        created_at=datetime.now(UTC),
     )
     snapshot.artifacts.state_path.write_text("vmstate")
     snapshot.artifacts.memory_path.write_text("memory")
@@ -522,7 +522,7 @@ def test_delete_snapshot_preserves_metadata_when_disk_cleanup_fails(
         ),
         vm_config=vm_info.config,
         network_config=vm_info.network,
-        created_at=datetime.now(timezone.utc),
+        created_at=datetime.now(UTC),
     )
     smol_vm.state.create_snapshot(snapshot)
 
@@ -653,7 +653,7 @@ def test_restore_firecracker_disk_snapshot_boots_fresh_without_loading_vmstate(
         ),
         vm_config=vm_info.config,
         network_config=vm_info.network,
-        created_at=datetime.now(timezone.utc),
+        created_at=datetime.now(UTC),
         snapshot_type=SnapshotType.DISK,
     )
     snapshot.artifacts.disk_path.write_text("disk-only-ext4")

--- a/tests/test_snapshot_qemu.py
+++ b/tests/test_snapshot_qemu.py
@@ -18,7 +18,7 @@ import json
 import shutil
 import subprocess
 import threading
-from datetime import datetime, timezone
+from datetime import UTC, datetime
 from pathlib import Path
 from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
@@ -503,7 +503,7 @@ def test_restore_qemu_snapshot_rehydrates_deleted_vm(
         artifacts=SnapshotArtifacts(disk_path=snapshot_dir / "disk.qcow2"),
         vm_config=vm_info.config.model_copy(update={"rootfs_format": None}),
         network_config=vm_info.network,
-        created_at=datetime.now(timezone.utc),
+        created_at=datetime.now(UTC),
     )
     snapshot.artifacts.disk_path.write_text("snapshotted-qcow2")
     qemu_smol_vm.state.create_snapshot(snapshot)
@@ -546,7 +546,7 @@ def test_restore_validates_artifacts_before_stopping_existing_vm(
         artifacts=SnapshotArtifacts(disk_path=qemu_smol_vm.snapshot_dir / "missing.qcow2"),
         vm_config=vm_info.config,
         network_config=vm_info.network,
-        created_at=datetime.now(timezone.utc),
+        created_at=datetime.now(UTC),
     )
     qemu_smol_vm.state.create_snapshot(snapshot)
 
@@ -579,7 +579,7 @@ def test_restore_qemu_snapshot_reserves_persisted_vsock_cid(
         artifacts=SnapshotArtifacts(disk_path=snapshot_dir / "disk.qcow2"),
         vm_config=vm_info.config,
         network_config=vm_info.network,
-        created_at=datetime.now(timezone.utc),
+        created_at=datetime.now(UTC),
     )
     snapshot.artifacts.disk_path.write_text("snapshotted-qcow2")
     qemu_smol_vm.state.create_snapshot(snapshot)
@@ -619,7 +619,7 @@ def test_restore_qemu_snapshot_persistence_failure_removes_placeholder(
             guest_mac="52:54:00:5d:00:04",
             ssh_host_port=2205,
         ),
-        created_at=datetime.now(timezone.utc),
+        created_at=datetime.now(UTC),
     )
     snapshot.artifacts.disk_path.write_text("snapshotted-qcow2")
     qemu_smol_vm.state.create_snapshot(snapshot)
@@ -650,7 +650,7 @@ def test_restore_qemu_snapshot_rolls_back_new_vm_resources_on_failure(
         artifacts=SnapshotArtifacts(disk_path=snapshot_dir / "disk.qcow2"),
         vm_config=vm_info.config,
         network_config=vm_info.network,
-        created_at=datetime.now(timezone.utc),
+        created_at=datetime.now(UTC),
     )
     snapshot.artifacts.disk_path.write_text("snapshotted-qcow2")
     qemu_smol_vm.state.create_snapshot(snapshot)
@@ -696,7 +696,7 @@ def test_restore_qemu_snapshot_restores_backup_when_status_update_fails(
         artifacts=SnapshotArtifacts(disk_path=snapshot_dir / "disk.qcow2"),
         vm_config=vm_info.config,
         network_config=vm_info.network,
-        created_at=datetime.now(timezone.utc),
+        created_at=datetime.now(UTC),
     )
     snapshot.artifacts.disk_path.write_text("snapshotted-qcow2")
     qemu_smol_vm.state.create_snapshot(snapshot)
@@ -729,7 +729,7 @@ def test_restore_qemu_snapshot_preserves_existing_managed_disk_on_failure(
         artifacts=SnapshotArtifacts(disk_path=snapshot_dir / "disk.qcow2"),
         vm_config=vm_info.config,
         network_config=vm_info.network,
-        created_at=datetime.now(timezone.utc),
+        created_at=datetime.now(UTC),
     )
     snapshot.artifacts.disk_path.write_text("snapshotted-qcow2")
     qemu_smol_vm.state.create_snapshot(snapshot)
@@ -803,7 +803,7 @@ def test_restore_qemu_snapshot_removes_replaced_disk_sidecars(
         artifacts=SnapshotArtifacts(disk_path=snapshot_disk),
         vm_config=config,
         network_config=qemu_smol_vm.state.get_vm("vm001").network,
-        created_at=datetime.now(timezone.utc),
+        created_at=datetime.now(UTC),
     )
     qemu_smol_vm.state.create_snapshot(snapshot)
     process = MagicMock()
@@ -838,7 +838,7 @@ def test_delete_qemu_snapshot_rejects_active_restored_vm(
         artifacts=SnapshotArtifacts(disk_path=snapshot_dir / "disk.qcow2"),
         vm_config=vm_info.config,
         network_config=vm_info.network,
-        created_at=datetime.now(timezone.utc),
+        created_at=datetime.now(UTC),
     )
     snapshot.artifacts.disk_path.write_text("snapshotted-qcow2")
     qemu_smol_vm.state.create_snapshot(snapshot)
@@ -2075,7 +2075,7 @@ def test_qemu_live_snapshot_preserves_persisted_published_artifact(
         artifacts=SnapshotArtifacts(disk_path=old_final),
         vm_config=qemu_smol_vm.get("vm001").config,
         network_config=qemu_smol_vm.get("vm001").network,
-        created_at=datetime.now(timezone.utc),
+        created_at=datetime.now(UTC),
         snapshot_type=SnapshotType.DISK,
     )
     qemu_smol_vm.state.create_snapshot(snapshot)
@@ -2164,7 +2164,7 @@ def test_restore_qemu_disk_snapshot_boots_fresh_without_loading_vmstate(
         artifacts=SnapshotArtifacts(disk_path=snapshot_dir / "disk.qcow2"),
         vm_config=vm_info.config,
         network_config=vm_info.network,
-        created_at=datetime.now(timezone.utc),
+        created_at=datetime.now(UTC),
         snapshot_type=SnapshotType.DISK,
     )
     snapshot.artifacts.disk_path.write_text("disk-only-qcow2")

--- a/tests/test_storage.py
+++ b/tests/test_storage.py
@@ -15,7 +15,7 @@
 """Tests for SmolVM storage module."""
 
 import sqlite3
-from datetime import datetime, timezone
+from datetime import UTC, datetime
 from pathlib import Path
 
 import pytest
@@ -455,7 +455,7 @@ class TestSnapshotStorage:
             ),
             vm_config=config_with_forwards,
             network_config=network,
-            created_at=datetime.now(timezone.utc),
+            created_at=datetime.now(UTC),
         )
         assert snapshot.artifacts.state_path is not None
         assert snapshot.artifacts.memory_path is not None
@@ -530,7 +530,7 @@ class TestSnapshotStorage:
             artifacts=SnapshotArtifacts(disk_path=disk_path),
             vm_config=qemu_config,
             network_config=network,
-            created_at=datetime.now(timezone.utc),
+            created_at=datetime.now(UTC),
             artifact_kind="incremental",
             virtual_size_bytes=10 * 1024 * 1024,
             changed_bytes=131072,
@@ -610,7 +610,7 @@ class TestBrowserSessionStorage:
             profile_id="acct-1",
             record_video=True,
         )
-        expires_at = datetime.now(timezone.utc)
+        expires_at = datetime.now(UTC)
         info = BrowserSessionInfo(
             session_id="browser-abc123",
             vm_id="browser-prof-acct-1-deadbeef",

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -15,7 +15,7 @@
 """Tests for SmolVM types module."""
 
 import re
-from datetime import datetime, timezone
+from datetime import UTC, datetime
 from pathlib import Path
 
 import pytest
@@ -484,7 +484,7 @@ class TestSnapshotInfo:
             ),
             vm_config=config,
             network_config=network,
-            created_at=datetime.now(timezone.utc),
+            created_at=datetime.now(UTC),
         )
 
         assert snapshot.snapshot_id == "snap-1234"


### PR DESCRIPTION
## What

Drops Python 3.10 support. `requires-python` is now `>=3.11`.

Updated in lockstep:

- `pyproject.toml` and `smolvm-core/pyproject.toml` — `requires-python`, classifiers
- `pyproject.toml` — ruff `target-version = "py311"`, mypy `python_version = "3.11"`
- `.github/workflows/publish-core.yml` — dropped 3.10 from the maturin interpreter matrix
- `README.md` badge, `docs/installation.md`

## Lint fallout

Bumping the ruff target to `py311` enabled new pyupgrade rules. Auto-fixes applied across 21 files:

| Rule | Change |
| --- | --- |
| UP017 | `datetime.timezone.utc` → `datetime.UTC` |
| UP035 | `typing_extensions.NotRequired` → `typing.NotRequired` |
| UP041 | `asyncio.TimeoutError` → `TimeoutError` |

**UP042 is ignored, not applied.** Converting `(str, Enum)` to `StrEnum` changes `str()` and f-string output from `VMState.RUNNING` to `running`, which would silently alter CLI output and JSON payloads. That's a behavior change beyond the scope of a version bump, so it's suppressed with a comment explaining why.

## Verification

- `uv run ruff check .` — all checks passed
- `uv run ruff format --check .` — 226 files already formatted
- `uv lock --check` — resolves cleanly
- `uv run pytest` — 1901 passed, 14 failed. All 14 failures reproduce on clean `main` (missing native `smolvm-core` extension and local-environment issues); this branch introduces no new failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Breaking Changes**
  * Python 3.11 or newer is now required to install and run SmolVM.
  * Python 3.10 is no longer supported.

* **Bug Fixes**
  * Improved consistency and compatibility of UTC timestamp handling across VM, snapshot, image, browser session, and benchmark operations.
  * Improved asynchronous command timeout handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->