### PR TITLE
Enable copy and paste for macOS sandbox desktops

### DIFF
--- a/docs/guides/macos.md
+++ b/docs/guides/macos.md
@@ -30,6 +30,18 @@ smolvm sandbox desktop test-mac
 
 SmolVM opens the built-in Screen Sharing app. The connection stays on this Mac and uses a temporary password that is not printed.
 
+## Copy and paste
+
+Copy and paste works in both directions between your Mac and the sandbox desktop. Copy on one side, paste on the other.
+
+Anything you copy on your Mac is readable inside the sandbox while it runs. If you would rather keep the two clipboards separate, turn it off when you create the sandbox:
+
+```bash
+smolvm sandbox create --os macos --name private-mac --no-clipboard
+```
+
+The choice is saved with the sandbox, so stopping and starting it keeps the same setting.
+
 ## Share files
 
 Add one local folder when you create the sandbox:

--- a/src/smolvm/cli/commands/app.py
+++ b/src/smolvm/cli/commands/app.py
@@ -87,6 +87,14 @@ def sandbox() -> None:
 @comm_channel_option
 @click.option("--mount", "mounts", multiple=True, metavar="HOST_PATH[:GUEST_PATH]")
 @click.option("--writable-mounts", is_flag=True, help="Allow writes to mounted host folders.")
+@click.option(
+    "--clipboard/--no-clipboard",
+    default=True,
+    help=(
+        "Copy and paste between this Mac and the macOS desktop (on by default). "
+        "Use --no-clipboard to keep the two clipboards separate."
+    ),
+)
 @click.option("--yes", is_flag=True, help="Confirm one-time macOS image preparation.")
 @click.option(
     "--network",
@@ -115,6 +123,7 @@ def sandbox_create(
     comm_channel: str | None,
     mounts: tuple[str, ...],
     writable_mounts: bool,
+    clipboard: bool,
     yes: bool,
     network_mode: str,
     bridge_name: str | None,
@@ -136,6 +145,7 @@ def sandbox_create(
             comm_channel=comm_channel,
             mounts=_mounts(mounts),
             writable_mounts=writable_mounts,
+            clipboard=clipboard,
             yes=yes,
             network_mode=network_mode,
             bridge_name=bridge_name,

--- a/src/smolvm/cli/main.py
+++ b/src/smolvm/cli/main.py
@@ -1291,6 +1291,7 @@ def _run_create(args: SimpleNamespace) -> int:
                         disk_size_mib=args.disk_size_mib,
                         ssh_key_path=None,
                         on_download=on_download,
+                        clipboard=getattr(args, "clipboard", True),
                     ),
                     boot_timeout=args.boot_timeout,
                     prepare_message=_create_progress_message(resolved_backend, resolved_guest_os),
@@ -1310,6 +1311,7 @@ def _run_create(args: SimpleNamespace) -> int:
                     memory=args.memory_mib,
                     disk_size_mib=args.disk_size_mib,
                     ssh_key_path=None,
+                    clipboard=getattr(args, "clipboard", True),
                 )
                 config = _apply_network_attachment(
                     config,

--- a/src/smolvm/facade.py
+++ b/src/smolvm/facade.py
@@ -565,6 +565,7 @@ def _build_auto_config(
     ssh_key_path: str | None = None,
     on_download: Callable[[str, int, int | None], None] | None = None,
     data_dir: Path | None = None,
+    clipboard: bool = True,
 ) -> tuple[VMConfig, str | None]:
     """Build the default SSH-ready VM config used by zero-config flows."""
     requested_os = _normalize_guest_os(os) if os is not None else None
@@ -599,7 +600,11 @@ def _build_auto_config(
                 f"This macOS image uses {manifest.memory_mib} MiB of memory; remove the custom "
                 "memory setting and create the sandbox again."
             )
-        machine = image_manager.machine_config(resolved_vm_name, data_dir=resolved_data_dir)
+        machine = image_manager.machine_config(
+            resolved_vm_name,
+            data_dir=resolved_data_dir,
+            clipboard=clipboard,
+        )
         config = VMConfig(
             vm_id=resolved_vm_name,
             vcpu_count=manifest.cpu_count,

--- a/src/smolvm/macos/images.py
+++ b/src/smolvm/macos/images.py
@@ -364,6 +364,7 @@ class MacOSImageManager:
         *,
         data_dir: Path,
         name: str = MACOS_DEFAULT_IMAGE,
+        clipboard: bool = True,
     ) -> MacOSMachineConfig:
         manifest = self.get(name)
         return MacOSMachineConfig(
@@ -373,4 +374,5 @@ class MacOSImageManager:
             guest_version=manifest.guest_version,
             guest_build=manifest.guest_build,
             disk_size_mib=manifest.disk_size_bytes // (1024 * 1024),
+            clipboard=clipboard,
         )

--- a/src/smolvm/macos/lume.py
+++ b/src/smolvm/macos/lume.py
@@ -383,6 +383,10 @@ class LumeDriver:
             "--network",
             "nat",
         ]
+        if request.clipboard:
+            # Copy and paste between this Mac and the sandbox desktop. Lume
+            # carries the text over its own SSH connection to the guest.
+            arguments.append("--clipboard")
         for mount in request.workspace_mounts:
             arguments.extend(
                 [

--- a/src/smolvm/macos/models.py
+++ b/src/smolvm/macos/models.py
@@ -93,6 +93,7 @@ class MacOSRunRequest:
     name: str
     storage_path: Path
     workspace_mounts: tuple[WorkspaceMount, ...] = ()
+    clipboard: bool = True
 
     def __post_init__(self) -> None:
         _validate_lume_name(self.name)

--- a/src/smolvm/runtime/vz.py
+++ b/src/smolvm/runtime/vz.py
@@ -78,6 +78,7 @@ class VzRuntimeAdapter(RuntimeAdapter):
                 name=vm_info.vm_id,
                 storage_path=machine.bundle_path.parent,
                 workspace_mounts=tuple(vm_info.config.workspace_mounts),
+                clipboard=machine.clipboard,
             ),
             log_path=log_path,
             timeout=boot_timeout,

--- a/src/smolvm/types.py
+++ b/src/smolvm/types.py
@@ -252,6 +252,7 @@ class MacOSMachineConfig(BaseModel):
     display_width: Annotated[int, Field(ge=1024, le=7680)] = 1440
     display_height: Annotated[int, Field(ge=768, le=4320)] = 900
     ssh_user: str = "lume"
+    clipboard: bool = True
 
     @field_validator("base_image", "guest_version", "ssh_user")
     @classmethod

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -767,6 +767,7 @@ class TestCliCreate:
             disk_size_mib=4096,
             ssh_key_path=None,
             on_download=ANY,
+            clipboard=True,
         )
         mock_vm_cls.assert_called_once_with(
             config,
@@ -844,6 +845,7 @@ class TestCliCreate:
             disk_size_mib=2048,
             ssh_key_path=None,
             on_download=ANY,
+            clipboard=True,
         )
         mock_vm_cls.assert_called_once_with(
             config,
@@ -943,6 +945,7 @@ class TestCliCreate:
             disk_size_mib=4096,
             ssh_key_path=None,
             on_download=ANY,
+            clipboard=True,
         )
         mock_vm_cls.assert_called_once_with(
             config,
@@ -1135,6 +1138,7 @@ class TestCliCreate:
             memory=None,
             disk_size_mib=None,
             ssh_key_path=None,
+            clipboard=True,
         )
         vm.start.assert_called_once_with(boot_timeout=30.0)
         vm.wait_for_ready.assert_called_once_with(timeout=30.0, on_progress=None)

--- a/tests/test_macos_lume.py
+++ b/tests/test_macos_lume.py
@@ -208,6 +208,43 @@ def test_lume_install_stream_splits_carriage_return_updates(tmp_path: Path) -> N
     ]
 
 
+def _recorded_run_command(request: MacOSRunRequest, tmp_path: Path, binary: Path) -> list[str]:
+    """Start a VM and return the argument list handed to the runtime."""
+    commands: list[list[str]] = []
+    real_popen = subprocess.Popen
+
+    def record(command: list[str], *args: object, **kwargs: object) -> object:
+        commands.append(command)
+        return real_popen(command, *args, **kwargs)  # type: ignore[arg-type]
+
+    driver = LumeDriver(binary)
+    with patch("smolvm.macos.lume.subprocess.Popen", side_effect=record):
+        process, _ = driver.start(request, log_path=tmp_path / "run.log", timeout=10)
+    process.terminate()
+    process.wait(timeout=5)
+    return commands[0]
+
+
+def test_lume_run_enables_clipboard_by_default(fake_lume: Path, tmp_path: Path) -> None:
+    command = _recorded_run_command(
+        MacOSRunRequest(name="macos-latest", storage_path=tmp_path),
+        tmp_path,
+        fake_lume,
+    )
+
+    assert "--clipboard" in command
+
+
+def test_lume_run_omits_clipboard_when_disabled(fake_lume: Path, tmp_path: Path) -> None:
+    command = _recorded_run_command(
+        MacOSRunRequest(name="macos-latest", storage_path=tmp_path, clipboard=False),
+        tmp_path,
+        fake_lume,
+    )
+
+    assert "--clipboard" not in command
+
+
 def test_lume_details_accept_null_stopped_vm_fields() -> None:
     details = LumeVMDetails.model_validate(
         {


### PR DESCRIPTION
## The bug

Customer feedback: copying text on the host and pasting it into the macOS sandbox desktop doesn't work.

The cause is narrow. lume 0.4 **already implements** bidirectional clipboard sync, behind a flag:

```
--clipboard    Enable bidirectional clipboard sync with the VM via SSH (experimental)
```

SmolVM never passed it. Grepping the codebase for `clipboard`/`pasteboard` returned nothing — the capability was simply never wired up.

## How it works

lume carries clipboard text over its own SSH connection into the guest — `pbpaste | base64` to read, `base64 -D | pbcopy` to write. It embeds a SwiftNIO SSH client, so there's no external dependency (the `sshpass` string in the binary is from `lume ssh` help text saying you *don't* need it), and `--unattended` images provision the `lume` account it authenticates with.

I verified against a booted guest that the transport this depends on is actually present and working:

- SSH into the guest succeeds as the `lume` user
- `/usr/bin/pbcopy` and `/usr/bin/pbpaste` both exist (guest is macOS 26.5.2)

## Default

**On by default**, matching Parallels and VMware, with an escape hatch:

```bash
smolvm sandbox create --os macos --name mac1                  # clipboard sync active
smolvm sandbox create --os macos --name mac1 --no-clipboard   # clipboards stay separate
```

⚠️ **Worth a second opinion from reviewers:** on-by-default means text copied on the host is readable from inside the sandbox while it runs. For a product whose pitch is "nothing touches the host," that's a real widening of what a sandboxed process can see — a password or token copied on the host becomes visible to whatever runs in the VM. This was a deliberate call for ergonomics; `--no-clipboard` is the opt-out, and the macOS guide states the exposure plainly rather than burying it. Easy to flip to opt-in if reviewers disagree.

## Implementation

The setting is stored on `MacOSMachineConfig`, so it survives stop/start instead of reverting on restart. Plumbing: CLI flag → `_build_auto_config` → `machine_config()` → `MacOSMachineConfig.clipboard` → `MacOSRunRequest.clipboard` → the lume argv.

Sandboxes created before this change have no stored value and default to on, consistent with new ones — verified with a JSON round trip.

## Testing

- Two new tests assert `--clipboard` is present by default and absent with `clipboard=False`, checked on the actual argv handed to the runtime
- Verified the field survives a config JSON round trip in both states, and that a config missing the field defaults to on
- Updated 4 `TestCliCreate` assertions for the new `clipboard=` kwarg — signature genuinely changed
- `uv run ruff check .` clean
- Full suite: **14 failures, identical to a clean tree** with these changes stashed (stale native extension build, ports in use, Bash 3.2 completion) — no regressions

## Not verified

The final host↔guest round trip — text actually crossing — is untested. Confirming it requires reading and overwriting the real host clipboard, which I couldn't do safely (I was unable to back it up to restore afterwards). Everything up to that last hop is verified. Suggest a reviewer copy some text and paste it into a sandbox desktop as a smoke check before merge.

Also note lume marks this flag **experimental**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added clipboard sharing between the host Mac and sandbox desktop by default.
  - Added `--no-clipboard` to keep host and sandbox clipboards separate.
  - Clipboard preferences are saved per sandbox and persist across restarts.

- **Documentation**
  - Added macOS guidance explaining clipboard sharing, disabling the feature, and persistence.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->