### PR TITLE
Test Python 3.14 in CI

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -13,20 +13,30 @@ jobs:
   pytest:
     runs-on: ubuntu-latest
 
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.13", "3.14"]
+
+    name: pytest (Python ${{ matrix.python-version }})
+
     steps:
       - name: Check out repository
         uses: actions/checkout@v4
         with:
           persist-credentials: false
 
-      - name: Set up Python 3.13
+      - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v5
         with:
-          python-version: "3.13"
+          python-version: ${{ matrix.python-version }}
 
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable
 
+      # The cache key includes the Python version: smolvm-core is a pyo3
+      # extension module linked against a specific interpreter, so build
+      # artifacts are not shareable across matrix entries.
       - name: Cache Rust build
         uses: actions/cache@v4
         with:
@@ -34,15 +44,15 @@ jobs:
             ~/.cargo/registry
             ~/.cargo/git
             target
-          key: rust-${{ runner.os }}-${{ hashFiles('Cargo.lock', 'Cargo.toml', 'smolvm-core/Cargo.toml', 'guest-agent/Cargo.toml') }}
-          restore-keys: rust-${{ runner.os }}-
+          key: rust-${{ runner.os }}-py${{ matrix.python-version }}-${{ hashFiles('Cargo.lock', 'Cargo.toml', 'smolvm-core/Cargo.toml', 'guest-agent/Cargo.toml') }}
+          restore-keys: rust-${{ runner.os }}-py${{ matrix.python-version }}-
 
       - name: Install uv
         uses: astral-sh/setup-uv@caf0cab7a618c569241d31dcd442f54681755d39 # v3.2.4
 
       # uv workspace resolves smolvm-core from local smolvm-core/ directory
       - name: Install dependencies
-        run: uv sync --extra dev
+        run: uv sync --extra dev --python ${{ matrix.python-version }}
 
       - name: Assert native extension available
         run: |
@@ -57,7 +67,10 @@ jobs:
       - name: Run pytest
         run: uv run pytest
 
+      # The guest agent is pure Rust and does not link against Python, so
+      # running it once is enough to cover the whole matrix.
       - name: Run Rust guest-agent tests
+        if: matrix.python-version == '3.13'
         run: cargo test -p smolvm-guest-agent
 
   package-smoke:


### PR DESCRIPTION
## Why

`pyproject.toml` has declared `Programming Language :: Python :: 3.14` for a while, but every CI job pins 3.13 — so 3.14 support was an unverified claim, not a tested one.

## What

Runs the `pytest` job as a matrix over 3.13 and 3.14.

Supporting details:

- **`fail-fast: false`** — a failure on one version still reports results for the other.
- **`uv sync --python ${{ matrix.python-version }}`** — without this, uv is free to resolve an interpreter other than the one `setup-python` installed, which would silently make both matrix entries test the same version.
- **Python version in the Rust cache key** — `smolvm-core` is a pyo3 extension module linked against a specific interpreter, so `target/` artifacts are not shareable across matrix entries. Sharing one key would cause cache thrash between the two jobs.
- **Rust guest-agent tests gated to the 3.13 entry** — the guest agent is pure Rust and does not link against Python, so running it twice is wasted CI time.

## Verification

Ran the full suite locally on both versions against this same tree (macOS, arm64):

| | 3.13 | 3.14 |
| --- | --- | --- |
| passed | 1860 | 1860 |
| failed | 14 | 14 |
| skipped | 12 | 12 |
| collected | 1883/1913 | 1883/1913 |

Byte-identical, including the same 14 failing test IDs. Those 14 are pre-existing failures on a clean `main` that are local-environment specific (sparse-file/reflink behavior on APFS, shell-completion install paths, and the native extension); they are not related to 3.14 and are expected to pass on the Linux runner.

Dependency resolution and the `smolvm-core` Rust build both succeed on 3.14.

## Not included

Two adjacent gaps I left alone rather than widening scope — happy to fold either in:

1. **3.11 is untested.** It is the declared floor as of #458, and no CI job runs it. Adding it to this matrix is a one-line change.
2. **`package-smoke` is still pinned to 3.13** (both `setup-python` and `uv venv .smoke-venv --python 3.13`). That job is what actually validates a wheel install, so it is arguably the more valuable place to exercise 3.14.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Expanded automated testing to run across Python 3.13 and 3.14.
  * Updated build caching to keep interpreter-specific artifacts separate.
  * Continued Rust guest-agent testing in a single matrix run.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->