### PR TITLE
Make unreadable-cache test permission independent

### DIFF
--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -4665,16 +4665,22 @@ class TestCliImage:
         rootfs = cache_dir / "rootfs.ext4"
         rootfs.write_text("cached")
         (layers / "layer0.bin").write_text("cached")
-        os.chmod(layers, 0o000)
 
         mock_ensure_published.side_effect = lambda *a, **k: LocalImage(
             name="codex-cache", kernel_path=cache_dir / "vmlinux.bin", rootfs_path=rootfs
         )
 
-        try:
+        real_scandir = os.scandir
+
+        def unreadable(
+            path: str | bytes | os.PathLike[str] | os.PathLike[bytes],
+        ) -> object:
+            if Path(os.fsdecode(path)) == layers:
+                raise PermissionError(13, "Permission denied", str(layers))
+            return real_scandir(path)
+
+        with patch("smolvm.cli.image.os.scandir", side_effect=unreadable):
             ret = main(["image", "pull", "codex", "--image-dir", str(tmp_path), "--json"])
-        finally:
-            os.chmod(layers, 0o755)
 
         assert ret == 0
         payload = json.loads(capsys.readouterr().out)


### PR DESCRIPTION
## Summary

Make the unreadable-cache regression test independent of the permissions of the process running pytest.

The test previously used `chmod(000)` to make a cache subdirectory inaccessible. A privileged process can still traverse that directory, and filesystem permission behavior also differs across platforms, so the test could exercise a normal complete scan instead of the intended failure path.

The test now patches `os.scandir` only for the target subdirectory. This makes `os.walk` invoke its real `onerror` path deterministically while allowing the rest of the cache tree to be scanned normally.

## Impact

Product behavior is unchanged. The regression test now verifies the fail-closed cache decision consistently across runners and privilege levels.

## Testing

- `uv run --extra dev python -m pytest tests/test_cli.py::TestCliImage -q` — 15 passed
- `uv run ruff check tests/test_cli.py` — clean
- `uv run ruff format --check tests/test_cli.py` — clean


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved coverage for handling inaccessible cache directories.
  * Tests now reliably simulate permission errors without changing filesystem permissions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->