### PR TITLE
Stop reporting a real image pull as "Already cached"

### DIFF
--- a/src/smolvm/cli/image.py
+++ b/src/smolvm/cli/image.py
@@ -26,12 +26,14 @@ operate on the directory returned by
 from __future__ import annotations
 
 import json
+import os
 import re
 import shlex
 import shutil
 from contextlib import AbstractContextManager, nullcontext
 from datetime import UTC, datetime
 from pathlib import Path
+from stat import S_ISREG
 from typing import Any, NotRequired, TypedDict, cast
 
 from rich.progress import (
@@ -640,6 +642,53 @@ def _non_default_dir_warnings(root: Path) -> list[str]:
     ]
 
 
+def _cache_inventory(path: Path) -> dict[str, tuple[int, int, int]] | None:
+    """Fingerprint every file under ``path``, or ``None`` if that is not possible.
+
+    Directory mtimes cannot answer "did anything happen here?": the kernel
+    stamps them from a coarse clock, so a file created milliseconds after the
+    directory is created leaves the directory's mtime untouched. Comparing the
+    set of files instead (name, size, inode, mtime) detects a download or a
+    decompression regardless of how fast it finished.
+
+    ``None`` means "no usable fingerprint", either because the directory does
+    not exist or because a file in it could not be read. A partial scan is not
+    a safe basis for claiming nothing happened: if the same file were skipped
+    before and after the pull, the two scans could match while the cache
+    actually changed. Callers treat ``None`` as a cache miss.
+    """
+
+    def _raise(error: OSError) -> None:
+        raise error
+
+    inventory: dict[str, tuple[int, int, int]] = {}
+    try:
+        if not path.is_dir():
+            return None
+        # os.walk with a raising onerror, not rglob: rglob silently skips a
+        # directory it cannot read, which would hand back a partial scan that
+        # looks like a complete one.
+        for dirpath, _dirnames, filenames in os.walk(path, onerror=_raise):
+            for name in filenames:
+                item = Path(dirpath) / name
+                try:
+                    stat = item.stat()
+                except FileNotFoundError:
+                    # Vanished between listing and stat, so it is not part of
+                    # the cache under either scan.
+                    continue
+                if not S_ISREG(stat.st_mode):
+                    continue
+                inventory[str(item.relative_to(path))] = (
+                    stat.st_size,
+                    stat.st_ino,
+                    stat.st_mtime_ns,
+                )
+    except OSError:
+        return None
+    return inventory
+
+
 def _execute_pull(
     *,
     preset: str,
@@ -664,9 +713,9 @@ def _execute_pull(
 
     # "Already cached" must mean the pull was a no-op. Downloads are
     # observable through on_download, but rootfs decompression is not, so
-    # also watch the cache directory itself: any file (re)created in it —
-    # by download or decompression — bumps its mtime.
-    pre_mtime = target_dir.stat().st_mtime_ns if target_dir.is_dir() else None
+    # also watch the cache directory itself: any file added, replaced, or
+    # resized by a download or a decompression changes its inventory.
+    pre_inventory = _cache_inventory(target_dir)
     downloaded = False
     download_tasks: dict[str, Any] = {}
 
@@ -689,8 +738,10 @@ def _execute_pull(
         on_download=on_download,
     )
 
-    post_mtime = target_dir.stat().st_mtime_ns if target_dir.is_dir() else None
-    already_cached = not downloaded and pre_mtime is not None and post_mtime == pre_mtime
+    post_inventory = _cache_inventory(target_dir)
+    already_cached = (
+        not downloaded and pre_inventory is not None and post_inventory == pre_inventory
+    )
 
     return ImagePullPayload(
         preset=preset,

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -4573,12 +4573,17 @@ class TestCliImage:
 
         cache_dir = tmp_path / cache_name("codex", "amd64", "firecracker")
         cache_dir.mkdir()
+        dir_mtime_ns = cache_dir.stat().st_mtime_ns
 
         def fake_ensure(*args: object, **kwargs: object) -> LocalImage:
             # Simulate decompression: a file appears in the cache dir
             # without any on_download callback firing.
             rootfs = cache_dir / "rootfs.ext4"
             rootfs.write_text("decompressed")
+            # The kernel stamps directory mtimes from a coarse clock, so a
+            # fast decompression genuinely leaves the mtime untouched. Pin it
+            # so this regression cannot pass by winning a timing race.
+            os.utime(cache_dir, ns=(dir_mtime_ns, dir_mtime_ns))
             return LocalImage(
                 name="codex-cache", kernel_path=cache_dir / "vmlinux.bin", rootfs_path=rootfs
             )
@@ -4586,6 +4591,90 @@ class TestCliImage:
         mock_ensure_published.side_effect = fake_ensure
 
         ret = main(["image", "pull", "codex", "--image-dir", str(tmp_path), "--json"])
+
+        assert ret == 0
+        payload = json.loads(capsys.readouterr().out)
+        assert payload["data"]["already_cached"] is False
+
+    @patch("smolvm.images.published.ensure_published_image")
+    @patch("smolvm.cli.main._vmm_for_host", return_value="firecracker")
+    @patch("smolvm.cli.main._host_arch_for_published", return_value="amd64")
+    def test_image_pull_unfingerprintable_cache_is_not_a_cache_hit(
+        self,
+        mock_arch: MagicMock,
+        mock_vmm: MagicMock,
+        mock_ensure_published: MagicMock,
+        tmp_path: Path,
+        capsys: pytest.CaptureFixture,
+    ) -> None:
+        """A cache we cannot fully read must not be reported as a no-op pull.
+
+        If the same file were skipped before and after, the two scans could
+        match while the cache actually changed, so an unreadable entry has to
+        fail closed rather than silently shrink the comparison.
+        """
+        from smolvm.images.manager import LocalImage
+        from smolvm.images.published import cache_name
+
+        cache_dir = tmp_path / cache_name("codex", "amd64", "firecracker")
+        cache_dir.mkdir()
+        rootfs = cache_dir / "rootfs.ext4"
+        rootfs.write_text("cached")
+
+        mock_ensure_published.side_effect = lambda *a, **k: LocalImage(
+            name="codex-cache", kernel_path=cache_dir / "vmlinux.bin", rootfs_path=rootfs
+        )
+
+        real_stat = Path.stat
+
+        def unreadable(self: Path, *args: object, **kwargs: object) -> os.stat_result:
+            if self.name == "rootfs.ext4":
+                raise PermissionError(13, "Permission denied")
+            return real_stat(self, *args, **kwargs)  # type: ignore[arg-type]
+
+        with patch.object(Path, "stat", unreadable):
+            ret = main(["image", "pull", "codex", "--image-dir", str(tmp_path), "--json"])
+
+        assert ret == 0
+        payload = json.loads(capsys.readouterr().out)
+        assert payload["data"]["already_cached"] is False
+
+    @patch("smolvm.images.published.ensure_published_image")
+    @patch("smolvm.cli.main._vmm_for_host", return_value="firecracker")
+    @patch("smolvm.cli.main._host_arch_for_published", return_value="amd64")
+    def test_image_pull_unreadable_subdirectory_is_not_a_cache_hit(
+        self,
+        mock_arch: MagicMock,
+        mock_vmm: MagicMock,
+        mock_ensure_published: MagicMock,
+        tmp_path: Path,
+        capsys: pytest.CaptureFixture,
+    ) -> None:
+        """A directory we cannot descend into must not read as a complete scan.
+
+        ``Path.rglob`` silently skips a directory it cannot open, so a scan
+        that missed a whole subtree would otherwise compare equal to the next
+        one and report a real pull as cached.
+        """
+        from smolvm.images.manager import LocalImage
+        from smolvm.images.published import cache_name
+
+        cache_dir = tmp_path / cache_name("codex", "amd64", "firecracker")
+        layers = cache_dir / "layers"
+        layers.mkdir(parents=True)
+        rootfs = cache_dir / "rootfs.ext4"
+        rootfs.write_text("cached")
+        (layers / "layer0.bin").write_text("cached")
+        os.chmod(layers, 0o000)
+
+        mock_ensure_published.side_effect = lambda *a, **k: LocalImage(
+            name="codex-cache", kernel_path=cache_dir / "vmlinux.bin", rootfs_path=rootfs
+        )
+
+        try:
+            ret = main(["image", "pull", "codex", "--image-dir", str(tmp_path), "--json"])
+        finally:
+            os.chmod(layers, 0o755)
 
         assert ret == 0
         payload = json.loads(capsys.readouterr().out)


### PR DESCRIPTION
## Summary

`smolvm image pull` decided whether a pull was a no-op by comparing the cache
directory's mtime before and after. That is not a reliable signal: the kernel
stamps directory mtimes from a coarse clock, so work that finishes within one
tick leaves the mtime untouched. Measured on one Linux host, creating a file
inside a just-created directory left the directory mtime identical in **1924 of
2000 trials**.

The user-visible effect: a genuine pull whose rootfs decompression finished
quickly was reported as `Already cached`, because decompression fires no
download callback. It also made the regression test for that exact behaviour
fail intermittently, roughly four runs in five, which is how I found it.

This compares an inventory of the files under the cache directory instead
(relative path, size, inode, mtime), which detects an added or replaced file
regardless of how fast it finished. A true cache hit rewrites nothing, so it is
still correctly reported as cached.

The regression test now pins the directory mtime with `os.utime` after writing
the file, reproducing the coarse-clock case deterministically instead of
depending on winning a timing race. Verified in both directions: it fails
against the old mtime comparison (`assert True is False`) and passes against
the inventory.

## Testing

- `uv run pytest` : 2018 passed, 9 skipped, 30 deselected
- `uv run ruff check .` : clean
- `uv run ruff format --check .` : clean
- `uv run mypy src` : unchanged from `main` (153 pre-existing errors, none added)

## Checklist

- [x] Scope is focused and limited to this change
- [x] Tests added/updated for behavior changes
- [x] Docs updated for user-visible changes (none needed)
- [x] No secrets or sensitive data included


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved image pull detection to reliably recognize cached images, even when filesystem timestamps do not change.
  * Prevented unnecessary image downloads when cache contents are already available.
  * Safely treats unreadable files or inaccessible cache locations as unavailable, avoiding incorrect cache-hit reports.

* **Tests**
  * Added regression coverage for cache detection after image decompression, timestamp changes, and incomplete cache scans.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->