### PR TITLE
Stream macOS install progress instead of buffering it

### DIFF
--- a/src/smolvm/macos/lume.py
+++ b/src/smolvm/macos/lume.py
@@ -17,7 +17,7 @@ import shlex
 import subprocess
 import threading
 import time
-from collections.abc import Callable
+from collections.abc import Callable, Iterator
 from contextlib import suppress
 from pathlib import Path
 from typing import BinaryIO
@@ -112,6 +112,37 @@ class LumeDriver:
             return MacOSInstallProgress("setup")
         return None
 
+    @staticmethod
+    def _iter_output_lines(stream: BinaryIO) -> Iterator[bytes]:
+        """Yield log lines as soon as they arrive, splitting on newline or return.
+
+        The install runs behind a terminal (see `install_base_image`), so read
+        raw chunks instead of `readline()`: a terminal can deliver partial
+        writes, and progress reporters often overwrite a line with a carriage
+        return rather than ending it with a newline.
+        """
+        buffer = b""
+        while True:
+            try:
+                chunk = stream.read(4096)
+            except OSError:
+                # macOS reports EIO on the terminal once the child exits.
+                break
+            except ValueError:
+                # A stuck runtime can outlive the reader, which closes the
+                # terminal out from under this loop while it waits.
+                break
+            if not chunk:
+                break
+            buffer += chunk
+            parts = re.split(rb"[\r\n]", buffer)
+            buffer = parts.pop()
+            for part in parts:
+                if part:
+                    yield part + b"\n"
+        if buffer:
+            yield buffer + b"\n"
+
     @classmethod
     def _stream_install_output(
         cls,
@@ -121,7 +152,7 @@ class LumeDriver:
     ) -> None:
         try:
             with log_path.open("ab") as log:
-                while raw_line := stream.readline():
+                for raw_line in cls._iter_output_lines(stream):
                     safe_line = re.sub(rb"vnc://[^\s@]*@", b"vnc://<redacted>@", raw_line)
                     log.write(safe_line)
                     log.flush()
@@ -134,6 +165,26 @@ class LumeDriver:
                                 on_progress(update)
         except OSError:
             return
+
+    @staticmethod
+    def _open_progress_terminal() -> tuple[BinaryIO, int]:
+        """Open a terminal pair so the child reports progress line by line.
+
+        Returns the readable end for SmolVM and the writable end to hand to the
+        child. Imported here because these modules are Unix-only, while this
+        file is imported wherever the macOS backend is merely referenced.
+        """
+        import pty
+        import termios
+
+        primary_fd, secondary_fd = pty.openpty()
+        with suppress(OSError, termios.error):
+            attributes = termios.tcgetattr(secondary_fd)
+            # Without this a terminal rewrites every "\n" as "\r\n", which would
+            # put stray carriage returns in the saved build log.
+            attributes[1] &= ~termios.ONLCR
+            termios.tcsetattr(secondary_fd, termios.TCSANOW, attributes)
+        return os.fdopen(primary_fd, "rb", buffering=0), secondary_fd
 
     def install_base_image(
         self,
@@ -171,23 +222,34 @@ class LumeDriver:
             initial_phase = "download" if ipsw == "latest" else "install"
             with suppress(Exception):
                 on_progress(MacOSInstallProgress(initial_phase, 0))
+        # Lume decides how much to buffer by looking at its own stdout. Down a
+        # plain pipe it buffers ~4 KiB, which on a slow connection holds back
+        # every percentage update until the download is most of the way done —
+        # the caller's progress bar sits at 0% for many minutes. Handing it a
+        # terminal makes it report each line as it happens.
+        stream, secondary_fd = self._open_progress_terminal()
         try:
             process = subprocess.Popen(
                 [str(self.binary), *arguments],
-                stdout=subprocess.PIPE,
-                stderr=subprocess.STDOUT,
+                stdout=secondary_fd,
+                stderr=secondary_fd,
+                stdin=subprocess.DEVNULL,
                 env=self._environment(log_level="info"),
                 start_new_session=True,
             )
         except OSError as exc:
+            stream.close()
+            os.close(secondary_fd)
             raise SmolVMError(
                 "macOS image preparation did not start; run "
                 f"'smolvm image build --os macos --ipsw {ipsw} -t {request.name}' to try again."
             ) from exc
-        assert process.stdout is not None
+        # The child owns the writable end now; keep it open here and the reader
+        # would never see end-of-file.
+        os.close(secondary_fd)
         reader = threading.Thread(
             target=self._stream_install_output,
-            args=(process.stdout, log_path, on_progress),
+            args=(stream, log_path, on_progress),
             daemon=True,
             name=f"smolvm-lume-install-{request.name}",
         )
@@ -209,6 +271,7 @@ class LumeDriver:
             ) from exc
         finally:
             reader.join(timeout=5)
+            stream.close()
         if return_code != 0:
             raise SmolVMError(
                 "macOS image preparation failed; inspect the image build log, then run "

--- a/tests/test_macos_lume.py
+++ b/tests/test_macos_lume.py
@@ -8,6 +8,7 @@
 
 import io
 import subprocess
+import threading
 import time
 from pathlib import Path
 from types import SimpleNamespace
@@ -136,6 +137,75 @@ def test_lume_progress_parser_recognizes_download_install_and_setup() -> None:
     assert LumeDriver._progress_from_line("INFO: Starting offline unattended setup") == (
         MacOSInstallProgress("setup")
     )
+
+
+def test_lume_install_gives_the_runtime_a_terminal(tmp_path: Path) -> None:
+    """Lume only reports progress line by line when its output is a terminal."""
+    binary = tmp_path / "lume-tty"
+    binary.write_text(
+        "#!/usr/bin/env python3\n"
+        "import sys\n"
+        "print(f'INFO: isatty={sys.stdout.isatty()}', flush=True)\n"
+    )
+    binary.chmod(0o755)
+
+    LumeDriver(binary).install_base_image(
+        MacOSInstallRequest(name="macos-latest", storage_path=tmp_path),
+        log_path=tmp_path / "build.log",
+        on_progress=None,
+    )
+
+    assert "INFO: isatty=True" in (tmp_path / "build.log").read_text()
+
+
+def test_lume_install_reports_progress_before_the_runtime_exits(tmp_path: Path) -> None:
+    """Progress must not be withheld until the child's output buffer fills."""
+    binary = tmp_path / "lume-unflushed"
+    # No flush= anywhere: a block-buffered child holds these back down a pipe.
+    binary.write_text(
+        "#!/usr/bin/env python3\n"
+        "import time\n"
+        "print('INFO: Downloading IPSW Progress: 7%')\n"
+        "time.sleep(30)\n"
+    )
+    binary.chmod(0o755)
+    driver = LumeDriver(binary)
+    seen = threading.Event()
+
+    def record(update: MacOSInstallProgress) -> None:
+        if update == MacOSInstallProgress("download", 7):
+            seen.set()
+
+    def install() -> None:
+        # Killing the child below makes the install fail; that is the teardown,
+        # not the thing under test.
+        with pytest.raises(SmolVMError):
+            driver.install_base_image(
+                MacOSInstallRequest(name="macos-latest", storage_path=tmp_path),
+                log_path=tmp_path / "build.log",
+                on_progress=record,
+            )
+
+    worker = threading.Thread(target=install, daemon=True)
+    worker.start()
+    try:
+        assert seen.wait(timeout=10), "download progress never reached the caller"
+    finally:
+        subprocess.run(["pkill", "-f", str(binary)], check=False)
+        worker.join(timeout=10)
+
+
+def test_lume_install_stream_splits_carriage_return_updates(tmp_path: Path) -> None:
+    """Progress reporters often overwrite one line instead of ending it."""
+    updates: list[MacOSInstallProgress] = []
+    stream = io.BytesIO(b"INFO: Downloading IPSW Progress: 3%\rINFO: Downloading IPSW Progress: 9%")
+
+    LumeDriver._stream_install_output(stream, tmp_path / "build.log", updates.append)
+
+    assert updates == [
+        MacOSInstallProgress("download", 3),
+        MacOSInstallProgress("download", 9),
+    ]
 
 
 def test_lume_details_accept_null_stopped_vm_fields() -> None:


### PR DESCRIPTION
## The bug

Customer feedback on macOS:

> `smolvm sandbox create --os macos --name nimble-test --mount ... --writable-mounts`
> This took 30+ mins with the progress bar stuck at 0%. Had to rerun multiple times to finish the download and complete the installation.

This was a real bug, not slow hardware.

`smolvm sandbox create --os macos` drives its progress bar by parsing lume's stdout for `Downloading IPSW Progress: N%` lines. SmolVM connected that stdout to a **pipe**, so lume — like most programs — checked whether its output was a terminal and switched to ~4 KiB block buffering. Nothing reached SmolVM until 4 KiB of log accumulated.

Measured on a Mac with a fast connection, running lume exactly the way SmolVM does:

| stdout | progress lines received |
|---|---|
| **pipe** (what SmolVM did) | **0 lines in ~13 minutes** |
| **terminal** | first line at 14s, then ~1% every 10s |

Each progress line is ~60 bytes, so the buffer needs roughly 68 updates before it flushes — about two-thirds of the download. On a slower link that is the entire 30 minutes at 0%. The bar was accurate about what SmolVM knew; SmolVM just wasn't being told.

The same buffering also stalled `~/.smolvm/images/macos/*.build.log`, so tailing the log wouldn't have helped either — exactly the "no visibility" the customer described.

## The fix

`src/smolvm/macos/lume.py` now hands lume a pty instead of a pipe, so it line-buffers:

- `_open_progress_terminal()` opens the pair and clears `ONLCR` so the saved build log doesn't fill with `\r`
- `_iter_output_lines()` replaces `readline()` with chunked reads split on `\n` *or* `\r`, since terminals deliver partial writes and progress reporters often overwrite a line with a carriage return
- EIO on child exit and the close-race `ValueError` are both handled

Verified end-to-end against the real lume binary through the patched code path: **12 live callbacks in 120 seconds**, versus 0 in 13 minutes before. The build log came out clean — 0 carriage returns, and the ~200 blank lines of noise it used to carry are gone.

## Why the existing tests didn't catch this

The fake lume in `tests/test_macos_lume.py` uses `print(..., flush=True)`, which real lume does not do — so the fake streamed even down a pipe.

Three new tests, each confirmed to **fail on the old code and pass on the new**:

- child sees a TTY on stdout
- progress reaches the caller from a deliberately unflushed child *before* it exits
- `\r`-separated updates are parsed

## Testing

- `uv run ruff check .` clean
- 37 macOS/VZ tests pass (`test_macos_lume`, `test_macos_images`, `test_cli_macos_desktop`, `test_runtime_vz`)
- Full suite has 14 failures, but they are **identical on a clean tree with these changes stashed** — pre-existing local environment issues (stale native extension build, ports already in use, shell rc state), none macOS-related

## Not fixed here — worth a follow-up

1. **No download resume.** lume discards the partial IPSW on abort (its temp dirs were 0 B after cancellation), and `_adopt_latest_ipsw` only rescues a *complete* file — so every rerun restarts the full ~16 GB. This is the direct cause of the customer's "had to rerun multiple times". Fixing it properly means SmolVM downloading the IPSW itself with HTTP range resume and passing `--ipsw <path>` to lume.
2. **`smolvm sandbox logs` for running macOS VMs likely lags the same way.** `LumeDriver.start()` still uses `subprocess.PIPE` via `_write_redacted_log`. It doesn't block anything functional — readiness comes from polling `inspect()`, not stdout — so I left the run path alone rather than change it without verifying against a booted VM.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved base image installation progress reporting so updates appear in real time.
  * Correctly handles progress output separated by carriage returns.
  * Preserves clean build logs while removing sensitive connection details.

* **Tests**
  * Added coverage for real-time progress updates, terminal output, and varied progress formatting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->