### PR TITLE
Run required checks for merge queue groups

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -20,6 +20,7 @@ on:
     branches: [main]
     types: [opened, synchronize, reopened, ready_for_review]
   merge_group:
+    branches: [main]
     types: [checks_requested]
   schedule:
     # 03:17 UTC nightly (off the top of the hour to dodge cron congestion).

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -19,6 +19,8 @@ on:
   pull_request:
     branches: [main]
     types: [opened, synchronize, reopened, ready_for_review]
+  merge_group:
+    types: [checks_requested]
   schedule:
     # 03:17 UTC nightly (off the top of the hour to dodge cron congestion).
     - cron: "17 3 * * *"

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -5,6 +5,8 @@ on:
     branches:
       - main
   pull_request:
+  merge_group:
+    types: [checks_requested]
 
 permissions:
   contents: read

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -6,6 +6,7 @@ on:
       - main
   pull_request:
   merge_group:
+    branches: [main]
     types: [checks_requested]
 
 permissions:


### PR DESCRIPTION
## Summary

Run the required Python and real-KVM checks for GitHub merge-group commits.

The `main` ruleset requires both Python test jobs plus the QEMU and Firecracker jobs. Those workflows previously listened only for pull requests and pushes, so the merge queue received no status reports for its temporary commit and removed #469 after the 60-minute response timeout.

Both workflows now handle the `merge_group` `checks_requested` event. Existing pull-request, push, scheduled, and manual behavior is unchanged.

After this lands, #469 can be added to the merge queue again.

## Testing

- Parsed both changed workflow files as YAML.
- Verified both workflows expose `merge_group` with the `checks_requested` activity.
- `git diff --check` passes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved automated quality checks for merge queue updates.
  * End-to-end and test validation now runs consistently when changes enter the merge queue, helping ensure code remains reliable before integration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->