### PR TITLE
fix: 16 latent bugs across image, ssh, env, runtime, network and transfer paths

### DIFF
--- a/src/smolvm/cli/_sqlite.py
+++ b/src/smolvm/cli/_sqlite.py
@@ -493,6 +493,11 @@ class SQLiteStateManager:
             raise ValueError("vm_id cannot be empty")
         if guest_port < 1 or guest_port > 65535:
             raise ValueError("guest_port must be 1-65535")
+        # Without this, an out-of-range request was persisted and only surfaced
+        # much later as an opaque hypervisor error at hostfwd time — and a
+        # stored port 0 means "any port", so the recorded number was wrong too.
+        if host_port is not None and (host_port < 1 or host_port > 65535):
+            raise ValueError("host_port must be 1-65535")
 
         now = now_iso()
 
@@ -1033,7 +1038,11 @@ class SQLiteStateManager:
 
             for row in running:
                 pid = row["pid"]
-                if pid is None:
+                # A non-positive pid is not a process: os.kill(0, 0) probes our
+                # own process group and os.kill(-1, 0) probes every process we
+                # may signal, so both "succeed" and the sandbox stays wedged in
+                # RUNNING forever instead of being reconciled.
+                if pid is None or pid <= 0:
                     stale_vms.append(row["id"])
                     continue
 

--- a/src/smolvm/comm/rust_http_vsock_channel.py
+++ b/src/smolvm/comm/rust_http_vsock_channel.py
@@ -178,8 +178,22 @@ def _vsock_unavailable_message(sandbox_name: str | None) -> str:
 
 
 def _parse_mode_header(value: str) -> int:
+    """Parse the guest's ``x-smolvm-file-mode`` header into safe permissions.
+
+    Masked for the same reason as :func:`_safe_tar_member_mode`: this value
+    comes from the untrusted sandbox and is applied to a file on the host, so
+    an unmasked ``int(value, 8)`` let a guest set setuid/setgid on a
+    downloaded file. Masking also bounds the value, which ``os.chmod``
+    otherwise rejects with ``OverflowError`` for an absurd header.
+    """
     value = value.strip().removeprefix("0o")
-    return int(value, 8)
+    try:
+        mode = int(value, 8)
+    except ValueError as exc:
+        raise SmolVMError(f"guest agent returned an invalid file mode: {value!r}") from exc
+    if mode < 0:
+        raise SmolVMError(f"guest agent returned a negative file mode: {value!r}")
+    return mode & 0o777
 
 
 def _parse_size_header(value: str, *, header: str, method: str, path: str) -> int:
@@ -371,6 +385,21 @@ def _add_tar_path(archive: tarfile.TarFile, path: Path, arcname: PurePosixPath) 
             _add_tar_path(archive, child, arcname / child.name)
 
 
+def _safe_tar_member_mode(mode: int) -> int:
+    """Return the permission bits safe to copy from a guest-supplied tar.
+
+    ``stat.S_IMODE`` keeps 0o7777, which includes setuid, setgid and the
+    sticky bit. This archive comes from the sandbox, which is untrusted by
+    design, and it is unpacked on the host — often under ``sudo``, since
+    SmolVM needs root for host networking. Honouring those bits let a guest
+    plant a setuid-root file on the host filesystem, so a directory download
+    became a privilege-escalation primitive. Ordinary read/write/execute
+    permissions are still preserved. Matches ``host/lume.py``, which already
+    masks its own extraction this way.
+    """
+    return mode & 0o777
+
+
 def _safe_extract_tar(data: bytes, destination: Path) -> None:
     destination.mkdir(parents=True, exist_ok=True)
     with tarfile.open(fileobj=io.BytesIO(data), mode="r:*") as archive:
@@ -382,7 +411,7 @@ def _safe_extract_tar(data: bytes, destination: Path) -> None:
             if member.isdir():
                 _safe_mkdir(destination, target)
                 if member.mode:
-                    os.chmod(target, stat.S_IMODE(member.mode))
+                    os.chmod(target, _safe_tar_member_mode(member.mode))
                 continue
             if not member.isfile():
                 raise SmolVMError(f"Refusing unsupported tar entry: {member.name}")
@@ -394,7 +423,7 @@ def _safe_extract_tar(data: bytes, destination: Path) -> None:
                 raise SmolVMError(f"Tar entry has no data: {member.name}")
             target.write_bytes(source.read())
             if member.mode:
-                os.chmod(target, stat.S_IMODE(member.mode))
+                os.chmod(target, _safe_tar_member_mode(member.mode))
 
 
 def _safe_tar_member_path(name: str) -> Path | None:

--- a/src/smolvm/dashboard/server.py
+++ b/src/smolvm/dashboard/server.py
@@ -47,6 +47,7 @@ from smolvm.dashboard.poller import poll_vm_state
 from smolvm.exceptions import SmolVMError, VMNotFoundError
 from smolvm.storage import StateManagerProtocol
 from smolvm.types import VMInfo, VMState
+from smolvm.utils import unsafe_tar_member_kind
 from smolvm.vm import SmolVMManager, resolve_data_dir
 
 logger = logging.getLogger(__name__)
@@ -215,14 +216,12 @@ def _download_asset(url: str, destination: Path) -> None:
 def _extract_dashboard_dist(archive_path: Path, extract_dir: Path) -> Path:
     """Extract dashboard archive and return the extracted dist directory."""
     with tarfile.open(archive_path, "r:gz") as tar:
+        # One shared rule — see smolvm.utils.unsafe_tar_member_kind.
         for member in tar.getmembers():
-            member_path = Path(member.name)
-            if member_path.is_absolute() or ".." in member_path.parts:
+            kind = unsafe_tar_member_kind(member)
+            if kind == "path":
                 raise RuntimeError(f"Unsafe path in dashboard archive: {member.name}")
-            # The unfiltered fallback below would create a symlink pointing
-            # outside extract_dir and then write "through" it — something the
-            # path check alone does not catch.
-            if member.issym() or member.islnk() or member.isdev():
+            if kind is not None:
                 raise RuntimeError(f"Unsafe entry in dashboard archive: {member.name}")
 
         if hasattr(tarfile, "data_filter"):

--- a/src/smolvm/dashboard/server.py
+++ b/src/smolvm/dashboard/server.py
@@ -219,6 +219,11 @@ def _extract_dashboard_dist(archive_path: Path, extract_dir: Path) -> Path:
             member_path = Path(member.name)
             if member_path.is_absolute() or ".." in member_path.parts:
                 raise RuntimeError(f"Unsafe path in dashboard archive: {member.name}")
+            # The unfiltered fallback below would create a symlink pointing
+            # outside extract_dir and then write "through" it — something the
+            # path check alone does not catch.
+            if member.issym() or member.islnk() or member.isdev():
+                raise RuntimeError(f"Unsafe entry in dashboard archive: {member.name}")
 
         if hasattr(tarfile, "data_filter"):
             tar.extractall(path=extract_dir, filter="data")

--- a/src/smolvm/env.py
+++ b/src/smolvm/env.py
@@ -140,13 +140,22 @@ def _atomic_write(ssh: CommChannel, content: str) -> "CommandResult":  # noqa: F
     payload (heredoc delimiter injection, quote escaping, etc.).
     A ``mktemp``-generated temp file prevents symlink attacks, and a
     ``trap`` ensures the temp file is cleaned up on any failure.
+
+    The temp file is created **next to the destination**, not in ``/tmp``.
+    ``rename(2)`` — the only thing that makes the swap atomic — cannot
+    cross filesystems, and ``/tmp`` is a separate tmpfs on most guest
+    images. Staging there silently downgraded the final ``mv`` to a
+    copy-then-unlink, so an interrupted write left every new login shell
+    sourcing a half-written env file.
     """
     from smolvm.types import CommandResult  # noqa: F401 - avoid circular import
 
     b64 = base64.b64encode(content.encode("utf-8")).decode("ascii")
+    env_dir = ENV_FILE.rsplit("/", 1)[0]
     cmd = (
         "set -e; "
-        "_t=$(mktemp /tmp/.smolvm_env.XXXXXXXXXX); "
+        f"mkdir -p {env_dir}; "
+        f"_t=$(mktemp {env_dir}/.smolvm_env.XXXXXXXXXX); "
         "trap 'rm -f \"$_t\"' EXIT; "
         f"printf '%s' '{b64}' | base64 -d > \"$_t\"; "
         f'chmod 0644 "$_t"; '

--- a/src/smolvm/host/manager.py
+++ b/src/smolvm/host/manager.py
@@ -290,10 +290,16 @@ class HostManager:
 
             # Extract
             with tarfile.open(tarball_path, "r:gz") as tar:
-                # Security: validate member paths to prevent path traversal
+                # Security: validate member paths to prevent path traversal.
+                # Links and device nodes are rejected too: the unfiltered
+                # fallback below would happily create a symlink pointing
+                # outside tmp_dir and then write "through" it, which the path
+                # check alone does not catch.
                 for member in tar.getmembers():
                     if member.name.startswith("/") or ".." in PurePosixPath(member.name).parts:
                         raise HostError(f"Refusing to extract suspicious path: {member.name}")
+                    if member.issym() or member.islnk() or member.isdev():
+                        raise HostError(f"Refusing to extract link or device: {member.name}")
                 if hasattr(tarfile, "data_filter"):
                     tar.extractall(path=tmp_dir, filter="data")
                 else:

--- a/src/smolvm/host/manager.py
+++ b/src/smolvm/host/manager.py
@@ -25,13 +25,13 @@ import stat
 import tarfile
 import tempfile
 from enum import Enum
-from pathlib import Path, PurePosixPath
+from pathlib import Path
 
 import requests
 from pydantic import BaseModel
 
 from smolvm.exceptions import HostError
-from smolvm.utils import which
+from smolvm.utils import unsafe_tar_member_kind, which
 
 logger = logging.getLogger(__name__)
 
@@ -290,15 +290,14 @@ class HostManager:
 
             # Extract
             with tarfile.open(tarball_path, "r:gz") as tar:
-                # Security: validate member paths to prevent path traversal.
-                # Links and device nodes are rejected too: the unfiltered
-                # fallback below would happily create a symlink pointing
-                # outside tmp_dir and then write "through" it, which the path
-                # check alone does not catch.
+                # Security: reject members that could escape tmp_dir, whether
+                # by path or through a link. One shared rule — see
+                # smolvm.utils.unsafe_tar_member_kind.
                 for member in tar.getmembers():
-                    if member.name.startswith("/") or ".." in PurePosixPath(member.name).parts:
+                    kind = unsafe_tar_member_kind(member)
+                    if kind == "path":
                         raise HostError(f"Refusing to extract suspicious path: {member.name}")
-                    if member.issym() or member.islnk() or member.isdev():
+                    if kind is not None:
                         raise HostError(f"Refusing to extract link or device: {member.name}")
                 if hasattr(tarfile, "data_filter"):
                     tar.extractall(path=tmp_dir, filter="data")

--- a/src/smolvm/host/network.py
+++ b/src/smolvm/host/network.py
@@ -1843,6 +1843,64 @@ class NetworkManager:
             comment=comment,
         )
 
+    def _egress_rule_lines(self, tap_device: str, allowed_ips: list[str]) -> list[str]:
+        """Build the nft rules enforcing an egress allowlist for one TAP.
+
+        Shared by the sync and async appliers so the two cannot drift — the
+        IPv6 gap below existed in both copies and would have had to be found
+        and fixed twice.
+
+        Rule order matters and is fail-closed:
+
+        1. Drop all IPv6 leaving the TAP. The allowlist is IPv4-only — the
+           accept and drop rules below match ``ip daddr``, which in an
+           ``inet`` table skips IPv6 packets entirely, and
+           ``resolve_domains_to_ips`` discards AAAA records so no IPv6
+           destination can ever be on the list. Without this rule IPv6
+           traffic matched nothing and fell through to the chain's
+           ``policy accept``, so a guest that picked up a global IPv6
+           address (via SLAAC on a bridged LAN, say) reached the whole
+           internet with the allowlist still nominally in force. This is
+           first so the established/related accept below cannot re-admit an
+           IPv6 flow.
+        2. Accept established/related return traffic.
+        3. Accept the allowed IPv4 destinations.
+        4. Drop everything else.
+        """
+        comment_prefix = f"smolvm:egress:{tap_device}"
+        tap = self._quote(tap_device)
+        lines = [
+            (
+                f"add rule {_NFT_FILTER_FAMILY} {_NFT_FILTER_TABLE} forward "
+                f"iifname {tap} meta nfproto ipv6 counter drop "
+                f"comment {self._quote(f'{comment_prefix}:drop6')}"
+            ),
+            (
+                f"add rule {_NFT_FILTER_FAMILY} {_NFT_FILTER_TABLE} forward "
+                f"iifname {tap} ct state established,related "
+                f"counter accept comment {self._quote(f'{comment_prefix}:established')}"
+            ),
+        ]
+
+        if allowed_ips:
+            # nftables anonymous set: ip daddr != { a, b, c }
+            ip_set = ", ".join(allowed_ips)
+            lines.append(
+                f"add rule {_NFT_FILTER_FAMILY} {_NFT_FILTER_TABLE} forward "
+                f"iifname {tap} ip daddr {{ {ip_set} }} "
+                f"counter accept comment {self._quote(f'{comment_prefix}:allow')}"
+            )
+            drop_expr = f"iifname {tap} ip daddr != {{ {ip_set} }} counter drop"
+        else:
+            # No IPs allowed — drop unconditionally.
+            drop_expr = f"iifname {tap} counter drop"
+
+        lines.append(
+            f"add rule {_NFT_FILTER_FAMILY} {_NFT_FILTER_TABLE} forward "
+            f"{drop_expr} comment {self._quote(f'{comment_prefix}:drop')}"
+        )
+        return lines
+
     def apply_egress_allowlist(
         self,
         tap_device: str,
@@ -1853,6 +1911,8 @@ class NetworkManager:
         Installs per-TAP rules in the SmolVM filter forward chain keyed by tap
         name so they are isolated between tenants::
 
+            # the allowlist is IPv4-only, so IPv6 egress is refused outright
+            iifname <tap> meta nfproto ipv6 counter drop
             # pass matching return traffic (established sessions)
             iifname <tap> ct state established,related counter accept
             # allow the configured destination set
@@ -1897,33 +1957,7 @@ class NetworkManager:
             _NFT_FILTER_TABLE,
             comment=f"smolvm:nat:tap:{tap_device}:to:{iface}",
         )
-        script_lines = [
-            (
-                f"add rule {_NFT_FILTER_FAMILY} {_NFT_FILTER_TABLE} forward "
-                f"iifname {self._quote(tap_device)} ct state established,related "
-                f"counter accept comment {self._quote(f'{comment_prefix}:established')}"
-            ),
-        ]
-
-        if allowed_ips:
-            # nftables anonymous set: ip daddr != { a, b, c }
-            ip_set = ", ".join(allowed_ips)
-            script_lines.append(
-                (
-                    f"add rule {_NFT_FILTER_FAMILY} {_NFT_FILTER_TABLE} forward "
-                    f"iifname {self._quote(tap_device)} ip daddr {{ {ip_set} }} "
-                    f"counter accept comment {self._quote(f'{comment_prefix}:allow')}"
-                ),
-            )
-            drop_expr = f"iifname {self._quote(tap_device)} ip daddr != {{ {ip_set} }} counter drop"
-        else:
-            # No IPs allowed — drop unconditionally.
-            drop_expr = f"iifname {self._quote(tap_device)} counter drop"
-
-        script_lines.append(
-            f"add rule {_NFT_FILTER_FAMILY} {_NFT_FILTER_TABLE} forward "
-            f"{drop_expr} comment {self._quote(f'{comment_prefix}:drop')}"
-        )
+        script_lines = self._egress_rule_lines(tap_device, allowed_ips)
 
         script_lines.extend(old_egress_delete_lines)
         script_lines.extend(old_nat_accept_delete_lines)
@@ -1973,31 +2007,7 @@ class NetworkManager:
             _NFT_FILTER_TABLE,
             comment=f"smolvm:nat:tap:{tap_device}:to:{iface}",
         )
-        script_lines = [
-            (
-                f"add rule {_NFT_FILTER_FAMILY} {_NFT_FILTER_TABLE} forward "
-                f"iifname {self._quote(tap_device)} ct state established,related "
-                f"counter accept comment {self._quote(f'{comment_prefix}:established')}"
-            ),
-        ]
-
-        if allowed_ips:
-            ip_set = ", ".join(allowed_ips)
-            script_lines.append(
-                (
-                    f"add rule {_NFT_FILTER_FAMILY} {_NFT_FILTER_TABLE} forward "
-                    f"iifname {self._quote(tap_device)} ip daddr {{ {ip_set} }} "
-                    f"counter accept comment {self._quote(f'{comment_prefix}:allow')}"
-                ),
-            )
-            drop_expr = f"iifname {self._quote(tap_device)} ip daddr != {{ {ip_set} }} counter drop"
-        else:
-            drop_expr = f"iifname {self._quote(tap_device)} counter drop"
-
-        script_lines.append(
-            f"add rule {_NFT_FILTER_FAMILY} {_NFT_FILTER_TABLE} forward "
-            f"{drop_expr} comment {self._quote(f'{comment_prefix}:drop')}"
-        )
+        script_lines = self._egress_rule_lines(tap_device, allowed_ips)
 
         script_lines.extend(old_egress_delete_lines)
         script_lines.extend(old_nat_accept_delete_lines)

--- a/src/smolvm/images/builder.py
+++ b/src/smolvm/images/builder.py
@@ -1161,9 +1161,9 @@ if len(sys.argv) != 3:
 
 port = int(sys.argv[1])
 timeout = float(sys.argv[2])
-deadline = time.time() + timeout
+deadline = time.monotonic() + timeout
 
-while time.time() < deadline:
+while time.monotonic() < deadline:
     with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
         sock.settimeout(1.0)
         if sock.connect_ex(("127.0.0.1", port)) == 0:

--- a/src/smolvm/images/manager.py
+++ b/src/smolvm/images/manager.py
@@ -57,15 +57,28 @@ def _normalize_digest(expected: str | None) -> str | None:
     unverifiable: the download "failed" its checksum every time and the
     cache never converged.
 
-    Only ``None`` means "no digest was pinned". A blank string is left blank
-    so it still fails comparison: callers disagree on whether blank means
-    unpinned (``_download_file`` tests truthiness) or pinned-but-empty
-    (``ensure_rootfs_only`` tests ``is not None``), and collapsing it here
-    would let the stricter caller accept an unverified image.
+    Only ``None`` means "no digest was pinned". A blank string is a malformed
+    pin, not an opt-out — see :func:`_reject_blank_digest`.
     """
     if expected is None:
         return None
     return expected.strip().lower()
+
+
+def _reject_blank_digest(expected: str | None, *, algorithm: str, source: str) -> None:
+    """Fail a download whose pin is present but empty.
+
+    A caller that passes a digest is asking for verification. Reading blank as
+    "no digest" let a malformed pin download an unverified image while the
+    cache check — which compares blank and fails — rejected the very same file,
+    so the image was re-fetched, unverified, on every call.
+    """
+    if expected is not None and not expected:
+        raise ImageError(
+            f"The {algorithm} checksum given for {source} is empty, so the download "
+            "cannot be verified. Supply the full checksum, or remove it to skip "
+            "verification deliberately."
+        )
 
 
 def _parse_content_length(raw_length: str | None) -> int | None:
@@ -564,6 +577,11 @@ class ImageManager:
         if not name:
             raise ValueError("image name cannot be empty")
 
+        # Fail before any network work, and with a message that names the real
+        # problem rather than a mismatch against an empty expected value.
+        _reject_blank_digest(_normalize_digest(sha256), algorithm="SHA-256", source=url)
+        _reject_blank_digest(_normalize_digest(sha512), algorithm="SHA-512", source=url)
+
         safe_filename = ImageSource.normalize_cache_filename(filename)
         image_dir = self.cache_dir / name
         rootfs_path = image_dir / safe_filename
@@ -672,6 +690,7 @@ class ImageManager:
         tmp_path = Path(tmp_path_str)
 
         expected = _normalize_digest(expected_sha256)
+        _reject_blank_digest(expected, algorithm="SHA-256", source=url)
 
         try:
             # Take ownership of the mkstemp descriptor before anything else can
@@ -970,6 +989,7 @@ class ImageManager:
         # different case, while the cache check accepted it — so the two
         # disagreed and the image could never be fetched.
         expected = _normalize_digest(expected_sha256)
+        _reject_blank_digest(expected, algorithm="SHA-256", source=f"s3://{bucket}/{key}")
 
         try:
             sha256 = hashlib.sha256() if expected else None

--- a/src/smolvm/images/manager.py
+++ b/src/smolvm/images/manager.py
@@ -684,13 +684,17 @@ class ImageManager:
         Raises:
             ImageError: If download or checksum verification fails.
         """
+        # Validate the pin before allocating anything. Both helpers are pure,
+        # and raising between mkstemp() and the try block below would leak the
+        # descriptor *and* orphan the .tmp file, since neither the `with` nor
+        # the `finally` would be reached.
+        expected = _normalize_digest(expected_sha256)
+        _reject_blank_digest(expected, algorithm="SHA-256", source=url)
+
         # Use a temp file in the same directory for atomic rename
         dest.parent.mkdir(parents=True, exist_ok=True)
         tmp_fd, tmp_path_str = tempfile.mkstemp(dir=dest.parent, suffix=".tmp")
         tmp_path = Path(tmp_path_str)
-
-        expected = _normalize_digest(expected_sha256)
-        _reject_blank_digest(expected, algorithm="SHA-256", source=url)
 
         try:
             # Take ownership of the mkstemp descriptor before anything else can
@@ -979,17 +983,19 @@ class ImageManager:
 
         Uses the same temp-file-then-rename pattern as :meth:`_download_file`.
         """
-        dest.parent.mkdir(parents=True, exist_ok=True)
-        tmp_fd, tmp_path_str = tempfile.mkstemp(dir=dest.parent, suffix=".tmp")
-        tmp_path = Path(tmp_path_str)
-
         # Same normalization as the HTTP path and the cache check. Without it
         # an uppercase digest in a ``smolvm-image.json`` failed every download
         # with a mismatch whose expected and actual were the same digest in
         # different case, while the cache check accepted it — so the two
-        # disagreed and the image could never be fetched.
+        # disagreed and the image could never be fetched. Runs before mkstemp
+        # for the same reason as in ``_download_file``: raising after it would
+        # leak the descriptor and orphan the .tmp file.
         expected = _normalize_digest(expected_sha256)
         _reject_blank_digest(expected, algorithm="SHA-256", source=f"s3://{bucket}/{key}")
+
+        dest.parent.mkdir(parents=True, exist_ok=True)
+        tmp_fd, tmp_path_str = tempfile.mkstemp(dir=dest.parent, suffix=".tmp")
+        tmp_path = Path(tmp_path_str)
 
         try:
             sha256 = hashlib.sha256() if expected else None

--- a/src/smolvm/images/manager.py
+++ b/src/smolvm/images/manager.py
@@ -57,13 +57,15 @@ def _normalize_digest(expected: str | None) -> str | None:
     unverifiable: the download "failed" its checksum every time and the
     cache never converged.
 
-    ``None`` — and a blank string, which every caller has always treated the
-    same way — means "no digest was pinned", so verification is skipped.
+    Only ``None`` means "no digest was pinned". A blank string is left blank
+    so it still fails comparison: callers disagree on whether blank means
+    unpinned (``_download_file`` tests truthiness) or pinned-but-empty
+    (``ensure_rootfs_only`` tests ``is not None``), and collapsing it here
+    would let the stricter caller accept an unverified image.
     """
     if expected is None:
         return None
-    normalized = expected.strip().lower()
-    return normalized or None
+    return expected.strip().lower()
 
 
 def _parse_content_length(raw_length: str | None) -> int | None:
@@ -962,8 +964,15 @@ class ImageManager:
         tmp_fd, tmp_path_str = tempfile.mkstemp(dir=dest.parent, suffix=".tmp")
         tmp_path = Path(tmp_path_str)
 
+        # Same normalization as the HTTP path and the cache check. Without it
+        # an uppercase digest in a ``smolvm-image.json`` failed every download
+        # with a mismatch whose expected and actual were the same digest in
+        # different case, while the cache check accepted it — so the two
+        # disagreed and the image could never be fetched.
+        expected = _normalize_digest(expected_sha256)
+
         try:
-            sha256 = hashlib.sha256() if expected_sha256 else None
+            sha256 = hashlib.sha256() if expected else None
             # Use get_object (single GetObject call) instead of
             # download_fileobj which issues HeadObject first — some
             # S3-compatible stores reject HeadObject.
@@ -977,12 +986,12 @@ class ImageManager:
                     if progress_callback is not None:
                         progress_callback(len(chunk), total)
 
-            if sha256 is not None and expected_sha256 is not None:
+            if sha256 is not None and expected is not None:
                 actual_hash = sha256.hexdigest()
-                if actual_hash != expected_sha256:
+                if actual_hash != expected:
                     raise ImageError(
                         f"SHA-256 mismatch for s3://{bucket}/{key}\n"
-                        f"  expected: {expected_sha256}\n"
+                        f"  expected: {expected}\n"
                         f"  actual:   {actual_hash}"
                     )
 

--- a/src/smolvm/images/manager.py
+++ b/src/smolvm/images/manager.py
@@ -48,6 +48,41 @@ _DOWNLOAD_CHUNK_SIZE = 8192
 IMAGE_DIR_ENV = "SMOLVM_IMAGE_DIR"
 
 
+def _normalize_digest(expected: str | None) -> str | None:
+    """Return a hex digest in the canonical form used for comparison.
+
+    Hex digests are case-insensitive, and publishers write them both ways
+    (``sha256sum`` lowercases, plenty of release pages and S3 manifests
+    uppercase). Comparing raw strings made an uppercase pin permanently
+    unverifiable: the download "failed" its checksum every time and the
+    cache never converged.
+
+    ``None`` — and a blank string, which every caller has always treated the
+    same way — means "no digest was pinned", so verification is skipped.
+    """
+    if expected is None:
+        return None
+    normalized = expected.strip().lower()
+    return normalized or None
+
+
+def _parse_content_length(raw_length: str | None) -> int | None:
+    """Return the response body size, or ``None`` when it isn't usable.
+
+    ``Content-Length`` is only a progress hint here. Some proxies emit a
+    repeated value ("123, 123") or drop the header entirely, and neither
+    should turn a working download into a crash.
+    """
+    if raw_length is None:
+        return None
+    try:
+        total = int(raw_length.strip())
+    except (AttributeError, ValueError):
+        logger.debug("Ignoring unparseable content-length header: %r", raw_length)
+        return None
+    return total if total >= 0 else None
+
+
 def _expand_image_dir(path: Path) -> Path:
     try:
         return path.expanduser()
@@ -634,17 +669,20 @@ class ImageManager:
         tmp_fd, tmp_path_str = tempfile.mkstemp(dir=dest.parent, suffix=".tmp")
         tmp_path = Path(tmp_path_str)
 
+        expected = _normalize_digest(expected_sha256)
+
         try:
-            response = requests.get(url, stream=True, timeout=300)
-            response.raise_for_status()
-
-            total: int | None = None
-            raw_length = response.headers.get("content-length")
-            if raw_length is not None:
-                total = int(raw_length)
-
-            sha256 = hashlib.sha256() if expected_sha256 else None
+            # Take ownership of the mkstemp descriptor before anything else can
+            # raise. Opening it inside the request block leaked one descriptor
+            # per failed download, and a retry loop then ran the process out of
+            # file handles.
             with open(tmp_fd, "wb") as f:
+                response = requests.get(url, stream=True, timeout=300)
+                response.raise_for_status()
+
+                total = _parse_content_length(response.headers.get("content-length"))
+
+                sha256 = hashlib.sha256() if expected else None
                 for chunk in response.iter_content(chunk_size=_DOWNLOAD_CHUNK_SIZE):
                     f.write(chunk)
                     if sha256 is not None:
@@ -652,12 +690,12 @@ class ImageManager:
                     if progress_callback is not None:
                         progress_callback(len(chunk), total)
 
-            if sha256 is not None and expected_sha256 is not None:
+            if sha256 is not None and expected is not None:
                 actual_hash = sha256.hexdigest()
-                if actual_hash != expected_sha256:
+                if actual_hash != expected:
                     raise ImageError(
                         f"SHA-256 mismatch for {url}\n"
-                        f"  expected: {expected_sha256}\n"
+                        f"  expected: {expected}\n"
                         f"  actual:   {actual_hash}"
                     )
 
@@ -682,7 +720,8 @@ class ImageManager:
         Returns:
             True if the checksum matches or if no hash was provided.
         """
-        if expected is None:
+        normalized = _normalize_digest(expected)
+        if normalized is None:
             return True
 
         sha256 = hashlib.sha256()
@@ -694,11 +733,11 @@ class ImageManager:
                 sha256.update(chunk)
 
         actual = sha256.hexdigest()
-        if actual != expected:
+        if actual != normalized:
             logger.debug(
                 "SHA-256 mismatch for %s: expected=%s, actual=%s",
                 path,
-                expected,
+                normalized,
                 actual,
             )
             return False
@@ -727,15 +766,16 @@ class ImageManager:
         Returns:
             True if the checksum matches or if no hash was provided.
         """
-        if expected is None:
+        normalized = _normalize_digest(expected)
+        if normalized is None:
             return True
 
         actual = cls._compute_sha512(path)
-        if actual != expected.lower():
+        if actual != normalized:
             logger.debug(
                 "SHA-512 mismatch for %s: expected=%s, actual=%s",
                 path,
-                expected,
+                normalized,
                 actual,
             )
             return False

--- a/src/smolvm/images/published.py
+++ b/src/smolvm/images/published.py
@@ -433,15 +433,21 @@ def _decompress_zstd(src: Path, dst: Path) -> None:
 
     staging = dst.with_name(f".{dst.name}.{uuid4().hex}.partial")
     try:
-        decompress_zstd_sparse(src, staging, chunk_size=_SPARSE_DECOMPRESS_CHUNK_SIZE)
-        staging.replace(dst)
-    except OSError as exc:
+        try:
+            decompress_zstd_sparse(src, staging, chunk_size=_SPARSE_DECOMPRESS_CHUNK_SIZE)
+            staging.replace(dst)
+        except OSError as exc:
+            if _looks_like_zstd_decode_error(exc):
+                import zstandard
+
+                raise zstandard.ZstdError(str(exc)) from exc
+            raise
+    except BaseException:
+        # Clean up on *any* failure, not just OSError. A corrupt archive
+        # (ZstdError) or a Ctrl-C used to leave the multi-GB partial behind,
+        # and every retry orphaned another copy of it.
         (staging.parent / (staging.name + ".tmp")).unlink(missing_ok=True)
         staging.unlink(missing_ok=True)
-        if _looks_like_zstd_decode_error(exc):
-            import zstandard
-
-            raise zstandard.ZstdError(str(exc)) from exc
         raise
 
 

--- a/src/smolvm/runtime/libkrun.py
+++ b/src/smolvm/runtime/libkrun.py
@@ -106,9 +106,12 @@ class LibkrunRuntimeAdapter(RuntimeAdapter):
         from contextlib import suppress
 
         settle = min(0.5, boot_timeout)
-        deadline = time.time() + settle
+        # Monotonic: the async twin already uses the loop clock, and a
+        # wall-clock step here would either skip the settle window entirely
+        # or stretch it far past the caller's boot timeout.
+        deadline = time.monotonic() + settle
 
-        while time.time() < deadline:
+        while time.monotonic() < deadline:
             rc = process.poll()
             if rc is not None:
                 raise SmolVMError(

--- a/src/smolvm/runtime/qemu.py
+++ b/src/smolvm/runtime/qemu.py
@@ -213,8 +213,10 @@ class _SwtpmSidecar:
                 },
             ) from exc
 
-        deadline = time.time() + timeout
-        while time.time() < deadline:
+        # Monotonic: a wall-clock deadline can be skipped past (or pushed out
+        # of reach) by an NTP step or a DST change mid-boot.
+        deadline = time.monotonic() + timeout
+        while time.monotonic() < deadline:
             if self._socket_path.exists():
                 break
             time.sleep(0.05)
@@ -245,8 +247,8 @@ class _SwtpmSidecar:
             if pid > 0 and self._context.is_process_running(pid):
                 with suppress(ProcessLookupError, OSError):
                     os.kill(pid, signal.SIGTERM)
-                deadline = time.time() + 5.0
-                while time.time() < deadline and self._context.is_process_running(pid):
+                deadline = time.monotonic() + 5.0
+                while time.monotonic() < deadline and self._context.is_process_running(pid):
                     time.sleep(0.05)
                 if self._context.is_process_running(pid):
                     with suppress(ProcessLookupError, OSError):
@@ -1726,8 +1728,8 @@ class QemuRuntimeAdapter(RuntimeAdapter):
 
     def _wait_for_runtime(self, process: Any, control_socket_path: Path, timeout: float) -> None:
         """Wait for QEMU to expose its QMP socket or fail fast if it exits."""
-        deadline = time.time() + timeout
-        while time.time() < deadline:
+        deadline = time.monotonic() + timeout
+        while time.monotonic() < deadline:
             exit_code = process.poll()
             if exit_code is not None:
                 raise SmolVMError(

--- a/src/smolvm/ssh.py
+++ b/src/smolvm/ssh.py
@@ -419,6 +419,12 @@ class SSHClient:
         and is used to efficiently poll for port readiness before attempting
         a paramiko connect.
         """
+        if timeout <= 0:
+            # ``socket.create_connection`` rejects a non-positive timeout with
+            # ValueError, which is not an OSError and would escape the caller's
+            # retry loop. A deadline that has already passed simply means the
+            # port is not open yet.
+            return False
         try:
             with socket.create_connection((self.host, self.port), timeout=timeout) as sock:
                 # Read the SSH banner to confirm sshd is actually ready,
@@ -469,19 +475,27 @@ class SSHClient:
 
         # Phase 1: Fast TCP probe — detect when sshd port is open.
         backoff = _WAIT_BACKOFF_START
+        port_opened = False
         while time.monotonic() < deadline:
             if self._tcp_port_open(timeout=min(0.5, deadline - time.monotonic())):
                 logger.debug("TCP port %d is open on %s", self.port, self.host)
+                port_opened = True
                 break
 
             remaining = deadline - time.monotonic()
             if remaining <= 0:
-                raise OperationTimeoutError(
-                    f"wait_for_ssh({self.host}:{self.port}): port never opened",
-                    timeout,
-                )
+                break
             time.sleep(min(backoff, remaining))
             backoff = min(backoff * _WAIT_BACKOFF_FACTOR, interval)
+
+        if not port_opened:
+            # Falling through to phase 2 here would burn no time (the deadline
+            # has passed) and then report an empty "last error", hiding the
+            # only fact we actually know: sshd never answered on the port.
+            raise OperationTimeoutError(
+                f"wait_for_ssh({self.host}:{self.port}): port never opened",
+                timeout,
+            )
 
         # Phase 2: Establish persistent paramiko connection. The TCP port is
         # already open, but sshd may still be mid-startup (and on QEMU user-mode

--- a/src/smolvm/storage/_memory.py
+++ b/src/smolvm/storage/_memory.py
@@ -236,6 +236,10 @@ class MemoryStateManager:
         excluded_host_ports: set[int] | None = None,
     ) -> int:
         del guest_port
+        # Same range check the SQLite backend applies, so both state managers
+        # reject an unusable port up front instead of at hypervisor start.
+        if host_port is not None and (host_port < 1 or host_port > 65535):
+            raise ValueError("host_port must be 1-65535")
         with self._lock:
             existing = self._ssh_ports.get(vm_id)
             if existing is not None:

--- a/src/smolvm/utils.py
+++ b/src/smolvm/utils.py
@@ -18,10 +18,11 @@ import logging
 import os
 import shutil
 import subprocess
+import tarfile
 import time
 from collections.abc import Sequence
 from contextlib import suppress
-from pathlib import Path
+from pathlib import Path, PurePosixPath
 
 from smolvm.exceptions import SmolVMError
 
@@ -200,6 +201,33 @@ def tail_file(path: Path, line_count: int) -> tuple[list[str], int, bool]:
         normalized = normalized[:-1]  # no trailing empty line, matching splitlines
     lines = normalized.split("\n") if normalized else []
     return lines[-line_count:], len(data), ends_with_newline
+
+
+def unsafe_tar_member_kind(member: "tarfile.TarInfo") -> str | None:
+    """Classify why *member* is unsafe to extract, or ``None`` if it is fine.
+
+    One definition of "unsafe tar member", shared by every extractor. Returns
+    a category — ``"path"``, ``"link"`` or ``"device"`` — rather than a
+    message, so each caller keeps its own exception type and its own wording.
+
+    Two rules, both needed. Absolute paths and ``..`` components escape the
+    destination directly. Links and device nodes escape indirectly: a member
+    like ``link -> /etc`` passes any name-based check, and a later member
+    written "through" it lands outside the destination entirely — which is why
+    a path check alone is not a traversal guard.
+
+    Python 3.12's ``filter="data"`` enforces all of this, but the extractors
+    still carry an unfiltered fallback for older interpreters, and that
+    fallback is exactly where these rules have to hold.
+    """
+    name = member.name
+    if name.startswith("/") or ".." in PurePosixPath(name).parts:
+        return "path"
+    if member.issym() or member.islnk():
+        return "link"
+    if member.isdev():
+        return "device"
+    return None
 
 
 def which(binary: str) -> Path | None:

--- a/src/smolvm/utils.py
+++ b/src/smolvm/utils.py
@@ -20,6 +20,7 @@ import shutil
 import subprocess
 import time
 from collections.abc import Sequence
+from contextlib import suppress
 from pathlib import Path
 
 from smolvm.exceptions import SmolVMError
@@ -268,15 +269,40 @@ def ensure_ssh_key(key_dir: Path | None = None) -> tuple[Path, Path]:
                 pass
         return private_key, public_key
 
-    # Only one half of the pair survived (an interrupted generation, or a
-    # deleted .pub). ssh-keygen would stop at an interactive "Overwrite (y/n)?"
-    # prompt it writes to the stderr we discard: the CLI either blocks forever
-    # on a terminal, or fails with no visible reason. Clear the leftovers so
-    # generation is unattended.
-    for leftover in (private_key, public_key):
-        if leftover.exists():
-            logger.warning("Removing incomplete SSH key file: %s", leftover)
-            leftover.unlink()
+    # The private key is what every existing sandbox trusts — its public half
+    # is already in their authorized_keys. Losing it locks the user out of all
+    # of them, so a missing .pub is repaired from the private key rather than
+    # triggering a silent key rotation.
+    if private_key.exists():
+        logger.info("Public key missing; deriving it from %s", private_key)
+        derived = subprocess.run(
+            ["ssh-keygen", "-y", "-f", str(private_key)],
+            check=False,
+            capture_output=True,
+            text=True,
+            stdin=subprocess.DEVNULL,
+        )
+        if derived.returncode != 0:
+            raise SmolVMError(
+                f"SmolVM's SSH key at '{private_key}' could not be read. Move it "
+                f"somewhere safe and delete '{key_dir}' to start over — sandboxes "
+                "created with the old key will need to be recreated.\n"
+                f"ssh-keygen stderr: {derived.stderr.strip()}"
+            )
+        public_key.write_text(derived.stdout)
+        public_key.chmod(0o644)
+        if sudo_uid is not None and sudo_gid is not None:
+            with suppress(OSError):
+                os.chown(public_key, sudo_uid, sudo_gid)
+        return private_key, public_key
+
+    # Only an orphaned .pub survived. Without its private half it authenticates
+    # nothing, and ssh-keygen would stop at an interactive "Overwrite (y/n)?"
+    # prompt written to the stderr we discard — blocking the CLI on a terminal,
+    # or failing invisibly otherwise. Clear it so generation is unattended.
+    if public_key.exists():
+        logger.warning("Removing orphaned SSH public key with no private half: %s", public_key)
+        public_key.unlink()
 
     logger.info("Generating new SSH key pair at %s...", key_dir)
     subprocess.run(

--- a/src/smolvm/utils.py
+++ b/src/smolvm/utils.py
@@ -268,6 +268,16 @@ def ensure_ssh_key(key_dir: Path | None = None) -> tuple[Path, Path]:
                 pass
         return private_key, public_key
 
+    # Only one half of the pair survived (an interrupted generation, or a
+    # deleted .pub). ssh-keygen would stop at an interactive "Overwrite (y/n)?"
+    # prompt it writes to the stderr we discard: the CLI either blocks forever
+    # on a terminal, or fails with no visible reason. Clear the leftovers so
+    # generation is unattended.
+    for leftover in (private_key, public_key):
+        if leftover.exists():
+            logger.warning("Removing incomplete SSH key file: %s", leftover)
+            leftover.unlink()
+
     logger.info("Generating new SSH key pair at %s...", key_dir)
     subprocess.run(
         [
@@ -282,6 +292,7 @@ def ensure_ssh_key(key_dir: Path | None = None) -> tuple[Path, Path]:
             "smolvm-auto",
         ],
         check=True,
+        stdin=subprocess.DEVNULL,
         stdout=subprocess.DEVNULL,
         stderr=subprocess.DEVNULL,
     )

--- a/src/smolvm/vm.py
+++ b/src/smolvm/vm.py
@@ -3525,8 +3525,11 @@ class SmolVMManager:
                 self._process_handles.pop(pid, None)
             return
 
-        start = time.time()
-        while time.time() - start < timeout:
+        # Monotonic: a wall-clock step forward would abandon the wait on a VM
+        # that is shutting down cleanly (the caller then escalates to SIGKILL),
+        # and a step backward would stall the wait well past *timeout*.
+        start = time.monotonic()
+        while time.monotonic() - start < timeout:
             if not self._is_process_running(pid):
                 return
             time.sleep(0.1)

--- a/tests/test_env.py
+++ b/tests/test_env.py
@@ -14,6 +14,7 @@
 
 """Tests for smolvm.env — environment variable injection helpers."""
 
+import subprocess
 from unittest.mock import MagicMock
 
 import pytest
@@ -218,6 +219,47 @@ class TestInjectEnvVars:
         with pytest.raises(ValueError, match="Invalid"):
             inject_env_vars(ssh, {"BAD KEY": "val"}, merge=False)
         ssh.run.assert_not_called()
+
+    def test_staging_file_is_a_sibling_of_the_env_file(self) -> None:
+        """The temp file must share a filesystem with its destination.
+
+        ``rename(2)`` is what makes the final swap atomic, and it cannot cross
+        filesystems. Staging under ``/tmp`` — a separate tmpfs on most guest
+        images — silently downgraded the ``mv`` to copy-then-unlink, so an
+        interrupted write left every new login shell sourcing a truncated file.
+        """
+        ssh = _make_ssh_mock()
+        inject_env_vars(ssh, {"FOO": "bar"}, merge=False)
+
+        call_cmd = ssh.run.call_args[0][0]
+        env_dir = ENV_FILE.rsplit("/", 1)[0]
+
+        assert f"mktemp {env_dir}/" in call_cmd
+        assert "mktemp /tmp/" not in call_cmd
+
+    def test_generated_script_writes_the_env_file(self, tmp_path, monkeypatch) -> None:
+        """Execute the generated shell script for real and check the result."""
+        env_file = tmp_path / "profile.d" / "smolvm_env.sh"
+        monkeypatch.setattr("smolvm.env.ENV_FILE", str(env_file))
+
+        ssh = MagicMock()
+
+        def _run(cmd: str, timeout: int | None = None) -> CommandResult:
+            completed = subprocess.run(["sh", "-c", cmd], capture_output=True, text=True)
+            return CommandResult(
+                exit_code=completed.returncode,
+                stdout=completed.stdout,
+                stderr=completed.stderr,
+            )
+
+        ssh.run = _run
+
+        inject_env_vars(ssh, {"FOO": "bar baz"}, merge=False)
+
+        assert env_file.read_text().splitlines()[-1] == "export FOO='bar baz'"
+        assert env_file.stat().st_mode & 0o777 == 0o644
+        # The trap cleaned up after itself: no staging file left behind.
+        assert [p.name for p in env_file.parent.iterdir()] == [env_file.name]
 
 
 # ── read_env_vars ────────────────────────────────────────────────────

--- a/tests/test_env.py
+++ b/tests/test_env.py
@@ -245,6 +245,7 @@ class TestInjectEnvVars:
         ssh = MagicMock()
 
         def _run(cmd: str, timeout: int | None = None) -> CommandResult:
+            """Execute the generated script for real instead of mocking it."""
             completed = subprocess.run(["sh", "-c", cmd], capture_output=True, text=True)
             return CommandResult(
                 exit_code=completed.returncode,

--- a/tests/test_images.py
+++ b/tests/test_images.py
@@ -443,20 +443,20 @@ class TestVerifySHA256:
         # Normalization must not turn a real mismatch into a pass.
         assert ImageManager._verify_sha256(file_path, "A" * 64) is False
 
-    def test_blank_hash_means_no_pin(self, tmp_path: Path) -> None:
-        """A blank digest reads as "not pinned", matching ``_download_file``.
+    def test_blank_hash_is_not_treated_as_unpinned(self, tmp_path: Path) -> None:
+        """A blank digest must still fail, never silently skip verification.
 
-        ``_download_file`` has always treated a falsy digest as "no pin" and
-        skipped verification, so a blank string never gated what landed in the
-        cache. The verifiers now agree with it instead of reporting a mismatch
-        that would re-download the same file forever.
+        Callers disagree on what blank means: ``_download_file`` tests
+        truthiness (unpinned) while ``ensure_rootfs_only`` tests ``is not
+        None`` (pinned). Normalizing blank to "no digest" would let the
+        stricter caller accept an unverified rootfs.
         """
         file_path = tmp_path / "test.bin"
         file_path.write_bytes(b"hello world")
 
-        assert ImageManager._verify_sha256(file_path, "") is True
-        assert ImageManager._verify_sha256(file_path, "   ") is True
-        assert ImageManager._verify_sha512(file_path, "") is True
+        assert ImageManager._verify_sha256(file_path, "") is False
+        assert ImageManager._verify_sha256(file_path, "   ") is False
+        assert ImageManager._verify_sha512(file_path, "") is False
 
     @patch("smolvm.images.manager.requests.get")
     def test_download_skips_sha_when_none(self, mock_get: MagicMock, tmp_path: Path) -> None:
@@ -600,6 +600,30 @@ class TestEnsureRootfsOnly:
 
         assert result.exists()
         assert result.read_bytes() == content
+
+    @patch("smolvm.images.manager.requests.get")
+    def test_blank_sha512_is_rejected_not_skipped(
+        self, mock_get: MagicMock, tmp_path: Path
+    ) -> None:
+        """A blank sha512 must not downgrade into "unverified, accepted".
+
+        This call site gates on ``sha512 is not None``, so a blank string is a
+        pin it expects to enforce. Treating blank as "no digest" would hand
+        back a rootfs that nothing checked.
+        """
+        mock_resp = MagicMock()
+        mock_resp.raise_for_status = MagicMock()
+        mock_resp.headers = {}
+        mock_resp.iter_content = lambda chunk_size: iter([b"rootfs bytes"])
+        mock_get.return_value = mock_resp
+
+        mgr = ImageManager(cache_dir=tmp_path / "images")
+        with pytest.raises(ImageError, match="SHA-512 mismatch"):
+            mgr.ensure_rootfs_only(
+                "blank-pin",
+                url="https://example.com/rootfs.qcow2",
+                sha512="",
+            )
 
 
 class TestImageManagerInit:
@@ -799,6 +823,50 @@ class TestEnsureS3Image:
         assert local.kernel_path.read_bytes() == kernel_content
         assert local.rootfs_path.read_bytes() == rootfs_content
         assert parsed_manifest.name == "test-image"
+
+    def test_uppercase_manifest_digests_are_accepted(self, tmp_path: Path) -> None:
+        """An S3 manifest may write its digests in uppercase.
+
+        The download check compared raw strings while the cache check
+        normalized, so the two disagreed: every fetch failed with a mismatch
+        whose ``expected`` and ``actual`` were the same digest in different
+        case, and the image could never be pulled.
+        """
+        kernel_content = b"fake-kernel"
+        rootfs_content = b"fake-rootfs"
+        manifest = _make_s3_manifest_data(
+            kernel_sha256=hashlib.sha256(kernel_content).hexdigest().upper(),
+            rootfs_sha256=hashlib.sha256(rootfs_content).hexdigest().upper(),
+        )
+        mock_s3 = self._mock_s3_client(
+            manifest,
+            {"vmlinux.bin": kernel_content, "rootfs.ext4": rootfs_content},
+        )
+
+        mgr = ImageManager(cache_dir=tmp_path / "images")
+        with patch("smolvm.images.manager._require_boto3", return_value=mock_s3):
+            local, _ = mgr.ensure_s3_image("s3://bucket/images/test/")
+
+        assert local.kernel_path.read_bytes() == kernel_content
+        assert local.rootfs_path.read_bytes() == rootfs_content
+
+    def test_uppercase_manifest_digest_still_detects_corruption(self, tmp_path: Path) -> None:
+        """Normalizing case must not stop the S3 path catching a bad asset."""
+        manifest = _make_s3_manifest_data(
+            kernel_sha256=("A" * 64),
+            rootfs_sha256=hashlib.sha256(b"fake-rootfs").hexdigest(),
+        )
+        mock_s3 = self._mock_s3_client(
+            manifest,
+            {"vmlinux.bin": b"corrupted", "rootfs.ext4": b"fake-rootfs"},
+        )
+
+        mgr = ImageManager(cache_dir=tmp_path / "images")
+        with (
+            patch("smolvm.images.manager._require_boto3", return_value=mock_s3),
+            pytest.raises(ImageError, match="SHA-256 mismatch"),
+        ):
+            mgr.ensure_s3_image("s3://bucket/images/test/")
 
     def test_cache_hit_skips_download(self, tmp_path: Path) -> None:
         """Second call should use cache and not re-download assets."""

--- a/tests/test_images.py
+++ b/tests/test_images.py
@@ -607,9 +607,10 @@ class TestEnsureRootfsOnly:
     ) -> None:
         """A blank sha512 must not downgrade into "unverified, accepted".
 
-        This call site gates on ``sha512 is not None``, so a blank string is a
-        pin it expects to enforce. Treating blank as "no digest" would hand
-        back a rootfs that nothing checked.
+        Passing a digest is a request for verification, so an empty one is
+        malformed input and says so by name — rather than surfacing as a
+        mismatch against an empty expected value, or (worse) being read as
+        "no digest" and handing back a rootfs that nothing checked.
         """
         mock_resp = MagicMock()
         mock_resp.raise_for_status = MagicMock()
@@ -618,12 +619,15 @@ class TestEnsureRootfsOnly:
         mock_get.return_value = mock_resp
 
         mgr = ImageManager(cache_dir=tmp_path / "images")
-        with pytest.raises(ImageError, match="SHA-512 mismatch"):
+        with pytest.raises(ImageError, match="SHA-512 checksum .* is empty"):
             mgr.ensure_rootfs_only(
                 "blank-pin",
                 url="https://example.com/rootfs.qcow2",
                 sha512="",
             )
+
+        # Nothing was fetched: the malformed pin fails before any network work.
+        mock_get.assert_not_called()
 
 
 class TestImageManagerInit:
@@ -1156,3 +1160,278 @@ class TestS3CredentialResolution:
             from smolvm.images.manager import _require_boto3
 
             _require_boto3()
+
+
+# ---------------------------------------------------------------------------
+# Digest handling is spread across four comparison sites and several public
+# entry points. Two bugs came from treating one of them in isolation: the S3
+# download path was left comparing raw strings while the cache check
+# normalized (so the two disagreed and an uppercase-pinned image could never
+# be fetched), and a "blank means unpinned" shortcut that suited
+# ``_download_file`` silently let ``ensure_rootfs_only`` accept an unverified
+# rootfs.
+#
+# The tests below exercise every entry point as a *set*, so a change to the
+# shared helper has to satisfy all of its callers at once rather than just the
+# one that prompted it. Adding a new digest-checked download path means adding
+# it to ``_digest_sinks`` — the structural test at the bottom fails if a new
+# comparison site skips normalization entirely.
+# ---------------------------------------------------------------------------
+
+_DIGEST_CONTENT = b"payload-under-test"
+_GOOD_SHA256 = hashlib.sha256(_DIGEST_CONTENT).hexdigest()
+_GOOD_SHA512 = hashlib.sha512(_DIGEST_CONTENT).hexdigest()
+_WRONG_SHA256 = "b" * 64
+_WRONG_SHA512 = "b" * 128
+
+
+def _http_response(content: bytes) -> MagicMock:
+    response = MagicMock()
+    response.raise_for_status = MagicMock()
+    response.headers = {}
+    response.iter_content = lambda chunk_size: iter([content])
+    return response
+
+
+def _s3_client(content: bytes) -> MagicMock:
+    client = MagicMock()
+    body = MagicMock()
+    body.iter_chunks.return_value = iter([content])
+    client.get_object.return_value = {"Body": body}
+    return client
+
+
+def _accepts_via_http_download(tmp_path: Path, digest: str) -> bool:
+    mgr = ImageManager(cache_dir=tmp_path)
+    with patch("smolvm.images.manager.requests.get", return_value=_http_response(_DIGEST_CONTENT)):
+        try:
+            mgr._download_file("https://example.com/f", tmp_path / "http.bin", digest)
+        except ImageError:
+            return False
+    return True
+
+
+def _accepts_via_s3_download(tmp_path: Path, digest: str) -> bool:
+    mgr = ImageManager(cache_dir=tmp_path)
+    try:
+        mgr._download_s3_file(
+            _s3_client(_DIGEST_CONTENT), "bucket", "key", tmp_path / "s3.bin", digest
+        )
+    except ImageError:
+        return False
+    return True
+
+
+def _accepts_via_cache_check_sha256(tmp_path: Path, digest: str) -> bool:
+    target = tmp_path / "cache256.bin"
+    target.write_bytes(_DIGEST_CONTENT)
+    return ImageManager._verify_sha256(target, digest)
+
+
+def _accepts_via_cache_check_sha512(tmp_path: Path, digest: str) -> bool:
+    target = tmp_path / "cache512.bin"
+    target.write_bytes(_DIGEST_CONTENT)
+    return ImageManager._verify_sha512(target, digest)
+
+
+def _accepts_via_ensure_rootfs_sha256(tmp_path: Path, digest: str) -> bool:
+    mgr = ImageManager(cache_dir=tmp_path / "cache")
+    with patch("smolvm.images.manager.requests.get", return_value=_http_response(_DIGEST_CONTENT)):
+        try:
+            mgr.ensure_rootfs_only("rootfs-256", url="https://example.com/r", sha256=digest)
+        except ImageError:
+            return False
+    return True
+
+
+def _accepts_via_ensure_rootfs_sha512(tmp_path: Path, digest: str) -> bool:
+    mgr = ImageManager(cache_dir=tmp_path / "cache")
+    with patch("smolvm.images.manager.requests.get", return_value=_http_response(_DIGEST_CONTENT)):
+        try:
+            mgr.ensure_rootfs_only("rootfs-512", url="https://example.com/r", sha512=digest)
+        except ImageError:
+            return False
+    return True
+
+
+def _accepts_via_ensure_image(tmp_path: Path, digest: str) -> bool:
+    source = ImageSource(
+        name="img",
+        kernel_url="https://example.com/k",
+        kernel_sha256=digest,
+        rootfs_url="https://example.com/r",
+        rootfs_sha256=digest,
+    )
+    mgr = ImageManager(cache_dir=tmp_path / "cache", registry={"img": source})
+    with patch("smolvm.images.manager.requests.get", return_value=_http_response(_DIGEST_CONTENT)):
+        try:
+            mgr.ensure_image("img")
+        except ImageError:
+            return False
+    return True
+
+
+# (label, accepts_fn, correct_digest, wrong_digest). Every caller-facing path
+# that checks a digest belongs here.
+_SHA256_SINKS = [
+    ("http download", _accepts_via_http_download, _GOOD_SHA256, _WRONG_SHA256),
+    ("s3 download", _accepts_via_s3_download, _GOOD_SHA256, _WRONG_SHA256),
+    ("cache check", _accepts_via_cache_check_sha256, _GOOD_SHA256, _WRONG_SHA256),
+    ("ensure_rootfs_only", _accepts_via_ensure_rootfs_sha256, _GOOD_SHA256, _WRONG_SHA256),
+    ("ensure_image", _accepts_via_ensure_image, _GOOD_SHA256, _WRONG_SHA256),
+]
+_SHA512_SINKS = [
+    ("cache check", _accepts_via_cache_check_sha512, _GOOD_SHA512, _WRONG_SHA512),
+    ("ensure_rootfs_only", _accepts_via_ensure_rootfs_sha512, _GOOD_SHA512, _WRONG_SHA512),
+]
+_DIGEST_SINKS = _SHA256_SINKS + _SHA512_SINKS
+
+
+def _spell(digest: str, style: str) -> str:
+    """Return an equivalent spelling of the same hex digest."""
+    if style == "lowercase":
+        return digest
+    if style == "uppercase":
+        return digest.upper()
+    if style == "mixed case":
+        return "".join(c.upper() if i % 2 else c for i, c in enumerate(digest))
+    if style == "surrounding whitespace":
+        return f"  {digest}\n"
+    raise AssertionError(f"unknown spelling: {style}")
+
+
+class TestDigestContractAcrossCallSites:
+    """The digest contract must hold at every call site, not just one."""
+
+    @pytest.mark.parametrize(
+        "style", ["lowercase", "uppercase", "mixed case", "surrounding whitespace"]
+    )
+    @pytest.mark.parametrize(("label", "accepts", "good", "_wrong"), _DIGEST_SINKS)
+    def test_every_call_site_accepts_every_spelling_of_a_correct_digest(
+        self,
+        tmp_path: Path,
+        label: str,
+        accepts: object,
+        good: str,
+        _wrong: str,
+        style: str,
+    ) -> None:
+        """Hex digests are case-insensitive, so all sites must agree on them.
+
+        The S3 download path once compared raw strings while the cache check
+        normalized. The two disagreed: an uppercase-pinned image failed every
+        fetch yet passed the cache check, so it could never be pulled.
+        """
+        assert accepts(tmp_path, _spell(good, style)) is True, (
+            f"{label} rejected a correct digest written in {style}"
+        )
+
+    @pytest.mark.parametrize(("label", "accepts", "_good", "wrong"), _DIGEST_SINKS)
+    def test_every_call_site_rejects_a_wrong_digest(
+        self, tmp_path: Path, label: str, accepts: object, _good: str, wrong: str
+    ) -> None:
+        """Normalizing case must never soften the check itself."""
+        assert accepts(tmp_path, wrong) is False, f"{label} accepted a wrong digest"
+
+    @pytest.mark.parametrize(("label", "accepts", "_good", "_wrong"), _DIGEST_SINKS)
+    def test_no_call_site_treats_a_blank_digest_as_verified(
+        self, tmp_path: Path, label: str, accepts: object, _good: str, _wrong: str
+    ) -> None:
+        """A blank digest must never read as "checked and correct".
+
+        Collapsing blank to "unpinned" inside the shared helper suited
+        ``_download_file`` (which tests truthiness) but broke
+        ``ensure_rootfs_only`` (which tests ``is not None``), turning a hard
+        failure into an accepted, unverified rootfs. Blank is malformed input;
+        no site may report it as a passing check.
+        """
+        assert accepts(tmp_path, "") is False, f"{label} accepted a blank digest as verified"
+
+    @pytest.mark.parametrize(("label", "accepts", "_good", "_wrong"), _DIGEST_SINKS)
+    def test_none_means_unpinned_everywhere(
+        self, tmp_path: Path, label: str, accepts: object, _good: str, _wrong: str
+    ) -> None:
+        """``None`` is the one value that means "no digest was pinned"."""
+        assert accepts(tmp_path, None) is True, f"{label} rejected an explicitly unpinned digest"
+
+
+class TestDigestNormalizationIsStructural:
+    """Guard against a new comparison site quietly skipping normalization."""
+
+    def test_every_computed_digest_comparison_normalizes_the_expected_value(self) -> None:
+        """Any function comparing a computed digest must normalize first.
+
+        This is the shape of the S3 bug: a second download path grew its own
+        ``actual_hash != expected_sha256`` comparison and simply never picked
+        up the shared helper. A behavioural test only catches that if someone
+        remembers to add the new path to ``_DIGEST_SINKS``; this catches it
+        even if they don't.
+        """
+        import ast
+        import inspect
+
+        from smolvm.images import manager
+
+        tree = ast.parse(inspect.getsource(manager))
+        # By convention in this module the freshly computed digest is bound to
+        # ``actual`` or ``actual_hash``.
+        computed_names = {"actual", "actual_hash"}
+        offenders: list[str] = []
+
+        for node in ast.walk(tree):
+            if not isinstance(node, ast.FunctionDef):
+                continue
+            compares_a_digest = any(
+                isinstance(child, ast.Name) and child.id in computed_names
+                for cmp_node in ast.walk(node)
+                if isinstance(cmp_node, ast.Compare)
+                for child in ast.walk(cmp_node)
+            )
+            if not compares_a_digest:
+                continue
+            normalizes = any(
+                isinstance(call, ast.Call)
+                and isinstance(call.func, ast.Name)
+                and call.func.id == "_normalize_digest"
+                for call in ast.walk(node)
+            )
+            if not normalizes:
+                offenders.append(node.name)
+
+        assert not offenders, (
+            f"{offenders} compare a computed digest without calling _normalize_digest(). "
+            "Route the expected value through it so every call site agrees on "
+            "case and whitespace, then add the path to _DIGEST_SINKS."
+        )
+
+    def test_the_structural_guard_can_actually_fail(self) -> None:
+        """The guard above is worthless if its detection never fires.
+
+        A structural test that silently matches nothing passes forever. This
+        pins the detection itself against a known-bad snippet.
+        """
+        import ast
+
+        bad = ast.parse(
+            "def _download_new_thing(expected_sha256):\n"
+            "    actual_hash = h.hexdigest()\n"
+            "    if actual_hash != expected_sha256:\n"
+            "        raise ImageError('mismatch')\n"
+        )
+        function = next(n for n in ast.walk(bad) if isinstance(n, ast.FunctionDef))
+
+        compares_a_digest = any(
+            isinstance(child, ast.Name) and child.id in {"actual", "actual_hash"}
+            for cmp_node in ast.walk(function)
+            if isinstance(cmp_node, ast.Compare)
+            for child in ast.walk(cmp_node)
+        )
+        normalizes = any(
+            isinstance(call, ast.Call)
+            and isinstance(call.func, ast.Name)
+            and call.func.id == "_normalize_digest"
+            for call in ast.walk(function)
+        )
+
+        assert compares_a_digest, "detection missed a plain digest comparison"
+        assert not normalizes, "detection wrongly reported normalization"

--- a/tests/test_images.py
+++ b/tests/test_images.py
@@ -20,6 +20,7 @@ from pathlib import Path
 from unittest.mock import MagicMock, patch
 
 import pytest
+import requests
 
 from smolvm.exceptions import ImageError
 from smolvm.images.manager import (
@@ -332,6 +333,75 @@ class TestDownloadFile:
                 image_manager._download_file("https://example.com/file", dest, None)
 
         assert len(list(fd_dir.iterdir())) == before
+
+    # Every way a download can fail before it completes. Pinning one failure
+    # mode is not enough: a later change added blank-digest validation between
+    # mkstemp() and the try block, which leaked both the descriptor and the
+    # .tmp file on a path this test did not cover. New early exits belong here.
+    _DOWNLOAD_FAILURE_MODES = [
+        ("network error", requests.ConnectionError("no network"), None),
+        ("http error", requests.HTTPError("500 server error"), None),
+        ("blank digest", None, ""),
+        ("digest mismatch", None, "a" * 64),
+    ]
+
+    @pytest.mark.parametrize(
+        ("label", "get_error", "digest"),
+        _DOWNLOAD_FAILURE_MODES,
+        ids=[case[0] for case in _DOWNLOAD_FAILURE_MODES],
+    )
+    @patch("smolvm.images.manager.requests.get")
+    def test_no_failure_mode_leaks_descriptors_or_temp_files(
+        self,
+        mock_get: MagicMock,
+        image_manager: ImageManager,
+        tmp_path: Path,
+        label: str,
+        get_error: Exception | None,
+        digest: str | None,
+    ) -> None:
+        """No early exit may strand the staging descriptor or its .tmp file."""
+        fd_dir = Path("/proc/self/fd")
+        if not fd_dir.is_dir():
+            pytest.skip("descriptor accounting requires /proc")
+
+        if get_error is not None:
+            mock_get.side_effect = get_error
+        else:
+            mock_get.return_value = _http_response(b"payload")
+
+        dest = tmp_path / "output.bin"
+        before = len(list(fd_dir.iterdir()))
+        for _ in range(25):
+            with pytest.raises(ImageError):
+                image_manager._download_file("https://example.com/file", dest, digest)
+
+        assert len(list(fd_dir.iterdir())) == before, f"{label} leaked descriptors"
+        assert not list(tmp_path.glob("*.tmp")), f"{label} orphaned staging files"
+
+    @pytest.mark.parametrize(
+        ("label", "digest"),
+        [("blank digest", ""), ("digest mismatch", "a" * 64)],
+        ids=["blank digest", "digest mismatch"],
+    )
+    def test_s3_failure_modes_do_not_leak_either(
+        self, image_manager: ImageManager, tmp_path: Path, label: str, digest: str
+    ) -> None:
+        """The S3 path allocates the same way and must release it the same way."""
+        fd_dir = Path("/proc/self/fd")
+        if not fd_dir.is_dir():
+            pytest.skip("descriptor accounting requires /proc")
+
+        dest = tmp_path / "output.bin"
+        before = len(list(fd_dir.iterdir()))
+        for _ in range(25):
+            with pytest.raises(ImageError):
+                image_manager._download_s3_file(
+                    _s3_client(b"payload"), "bucket", "key", dest, digest
+                )
+
+        assert len(list(fd_dir.iterdir())) == before, f"{label} leaked descriptors"
+        assert not list(tmp_path.glob("*.tmp")), f"{label} orphaned staging files"
 
     @patch("smolvm.images.manager.requests.get")
     def test_unparseable_content_length_is_ignored(
@@ -1186,6 +1256,7 @@ _WRONG_SHA512 = "b" * 128
 
 
 def _http_response(content: bytes) -> MagicMock:
+    """A minimal mocked ``requests`` response serving *content* in one chunk."""
     response = MagicMock()
     response.raise_for_status = MagicMock()
     response.headers = {}
@@ -1194,6 +1265,7 @@ def _http_response(content: bytes) -> MagicMock:
 
 
 def _s3_client(content: bytes) -> MagicMock:
+    """A minimal mocked boto3 client whose object body is *content*."""
     client = MagicMock()
     body = MagicMock()
     body.iter_chunks.return_value = iter([content])
@@ -1202,6 +1274,7 @@ def _s3_client(content: bytes) -> MagicMock:
 
 
 def _accepts_via_http_download(tmp_path: Path, digest: str) -> bool:
+    """Whether the HTTP download path accepts *digest*."""
     mgr = ImageManager(cache_dir=tmp_path)
     with patch("smolvm.images.manager.requests.get", return_value=_http_response(_DIGEST_CONTENT)):
         try:
@@ -1212,6 +1285,7 @@ def _accepts_via_http_download(tmp_path: Path, digest: str) -> bool:
 
 
 def _accepts_via_s3_download(tmp_path: Path, digest: str) -> bool:
+    """Whether the S3 download path accepts *digest*."""
     mgr = ImageManager(cache_dir=tmp_path)
     try:
         mgr._download_s3_file(
@@ -1223,18 +1297,21 @@ def _accepts_via_s3_download(tmp_path: Path, digest: str) -> bool:
 
 
 def _accepts_via_cache_check_sha256(tmp_path: Path, digest: str) -> bool:
+    """Whether the SHA-256 cache verifier accepts *digest*."""
     target = tmp_path / "cache256.bin"
     target.write_bytes(_DIGEST_CONTENT)
     return ImageManager._verify_sha256(target, digest)
 
 
 def _accepts_via_cache_check_sha512(tmp_path: Path, digest: str) -> bool:
+    """Whether the SHA-512 cache verifier accepts *digest*."""
     target = tmp_path / "cache512.bin"
     target.write_bytes(_DIGEST_CONTENT)
     return ImageManager._verify_sha512(target, digest)
 
 
 def _accepts_via_ensure_rootfs_sha256(tmp_path: Path, digest: str) -> bool:
+    """Whether ``ensure_rootfs_only``'s sha256 pin accepts *digest*."""
     mgr = ImageManager(cache_dir=tmp_path / "cache")
     with patch("smolvm.images.manager.requests.get", return_value=_http_response(_DIGEST_CONTENT)):
         try:
@@ -1245,6 +1322,7 @@ def _accepts_via_ensure_rootfs_sha256(tmp_path: Path, digest: str) -> bool:
 
 
 def _accepts_via_ensure_rootfs_sha512(tmp_path: Path, digest: str) -> bool:
+    """Whether ``ensure_rootfs_only``'s sha512 pin accepts *digest*."""
     mgr = ImageManager(cache_dir=tmp_path / "cache")
     with patch("smolvm.images.manager.requests.get", return_value=_http_response(_DIGEST_CONTENT)):
         try:
@@ -1255,6 +1333,7 @@ def _accepts_via_ensure_rootfs_sha512(tmp_path: Path, digest: str) -> bool:
 
 
 def _accepts_via_ensure_image(tmp_path: Path, digest: str) -> bool:
+    """Whether the public ``ensure_image`` entry point accepts *digest*."""
     source = ImageSource(
         name="img",
         kernel_url="https://example.com/k",

--- a/tests/test_images.py
+++ b/tests/test_images.py
@@ -307,6 +307,95 @@ class TestDownloadFile:
         with pytest.raises(ImageError, match="Download failed"):
             image_manager._download_file("https://example.com/file", dest, "abc123")
 
+    @patch("smolvm.images.manager.requests.get")
+    def test_failed_download_does_not_leak_file_descriptors(
+        self, mock_get: MagicMock, image_manager: ImageManager, tmp_path: Path
+    ) -> None:
+        """A failing download must close its staging descriptor.
+
+        The staging file comes from ``mkstemp``, which hands back an already-open
+        descriptor. Opening it only after the request succeeded leaked one
+        descriptor per failure, and a retry loop then exhausted the process.
+        """
+        import requests
+
+        fd_dir = Path("/proc/self/fd")
+        if not fd_dir.is_dir():
+            pytest.skip("descriptor accounting requires /proc")
+
+        mock_get.side_effect = requests.ConnectionError("no network")
+        dest = tmp_path / "output.bin"
+
+        before = len(list(fd_dir.iterdir()))
+        for _ in range(25):
+            with pytest.raises(ImageError):
+                image_manager._download_file("https://example.com/file", dest, None)
+
+        assert len(list(fd_dir.iterdir())) == before
+
+    @patch("smolvm.images.manager.requests.get")
+    def test_unparseable_content_length_is_ignored(
+        self, mock_get: MagicMock, image_manager: ImageManager, tmp_path: Path
+    ) -> None:
+        """A malformed ``Content-Length`` is a progress hint, not a failure."""
+        content = b"payload"
+        mock_resp = MagicMock()
+        mock_resp.raise_for_status = MagicMock()
+        # Proxies sometimes fold a repeated header into one comma-joined value.
+        mock_resp.headers = {"content-length": "7, 7"}
+        mock_resp.iter_content = lambda chunk_size: iter([content])
+        mock_get.return_value = mock_resp
+
+        dest = tmp_path / "output.bin"
+        totals: list[int | None] = []
+        image_manager._download_file(
+            "https://example.com/file",
+            dest,
+            hashlib.sha256(content).hexdigest(),
+            progress_callback=lambda _chunk, total: totals.append(total),
+        )
+
+        assert dest.read_bytes() == content
+        assert totals == [None]
+
+    @patch("smolvm.images.manager.requests.get")
+    def test_uppercase_expected_sha256_accepted(
+        self, mock_get: MagicMock, image_manager: ImageManager, tmp_path: Path
+    ) -> None:
+        """Hex digests are case-insensitive; an uppercase pin must verify."""
+        content = b"payload"
+        mock_resp = MagicMock()
+        mock_resp.raise_for_status = MagicMock()
+        mock_resp.headers = {}
+        mock_resp.iter_content = lambda chunk_size: iter([content])
+        mock_get.return_value = mock_resp
+
+        dest = tmp_path / "output.bin"
+        image_manager._download_file(
+            "https://example.com/file",
+            dest,
+            hashlib.sha256(content).hexdigest().upper(),
+        )
+
+        assert dest.read_bytes() == content
+
+    @patch("smolvm.images.manager.requests.get")
+    def test_uppercase_expected_sha256_still_detects_mismatch(
+        self, mock_get: MagicMock, image_manager: ImageManager, tmp_path: Path
+    ) -> None:
+        """Case-insensitive comparison must not weaken the check itself."""
+        mock_resp = MagicMock()
+        mock_resp.raise_for_status = MagicMock()
+        mock_resp.headers = {}
+        mock_resp.iter_content = lambda chunk_size: iter([b"wrong content"])
+        mock_get.return_value = mock_resp
+
+        dest = tmp_path / "output.bin"
+        with pytest.raises(ImageError, match="SHA-256 mismatch"):
+            image_manager._download_file("https://example.com/file", dest, "A" * 64)
+
+        assert not dest.exists()
+
 
 class TestVerifySHA256:
     """Tests for SHA-256 verification."""
@@ -333,6 +422,41 @@ class TestVerifySHA256:
         file_path.write_bytes(b"any content")
 
         assert ImageManager._verify_sha256(file_path, None) is True
+
+    def test_hash_comparison_is_case_insensitive(self, tmp_path: Path) -> None:
+        """An uppercase or padded digest verifies the same as a lowercase one.
+
+        Comparing raw strings made an uppercase pin permanently unverifiable:
+        the cached file "failed" its checksum on every run and was re-downloaded
+        forever. ``_verify_sha512`` already normalized; ``_verify_sha256`` did not.
+        """
+        content = b"hello world"
+        file_path = tmp_path / "test.bin"
+        file_path.write_bytes(content)
+
+        sha256 = hashlib.sha256(content).hexdigest()
+        sha512 = hashlib.sha512(content).hexdigest()
+
+        assert ImageManager._verify_sha256(file_path, sha256.upper()) is True
+        assert ImageManager._verify_sha256(file_path, f"  {sha256.upper()}\n") is True
+        assert ImageManager._verify_sha512(file_path, sha512.upper()) is True
+        # Normalization must not turn a real mismatch into a pass.
+        assert ImageManager._verify_sha256(file_path, "A" * 64) is False
+
+    def test_blank_hash_means_no_pin(self, tmp_path: Path) -> None:
+        """A blank digest reads as "not pinned", matching ``_download_file``.
+
+        ``_download_file`` has always treated a falsy digest as "no pin" and
+        skipped verification, so a blank string never gated what landed in the
+        cache. The verifiers now agree with it instead of reporting a mismatch
+        that would re-download the same file forever.
+        """
+        file_path = tmp_path / "test.bin"
+        file_path.write_bytes(b"hello world")
+
+        assert ImageManager._verify_sha256(file_path, "") is True
+        assert ImageManager._verify_sha256(file_path, "   ") is True
+        assert ImageManager._verify_sha512(file_path, "") is True
 
     @patch("smolvm.images.manager.requests.get")
     def test_download_skips_sha_when_none(self, mock_get: MagicMock, tmp_path: Path) -> None:

--- a/tests/test_network.py
+++ b/tests/test_network.py
@@ -761,6 +761,7 @@ class TestEgressAllowlist:
         import asyncio
 
         def _make() -> NetworkManager:
+            """A NetworkManager with both sync and async nft plumbing mocked."""
             nm = NetworkManager()
             nm._outbound_interface = "eth0"
             nm._ensure_nftables_base = MagicMock()

--- a/tests/test_network.py
+++ b/tests/test_network.py
@@ -686,3 +686,102 @@ class TestEgressAllowlist:
         # TAP should also be removed from allowed_taps set.
         all_scripts = "\n".join(c.args[0] for c in nm._run_nft_script.call_args_list)
         assert 'delete element inet smolvm_filter allowed_taps { "tap42" }' in all_scripts
+
+    @pytest.mark.parametrize(
+        ("label", "allowed_ips"),
+        [("allowlist", ["1.1.1.1"]), ("deny all", [])],
+    )
+    def test_egress_allowlist_refuses_ipv6(self, label: str, allowed_ips: list[str]) -> None:
+        """An egress allowlist must not leave IPv6 wide open.
+
+        The allow/drop rules match ``ip daddr``, which in an ``inet`` table
+        only matches IPv4 packets, and ``resolve_domains_to_ips`` discards
+        AAAA records so no IPv6 destination can ever reach the list. IPv6
+        therefore matched nothing and fell through to the forward chain's
+        ``policy accept`` — a guest that picked up a global IPv6 address
+        reached the whole internet with the allowlist nominally in force.
+        """
+        nm = NetworkManager()
+        nm._outbound_interface = "eth0"
+        nm._ensure_nftables_base = MagicMock()
+        nm._nft_list_table = MagicMock(
+            return_value="table inet smolvm_filter {\n  chain forward {\n  }\n}\n"
+        )
+        nm._run_nft_script = MagicMock()
+
+        nm.apply_egress_allowlist("tap42", allowed_ips)
+        script = nm._run_nft_script.call_args_list[0].args[0]
+
+        drop_ipv6 = (
+            'add rule inet smolvm_filter forward iifname "tap42" meta nfproto ipv6 '
+            'counter drop comment "smolvm:egress:tap42:drop6"'
+        )
+        assert drop_ipv6 in script, f"{label} left IPv6 unrestricted"
+
+        # First, so the established/related accept cannot re-admit an IPv6 flow.
+        established = (
+            'add rule inet smolvm_filter forward iifname "tap42" ct state established,related'
+        )
+        assert script.index(drop_ipv6) < script.index(established)
+
+    def test_egress_ipv6_drop_is_cleaned_up_with_the_rest(self) -> None:
+        """The IPv6 rule must not outlive the sandbox it belongs to.
+
+        Cleanup matches on the ``smolvm:egress:<tap>:`` comment prefix, so a
+        rule tagged outside that prefix would leak into the host ruleset and
+        keep dropping traffic for a TAP name that gets reused later.
+        """
+        nm = NetworkManager()
+        nm._ensure_nftables_base = MagicMock()
+        nm._nft_list_table = MagicMock(
+            return_value=(
+                "table inet smolvm_filter {\n"
+                "  chain forward {\n"
+                '    iifname "tap42" meta nfproto ipv6 counter drop '
+                'comment "smolvm:egress:tap42:drop6" # handle 40\n'
+                '    iifname "tap42" counter drop comment "smolvm:egress:tap42:drop" # handle 42\n'
+                "  }\n"
+                "}\n"
+            )
+        )
+        nm._run_nft_script = MagicMock()
+
+        nm.remove_egress_rules("tap42")
+
+        script = "\n".join(c.args[0] for c in nm._run_nft_script.call_args_list)
+        assert "delete rule inet smolvm_filter forward handle 40" in script
+        assert "delete rule inet smolvm_filter forward handle 42" in script
+
+    def test_sync_and_async_appliers_emit_identical_rules(self) -> None:
+        """The twins must not drift — the IPv6 gap was duplicated in both.
+
+        Both paths build their rules from one helper now; this pins that so a
+        future edit to one copy cannot silently leave the other behind.
+        """
+        import asyncio
+
+        def _make() -> NetworkManager:
+            nm = NetworkManager()
+            nm._outbound_interface = "eth0"
+            nm._ensure_nftables_base = MagicMock()
+            nm._async_ensure_nftables_base = AsyncMock()
+            nm._nft_list_table = MagicMock(
+                return_value="table inet smolvm_filter {\n  chain forward {\n  }\n}\n"
+            )
+            nm._async_nft_list_table = AsyncMock(
+                return_value="table inet smolvm_filter {\n  chain forward {\n  }\n}\n"
+            )
+            nm._run_nft_script = MagicMock()
+            nm._async_run_nft_script = AsyncMock()
+            nm._async_delete_nft_elements_best_effort = AsyncMock()
+            return nm
+
+        sync_nm = _make()
+        sync_nm.apply_egress_allowlist("tap42", ["1.1.1.1", "8.8.8.8"])
+        sync_script = sync_nm._run_nft_script.call_args_list[0].args[0]
+
+        async_nm = _make()
+        asyncio.run(async_nm.async_apply_egress_allowlist("tap42", ["1.1.1.1", "8.8.8.8"]))
+        async_script = async_nm._async_run_nft_script.call_args_list[0].args[0]
+
+        assert sync_script == async_script

--- a/tests/test_published_images.py
+++ b/tests/test_published_images.py
@@ -1051,6 +1051,7 @@ class TestDecompressZstd:
         dst = tmp_path / "rootfs.ext4"
 
         def _fail_after_creating_staging(_src: object, target: object, **_kwargs: object) -> str:
+            """Create the staging file, then fail with a non-OSError."""
             Path(target).write_bytes(b"\0" * 4096)
             raise zstandard.ZstdError("corrupt frame")
 
@@ -1076,6 +1077,7 @@ class TestDecompressZstd:
         dst = tmp_path / "rootfs.ext4"
 
         def _interrupt(_src: object, target: object, **_kwargs: object) -> str:
+            """Create the staging file, then raise KeyboardInterrupt."""
             Path(target).write_bytes(b"\0" * 4096)
             raise KeyboardInterrupt
 

--- a/tests/test_published_images.py
+++ b/tests/test_published_images.py
@@ -1036,3 +1036,53 @@ class TestDecompressZstd:
         assert not dst.exists()
         assert not staging.exists()
         assert not helper_tmp.exists()
+
+    def test_non_oserror_failure_removes_staging_file(self, tmp_path: Path) -> None:
+        """Cleanup must not be limited to ``OSError``.
+
+        The staging file is a full-size rootfs. Only cleaning up on ``OSError``
+        meant a decoder that raised anything else orphaned a multi-GB partial —
+        and every retry orphaned another one.
+        """
+        import zstandard
+
+        src = tmp_path / "rootfs.ext4.zst"
+        src.write_bytes(zstandard.ZstdCompressor().compress(b"payload"))
+        dst = tmp_path / "rootfs.ext4"
+
+        def _fail_after_creating_staging(_src: object, target: object, **_kwargs: object) -> str:
+            Path(target).write_bytes(b"\0" * 4096)
+            raise zstandard.ZstdError("corrupt frame")
+
+        for _ in range(3):
+            with (
+                patch(
+                    "smolvm.host.disk.decompress_zstd_sparse",
+                    side_effect=_fail_after_creating_staging,
+                ),
+                pytest.raises(zstandard.ZstdError),
+            ):
+                _decompress_zstd(src, dst)
+
+        assert not dst.exists()
+        assert not list(tmp_path.glob("*.partial"))
+
+    def test_keyboard_interrupt_removes_staging_file(self, tmp_path: Path) -> None:
+        """Ctrl-C mid-decompress must not orphan the staging file either."""
+        import zstandard
+
+        src = tmp_path / "rootfs.ext4.zst"
+        src.write_bytes(zstandard.ZstdCompressor().compress(b"payload"))
+        dst = tmp_path / "rootfs.ext4"
+
+        def _interrupt(_src: object, target: object, **_kwargs: object) -> str:
+            Path(target).write_bytes(b"\0" * 4096)
+            raise KeyboardInterrupt
+
+        with (
+            patch("smolvm.host.disk.decompress_zstd_sparse", side_effect=_interrupt),
+            pytest.raises(KeyboardInterrupt),
+        ):
+            _decompress_zstd(src, dst)
+
+        assert not list(tmp_path.glob("*.partial"))

--- a/tests/test_ssh.py
+++ b/tests/test_ssh.py
@@ -328,6 +328,7 @@ class TestSSHClientWaitForSSH:
         monkeypatch.setattr("smolvm.ssh.time.monotonic", lambda: now[0])
 
         def _advance(seconds: float) -> None:
+            """Stand in for time.sleep by moving the fake clock forward."""
             assert seconds >= 0
             now[0] += seconds
 

--- a/tests/test_ssh.py
+++ b/tests/test_ssh.py
@@ -311,6 +311,48 @@ class TestSSHClientWaitForSSH:
         with pytest.raises(ValueError, match="timeout must be"):
             client.wait_for_ssh(timeout=0)
 
+    def test_timeout_names_the_unopened_port(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """A port that never opens must say so, not report an empty error.
+
+        Phase 1 used to fall out of its ``while`` on timeout and continue into
+        phase 2. Phase 2's loop then never ran (the deadline had already
+        passed), so the raised message ended with ``last error:`` and nothing
+        after it — the one fact we knew, that sshd never answered, was dropped.
+
+        The clock advances inside ``sleep`` — the real cadence — so the backoff
+        eventually consumes the last of the budget and the loop exits via its
+        ``while`` condition. That is the path that used to fall through; the
+        in-loop deadline check masked it.
+        """
+        now = [0.0]
+        monkeypatch.setattr("smolvm.ssh.time.monotonic", lambda: now[0])
+
+        def _advance(seconds: float) -> None:
+            assert seconds >= 0
+            now[0] += seconds
+
+        monkeypatch.setattr("smolvm.ssh.time.sleep", _advance)
+        monkeypatch.setattr(SSHClient, "_tcp_port_open", lambda self, timeout=0.1: False)
+        monkeypatch.setattr(
+            SSHClient, "_connect", lambda self: pytest.fail("phase 2 must not be reached")
+        )
+
+        client = SSHClient("172.16.0.2")
+        with pytest.raises(OperationTimeoutError, match="port never opened"):
+            client.wait_for_ssh(timeout=1.0)
+
+    def test_tcp_probe_tolerates_an_expired_deadline(self) -> None:
+        """A non-positive probe timeout means "not open yet", not a crash.
+
+        ``wait_for_ssh`` derives the probe timeout from the remaining budget,
+        which can go non-positive. ``socket.create_connection`` rejects that
+        with ``ValueError`` — not an ``OSError``, so it escaped the retry loop.
+        """
+        client = SSHClient("172.16.0.2")
+
+        assert client._tcp_port_open(timeout=0) is False
+        assert client._tcp_port_open(timeout=-0.5) is False
+
     @patch.object(SSHClient, "_tcp_port_open", return_value=True)
     def test_connect_loop_uses_tight_backoff_first(
         self, _mock_port: MagicMock, monkeypatch: pytest.MonkeyPatch

--- a/tests/test_storage.py
+++ b/tests/test_storage.py
@@ -14,6 +14,7 @@
 
 """Tests for SmolVM storage module."""
 
+import os
 import sqlite3
 from datetime import datetime, timezone
 from pathlib import Path
@@ -342,6 +343,35 @@ class TestSSHPortAllocation:
         """The SSH port pool must not allocate invalid TCP ports."""
         assert SSH_PORT_END == 65535
 
+    @pytest.mark.parametrize("host_port", [0, -1, 65536])
+    def test_requested_host_port_must_be_a_valid_tcp_port(
+        self,
+        state_manager: StateManager,
+        sample_config: VMConfig,
+        host_port: int,
+    ) -> None:
+        """An unusable requested port is rejected up front.
+
+        ``guest_port`` was range-checked but ``host_port`` was not, so an
+        out-of-range value was persisted and only surfaced much later as an
+        opaque hypervisor error. Port 0 was worse: it means "any port", so the
+        number recorded in state did not match what the VM actually listened on.
+        """
+        state_manager.create_vm(sample_config)
+
+        with pytest.raises(ValueError, match="host_port must be 1-65535"):
+            state_manager.reserve_ssh_port("vm001", host_port=host_port)
+
+        assert state_manager.get_ssh_port("vm001") is None
+
+    def test_valid_requested_host_port_is_reserved(
+        self, state_manager: StateManager, sample_config: VMConfig
+    ) -> None:
+        """The range check must not reject legitimate ports."""
+        state_manager.create_vm(sample_config)
+
+        assert state_manager.reserve_ssh_port("vm001", host_port=65535) == 65535
+
     def test_reserve_ssh_port_is_stable(
         self, state_manager: StateManager, sample_config: VMConfig
     ) -> None:
@@ -593,6 +623,37 @@ class TestReconciliation:
         vm_info = state_manager.get_vm("vm001")
         assert vm_info.status == VMState.ERROR
         assert vm_info.pid is None
+
+    @pytest.mark.parametrize("pid", [0, -1])
+    def test_reconcile_non_positive_pid(
+        self,
+        state_manager: StateManager,
+        sample_config: VMConfig,
+        pid: int,
+    ) -> None:
+        """A pid of 0 or -1 is not a live VM.
+
+        ``os.kill(0, 0)`` probes our own process group and ``os.kill(-1, 0)``
+        probes every process we may signal, so both return successfully and the
+        sandbox stayed wedged in RUNNING forever instead of being reconciled.
+        """
+        state_manager.create_vm(sample_config)
+        state_manager.update_vm("vm001", status=VMState.RUNNING, pid=pid)
+
+        assert "vm001" in state_manager.reconcile()
+        assert state_manager.get_vm("vm001").status == VMState.ERROR
+
+    def test_reconcile_leaves_live_process_alone(
+        self,
+        state_manager: StateManager,
+        sample_config: VMConfig,
+    ) -> None:
+        """A real, running pid must not be reconciled away."""
+        state_manager.create_vm(sample_config)
+        state_manager.update_vm("vm001", status=VMState.RUNNING, pid=os.getpid())
+
+        assert state_manager.reconcile() == []
+        assert state_manager.get_vm("vm001").status == VMState.RUNNING
 
 
 class TestBrowserSessionStorage:

--- a/tests/test_swtpm_sidecar.py
+++ b/tests/test_swtpm_sidecar.py
@@ -165,3 +165,51 @@ def test_stop_is_safe_when_pidfile_missing(tmp_path: Path) -> None:
     )
     # Don't create any files. stop() should be a clean no-op.
     sidecar.stop()
+
+
+def _no_wall_clock() -> float:
+    """Stand-in for ``time.time`` that fails if a wait loop consults it."""
+    raise AssertionError(
+        "runtime wait loops must use time.monotonic(); a wall-clock deadline can "
+        "be skipped past (or pushed out of reach) by an NTP step or DST change"
+    )
+
+
+def test_socket_wait_uses_a_monotonic_deadline(tmp_path: Path) -> None:
+    """``start()`` must time its socket wait against the monotonic clock."""
+    context = _make_context(tmp_path)
+    sidecar = _SwtpmSidecar(vm_id="vm-win", firmware_dir=tmp_path, context=context)
+
+    def fake_run(cmd: list[str], **_kwargs: object) -> subprocess.CompletedProcess[str]:
+        sidecar.socket_path.touch()
+        sidecar.pidfile_path.write_text("4242\n")
+        return subprocess.CompletedProcess(cmd, returncode=0, stdout="", stderr="")
+
+    with (
+        patch("smolvm.runtime.qemu.which", return_value=Path("/usr/bin/swtpm")),
+        patch("smolvm.runtime.qemu.subprocess.run", side_effect=fake_run),
+        patch("smolvm.runtime.qemu.time.time", side_effect=_no_wall_clock),
+    ):
+        assert sidecar.start() == 4242
+
+
+def test_shutdown_wait_uses_a_monotonic_deadline(tmp_path: Path) -> None:
+    """``stop()`` must time its post-SIGTERM wait against the monotonic clock."""
+    context = _make_context(tmp_path)
+    sidecar = _SwtpmSidecar(vm_id="vm-win", firmware_dir=tmp_path, context=context)
+
+    sidecar.socket_path.parent.mkdir(parents=True, exist_ok=True)
+    sidecar.socket_path.touch()
+    sidecar.pidfile_path.write_text("12345\n")
+
+    # Alive for the signal, then gone for the wait loop and the SIGKILL re-check.
+    context.is_process_running.side_effect = [True, False, False, False]
+
+    with (
+        patch("smolvm.runtime.qemu.os.kill"),
+        patch("smolvm.runtime.qemu.time.time", side_effect=_no_wall_clock),
+    ):
+        sidecar.stop()
+
+    assert not sidecar.socket_path.exists()
+    assert not sidecar.pidfile_path.exists()

--- a/tests/test_swtpm_sidecar.py
+++ b/tests/test_swtpm_sidecar.py
@@ -181,6 +181,7 @@ def test_socket_wait_uses_a_monotonic_deadline(tmp_path: Path) -> None:
     sidecar = _SwtpmSidecar(vm_id="vm-win", firmware_dir=tmp_path, context=context)
 
     def fake_run(cmd: list[str], **_kwargs: object) -> subprocess.CompletedProcess[str]:
+        """Simulate swtpm forking: create the socket and pidfile."""
         sidecar.socket_path.touch()
         sidecar.pidfile_path.write_text("4242\n")
         return subprocess.CompletedProcess(cmd, returncode=0, stdout="", stderr="")

--- a/tests/test_tar_extraction_security.py
+++ b/tests/test_tar_extraction_security.py
@@ -65,6 +65,17 @@ def _make_tarball_with_member(arcname: str) -> bytes:
     return buf.getvalue()
 
 
+def _make_tarball_with_symlink(arcname: str, target: str) -> bytes:
+    """Create a minimal .tar.gz whose single member is a symlink."""
+    buf = io.BytesIO()
+    with tarfile.open(fileobj=buf, mode="w:gz") as tar:
+        info = tarfile.TarInfo(name=arcname)
+        info.type = tarfile.SYMTYPE
+        info.linkname = target
+        tar.addfile(info)
+    return buf.getvalue()
+
+
 def _mock_response(tarball_bytes: bytes) -> MagicMock:
     mock_response = MagicMock()
     mock_response.raise_for_status = MagicMock()
@@ -325,3 +336,140 @@ class TestDashboardExtractDist:
             assert extractall_calls[0].get("filter") == "data"
         else:
             assert "filter" not in extractall_calls[0]
+
+
+class TestGuestTarModeBits:
+    """The sandbox is untrusted; its tar must not carry mode bits to the host."""
+
+    @staticmethod
+    def _guest_tarball() -> bytes:
+        buffer = io.BytesIO()
+        with tarfile.open(fileobj=buffer, mode="w") as archive:
+            directory = tarfile.TarInfo("subdir")
+            directory.type = tarfile.DIRTYPE
+            directory.mode = 0o2777
+            archive.addfile(directory)
+            for name, mode in (
+                ("setuid_root", 0o4755),
+                ("setgid", 0o2755),
+                ("sticky", 0o1777),
+                ("plain", 0o644),
+                ("script", 0o755),
+            ):
+                member = tarfile.TarInfo(name)
+                member.size = 4
+                member.mode = mode
+                archive.addfile(member, io.BytesIO(b"data"))
+        return buffer.getvalue()
+
+    def test_setuid_setgid_and_sticky_bits_are_stripped(self, tmp_path: Path) -> None:
+        """A guest tar must not be able to plant a setuid file on the host.
+
+        ``stat.S_IMODE`` keeps 0o7777 — setuid, setgid and sticky included —
+        and this archive is produced inside the sandbox and unpacked on the
+        host, often under ``sudo`` because SmolVM needs root for host
+        networking. Honouring those bits turned a directory download into a
+        privilege-escalation primitive.
+        """
+        import stat as stat_module
+
+        from smolvm.comm.rust_http_vsock_channel import _safe_extract_tar
+
+        destination = tmp_path / "downloaded"
+        _safe_extract_tar(self._guest_tarball(), destination)
+
+        dangerous = stat_module.S_ISUID | stat_module.S_ISGID | stat_module.S_ISVTX
+        offenders = [path.name for path in destination.iterdir() if path.stat().st_mode & dangerous]
+        assert not offenders, f"guest-supplied special mode bits survived on {offenders}"
+
+    def test_ordinary_permissions_are_still_preserved(self, tmp_path: Path) -> None:
+        """Stripping the dangerous bits must not flatten normal permissions."""
+        import stat as stat_module
+
+        from smolvm.comm.rust_http_vsock_channel import _safe_extract_tar
+
+        destination = tmp_path / "downloaded"
+        _safe_extract_tar(self._guest_tarball(), destination)
+
+        modes = {
+            path.name: stat_module.S_IMODE(path.stat().st_mode) for path in destination.iterdir()
+        }
+        assert modes["plain"] == 0o644
+        assert modes["script"] == 0o755
+        # The dangerous bit is dropped; the permission bits beneath it stay.
+        assert modes["setuid_root"] == 0o755
+        assert modes["setgid"] == 0o755
+        assert modes["sticky"] == 0o777
+
+
+class TestLinkMembersRejected:
+    """Path validation must also cover links, not just ``..`` and ``/``."""
+
+    def test_host_manager_rejects_symlink_member(self, tmp_path: Path) -> None:
+        """A symlink escaping the extraction directory must be refused.
+
+        On Python without PEP 706's ``data`` filter these archives are
+        extracted unfiltered, and the name check alone does not stop a member
+        like ``link -> /etc`` — a later member written "through" that link
+        lands outside the temporary directory entirely.
+        """
+        from smolvm.host.manager import HostManager
+
+        tarball_bytes = _make_tarball_with_symlink("release/link", "/etc")
+        mock_get = patch(
+            "smolvm.host.manager.requests.get",
+            return_value=_mock_response(tarball_bytes),
+        )
+
+        hm = HostManager()
+        with mock_get, pytest.raises(HostError, match="link or device"):
+            hm._download_and_extract(
+                url="http://example.com/fc.tgz",
+                dest=tmp_path / "fc",
+                version="v1.13.0",
+                arch="x86_64",
+            )
+
+    def test_dashboard_rejects_symlink_member(self, tmp_path: Path) -> None:
+        """Same guard on the dashboard archive."""
+        _ensure_dashboard_importable()
+        from smolvm.dashboard.server import _extract_dashboard_dist
+
+        archive = tmp_path / "dash.tar.gz"
+        archive.write_bytes(_make_tarball_with_symlink("dist/link", "/etc"))
+
+        with pytest.raises(RuntimeError, match="Unsafe entry"):
+            _extract_dashboard_dist(archive, tmp_path / "out")
+
+
+class TestGuestFileModeHeader:
+    """The guest's file-mode header is untrusted input applied on the host."""
+
+    def test_setuid_and_setgid_are_masked_off(self) -> None:
+        """``x-smolvm-file-mode`` must not be able to set setuid on the host.
+
+        This is the single-file sibling of the tar extraction path — the same
+        bug, one function away, and it would have survived a fix that only
+        looked at directory downloads.
+        """
+        from smolvm.comm.rust_http_vsock_channel import _parse_mode_header
+
+        assert _parse_mode_header("0o4755") == 0o755
+        assert _parse_mode_header("2755") == 0o755
+        assert _parse_mode_header("1777") == 0o777
+
+    def test_ordinary_modes_survive(self) -> None:
+        """Masking must not disturb normal permissions."""
+        from smolvm.comm.rust_http_vsock_channel import _parse_mode_header
+
+        assert _parse_mode_header("644") == 0o644
+        assert _parse_mode_header("0o600") == 0o600
+
+    @pytest.mark.parametrize("value", ["not-octal", "-1", ""])
+    def test_malformed_mode_raises_a_smolvm_error(self, value: str) -> None:
+        """A malformed header is a protocol error, not a bare ValueError."""
+        from smolvm.comm.rust_http_vsock_channel import _parse_mode_header
+        from smolvm.exceptions import SmolVMError
+
+        with pytest.raises(SmolVMError, match="file mode"):
+            _parse_mode_header(value)

--- a/tests/test_tar_extraction_security.py
+++ b/tests/test_tar_extraction_security.py
@@ -343,6 +343,7 @@ class TestGuestTarModeBits:
 
     @staticmethod
     def _guest_tarball() -> bytes:
+        """A tar as an untrusted guest agent could produce it."""
         buffer = io.BytesIO()
         with tarfile.open(fileobj=buffer, mode="w") as archive:
             directory = tarfile.TarInfo("subdir")

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -14,6 +14,7 @@
 
 """Tests for SmolVM utils module."""
 
+import shutil
 import subprocess
 from unittest.mock import MagicMock, patch
 
@@ -234,3 +235,55 @@ class TestEnsureSSHKey:
         assert private_key == key_dir / "id_ed25519"
         assert public_key == key_dir / "id_ed25519.pub"
         mock_run.assert_called_once()
+
+    def test_complete_key_pair_is_reused(self, tmp_path) -> None:
+        """An intact pair is returned as-is, never regenerated."""
+        key_dir = tmp_path / "keys"
+        key_dir.mkdir()
+        (key_dir / "id_ed25519").write_text("private")
+        (key_dir / "id_ed25519.pub").write_text("public")
+
+        with patch("smolvm.utils.subprocess.run") as mock_run:
+            ensure_ssh_key(key_dir=key_dir)
+
+        mock_run.assert_not_called()
+        assert (key_dir / "id_ed25519").read_text() == "private"
+
+    @pytest.mark.parametrize("survivor", ["id_ed25519", "id_ed25519.pub"])
+    def test_half_present_key_pair_is_regenerated(self, tmp_path, survivor: str) -> None:
+        """A leftover half of a pair is cleared before ssh-keygen runs.
+
+        ssh-keygen refuses to overwrite an existing key file without answering
+        an interactive "Overwrite (y/n)?" prompt. That prompt goes to the stderr
+        this call discards, so a half-written pair (interrupted generation, or a
+        deleted ``.pub``) either blocked the CLI on a terminal or failed with no
+        visible reason.
+        """
+        key_dir = tmp_path / "keys"
+        key_dir.mkdir()
+        (key_dir / survivor).write_text("leftover")
+
+        with patch("smolvm.utils.subprocess.run") as mock_run:
+            ensure_ssh_key(key_dir=key_dir)
+
+        mock_run.assert_called_once()
+        # The leftover is gone, so ssh-keygen writes both halves unprompted.
+        assert not (key_dir / survivor).exists()
+        # And stdin is closed, so a future prompt can never block the CLI.
+        assert mock_run.call_args.kwargs["stdin"] is subprocess.DEVNULL
+
+    def test_generated_key_pair_is_usable(self, tmp_path) -> None:
+        """End-to-end: recovery from a half-present pair yields a real key."""
+        if shutil.which("ssh-keygen") is None:
+            pytest.skip("ssh-keygen is not installed")
+
+        key_dir = tmp_path / "keys"
+        private_key, public_key = ensure_ssh_key(key_dir=key_dir)
+        original = private_key.read_bytes()
+
+        public_key.unlink()
+        private_key, public_key = ensure_ssh_key(key_dir=key_dir)
+
+        assert private_key.exists() and public_key.exists()
+        assert private_key.read_bytes() != original
+        assert public_key.read_text().startswith("ssh-ed25519 ")

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -249,41 +249,84 @@ class TestEnsureSSHKey:
         mock_run.assert_not_called()
         assert (key_dir / "id_ed25519").read_text() == "private"
 
-    @pytest.mark.parametrize("survivor", ["id_ed25519", "id_ed25519.pub"])
-    def test_half_present_key_pair_is_regenerated(self, tmp_path, survivor: str) -> None:
-        """A leftover half of a pair is cleared before ssh-keygen runs.
+    def test_orphaned_public_key_is_cleared_before_generating(self, tmp_path) -> None:
+        """A ``.pub`` with no private half authenticates nothing — clear it.
 
         ssh-keygen refuses to overwrite an existing key file without answering
-        an interactive "Overwrite (y/n)?" prompt. That prompt goes to the stderr
-        this call discards, so a half-written pair (interrupted generation, or a
-        deleted ``.pub``) either blocked the CLI on a terminal or failed with no
-        visible reason.
+        an interactive "Overwrite (y/n)?" prompt, and that prompt goes to the
+        stderr this call discards: on a terminal it blocked the CLI forever,
+        otherwise it failed with no visible reason.
         """
         key_dir = tmp_path / "keys"
         key_dir.mkdir()
-        (key_dir / survivor).write_text("leftover")
+        (key_dir / "id_ed25519.pub").write_text("orphaned")
 
         with patch("smolvm.utils.subprocess.run") as mock_run:
             ensure_ssh_key(key_dir=key_dir)
 
         mock_run.assert_called_once()
-        # The leftover is gone, so ssh-keygen writes both halves unprompted.
-        assert not (key_dir / survivor).exists()
-        # And stdin is closed, so a future prompt can never block the CLI.
+        # Cleared before the call, so ssh-keygen writes both halves unprompted
+        # (the real binary is mocked here, hence the file simply stays gone)...
+        assert not (key_dir / "id_ed25519.pub").exists()
+        # ...and stdin is closed, so a prompt can never block the CLI anyway.
         assert mock_run.call_args.kwargs["stdin"] is subprocess.DEVNULL
 
-    def test_generated_key_pair_is_usable(self, tmp_path) -> None:
-        """End-to-end: recovery from a half-present pair yields a real key."""
+    def test_missing_public_key_never_rotates_the_private_key(self, tmp_path) -> None:
+        """A missing ``.pub`` is repaired, not treated as a reason to rotate.
+
+        The private key is what every existing sandbox trusts — its public half
+        is already in their ``authorized_keys``. Deleting it to regenerate a
+        fresh pair silently locks the user out of every sandbox they have, and
+        the ``.pub`` is derivable from the private key anyway.
+        """
         if shutil.which("ssh-keygen") is None:
             pytest.skip("ssh-keygen is not installed")
 
         key_dir = tmp_path / "keys"
         private_key, public_key = ensure_ssh_key(key_dir=key_dir)
-        original = private_key.read_bytes()
+        original_private = private_key.read_bytes()
+        original_public = public_key.read_text().split()[1]
 
         public_key.unlink()
         private_key, public_key = ensure_ssh_key(key_dir=key_dir)
 
-        assert private_key.exists() and public_key.exists()
-        assert private_key.read_bytes() != original
+        assert private_key.read_bytes() == original_private
+        # The re-derived public key is the same key material, not a new one.
+        assert public_key.read_text().split()[1] == original_public
         assert public_key.read_text().startswith("ssh-ed25519 ")
+
+    def test_unreadable_private_key_fails_loudly(self, tmp_path) -> None:
+        """An unrepairable key must not be silently replaced.
+
+        Rotating here would lock the user out of every existing sandbox without
+        telling them, so the failure is surfaced with a recovery instead.
+        """
+        if shutil.which("ssh-keygen") is None:
+            pytest.skip("ssh-keygen is not installed")
+
+        key_dir = tmp_path / "keys"
+        key_dir.mkdir()
+        private_key = key_dir / "id_ed25519"
+        private_key.write_text("this is not a key")
+
+        with pytest.raises(SmolVMError, match="could not be read"):
+            ensure_ssh_key(key_dir=key_dir)
+
+        # The unreadable key is left exactly where it was for the user to save.
+        assert private_key.read_text() == "this is not a key"
+
+    def test_generated_key_pair_is_usable(self, tmp_path) -> None:
+        """End-to-end: a fresh generation yields a real, matching pair."""
+        if shutil.which("ssh-keygen") is None:
+            pytest.skip("ssh-keygen is not installed")
+
+        private_key, public_key = ensure_ssh_key(key_dir=tmp_path / "keys")
+
+        assert public_key.read_text().startswith("ssh-ed25519 ")
+        derived = subprocess.run(
+            ["ssh-keygen", "-y", "-f", str(private_key)],
+            capture_output=True,
+            text=True,
+            check=True,
+        )
+        assert derived.stdout.split()[1] == public_key.read_text().split()[1]


### PR DESCRIPTION
## Summary

A bug sweep over the codebase. 16 fixes, each with a regression test verified to fail against the code before it. No behaviour was changed except where it was the bug.

Two are security-relevant and worth reviewing first:

- **IPv6 completely bypassed the egress allowlist** (`host/network.py`). The accept and drop rules match `ip daddr`, which inside an `inet` table only matches IPv4, and `resolve_domains_to_ips` discards AAAA records — so no IPv6 destination could ever be *on* the list. IPv6 matched no rule and fell through to the forward chain's `policy accept`. A guest that picked up a global IPv6 address (SLAAC on a bridged LAN) reached the whole internet with the allowlist nominally in force. IPv6 leaving the TAP is now dropped, first in the chain so the established/related accept cannot re-admit a flow. The rules were duplicated in the sync and async appliers, so the gap existed twice; both now build from one helper, with a test pinning that they stay identical.
- **A guest could plant a setuid-root file on the host** (`comm/rust_http_vsock_channel.py`). File modes from the sandbox were applied host-side via `stat.S_IMODE`, which keeps 0o7777 — setuid, setgid and sticky included. Since SmolVM needs root for host networking, `smolvm sandbox download` became a privilege-escalation primitive from a sandbox documented as "nothing touches the host". Both the tar path and the single-file `x-smolvm-file-mode` header now mask to 0o777, matching `host/lume.py`, which already did.

Neither is remotely triggerable alone: the first needs bridge mode with IPv6 on the LAN, the second needs a hostile guest plus a root CLI.

### Images and downloads — `images/manager.py`, `images/published.py`

- `_download_file` leaked the `mkstemp` descriptor whenever the request failed before the write block. Measured 50 leaked descriptors from 50 failures; a retry loop exhausts the process.
- SHA-256 comparison was case-sensitive while SHA-512 already lowercased. An uppercase pin was permanently unverifiable — the download "failed" its checksum every time and the cache never converged.
- `_download_s3_file` never adopted the normalization, so the cache check and the download check disagreed: an uppercase digest in a `smolvm-image.json` failed every fetch with a mismatch printing the same digest twice in different case, while the cache accepted it. The image could never be pulled.
- A blank digest was read as "no digest pinned" by the download paths but compared (and failed) by the verifiers. `ensure_rootfs_only(sha256="")` therefore returned an **unverified** rootfs, which the cache check then rejected — re-fetching it, still unverified, on every call. A blank pin is malformed input, not an opt-out, and is now refused by name before any network work.
- A malformed `Content-Length` (proxies fold repeats into `"123, 123"`) raised a bare `ValueError` past the `RequestException` handler. It is only a progress hint.
- `_decompress_zstd` cleaned up its staging file only on `OSError`, so a corrupt archive or a Ctrl-C orphaned a full-size rootfs on every retry.

### SSH and keys — `ssh.py`, `utils.py`

- `_tcp_port_open` received the remaining time budget, which can go non-positive; `socket.create_connection` rejects that with `ValueError`, not an `OSError`, so it escaped the retry loop.
- When the port never opened, phase 1 fell through to phase 2, whose loop could not run, so the error ended with an empty `last error:` instead of naming the unopened port.
- `ensure_ssh_key` hit ssh-keygen's interactive `Overwrite (y/n)?` prompt when only one half of the pair existed — a prompt written to the stderr the call discards, so it either blocked the CLI on a terminal or failed invisibly. `stdin` is now closed. A missing `.pub` is re-derived with `ssh-keygen -y -f`; the private key is never deleted, since every existing sandbox already trusts its public half and rotating it would silently lock the user out of all of them. An unreadable private key raises with a recovery rather than being replaced.

### Guest environment — `env.py`

- `_atomic_write` staged in `/tmp` and `mv`'d to `/etc/profile.d`. `rename(2)` cannot cross filesystems and `/tmp` is a separate tmpfs on most guest images, so the documented atomic swap was really copy-then-unlink — an interrupted write left every login shell sourcing a truncated env file. Staging now sits beside the destination.

### Runtime timing — `runtime/qemu.py`, `runtime/libkrun.py`, `vm.py`, `images/builder.py`

- Six wait loops timed themselves against `time.time()`. A wall-clock step can skip a deadline or push it out of reach, which either abandons a VM that is shutting down cleanly (the caller then escalates to SIGKILL) or stalls the wait well past its timeout. All now use `time.monotonic()`, matching the rest of the codebase.

### State — `cli/_sqlite.py`, `storage/_memory.py`

- `reconcile()` passed unvalidated pids to `os.kill(pid, 0)`. A pid of 0 probes our own process group and -1 probes every signalable process, so both "succeeded" and the sandbox stayed wedged in RUNNING forever.
- `reserve_ssh_port` range-checked `guest_port` but not `host_port`, so an unusable value was persisted and only surfaced later as an opaque hypervisor error. Port 0 was worse — it means "any port", so the number recorded in state did not match what the VM listened on.

### Archive extraction — `host/manager.py`, `dashboard/server.py`

- The pre-3.12 unfiltered `extractall` fallbacks validated member names for `..` and `/` but not link members, so a symlink pointing outside the extraction directory passed the check the comment calls a traversal guard. Links and device nodes are now rejected alongside bad paths.

## Testing

- `uv run pytest` — 2000 passed, 16 skipped, 30 deselected, 0 failures.
- `uv run ruff check .` — clean. `uv run ruff format --check .` — clean.
- `uv run mypy src` — 155 errors in 30 files, unchanged from `main` (same count before and after; all pre-existing and untouched by this branch).
- Every fix was reproduced before being fixed, and each regression test was re-run against the pre-fix tree to confirm it fails there. The descriptor leak was measured via `/proc/self/fd`; the nftables ruleset was loaded on a real kernel in a network namespace rather than only asserted as a string; the setuid escalation was demonstrated by extracting a crafted tar as uid 0.

Two test-quality changes came out of review feedback on this branch:

- The digest contract is now exercised across **all seven** entry points at once (both download paths, both cache verifiers, `ensure_rootfs_only`'s two pins, `ensure_image`) instead of per-helper. Testing a shared helper in isolation is what let the S3 path and the blank-digest semantics diverge; that test found the blank-digest bug immediately.
- A structural test fails when any function comparing a computed digest skips `_normalize_digest`, naming the offender — the behavioural matrix only protects a *new* download path if someone remembers to extend it, which is exactly what did not happen for S3. The guard is itself pinned against a known-bad snippet, since a structural check that matches nothing passes forever.

## Related Issues

None — these were found by inspection, not filed.

## Checklist

- [x] Scope is focused and limited to this change — though note the change *is* a sweep: 24 files across 8 subsystems. It is organised as four commits (initial fixes, review fixes, test hardening, second sweep) and reviewable commit by commit.
- [x] Tests added/updated for behavior changes — 40+ tests, each confirmed to fail before its fix
- [x] Docs updated for user-visible changes — no user-facing docs affected; corrected docstrings that documented behaviour the code did not implement (`_atomic_write`'s atomicity claim, `apply_egress_allowlist`'s "drop everything else")
- [x] No secrets or sensitive data included

Note: These bugs/fixes were done using Claude Opus 5 (MAX Effort).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Added validation for SSH host-port inputs and improved VM reconciliation when process identifiers are missing or non-positive.
  * Improved SSH readiness/timeout error handling and hardened SSH key repair/cleanup.
  * Strengthened digest pin handling (normalizes case/whitespace, rejects blank pins) and verifies downloads with safer checksum parsing.

* **Security**
  * Hardened tar extraction for host and dashboard flows by classifying unsafe members, rejecting dangerous link/device entries, and masking unsafe permission bits.
  * Made egress allowlists fail-closed for IPv6 with explicit rule ordering.

* **Reliability / Performance**
  * Switched multiple boot/polling timeouts to monotonic clocks; improved atomic environment staging and broader partial-artifact cleanup.

* **Tests**
  * Expanded security, digest, SSH, networking, and cleanup regression coverage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->