### PR TITLE
Stop losing per-VM disks when a sandbox goes away

### DIFF
--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -27,7 +27,7 @@ Run these in the order you need them:
 | `smolvm sandbox start` / `stop` | Start or stop a sandbox. |
 | `smolvm sandbox pause` / `resume` | Temporarily freeze and continue a running sandbox. |
 | `smolvm sandbox delete` | Remove one or more sandboxes. |
-| `smolvm sandbox prune` | Delete files left behind by sandboxes that no longer exist. Add `--dry-run` to see what would go first. |
+| `smolvm sandbox prune` | Delete disks and logs left behind by sandboxes that no longer exist. Add `--dry-run` to list those files without deleting them. Disks you asked SmolVM to save are kept unless you add `--include-saved`. |
 
 ### Sandbox data and connections
 

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -27,6 +27,7 @@ Run these in the order you need them:
 | `smolvm sandbox start` / `stop` | Start or stop a sandbox. |
 | `smolvm sandbox pause` / `resume` | Temporarily freeze and continue a running sandbox. |
 | `smolvm sandbox delete` | Remove one or more sandboxes. |
+| `smolvm sandbox prune` | Delete files left behind by sandboxes that no longer exist. Add `--dry-run` to see what would go first. |
 
 ### Sandbox data and connections
 

--- a/src/smolvm/cli/cleanup.py
+++ b/src/smolvm/cli/cleanup.py
@@ -20,7 +20,7 @@ import os
 import sys
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from dataclasses import asdict, dataclass
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 from rich.panel import Panel
 from rich.table import Table
@@ -60,6 +60,27 @@ class DeleteSummary:
     target_count: int
     deleted_count: int
     failed_count: int
+
+
+@dataclass(frozen=True)
+class LeftoverEntry:
+    """One file left behind by a sandbox that no longer exists."""
+
+    vm_id: str
+    path: str
+    kind: str
+    size_bytes: int
+    retained: bool
+
+
+@dataclass(frozen=True)
+class PruneResult:
+    """Structured result for ``smolvm sandbox prune``."""
+
+    removed: list[LeftoverEntry]
+    kept: list[LeftoverEntry]
+    freed_bytes: int
+    dry_run: bool = False
 
 
 @dataclass(frozen=True)
@@ -169,6 +190,23 @@ def _render_result(result: DeleteResult, *, command: str, warn_not_root: bool) -
 # ---------------------------------------------------------------------------
 
 
+def _delete_one(sdk: SmolVMManager, vm_id: str) -> None:
+    """Delete a sandbox, treating a reclaimed leftover as a successful delete.
+
+    A sandbox whose inventory row is already gone still owns files on disk.
+    ``delete()`` removes them and then reports the missing row, so only call
+    that a failure when there was nothing left to clean up.
+    """
+    from smolvm.exceptions import VMNotFoundError
+
+    leftovers = sdk.leftover_paths_for_vm(vm_id)
+    try:
+        sdk.delete(vm_id)
+    except VMNotFoundError:
+        if not leftovers or any(path.exists() for path in leftovers):
+            raise
+
+
 def _delete_vms_concurrent(
     sdk: SmolVMManager,
     target_ids: list[str],
@@ -183,7 +221,7 @@ def _delete_vms_concurrent(
     if len(target_ids) == 1:
         vm_id = target_ids[0]
         try:
-            sdk.delete(vm_id)
+            _delete_one(sdk, vm_id)
             deleted.append(vm_id)
         except Exception as exc:
             failed.append(DeleteFailure(vm_id=vm_id, error=str(exc)))
@@ -191,7 +229,7 @@ def _delete_vms_concurrent(
 
     def _do_delete(vm_id: str) -> tuple[str, Exception | None]:
         try:
-            sdk.delete(vm_id)
+            _delete_one(sdk, vm_id)
             return vm_id, None
         except Exception as exc:  # noqa: BLE001
             return vm_id, exc
@@ -364,6 +402,160 @@ def run_cleanup(
                 _render_result(result, command="delete", warn_not_root=warn_not_root)
 
             return exit_code
+    except Exception as exc:
+        if json_output:
+            emit_error(command_name, exit_code=1, **_error_payload(exc))
+        else:
+            render_error(f"Error: {exc}")
+        return 1
+
+
+# ---------------------------------------------------------------------------
+# smolvm sandbox prune
+# ---------------------------------------------------------------------------
+
+
+def _format_bytes(size: float) -> str:
+    for unit in ("B", "KiB", "MiB", "GiB"):
+        if abs(size) < 1024:
+            return f"{size:.1f} {unit}"
+        size /= 1024
+    return f"{size:.1f} TiB"
+
+
+def _to_entry(artifact: Any) -> LeftoverEntry:
+    return LeftoverEntry(
+        vm_id=artifact.vm_id,
+        path=str(artifact.path),
+        kind=artifact.kind,
+        size_bytes=artifact.size_bytes,
+        retained=artifact.retained,
+    )
+
+
+def _confirm_prune(entries: list[LeftoverEntry], *, freed_bytes: int) -> bool:
+    """Ask before deleting. Returns False when the user backs out."""
+    console = console_stdout()
+    console.print(
+        f"This will delete [bold]{len(entries)}[/bold] file(s) "
+        f"({_format_bytes(freed_bytes)}) left over from sandboxes that no longer exist."
+    )
+    console.print("[yellow]This action cannot be undone.[/yellow]")
+    try:
+        console.print("Continue? \\[y/N] ", end="")
+        answer = input("").strip().lower()
+    except (EOFError, KeyboardInterrupt):
+        console.print("\nAborted.")
+        return False
+    if answer not in {"y", "yes"}:
+        console.print("Aborted.")
+        return False
+    return True
+
+
+def _render_prune(result: PruneResult) -> None:
+    console = console_stdout()
+
+    if result.kept:
+        kept_bytes = sum(entry.size_bytes for entry in result.kept)
+        console.print(
+            Panel.fit(
+                f"Kept {len(result.kept)} file(s) ({_format_bytes(kept_bytes)}) you asked "
+                "SmolVM to save. Run 'smolvm sandbox prune --include-saved' to delete "
+                "those too.",
+                title="Kept",
+                border_style="cyan",
+            )
+        )
+
+    if not result.removed:
+        render_empty("Prune", "Nothing to clean up.")
+        return
+
+    table = Table(
+        title=f"{'Would remove' if result.dry_run else 'Removed'} ({len(result.removed)})"
+    )
+    table.add_column("Sandbox")
+    table.add_column("File")
+    table.add_column("Size", justify="right")
+    for entry in result.removed:
+        table.add_row(entry.vm_id, entry.path, _format_bytes(entry.size_bytes))
+    console.print(table)
+
+    verb = "Would free" if result.dry_run else "Freed"
+    console.print(
+        Panel.fit(
+            f"{verb} {_format_bytes(result.freed_bytes)}",
+            title="Prune Summary",
+            border_style="cyan" if result.dry_run else "green",
+        )
+    )
+
+
+def run_prune_sandboxes(
+    *,
+    dry_run: bool = False,
+    force: bool = False,
+    include_retained: bool = False,
+    json_output: bool = False,
+    command_name: str = "sandbox.prune",
+) -> int:
+    """Delete disks and logs left behind by sandboxes that no longer exist."""
+    try:
+        with CLIService().manager() as sdk:
+            sdk.reconcile()
+            artifacts = sdk.find_leftover_artifacts()
+            candidates = [
+                _to_entry(artifact)
+                for artifact in artifacts
+                if include_retained or not artifact.retained
+            ]
+            kept = (
+                []
+                if include_retained
+                else [_to_entry(artifact) for artifact in artifacts if artifact.retained]
+            )
+            freed_bytes = sum(entry.size_bytes for entry in candidates)
+
+            if candidates and not dry_run and not force:
+                if json_output:
+                    return emit_error(
+                        command_name,
+                        "refused",
+                        "Refusing to delete leftover files without --force in --json mode. "
+                        "Run 'smolvm sandbox prune --force --json' to confirm.",
+                        recovery="Run 'smolvm sandbox prune --force --json' to confirm.",
+                        exit_code=1,
+                    )
+                if not sys.stdin.isatty():
+                    render_error(
+                        "Refusing to delete leftover files without a confirmation prompt. "
+                        "Pass --force to confirm."
+                    )
+                    return 1
+                if not _confirm_prune(candidates, freed_bytes=freed_bytes):
+                    return 0
+
+            removed = candidates
+            if not dry_run and candidates:
+                removed = [
+                    _to_entry(artifact)
+                    for artifact in sdk.prune_leftover_artifacts(include_retained=include_retained)
+                ]
+                freed_bytes = sum(entry.size_bytes for entry in removed)
+
+            result = PruneResult(
+                removed=removed,
+                kept=kept,
+                freed_bytes=freed_bytes,
+                dry_run=dry_run,
+            )
+
+            if json_output:
+                emit_json(command_name, 0, data=asdict(result))
+            else:
+                _render_prune(result)
+            return 0
     except Exception as exc:
         if json_output:
             emit_error(command_name, exit_code=1, **_error_payload(exc))

--- a/src/smolvm/cli/cleanup.py
+++ b/src/smolvm/cli/cleanup.py
@@ -19,7 +19,7 @@ from __future__ import annotations
 import os
 import sys
 from concurrent.futures import ThreadPoolExecutor, as_completed
-from dataclasses import asdict, dataclass
+from dataclasses import asdict, dataclass, field
 from typing import TYPE_CHECKING, Any
 
 from rich.panel import Panel
@@ -81,6 +81,7 @@ class PruneResult:
     kept: list[LeftoverEntry]
     freed_bytes: int
     dry_run: bool = False
+    failed: list[LeftoverEntry] = field(default_factory=list)
 
 
 @dataclass(frozen=True)
@@ -468,6 +469,16 @@ def _render_prune(result: PruneResult) -> None:
             )
         )
 
+    if result.failed:
+        console.print(
+            Panel.fit(
+                f"Could not delete {len(result.failed)} file(s):\n"
+                + "\n".join(entry.path for entry in result.failed),
+                title="Left in place",
+                border_style="red",
+            )
+        )
+
     if not result.removed:
         render_empty("Prune", "Nothing to clean up.")
         return
@@ -537,25 +548,30 @@ def run_prune_sandboxes(
                     return 0
 
             removed = candidates
+            failed: list[LeftoverEntry] = []
             if not dry_run and candidates:
                 removed = [
                     _to_entry(artifact)
                     for artifact in sdk.prune_leftover_artifacts(include_retained=include_retained)
                 ]
                 freed_bytes = sum(entry.size_bytes for entry in removed)
+                gone = {entry.path for entry in removed}
+                failed = [entry for entry in candidates if entry.path not in gone]
 
             result = PruneResult(
                 removed=removed,
                 kept=kept,
                 freed_bytes=freed_bytes,
                 dry_run=dry_run,
+                failed=failed,
             )
+            exit_code = 1 if failed else 0
 
             if json_output:
-                emit_json(command_name, 0, data=asdict(result))
+                emit_json(command_name, exit_code, data=asdict(result))
             else:
                 _render_prune(result)
-            return 0
+            return exit_code
     except Exception as exc:
         if json_output:
             emit_error(command_name, exit_code=1, **_error_payload(exc))

--- a/src/smolvm/cli/commands/app.py
+++ b/src/smolvm/cli/commands/app.py
@@ -430,6 +430,33 @@ def sandbox_delete(
     )
 
 
+@sandbox.command("prune")
+@click.option("--dry-run", is_flag=True, help="Show what would be deleted.")
+@click.option("--force", is_flag=True, help="Skip the confirmation prompt.")
+@click.option(
+    "--include-saved",
+    is_flag=True,
+    help="Also delete disks you asked SmolVM to save.",
+)
+@json_option
+def sandbox_prune(
+    dry_run: bool,
+    force: bool,
+    include_saved: bool,
+    json_output: bool,
+) -> Any:
+    """Delete files left behind by sandboxes that no longer exist."""
+    _before_command(json_output=json_output)
+    from smolvm.cli.cleanup import run_prune_sandboxes
+
+    return run_prune_sandboxes(
+        dry_run=dry_run,
+        force=force,
+        include_retained=include_saved,
+        json_output=json_output,
+    )
+
+
 @cli.command("setup", help="Install or validate local runtime dependencies.")
 @click.option("--check-only", is_flag=True, help="Check what is needed without installing.")
 @click.option("--with-docker", is_flag=True, help="Also install or check Docker.")

--- a/src/smolvm/vm.py
+++ b/src/smolvm/vm.py
@@ -37,6 +37,7 @@ import sys
 import time
 from collections.abc import Iterator
 from contextlib import asynccontextmanager, contextmanager, suppress
+from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, TextIO
 from uuid import uuid4
@@ -103,12 +104,35 @@ DEFAULT_DATA_DIR_ENV = "SMOLVM_DATA_DIR"
 DEFAULT_SYSTEM_DATA_DIR = Path("/var/lib/smolvm")
 DEFAULT_SOCKET_DIR = Path("/tmp")
 
+# Marks a per-VM disk that outlives its VM row on purpose, so the reclaim
+# sweep can tell a deliberately kept disk from a leaked one.
+RETAINED_DISK_MARKER_SUFFIX = ".retained"
+
 # Backend-specific defaults
 QEMU_GUEST_IP = "10.0.2.15"
 _MIB = 1024 * 1024
 LIBKRUN_GUEST_IP = "192.168.127.2"
 LIBKRUN_GATEWAY_IP = "192.168.127.1"
 _QEMU_VSOCK_CID_RE = re.compile(r"vhost-vsock-(?:pci|device),guest-cid=(\d+)")
+
+
+@dataclass(frozen=True)
+class LeftoverArtifact:
+    """A file left behind by a sandbox that no longer exists."""
+
+    vm_id: str
+    path: Path
+    size_bytes: int
+    kind: str  # "disk" or "log"
+    retained: bool = False
+
+
+def _file_size(path: Path) -> int:
+    """Return a file's size, or 0 when it cannot be read."""
+    try:
+        return path.stat().st_size
+    except OSError:
+        return 0
 
 
 def _linux_os_release_ids(os_release_path: Path = Path("/etc/os-release")) -> set[str]:
@@ -1019,6 +1043,9 @@ class SmolVMManager:
                 config.vm_id,
                 instance_rootfs,
             )
+
+        # A VM row owns this disk again, so it is no longer a kept leftover.
+        self._clear_retained_marker(instance_rootfs)
 
         return config.model_copy(
             update={"rootfs_path": instance_rootfs, "rootfs_format": materialized_format}
@@ -2022,7 +2049,10 @@ class SmolVMManager:
                     effective_config = self._resize_materialized_rootfs(effective_config)
                     self._materialize_firmware(effective_config)
                 self._discard_existing_managed_disk_backup(managed_disk_backup)
-            except Exception:
+            except BaseException:
+                # BaseException, not Exception: a Ctrl-C here lands between the
+                # disk being written and the VM row existing, and a disk with no
+                # row can never be found again.
                 self._restore_existing_managed_disk_backup(managed_disk_backup)
                 if vm_record_created:
                     with suppress(Exception):
@@ -2190,8 +2220,9 @@ class SmolVMManager:
             )
             return vm_info
 
-        except Exception as e:
-            # Rollback on failure
+        except BaseException as e:
+            # Rollback on failure, including Ctrl-C: the VM row is about to go,
+            # so its disk has to go with it.
             logger.error("Failed to create VM %s: %s", effective_config.vm_id, e)
             self._cleanup_resources(
                 effective_config.vm_id,
@@ -3633,6 +3664,12 @@ class SmolVMManager:
     ) -> None:
         """Clean up resources for a VM.
 
+        Host teardown (network, leases, sockets) and artifact removal (disk,
+        firmware, runtime log) run as two independent steps on purpose. The
+        callers delete the VM row whatever cleanup manages to do, and a disk
+        with no row is unreachable, so a failing host step must never cost
+        the caller their disk.
+
         Args:
             vm_id: The VM identifier.
             preserve_managed_disk: Keep the managed disk during create rollback
@@ -3640,175 +3677,460 @@ class SmolVMManager:
             require_bridge_cleanup: Abort deletion and retain state when an owned
                 bridge interface cannot be removed.
         """
+        vm_info = self._vm_info_for_cleanup(vm_id)
         try:
-            vm_info = None
-            with suppress(VMNotFoundError):
-                vm_info = self.state.get_vm(vm_id)
-
-            backend = self.backend
-            if vm_info is not None:
-                with suppress(SmolVMError):
-                    backend = self._backend_for_vm(vm_info)
-
-            lease = self.state.get_ip_lease(vm_id)
-
-            # Check for a bridge-mode TAP allocation (no IP lease).
-            tap_alloc = self.state.get_tap_allocation(vm_id)
-
-            ssh_host_port: int | None = None
-            guest_ip: str | None = lease[0] if lease else None
-            if vm_info and vm_info.network:
-                ssh_host_port = vm_info.network.ssh_host_port
-                guest_ip = vm_info.network.guest_ip
-            else:
-                ssh_host_port = self.state.get_ssh_port(vm_id)
-
-            # Determine if this is a bridge-mode VM.
-            is_bridge = (
-                vm_info is not None
-                and vm_info.network is not None
-                and vm_info.network.mode == "bridge"
-            ) or (tap_alloc is not None and tap_alloc[1] == "bridge")
-
-            # Firecracker and QEMU-on-TAP both provision host TAP/NAT/ssh-forward
-            # resources; slirp-mode QEMU and libkrun do not. When vm_info is gone
-            # (early-failure cleanup) the IP lease or TAP allocation is the
-            # definitive tell that a TAP existed.
-            if vm_info is not None:
-                uses_tap = self._uses_host_tap_networking(vm_info.config, backend)
-            else:
-                uses_tap = lease is not None or tap_alloc is not None
-
-            # Bridge mode: clean up TAP and TAP allocation only.
-            # No NAT, route, SSH forward, or egress rules to remove.
-            if is_bridge:
-                tap_device = tap_alloc[0] if tap_alloc else None
-                if tap_device is None and vm_info is not None and vm_info.network is not None:
-                    tap_device = vm_info.network.tap_device
-                if tap_device:
-                    try:
-                        self.network.cleanup_bridged_tap(tap_device, vm_id)
-                    except BridgeTapOwnershipError as exc:
-                        # The reservation is stale and the foreign replacement
-                        # must survive. It is safe to forget only this stale name.
-                        logger.warning(
-                            "Did not remove foreign bridge interface %s for %s: %s",
-                            tap_device,
-                            vm_id,
-                            exc,
-                        )
-                        if tap_alloc:
-                            self.state.release_tap_name(vm_id)
-                    except Exception:
-                        # Keep both the VM row and allocation so a later delete
-                        # can retry ownership-checked cleanup.
-                        if require_bridge_cleanup:
-                            raise
-                        logger.warning(
-                            "Could not remove owned bridge interface %s for %s; "
-                            "retaining its reservation",
-                            tap_device,
-                            vm_id,
-                        )
-                    else:
-                        if tap_alloc:
-                            self.state.release_tap_name(vm_id)
-            else:
-                # NAT mode cleanup
-                if uses_tap and ssh_host_port is not None and guest_ip:
-                    with suppress(Exception):
-                        self.network.cleanup_ssh_port_forward(
-                            vm_id=vm_id,
-                            guest_ip=guest_ip,
-                            host_port=ssh_host_port,
-                        )
-
-                # Reconnect flows may not have in-memory local-forward state.
-                # Always remove any persisted localhost forwarding rules by vm_id.
-                with suppress(Exception):
-                    self.network.cleanup_all_local_port_forwards(vm_id)
-
-                # Get IP lease info
-                if lease:
-                    _, tap_device = lease
-
-                    if uses_tap:
-                        # Tear down host TAP/NAT for backends that provisioned it.
-                        with suppress(Exception):
-                            self.network.remove_egress_rules(tap_device)
-                        self.network.cleanup_nat_rules(tap_device)
-                        self.network.cleanup_tap(tap_device)
-
-                    # Release IP lease regardless of backend.
-                    self.state.release_ip(vm_id)
-
-            if ssh_host_port is not None and not is_bridge:
-                self.state.release_ssh_port(vm_id)
-
-            for socket_path in (
-                self.socket_dir / f"fc-{vm_id}.sock",
-                self.socket_dir / f"qmp-{vm_id}.sock",
-            ):
-                if socket_path.exists():
-                    self._unlink_socket(socket_path)
-
-            self._close_runtime_log(vm_id, BACKEND_FIRECRACKER)
-            self._close_runtime_log(vm_id, BACKEND_QEMU)
-            self._close_runtime_log(vm_id, BACKEND_LIBKRUN)
-            self._close_runtime_log(vm_id, BACKEND_VZ)
-
-            managed_disk = self._managed_disk_for_vm(vm_info)
-            if managed_disk and managed_disk.exists():
-                if preserve_managed_disk or vm_info.config.retain_disk_on_delete:
-                    logger.info(
-                        "Retaining isolated disk for VM %s at %s",
-                        vm_id,
-                        managed_disk,
-                    )
-                else:
-                    managed_sidecars = self._managed_disk_backing_sidecars(managed_disk)
-                    with suppress(Exception):
-                        managed_disk.unlink()
-                        logger.info("Removed isolated disk for VM %s: %s", vm_id, managed_disk)
-                    for sidecar in managed_sidecars:
-                        with suppress(Exception):
-                            sidecar.unlink()
-                            logger.info(
-                                "Removed isolated disk sidecar for VM %s: %s",
-                                vm_id,
-                                sidecar,
-                            )
-
-            # Per-VM firmware state (OVMF NVRAM + swtpm). Coupled to the
-            # disk lifecycle — kept iff retain_disk_on_delete is set so
-            # Secure Boot enrollment persists for a later VM with the
-            # same ID.
-            firmware_state = self.data_dir / "firmware" / vm_id
-            if firmware_state.exists():
-                retain = vm_info is not None and vm_info.config.retain_disk_on_delete
-                if retain:
-                    logger.info(
-                        "Retaining per-VM firmware state for VM %s at %s",
-                        vm_id,
-                        firmware_state,
-                    )
-                else:
-                    with suppress(Exception):
-                        shutil.rmtree(firmware_state)
-                        logger.info(
-                            "Removed per-VM firmware state for VM %s: %s",
-                            vm_id,
-                            firmware_state,
-                        )
-
+            self._cleanup_host_resources(
+                vm_id,
+                vm_info,
+                require_bridge_cleanup=require_bridge_cleanup,
+            )
         except Exception as e:
             logger.warning("Error during cleanup for %s: %s", vm_id, e)
             if require_bridge_cleanup:
+                # The VM row and its disk must survive so a later delete can
+                # retry the ownership-checked bridge teardown.
                 raise
+        self._cleanup_vm_artifacts(
+            vm_id,
+            vm_info,
+            preserve_managed_disk=preserve_managed_disk,
+        )
 
-    # ==================================================================
-    # Async lifecycle methods
-    #
+    @contextmanager
+    def _cleanup_step(self, vm_id: str, description: str) -> Iterator[None]:
+        """Run one teardown step, logging and continuing when it fails.
+
+        Cleanup is a list of independent releases. One that fails must not
+        skip the others, because the caller drops the VM row regardless and
+        nothing else knows to retry them.
+        """
+        try:
+            yield
+        except Exception as exc:  # noqa: BLE001 - one failed step must not skip the rest
+            logger.warning("Could not %s for %s: %s", description, vm_id, exc)
+
+    def _vm_info_for_cleanup(self, vm_id: str) -> VMInfo | None:
+        """Return the VM row to clean up, or None when it is already gone."""
+        try:
+            return self.state.get_vm(vm_id)
+        except VMNotFoundError:
+            return None
+        except Exception as exc:  # noqa: BLE001 - inventory faults must not block cleanup
+            logger.warning("Could not read the VM row for %s during cleanup: %s", vm_id, exc)
+            return None
+
+    def _cleanup_host_resources(
+        self,
+        vm_id: str,
+        vm_info: VMInfo | None,
+        *,
+        require_bridge_cleanup: bool = False,
+    ) -> None:
+        """Release host-side resources: network, leases, sockets, log handles."""
+        backend = self.backend
+        if vm_info is not None:
+            with suppress(SmolVMError):
+                backend = self._backend_for_vm(vm_info)
+
+        lease = self.state.get_ip_lease(vm_id)
+
+        # Check for a bridge-mode TAP allocation (no IP lease).
+        tap_alloc = self.state.get_tap_allocation(vm_id)
+
+        ssh_host_port: int | None = None
+        guest_ip: str | None = lease[0] if lease else None
+        if vm_info and vm_info.network:
+            ssh_host_port = vm_info.network.ssh_host_port
+            guest_ip = vm_info.network.guest_ip
+        else:
+            ssh_host_port = self.state.get_ssh_port(vm_id)
+
+        # Determine if this is a bridge-mode VM.
+        is_bridge = (
+            vm_info is not None and vm_info.network is not None and vm_info.network.mode == "bridge"
+        ) or (tap_alloc is not None and tap_alloc[1] == "bridge")
+
+        # Firecracker and QEMU-on-TAP both provision host TAP/NAT/ssh-forward
+        # resources; slirp-mode QEMU and libkrun do not. When vm_info is gone
+        # (early-failure cleanup) the IP lease or TAP allocation is the
+        # definitive tell that a TAP existed.
+        if vm_info is not None:
+            uses_tap = self._uses_host_tap_networking(vm_info.config, backend)
+        else:
+            uses_tap = lease is not None or tap_alloc is not None
+
+        # Bridge mode: clean up TAP and TAP allocation only.
+        # No NAT, route, SSH forward, or egress rules to remove.
+        if is_bridge:
+            tap_device = tap_alloc[0] if tap_alloc else None
+            if tap_device is None and vm_info is not None and vm_info.network is not None:
+                tap_device = vm_info.network.tap_device
+            if tap_device:
+                try:
+                    self.network.cleanup_bridged_tap(tap_device, vm_id)
+                except BridgeTapOwnershipError as exc:
+                    # The reservation is stale and the foreign replacement
+                    # must survive. It is safe to forget only this stale name.
+                    logger.warning(
+                        "Did not remove foreign bridge interface %s for %s: %s",
+                        tap_device,
+                        vm_id,
+                        exc,
+                    )
+                    if tap_alloc:
+                        self.state.release_tap_name(vm_id)
+                except Exception:
+                    # Keep both the VM row and allocation so a later delete
+                    # can retry ownership-checked cleanup.
+                    if require_bridge_cleanup:
+                        raise
+                    logger.warning(
+                        "Could not remove owned bridge interface %s for %s; "
+                        "retaining its reservation",
+                        tap_device,
+                        vm_id,
+                    )
+                else:
+                    if tap_alloc:
+                        self.state.release_tap_name(vm_id)
+        else:
+            # NAT mode cleanup
+            if uses_tap and ssh_host_port is not None and guest_ip:
+                with suppress(Exception):
+                    self.network.cleanup_ssh_port_forward(
+                        vm_id=vm_id,
+                        guest_ip=guest_ip,
+                        host_port=ssh_host_port,
+                    )
+
+            # Reconnect flows may not have in-memory local-forward state.
+            # Always remove any persisted localhost forwarding rules by vm_id.
+            with suppress(Exception):
+                self.network.cleanup_all_local_port_forwards(vm_id)
+
+            # Get IP lease info
+            if lease:
+                _, tap_device = lease
+
+                if uses_tap:
+                    # Tear down host TAP/NAT for backends that provisioned it.
+                    with suppress(Exception):
+                        self.network.remove_egress_rules(tap_device)
+                    with self._cleanup_step(vm_id, "remove host network rules"):
+                        self.network.cleanup_nat_rules(tap_device)
+                    with self._cleanup_step(vm_id, "remove the host network device"):
+                        self.network.cleanup_tap(tap_device)
+
+                # Release IP lease regardless of backend.
+                with self._cleanup_step(vm_id, "release the IP address"):
+                    self.state.release_ip(vm_id)
+
+        if ssh_host_port is not None and not is_bridge:
+            with self._cleanup_step(vm_id, "release the SSH port"):
+                self.state.release_ssh_port(vm_id)
+
+        for socket_path in (
+            self.socket_dir / f"fc-{vm_id}.sock",
+            self.socket_dir / f"qmp-{vm_id}.sock",
+        ):
+            if socket_path.exists():
+                with self._cleanup_step(vm_id, "remove the control socket"):
+                    self._unlink_socket(socket_path)
+
+        self._close_runtime_log(vm_id, BACKEND_FIRECRACKER)
+        self._close_runtime_log(vm_id, BACKEND_QEMU)
+        self._close_runtime_log(vm_id, BACKEND_LIBKRUN)
+        self._close_runtime_log(vm_id, BACKEND_VZ)
+
+    def _cleanup_vm_artifacts(
+        self,
+        vm_id: str,
+        vm_info: VMInfo | None,
+        *,
+        preserve_managed_disk: bool = False,
+    ) -> None:
+        """Remove the on-disk artifacts a VM owns: disk, firmware, runtime log.
+
+        Each artifact is removed independently so one failure cannot strand
+        the rest. Safe to call for a VM whose row is already gone: the disk
+        path is derivable from the VM ID, which is what makes
+        ``smolvm sandbox delete <id>`` able to reclaim a leaked disk.
+        """
+        retain_requested = vm_info is not None and vm_info.config.retain_disk_on_delete
+
+        for managed_disk in self._managed_disks_for_cleanup(vm_id, vm_info):
+            if not managed_disk.exists():
+                continue
+            if retain_requested:
+                self._mark_disk_retained(managed_disk)
+                logger.info("Retaining isolated disk for VM %s at %s", vm_id, managed_disk)
+            elif preserve_managed_disk or self._retained_marker_path(managed_disk).exists():
+                logger.info("Retaining isolated disk for VM %s at %s", vm_id, managed_disk)
+            else:
+                self._remove_managed_disk(vm_id, managed_disk)
+
+        # Per-VM firmware state (OVMF NVRAM + swtpm). Coupled to the
+        # disk lifecycle - kept iff retain_disk_on_delete is set so
+        # Secure Boot enrollment persists for a later VM with the
+        # same ID.
+        firmware_state = self.data_dir / "firmware" / vm_id
+        if firmware_state.exists():
+            if retain_requested:
+                logger.info(
+                    "Retaining per-VM firmware state for VM %s at %s",
+                    vm_id,
+                    firmware_state,
+                )
+            else:
+                with suppress(Exception):
+                    shutil.rmtree(firmware_state)
+                    logger.info(
+                        "Removed per-VM firmware state for VM %s: %s",
+                        vm_id,
+                        firmware_state,
+                    )
+
+        # The runtime log belongs to this VM alone and nothing else reads it
+        # once the VM is gone.
+        with suppress(Exception):
+            runtime_log = self.data_dir / f"{vm_id}.log"
+            if runtime_log.is_file():
+                runtime_log.unlink()
+                logger.info("Removed runtime log for VM %s: %s", vm_id, runtime_log)
+
+    def _managed_disks_for_cleanup(self, vm_id: str, vm_info: VMInfo | None) -> list[Path]:
+        """Return the managed disks that cleanup owns for this VM."""
+        if vm_info is not None:
+            managed_disk = self._managed_disk_for_vm(vm_info)
+            return [managed_disk] if managed_disk else []
+        # No row: fall back to the deterministic per-VM disk names so a disk
+        # orphaned by a crash or a failed teardown is still reclaimable.
+        return self._instance_disk_paths_for_id(vm_id)
+
+    def _instance_disk_paths_for_id(self, vm_id: str) -> list[Path]:
+        """Return existing managed disks named after *vm_id*, whatever the format."""
+        paths = []
+        for suffix in (".qcow2", ".ext4"):
+            candidate = self.disk_dir / f"{vm_id}{suffix}"
+            if candidate.is_file():
+                paths.append(candidate)
+        return paths
+
+    @staticmethod
+    def _retained_marker_path(managed_disk: Path) -> Path:
+        """Return the marker that flags a disk as deliberately kept."""
+        return managed_disk.with_name(f"{managed_disk.name}{RETAINED_DISK_MARKER_SUFFIX}")
+
+    def _mark_disk_retained(self, managed_disk: Path) -> None:
+        """Record that this disk outlives its VM row on purpose.
+
+        Without the marker a retained disk is indistinguishable from a leaked
+        one, so the reclaim sweep would delete state the user asked to keep.
+        """
+        with suppress(OSError):
+            self._retained_marker_path(managed_disk).touch()
+
+    def _clear_retained_marker(self, managed_disk: Path) -> None:
+        """Drop the retention marker once a VM row owns this disk again."""
+        with suppress(OSError):
+            self._retained_marker_path(managed_disk).unlink(missing_ok=True)
+
+    def _managed_disk_companions(self, managed_disk: Path) -> list[Path]:
+        """Return files that exist only to serve *managed_disk*.
+
+        Backing sidecars, restore staging copies, create-time backups and the
+        retention marker are all named after the disk itself, so they are the
+        disk's to remove.
+        """
+        companions = dict.fromkeys(self._managed_disk_backing_sidecars(managed_disk))
+        with suppress(OSError):
+            for path in sorted(managed_disk.parent.glob(f"{managed_disk.name}.*")):
+                if path.is_file():
+                    companions[path] = None
+        return list(companions)
+
+    # ------------------------------------------------------------------
+    # Reclaiming leftovers
+    # ------------------------------------------------------------------
+
+    def find_leftover_artifacts(self) -> list[LeftoverArtifact]:
+        """Return disks and logs whose sandbox no longer exists.
+
+        A per-VM disk is only reachable through its row in the inventory, so
+        one that outlived its row can never be found by name again. This walks
+        the data directory instead and reports what is safe to delete.
+        """
+        live_ids = {vm.vm_id for vm in self.state.list_vms()}
+        with suppress(Exception):
+            # Browser sandboxes are tracked in their own table; their VMs must
+            # not look like leftovers while a session still owns them.
+            for session in self.state.list_browser_sessions():
+                live_ids.add(session.session_id)
+                if session.vm_id:
+                    live_ids.add(session.vm_id)
+
+        in_use = self._running_process_args()
+
+        leftovers: list[LeftoverArtifact] = []
+        for managed_disk in self._all_managed_disks():
+            vm_id = managed_disk.name.rsplit(".", 1)[0]
+            if vm_id in live_ids:
+                continue
+            if self._path_in_use(managed_disk, in_use):
+                # A sandbox started from an SDK script keeps its inventory in
+                # memory, so the disk of a live VM can look unreferenced here.
+                logger.debug("Skipping in-use disk %s", managed_disk)
+                continue
+            retained = self._retained_marker_path(managed_disk).exists()
+            for path in (managed_disk, *self._managed_disk_companions(managed_disk)):
+                leftovers.append(
+                    LeftoverArtifact(
+                        vm_id=vm_id,
+                        path=path,
+                        size_bytes=_file_size(path),
+                        kind="disk",
+                        retained=retained,
+                    )
+                )
+            log_path = self.data_dir / f"{vm_id}.log"
+            if log_path.is_file():
+                leftovers.append(
+                    LeftoverArtifact(
+                        vm_id=vm_id,
+                        path=log_path,
+                        size_bytes=_file_size(log_path),
+                        kind="log",
+                        retained=retained,
+                    )
+                )
+
+        seen = {leftover.path for leftover in leftovers}
+        for log_path in sorted(self.data_dir.glob("*.log")):
+            vm_id = log_path.name[: -len(".log")]
+            if not log_path.is_file() or log_path in seen or vm_id in live_ids:
+                continue
+            leftovers.append(
+                LeftoverArtifact(
+                    vm_id=vm_id,
+                    path=log_path,
+                    size_bytes=_file_size(log_path),
+                    kind="log",
+                )
+            )
+
+        return sorted(leftovers, key=lambda leftover: (leftover.vm_id, str(leftover.path)))
+
+    def leftover_paths_for_vm(self, vm_id: str) -> list[Path]:
+        """Return files a deleted sandbox would leave behind, by name.
+
+        Cheap enough to call before a delete: it only checks the handful of
+        paths a VM ID can own.
+        """
+        paths = list(self._instance_disk_paths_for_id(vm_id))
+        for managed_disk in list(paths):
+            paths.extend(self._managed_disk_companions(managed_disk))
+        runtime_log = self.data_dir / f"{vm_id}.log"
+        if runtime_log.is_file():
+            paths.append(runtime_log)
+        return paths
+
+    def prune_leftover_artifacts(
+        self,
+        *,
+        include_retained: bool = False,
+        dry_run: bool = False,
+    ) -> list[LeftoverArtifact]:
+        """Delete leftover disks and logs, and return what was removed.
+
+        Disks kept on purpose (``retain_disk_on_delete``) are skipped unless
+        *include_retained* is set.
+        """
+        removable = [
+            leftover
+            for leftover in self.find_leftover_artifacts()
+            if include_retained or not leftover.retained
+        ]
+        if dry_run:
+            return removable
+
+        removed: list[LeftoverArtifact] = []
+        for leftover in removable:
+            try:
+                leftover.path.unlink()
+            except FileNotFoundError:
+                continue
+            except OSError as exc:
+                logger.warning("Could not remove leftover file %s: %s", leftover.path, exc)
+                continue
+            logger.info(
+                "Removed leftover %s for %s: %s", leftover.kind, leftover.vm_id, leftover.path
+            )
+            removed.append(leftover)
+        return removed
+
+    @staticmethod
+    def _path_in_use(path: Path, process_args: str) -> bool:
+        """Return whether a running process names this exact file."""
+        candidates = {str(path)}
+        with suppress(OSError):
+            candidates.add(str(path.resolve()))
+        return any(candidate in process_args for candidate in candidates)
+
+    def _running_process_args(self) -> str:
+        """Return the command lines of running processes, best effort.
+
+        Sandboxes started from an SDK script keep their inventory in memory,
+        so their disks are not in the CLI database. Matching against live
+        hypervisor command lines keeps the reclaim sweep off those disks.
+        """
+        try:
+            result = subprocess.run(
+                ["ps", "-Awwo", "args="],
+                capture_output=True,
+                text=True,
+                timeout=10,
+                check=False,
+            )
+        except (OSError, subprocess.SubprocessError) as exc:
+            logger.warning(
+                "Could not list running processes (%s); "
+                "sandboxes started outside this command may not be detected.",
+                exc,
+            )
+            return ""
+        return result.stdout
+
+    def _all_managed_disks(self) -> list[Path]:
+        """Return every per-VM disk in the disk directory.
+
+        Sidecars are named after their disk (``sbx-a.qcow2.backing-1.qcow2``)
+        and VM IDs never contain a dot, so a single dot marks a real disk.
+        """
+        disks: list[Path] = []
+        with suppress(OSError):
+            for path in sorted(self.disk_dir.iterdir()):
+                if not path.is_file():
+                    continue
+                stem, dot, suffix = path.name.partition(".")
+                if dot and stem and suffix in {"qcow2", "ext4"}:
+                    disks.append(path)
+        return disks
+
+    def _remove_managed_disk(self, vm_id: str, managed_disk: Path) -> None:
+        """Remove a managed disk and every file that only serves it."""
+        companions = self._managed_disk_companions(managed_disk)
+        with suppress(Exception):
+            managed_disk.unlink()
+            logger.info("Removed isolated disk for VM %s: %s", vm_id, managed_disk)
+        for companion in companions:
+            with suppress(Exception):
+                companion.unlink()
+                logger.info(
+                    "Removed isolated disk sidecar for VM %s: %s",
+                    vm_id,
+                    companion,
+                )
+
     # Each async method mirrors its sync counterpart, replacing blocking
     # subprocess calls and time.sleep() with asyncio equivalents.
     # ==================================================================
@@ -3893,7 +4215,8 @@ class SmolVMManager:
                     self._discard_existing_managed_disk_backup,
                     managed_disk_backup,
                 )
-            except Exception:
+            except BaseException:
+                # See create(): Ctrl-C must not strand an unreferenced disk.
                 await asyncio.to_thread(
                     self._restore_existing_managed_disk_backup,
                     managed_disk_backup,
@@ -4038,7 +4361,8 @@ class SmolVMManager:
 
             return vm_info
 
-        except Exception as e:
+        except BaseException as e:
+            # See create(): roll back on Ctrl-C too.
             logger.error("Failed to create VM %s: %s", effective_config.vm_id, e)
             await self._async_cleanup_resources(
                 effective_config.vm_id,
@@ -4205,6 +4529,9 @@ class SmolVMManager:
             else:
                 await self._async_copy_with_reflink(config.rootfs_path, instance_rootfs)
 
+        # A VM row owns this disk again, so it is no longer a kept leftover.
+        self._clear_retained_marker(instance_rootfs)
+
         return config.model_copy(
             update={"rootfs_path": instance_rootfs, "rootfs_format": materialized_format}
         )
@@ -4318,149 +4645,128 @@ class SmolVMManager:
         require_bridge_cleanup: bool = False,
     ) -> None:
         """Async version of :meth:`_cleanup_resources`."""
+        vm_info = self._vm_info_for_cleanup(vm_id)
         try:
-            vm_info = None
-            with suppress(VMNotFoundError):
-                vm_info = self.state.get_vm(vm_id)
-
-            backend = self.backend
-            if vm_info is not None:
-                with suppress(SmolVMError):
-                    backend = self._backend_for_vm(vm_info)
-
-            lease = self.state.get_ip_lease(vm_id)
-
-            tap_alloc = self.state.get_tap_allocation(vm_id)
-
-            ssh_host_port: int | None = None
-            guest_ip: str | None = lease[0] if lease else None
-            if vm_info and vm_info.network:
-                ssh_host_port = vm_info.network.ssh_host_port
-                guest_ip = vm_info.network.guest_ip
-            else:
-                ssh_host_port = self.state.get_ssh_port(vm_id)
-
-            is_bridge = (
-                vm_info is not None
-                and vm_info.network is not None
-                and vm_info.network.mode == "bridge"
-            ) or (tap_alloc is not None and tap_alloc[1] == "bridge")
-
-            # See the sync cleanup path for the TAP-vs-slirp rationale.
-            if vm_info is not None:
-                uses_tap = self._uses_host_tap_networking(vm_info.config, backend)
-            else:
-                uses_tap = lease is not None or tap_alloc is not None
-
-            if is_bridge:
-                tap_device = tap_alloc[0] if tap_alloc else None
-                if tap_device is None and vm_info is not None and vm_info.network is not None:
-                    tap_device = vm_info.network.tap_device
-                if tap_device:
-                    try:
-                        await self.network.async_cleanup_bridged_tap(tap_device, vm_id)
-                    except BridgeTapOwnershipError as exc:
-                        logger.warning(
-                            "Did not remove foreign bridge interface %s for %s: %s",
-                            tap_device,
-                            vm_id,
-                            exc,
-                        )
-                        if tap_alloc:
-                            self.state.release_tap_name(vm_id)
-                    except Exception:
-                        if require_bridge_cleanup:
-                            raise
-                        logger.warning(
-                            "Could not remove owned bridge interface %s for %s; "
-                            "retaining its reservation",
-                            tap_device,
-                            vm_id,
-                        )
-                    else:
-                        if tap_alloc:
-                            self.state.release_tap_name(vm_id)
-            else:
-                if uses_tap and ssh_host_port is not None and guest_ip:
-                    with suppress(Exception):
-                        await self.network.async_cleanup_ssh_port_forward(
-                            vm_id=vm_id,
-                            guest_ip=guest_ip,
-                            host_port=ssh_host_port,
-                        )
-
-                with suppress(Exception):
-                    await self.network.async_cleanup_all_local_port_forwards(vm_id)
-
-                if lease:
-                    _, tap_device = lease
-
-                    if uses_tap:
-                        with suppress(Exception):
-                            await self.network.async_remove_egress_rules(tap_device)
-                        await self.network.async_cleanup_nat_rules(tap_device)
-                        await self.network.async_cleanup_tap(tap_device)
-
-                    self.state.release_ip(vm_id)
-
-            if ssh_host_port is not None and not is_bridge:
-                self.state.release_ssh_port(vm_id)
-
-            for socket_path in (
-                self.socket_dir / f"fc-{vm_id}.sock",
-                self.socket_dir / f"qmp-{vm_id}.sock",
-            ):
-                if socket_path.exists():
-                    await self._async_unlink_socket(socket_path)
-
-            self._close_runtime_log(vm_id, BACKEND_FIRECRACKER)
-            self._close_runtime_log(vm_id, BACKEND_QEMU)
-            self._close_runtime_log(vm_id, BACKEND_LIBKRUN)
-            self._close_runtime_log(vm_id, BACKEND_VZ)
-
-            managed_disk = self._managed_disk_for_vm(vm_info)
-            if managed_disk and managed_disk.exists():
-                if preserve_managed_disk or vm_info.config.retain_disk_on_delete:
-                    logger.info("Retaining isolated disk for VM %s at %s", vm_id, managed_disk)
-                else:
-                    managed_sidecars = await asyncio.to_thread(
-                        self._managed_disk_backing_sidecars,
-                        managed_disk,
-                    )
-                    with suppress(Exception):
-                        managed_disk.unlink()
-                        logger.info("Removed isolated disk for VM %s: %s", vm_id, managed_disk)
-                    for sidecar in managed_sidecars:
-                        with suppress(Exception):
-                            sidecar.unlink()
-                            logger.info(
-                                "Removed isolated disk sidecar for VM %s: %s",
-                                vm_id,
-                                sidecar,
-                            )
-
-            # Per-VM firmware state (OVMF NVRAM + swtpm). Mirrors the sync
-            # _cleanup_resources path so async_delete() doesn't leave
-            # Windows-guest firmware behind.
-            firmware_state = self.data_dir / "firmware" / vm_id
-            if firmware_state.exists():
-                retain = vm_info is not None and vm_info.config.retain_disk_on_delete
-                if retain:
-                    logger.info(
-                        "Retaining per-VM firmware state for VM %s at %s",
-                        vm_id,
-                        firmware_state,
-                    )
-                else:
-                    with suppress(Exception):
-                        shutil.rmtree(firmware_state)
-                        logger.info(
-                            "Removed per-VM firmware state for VM %s: %s",
-                            vm_id,
-                            firmware_state,
-                        )
-
+            await self._async_cleanup_host_resources(
+                vm_id,
+                vm_info,
+                require_bridge_cleanup=require_bridge_cleanup,
+            )
         except Exception as e:
             logger.warning("Error during async cleanup for %s: %s", vm_id, e)
             if require_bridge_cleanup:
+                # See :meth:`_cleanup_resources`: the row and disk must
+                # survive so a later delete can retry bridge teardown.
                 raise
+        await asyncio.to_thread(
+            self._cleanup_vm_artifacts,
+            vm_id,
+            vm_info,
+            preserve_managed_disk=preserve_managed_disk,
+        )
+
+    async def _async_cleanup_host_resources(
+        self,
+        vm_id: str,
+        vm_info: VMInfo | None,
+        *,
+        require_bridge_cleanup: bool = False,
+    ) -> None:
+        """Async version of :meth:`_cleanup_host_resources`."""
+        backend = self.backend
+        if vm_info is not None:
+            with suppress(SmolVMError):
+                backend = self._backend_for_vm(vm_info)
+
+        lease = self.state.get_ip_lease(vm_id)
+
+        tap_alloc = self.state.get_tap_allocation(vm_id)
+
+        ssh_host_port: int | None = None
+        guest_ip: str | None = lease[0] if lease else None
+        if vm_info and vm_info.network:
+            ssh_host_port = vm_info.network.ssh_host_port
+            guest_ip = vm_info.network.guest_ip
+        else:
+            ssh_host_port = self.state.get_ssh_port(vm_id)
+
+        is_bridge = (
+            vm_info is not None and vm_info.network is not None and vm_info.network.mode == "bridge"
+        ) or (tap_alloc is not None and tap_alloc[1] == "bridge")
+
+        # See the sync cleanup path for the TAP-vs-slirp rationale.
+        if vm_info is not None:
+            uses_tap = self._uses_host_tap_networking(vm_info.config, backend)
+        else:
+            uses_tap = lease is not None or tap_alloc is not None
+
+        if is_bridge:
+            tap_device = tap_alloc[0] if tap_alloc else None
+            if tap_device is None and vm_info is not None and vm_info.network is not None:
+                tap_device = vm_info.network.tap_device
+            if tap_device:
+                try:
+                    await self.network.async_cleanup_bridged_tap(tap_device, vm_id)
+                except BridgeTapOwnershipError as exc:
+                    logger.warning(
+                        "Did not remove foreign bridge interface %s for %s: %s",
+                        tap_device,
+                        vm_id,
+                        exc,
+                    )
+                    if tap_alloc:
+                        self.state.release_tap_name(vm_id)
+                except Exception:
+                    if require_bridge_cleanup:
+                        raise
+                    logger.warning(
+                        "Could not remove owned bridge interface %s for %s; "
+                        "retaining its reservation",
+                        tap_device,
+                        vm_id,
+                    )
+                else:
+                    if tap_alloc:
+                        self.state.release_tap_name(vm_id)
+        else:
+            if uses_tap and ssh_host_port is not None and guest_ip:
+                with suppress(Exception):
+                    await self.network.async_cleanup_ssh_port_forward(
+                        vm_id=vm_id,
+                        guest_ip=guest_ip,
+                        host_port=ssh_host_port,
+                    )
+
+            with suppress(Exception):
+                await self.network.async_cleanup_all_local_port_forwards(vm_id)
+
+            if lease:
+                _, tap_device = lease
+
+                if uses_tap:
+                    with suppress(Exception):
+                        await self.network.async_remove_egress_rules(tap_device)
+                    with self._cleanup_step(vm_id, "remove host network rules"):
+                        await self.network.async_cleanup_nat_rules(tap_device)
+                    with self._cleanup_step(vm_id, "remove the host network device"):
+                        await self.network.async_cleanup_tap(tap_device)
+
+                with self._cleanup_step(vm_id, "release the IP address"):
+                    self.state.release_ip(vm_id)
+
+        if ssh_host_port is not None and not is_bridge:
+            with self._cleanup_step(vm_id, "release the SSH port"):
+                self.state.release_ssh_port(vm_id)
+
+        for socket_path in (
+            self.socket_dir / f"fc-{vm_id}.sock",
+            self.socket_dir / f"qmp-{vm_id}.sock",
+        ):
+            if socket_path.exists():
+                with self._cleanup_step(vm_id, "remove the control socket"):
+                    await self._async_unlink_socket(socket_path)
+
+        self._close_runtime_log(vm_id, BACKEND_FIRECRACKER)
+        self._close_runtime_log(vm_id, BACKEND_QEMU)
+        self._close_runtime_log(vm_id, BACKEND_LIBKRUN)
+        self._close_runtime_log(vm_id, BACKEND_VZ)

--- a/src/smolvm/vm.py
+++ b/src/smolvm/vm.py
@@ -1044,9 +1044,6 @@ class SmolVMManager:
                 instance_rootfs,
             )
 
-        # A VM row owns this disk again, so it is no longer a kept leftover.
-        self._clear_retained_marker(instance_rootfs)
-
         return config.model_copy(
             update={"rootfs_path": instance_rootfs, "rootfs_format": materialized_format}
         )
@@ -2012,6 +2009,10 @@ class SmolVMManager:
             managed_disk_existed = (
                 managed_disk_path.exists() if managed_disk_path is not None else False
             )
+            managed_disk_was_saved = managed_disk_existed and (
+                managed_disk_path is not None
+                and self._retained_marker_path(managed_disk_path).exists()
+            )
             firmware_state = self.data_dir / "firmware" / effective_config.vm_id
             firmware_existed = firmware_state.exists()
             macos_bundle = (
@@ -2045,6 +2046,11 @@ class SmolVMManager:
                 # mutate a retained managed disk without a VM row.
                 self.state.create_vm(effective_config)
                 vm_record_created = True
+                # A row owns this disk again, so it is no longer a kept
+                # leftover. Only now: a create that fails after reusing a
+                # saved disk has to leave it marked as saved.
+                if managed_disk_path is not None:
+                    self._clear_retained_marker(managed_disk_path)
                 if effective_config.guest_os is not GuestOS.MACOS:
                     effective_config = self._resize_materialized_rootfs(effective_config)
                     self._materialize_firmware(effective_config)
@@ -2061,6 +2067,7 @@ class SmolVMManager:
                     managed_disk_path,
                     existed_before=managed_disk_existed,
                 )
+                self._restore_retained_marker(managed_disk_path, managed_disk_was_saved)
                 self._cleanup_unpersisted_firmware(
                     effective_config.vm_id,
                     existed_before=firmware_existed,
@@ -2228,6 +2235,7 @@ class SmolVMManager:
                 effective_config.vm_id,
                 preserve_managed_disk=managed_disk_existed,
             )
+            self._restore_retained_marker(managed_disk_path, managed_disk_was_saved)
             # Delete the VM record that was created
             with suppress(Exception):
                 self.state.delete_vm(effective_config.vm_id)
@@ -3930,6 +3938,17 @@ class SmolVMManager:
         with suppress(OSError):
             self._retained_marker_path(managed_disk).touch()
 
+    def _restore_retained_marker(self, managed_disk: Path | None, was_saved: bool) -> None:
+        """Re-mark a saved disk that a failed create preserved.
+
+        A create clears the mark once a row owns the disk. If that create then
+        fails, the disk survives without its row, so the mark has to come back
+        or the reclaim sweep would treat saved state as a leftover.
+        """
+        if not was_saved or managed_disk is None or not managed_disk.exists():
+            return
+        self._mark_disk_retained(managed_disk)
+
     def _clear_retained_marker(self, managed_disk: Path) -> None:
         """Drop the retention marker once a VM row owns this disk again."""
         with suppress(OSError):
@@ -3970,6 +3989,11 @@ class SmolVMManager:
                     live_ids.add(session.vm_id)
 
         in_use = self._running_process_args()
+        if in_use is None:
+            raise SmolVMError(
+                "Cannot check which sandboxes are running right now, so nothing "
+                "was deleted. Retry 'smolvm sandbox prune' in a moment."
+            )
 
         leftovers: list[LeftoverArtifact] = []
         for managed_disk in self._all_managed_disks():
@@ -4076,12 +4100,13 @@ class SmolVMManager:
             candidates.add(str(path.resolve()))
         return any(candidate in process_args for candidate in candidates)
 
-    def _running_process_args(self) -> str:
-        """Return the command lines of running processes, best effort.
+    def _running_process_args(self) -> str | None:
+        """Return the command lines of running processes, or None on failure.
 
         Sandboxes started from an SDK script keep their inventory in memory,
         so their disks are not in the CLI database. Matching against live
-        hypervisor command lines keeps the reclaim sweep off those disks.
+        hypervisor command lines keeps the reclaim sweep off those disks, so
+        failing to read the list has to stop the sweep rather than widen it.
         """
         try:
             result = subprocess.run(
@@ -4092,12 +4117,11 @@ class SmolVMManager:
                 check=False,
             )
         except (OSError, subprocess.SubprocessError) as exc:
-            logger.warning(
-                "Could not list running processes (%s); "
-                "sandboxes started outside this command may not be detected.",
-                exc,
-            )
-            return ""
+            logger.warning("Could not list running processes: %s", exc)
+            return None
+        if result.returncode != 0:
+            logger.warning("Could not list running processes: %s", (result.stderr or "").strip())
+            return None
         return result.stdout
 
     def _all_managed_disks(self) -> list[Path]:
@@ -4172,6 +4196,10 @@ class SmolVMManager:
             managed_disk_existed = (
                 managed_disk_path.exists() if managed_disk_path is not None else False
             )
+            managed_disk_was_saved = managed_disk_existed and (
+                managed_disk_path is not None
+                and self._retained_marker_path(managed_disk_path).exists()
+            )
             firmware_state = self.data_dir / "firmware" / effective_config.vm_id
             firmware_existed = firmware_state.exists()
             macos_bundle = (
@@ -4204,6 +4232,9 @@ class SmolVMManager:
 
                 self.state.create_vm(effective_config)
                 vm_record_created = True
+                # See create(): clear the mark only once a row owns the disk.
+                if managed_disk_path is not None:
+                    self._clear_retained_marker(managed_disk_path)
                 if effective_config.guest_os is not GuestOS.MACOS:
                     effective_config = await asyncio.to_thread(
                         self._resize_materialized_rootfs,
@@ -4228,6 +4259,7 @@ class SmolVMManager:
                     managed_disk_path,
                     existed_before=managed_disk_existed,
                 )
+                self._restore_retained_marker(managed_disk_path, managed_disk_was_saved)
                 self._cleanup_unpersisted_firmware(
                     effective_config.vm_id,
                     existed_before=firmware_existed,
@@ -4368,6 +4400,7 @@ class SmolVMManager:
                 effective_config.vm_id,
                 preserve_managed_disk=managed_disk_existed,
             )
+            self._restore_retained_marker(managed_disk_path, managed_disk_was_saved)
             with suppress(Exception):
                 self.state.delete_vm(effective_config.vm_id)
             raise
@@ -4528,9 +4561,6 @@ class SmolVMManager:
                 )
             else:
                 await self._async_copy_with_reflink(config.rootfs_path, instance_rootfs)
-
-        # A VM row owns this disk again, so it is no longer a kept leftover.
-        self._clear_retained_marker(instance_rootfs)
 
         return config.model_copy(
             update={"rootfs_path": instance_rootfs, "rootfs_format": materialized_format}

--- a/tests/test_cleanup.py
+++ b/tests/test_cleanup.py
@@ -15,11 +15,12 @@
 """Tests for delete and cleanup CLI commands."""
 
 import json
+from pathlib import Path
 from unittest.mock import MagicMock, patch
 
 import pytest
 
-from smolvm.cli.cleanup import run_cleanup, run_delete
+from smolvm.cli.cleanup import run_cleanup, run_delete, run_prune_sandboxes
 from smolvm.cli.main import main as cli_main
 
 
@@ -378,3 +379,146 @@ class TestCleanup:
             == "Run 'smolvm sandbox delete --all --force --json' to confirm."
         )
         mock_run_cleanup.assert_not_called()
+
+
+class TestSandboxPrune:
+    """Tests for ``smolvm sandbox prune``."""
+
+    @pytest.fixture
+    def mock_sdk_cls(self) -> MagicMock:
+        with patch("smolvm.cli.cleanup.CLIService") as mock_service_cls:
+            sdk = MagicMock()
+            manager = mock_service_cls.return_value.manager.return_value
+            manager.__enter__.return_value = sdk
+            manager.__exit__.return_value = None
+            yield sdk
+
+    @staticmethod
+    def _leftover(
+        vm_id: str, name: str, *, kind: str = "disk", retained: bool = False
+    ) -> MagicMock:
+        artifact = MagicMock()
+        artifact.vm_id = vm_id
+        artifact.path = Path(f"/data/disks/{name}")
+        artifact.kind = kind
+        artifact.size_bytes = 1024
+        artifact.retained = retained
+        return artifact
+
+    def test_prune_removes_leftovers(
+        self,
+        mock_sdk_cls: MagicMock,
+        capsys: pytest.CaptureFixture,
+    ) -> None:
+        """Leftover files are deleted and the freed space is reported."""
+        sdk = mock_sdk_cls
+        leftover = self._leftover("sbx-gone", "sbx-gone.qcow2")
+        sdk.find_leftover_artifacts.return_value = [leftover]
+        sdk.prune_leftover_artifacts.return_value = [leftover]
+
+        ret = run_prune_sandboxes(force=True)
+
+        assert ret == 0
+        sdk.prune_leftover_artifacts.assert_called_once_with(include_retained=False)
+        out = capsys.readouterr().out
+        assert "sbx-gone.qcow2" in out
+        assert "Freed" in out
+
+    def test_prune_dry_run_keeps_files(
+        self,
+        mock_sdk_cls: MagicMock,
+        capsys: pytest.CaptureFixture,
+    ) -> None:
+        """A dry run reports the same list without deleting anything."""
+        sdk = mock_sdk_cls
+        sdk.find_leftover_artifacts.return_value = [self._leftover("sbx-gone", "sbx-gone.qcow2")]
+
+        ret = run_prune_sandboxes(dry_run=True)
+
+        assert ret == 0
+        sdk.prune_leftover_artifacts.assert_not_called()
+        assert "Would free" in capsys.readouterr().out
+
+    def test_prune_reports_saved_disks_it_skipped(
+        self,
+        mock_sdk_cls: MagicMock,
+        capsys: pytest.CaptureFixture,
+    ) -> None:
+        """Saved disks are left alone, and the user is told how to remove them."""
+        sdk = mock_sdk_cls
+        sdk.find_leftover_artifacts.return_value = [
+            self._leftover("sbx-saved", "sbx-saved.qcow2", retained=True)
+        ]
+
+        ret = run_prune_sandboxes(force=True)
+
+        assert ret == 0
+        sdk.prune_leftover_artifacts.assert_not_called()
+        out = capsys.readouterr().out
+        assert "--include-saved" in out
+        assert "Nothing to clean up" in out
+
+    def test_prune_include_saved_removes_them(
+        self,
+        mock_sdk_cls: MagicMock,
+    ) -> None:
+        """``--include-saved`` opts in to deleting kept disks."""
+        sdk = mock_sdk_cls
+        saved = self._leftover("sbx-saved", "sbx-saved.qcow2", retained=True)
+        sdk.find_leftover_artifacts.return_value = [saved]
+        sdk.prune_leftover_artifacts.return_value = [saved]
+
+        ret = run_prune_sandboxes(force=True, include_retained=True)
+
+        assert ret == 0
+        sdk.prune_leftover_artifacts.assert_called_once_with(include_retained=True)
+
+    def test_prune_json_requires_force(
+        self,
+        mock_sdk_cls: MagicMock,
+        capsys: pytest.CaptureFixture,
+    ) -> None:
+        """Unattended JSON callers must confirm before anything is deleted."""
+        sdk = mock_sdk_cls
+        sdk.find_leftover_artifacts.return_value = [self._leftover("sbx-gone", "sbx-gone.qcow2")]
+
+        ret = run_prune_sandboxes(json_output=True)
+
+        assert ret == 1
+        sdk.prune_leftover_artifacts.assert_not_called()
+        payload = json.loads(capsys.readouterr().out)
+        assert payload["ok"] is False
+        assert "smolvm sandbox prune --force --json" in payload["error"]["message"]
+
+    def test_prune_json_payload(
+        self,
+        mock_sdk_cls: MagicMock,
+        capsys: pytest.CaptureFixture,
+    ) -> None:
+        """JSON output lists what was removed and how much it freed."""
+        sdk = mock_sdk_cls
+        leftover = self._leftover("sbx-gone", "sbx-gone.qcow2")
+        sdk.find_leftover_artifacts.return_value = [leftover]
+        sdk.prune_leftover_artifacts.return_value = [leftover]
+
+        ret = run_prune_sandboxes(force=True, json_output=True)
+
+        assert ret == 0
+        payload = json.loads(capsys.readouterr().out)
+        assert payload["command"] == "sandbox.prune"
+        assert payload["ok"] is True
+        assert payload["data"]["removed"][0]["vm_id"] == "sbx-gone"
+        assert payload["data"]["freed_bytes"] == 1024
+
+    def test_cli_wires_prune_command(self) -> None:
+        """``smolvm sandbox prune`` reaches the runner with its flags."""
+        with patch("smolvm.cli.cleanup.run_prune_sandboxes", return_value=0) as runner:
+            ret = cli_main(["sandbox", "prune", "--dry-run", "--include-saved"])
+
+        assert ret == 0
+        runner.assert_called_once_with(
+            dry_run=True,
+            force=False,
+            include_retained=True,
+            json_output=False,
+        )

--- a/tests/test_cleanup.py
+++ b/tests/test_cleanup.py
@@ -510,6 +510,25 @@ class TestSandboxPrune:
         assert payload["data"]["removed"][0]["vm_id"] == "sbx-gone"
         assert payload["data"]["freed_bytes"] == 1024
 
+    def test_prune_reports_files_it_could_not_delete(
+        self,
+        mock_sdk_cls: MagicMock,
+        capsys: pytest.CaptureFixture,
+    ) -> None:
+        """A file that would not go must not be reported as a clean sweep."""
+        sdk = mock_sdk_cls
+        stubborn = self._leftover("sbx-gone", "sbx-gone.qcow2")
+        removed = self._leftover("sbx-gone", "sbx-gone.log", kind="log")
+        sdk.find_leftover_artifacts.return_value = [stubborn, removed]
+        sdk.prune_leftover_artifacts.return_value = [removed]
+
+        ret = run_prune_sandboxes(force=True)
+
+        assert ret == 1
+        out = capsys.readouterr().out
+        assert "Could not delete 1 file(s)" in out
+        assert "sbx-gone.qcow2" in out
+
     def test_cli_wires_prune_command(self) -> None:
         """``smolvm sandbox prune`` reaches the runner with its flags."""
         with patch("smolvm.cli.cleanup.run_prune_sandboxes", return_value=0) as runner:

--- a/tests/test_disk_reclaim.py
+++ b/tests/test_disk_reclaim.py
@@ -138,6 +138,7 @@ class TestFailedTeardownKeepsNoDisk:
 
         manager.delete("sbx-disk")
 
+        manager.network.cleanup_nat_rules.assert_called_once()
         assert manager.state.get_ssh_port("sbx-disk") is None
         assert manager.state.get_ip_lease("sbx-disk") is None
         assert not _disk(manager).exists()
@@ -257,6 +258,27 @@ class TestReclaimingDisksWithoutRows:
         assert disk.exists()
         assert not marker.exists()
 
+    def test_failed_create_leaves_a_saved_disk_still_marked(
+        self,
+        manager: SmolVMManager,
+        config: VMConfig,
+    ) -> None:
+        """A create that reuses a saved disk and then fails must not unmark it."""
+        saved = config.model_copy(update={"retain_disk_on_delete": True})
+        manager.create(saved)
+        disk = _disk(manager)
+        marker = disk.with_name(f"{disk.name}.retained")
+        manager.delete("sbx-disk")
+        assert marker.exists()
+
+        manager.network.prepare_tap_device.side_effect = SmolVMError("no sudo")
+        with pytest.raises(SmolVMError, match="no sudo"):
+            manager.create(config)
+
+        assert disk.exists()
+        assert marker.exists()
+        assert manager.prune_leftover_artifacts() == []
+
     def test_delete_removes_the_runtime_log(
         self,
         manager: SmolVMManager,
@@ -341,6 +363,23 @@ class TestLeftoverSweep:
             return_value=f"qemu-system-aarch64 -drive file={_disk(manager)},if=virtio",
         ):
             assert manager.find_leftover_artifacts() == []
+
+        assert _disk(manager).exists()
+
+    def test_refuses_to_sweep_when_running_sandboxes_cannot_be_listed(
+        self,
+        manager: SmolVMManager,
+        config: VMConfig,
+    ) -> None:
+        """Without that check the sweep could delete a live sandbox's disk."""
+        manager.create(config)
+        manager.state.delete_vm("sbx-disk")
+
+        with (
+            patch.object(SmolVMManager, "_running_process_args", return_value=None),
+            pytest.raises(SmolVMError, match="Cannot check which sandboxes are running"),
+        ):
+            manager.prune_leftover_artifacts()
 
         assert _disk(manager).exists()
 

--- a/tests/test_disk_reclaim.py
+++ b/tests/test_disk_reclaim.py
@@ -1,0 +1,346 @@
+# Copyright 2026 Celesto AI
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Regression tests for per-VM disks outliving their sandbox.
+
+A disk under ``data_dir/disks`` is only reachable through its inventory row.
+Once the row is gone the file cannot be found by name again, so every path
+that drops a row has to take the disk with it.
+"""
+
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from smolvm.exceptions import SmolVMError, VMNotFoundError
+from smolvm.types import VMConfig
+from smolvm.vm import SmolVMManager
+
+
+@pytest.fixture
+def manager(tmp_path: Path) -> SmolVMManager:
+    """A manager with temporary directories and a stubbed host network."""
+    vm_manager = SmolVMManager(
+        data_dir=tmp_path / "data",
+        socket_dir=tmp_path / "sockets",
+        backend="firecracker",
+    )
+    network = MagicMock()
+    network.host_ip = "172.16.0.1"
+    network.generate_mac.return_value = "AA:FC:00:00:00:01"
+    network.async_prepare_tap_device = AsyncMock()
+    network.async_add_route = AsyncMock()
+    network.async_setup_nat = AsyncMock()
+    network.async_setup_ssh_port_forward = AsyncMock()
+    network.async_cleanup_nat_rules = AsyncMock()
+    network.async_cleanup_tap = AsyncMock()
+    network.async_cleanup_ssh_port_forward = AsyncMock()
+    network.async_cleanup_all_local_port_forwards = AsyncMock()
+    network.async_remove_egress_rules = AsyncMock()
+    vm_manager.network = network
+    return vm_manager
+
+
+@pytest.fixture
+def config(tmp_path: Path) -> VMConfig:
+    """A minimal config whose rootfs is cloned into an isolated per-VM disk."""
+    kernel = tmp_path / "vmlinux"
+    rootfs = tmp_path / "rootfs.ext4"
+    kernel.touch()
+    rootfs.write_bytes(b"rootfs")
+    return VMConfig(vm_id="sbx-disk", kernel_path=kernel, rootfs_path=rootfs)
+
+
+def _disk(manager: SmolVMManager, vm_id: str = "sbx-disk") -> Path:
+    return manager.data_dir / "disks" / f"{vm_id}.ext4"
+
+
+class TestFailedTeardownKeepsNoDisk:
+    """A host-teardown failure must not cost the caller their disk."""
+
+    def test_delete_removes_disk_when_a_teardown_step_fails(
+        self,
+        manager: SmolVMManager,
+        config: VMConfig,
+    ) -> None:
+        """delete() drops the row either way, so the disk has to go too."""
+        manager.create(config)
+        assert _disk(manager).exists()
+
+        manager.state.release_ssh_port = MagicMock(  # type: ignore[method-assign]
+            side_effect=OSError("host teardown failed")
+        )
+
+        manager.delete("sbx-disk")
+
+        assert not _disk(manager).exists()
+        assert manager.list_vms() == []
+
+    @pytest.mark.asyncio
+    async def test_async_delete_removes_disk_when_a_teardown_step_fails(
+        self,
+        manager: SmolVMManager,
+        config: VMConfig,
+    ) -> None:
+        """The async path drops the row the same way, so it must clean up too."""
+        await manager.async_create(config)
+        assert _disk(manager).exists()
+
+        manager.state.release_ssh_port = MagicMock(  # type: ignore[method-assign]
+            side_effect=OSError("host teardown failed")
+        )
+
+        await manager.async_delete("sbx-disk")
+
+        assert not _disk(manager).exists()
+        assert manager.list_vms() == []
+
+    def test_failed_network_teardown_still_releases_reservations(
+        self,
+        manager: SmolVMManager,
+        config: VMConfig,
+    ) -> None:
+        """Leases and ports outlive the row too, so every release must run."""
+        manager.create(config)
+        assert manager.state.get_ssh_port("sbx-disk") is not None
+        manager.network.cleanup_nat_rules.side_effect = SmolVMError("no outbound interface")
+
+        manager.delete("sbx-disk")
+
+        assert manager.state.get_ssh_port("sbx-disk") is None
+        assert manager.state.get_ip_lease("sbx-disk") is None
+        assert not _disk(manager).exists()
+
+    def test_create_rollback_removes_disk_when_cleanup_fails(
+        self,
+        manager: SmolVMManager,
+        config: VMConfig,
+    ) -> None:
+        """A create that fails at TAP setup must not leave a full disk copy."""
+        manager.network.prepare_tap_device.side_effect = SmolVMError("no sudo")
+        manager.network.cleanup_nat_rules.side_effect = SmolVMError("no outbound interface")
+
+        with pytest.raises(SmolVMError, match="no sudo"):
+            manager.create(config)
+
+        assert not _disk(manager).exists()
+        assert manager.list_vms() == []
+
+
+class TestInterruptedCreate:
+    """Ctrl-C lands between writing the disk and writing the row."""
+
+    def test_keyboard_interrupt_while_materializing_leaves_no_disk(
+        self,
+        manager: SmolVMManager,
+        config: VMConfig,
+    ) -> None:
+        """KeyboardInterrupt is a BaseException; the rollback must still run."""
+
+        def interrupt(*_args: object, **_kwargs: object) -> None:
+            _disk(manager).write_bytes(b"partial copy")
+            raise KeyboardInterrupt
+
+        with (
+            patch.object(SmolVMManager, "_copy_with_reflink", side_effect=interrupt),
+            pytest.raises(KeyboardInterrupt),
+        ):
+            manager.create(config)
+
+        assert not _disk(manager).exists()
+
+    @pytest.mark.asyncio
+    async def test_keyboard_interrupt_while_materializing_async_leaves_no_disk(
+        self,
+        manager: SmolVMManager,
+        config: VMConfig,
+    ) -> None:
+        """Same guarantee for async_create()."""
+
+        async def interrupt(*_args: object, **_kwargs: object) -> None:
+            _disk(manager).write_bytes(b"partial copy")
+            raise KeyboardInterrupt
+
+        with (
+            patch.object(SmolVMManager, "_async_copy_with_reflink", side_effect=interrupt),
+            pytest.raises(KeyboardInterrupt),
+        ):
+            await manager.async_create(config)
+
+        assert not _disk(manager).exists()
+
+
+class TestReclaimingDisksWithoutRows:
+    """A disk whose row is already gone still has to be reachable."""
+
+    def test_delete_reclaims_a_disk_whose_row_is_missing(
+        self,
+        manager: SmolVMManager,
+        config: VMConfig,
+    ) -> None:
+        """Deleting by name reclaims files an older SmolVM stranded."""
+        manager.create(config)
+        disk = _disk(manager)
+        log = manager.data_dir / "sbx-disk.log"
+        log.write_text("boot log")
+        manager.state.delete_vm("sbx-disk")
+
+        with pytest.raises(VMNotFoundError):
+            manager.delete("sbx-disk")
+
+        assert not disk.exists()
+        assert not log.exists()
+
+    def test_delete_keeps_a_saved_disk_whose_row_is_missing(
+        self,
+        manager: SmolVMManager,
+        config: VMConfig,
+    ) -> None:
+        """A disk the user asked SmolVM to keep survives a later delete."""
+        saved = config.model_copy(update={"retain_disk_on_delete": True})
+        manager.create(saved)
+        disk = _disk(manager)
+        manager.delete("sbx-disk")
+        assert disk.exists()
+
+        with pytest.raises(VMNotFoundError):
+            manager.delete("sbx-disk")
+
+        assert disk.exists()
+
+    def test_saved_disk_is_marked_and_the_mark_clears_on_reuse(
+        self,
+        manager: SmolVMManager,
+        config: VMConfig,
+    ) -> None:
+        """The marker is what tells a kept disk apart from a leaked one."""
+        saved = config.model_copy(update={"retain_disk_on_delete": True})
+        manager.create(saved)
+        disk = _disk(manager)
+        marker = disk.with_name(f"{disk.name}.retained")
+
+        manager.delete("sbx-disk")
+        assert marker.exists()
+
+        manager.create(saved)
+        assert disk.exists()
+        assert not marker.exists()
+
+    def test_delete_removes_the_runtime_log(
+        self,
+        manager: SmolVMManager,
+        config: VMConfig,
+    ) -> None:
+        """Logs are per-VM and nothing reads them once the VM is gone."""
+        manager.create(config)
+        log = manager.data_dir / "sbx-disk.log"
+        log.write_text("boot log")
+
+        manager.delete("sbx-disk")
+
+        assert not log.exists()
+
+
+class TestLeftoverSweep:
+    """``smolvm sandbox prune`` needs an accurate view of what is reclaimable."""
+
+    def test_reports_leftovers_and_leaves_live_sandboxes_alone(
+        self,
+        manager: SmolVMManager,
+        config: VMConfig,
+    ) -> None:
+        """Only files whose sandbox is gone count as leftovers."""
+        manager.create(config)
+        manager.create(config.model_copy(update={"vm_id": "sbx-live"}))
+        (manager.data_dir / "sbx-disk.log").write_text("boot log")
+        manager.state.delete_vm("sbx-disk")
+
+        found = {(item.vm_id, item.path.name) for item in manager.find_leftover_artifacts()}
+
+        assert found == {("sbx-disk", "sbx-disk.ext4"), ("sbx-disk", "sbx-disk.log")}
+
+    def test_skips_saved_disks_unless_asked(
+        self,
+        manager: SmolVMManager,
+        config: VMConfig,
+    ) -> None:
+        """Deleting state the user asked to keep needs an explicit opt-in."""
+        saved = config.model_copy(update={"retain_disk_on_delete": True})
+        manager.create(saved)
+        manager.delete("sbx-disk")
+        disk = _disk(manager)
+
+        assert manager.prune_leftover_artifacts() == []
+        assert disk.exists()
+
+        removed = manager.prune_leftover_artifacts(include_retained=True)
+
+        assert {item.path.name for item in removed} == {
+            "sbx-disk.ext4",
+            "sbx-disk.ext4.retained",
+        }
+        assert not disk.exists()
+
+    def test_dry_run_reports_without_deleting(
+        self,
+        manager: SmolVMManager,
+        config: VMConfig,
+    ) -> None:
+        """A dry run has to be safe to run on a production data directory."""
+        manager.create(config)
+        manager.state.delete_vm("sbx-disk")
+
+        planned = manager.prune_leftover_artifacts(dry_run=True)
+
+        assert [item.path.name for item in planned] == ["sbx-disk.ext4"]
+        assert _disk(manager).exists()
+
+    def test_skips_a_disk_a_running_process_is_using(
+        self,
+        manager: SmolVMManager,
+        config: VMConfig,
+    ) -> None:
+        """Sandboxes started from an SDK script are not in the CLI inventory."""
+        manager.create(config)
+        manager.state.delete_vm("sbx-disk")
+
+        with patch.object(
+            SmolVMManager,
+            "_running_process_args",
+            return_value=f"qemu-system-aarch64 -drive file={_disk(manager)},if=virtio",
+        ):
+            assert manager.find_leftover_artifacts() == []
+
+        assert _disk(manager).exists()
+
+
+class TestStrictBridgeCleanup:
+    """The one failure that must still abort a delete."""
+
+    def test_failed_bridge_teardown_keeps_the_row_and_the_disk(
+        self,
+        manager: SmolVMManager,
+        config: VMConfig,
+    ) -> None:
+        """Both have to survive so a later delete can retry the teardown."""
+        manager.create(config)
+        manager.state.get_ip_lease = MagicMock(  # type: ignore[method-assign]
+            side_effect=OSError("bridge teardown failed")
+        )
+
+        with pytest.raises(OSError, match="bridge teardown failed"):
+            manager._cleanup_resources("sbx-disk", require_bridge_cleanup=True)
+
+        assert _disk(manager).exists()

--- a/tests/test_disk_reclaim.py
+++ b/tests/test_disk_reclaim.py
@@ -25,7 +25,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 
 from smolvm.exceptions import SmolVMError, VMNotFoundError
-from smolvm.types import VMConfig
+from smolvm.types import NetworkConfig, VMConfig
 from smolvm.vm import SmolVMManager
 
 
@@ -114,7 +114,26 @@ class TestFailedTeardownKeepsNoDisk:
     ) -> None:
         """Leases and ports outlive the row too, so every release must run."""
         manager.create(config)
-        assert manager.state.get_ssh_port("sbx-disk") is not None
+        # Pin the reservations rather than relying on which ones a given host
+        # hands out: what matters is that a failure does not skip them.
+        lease = manager.state.get_ip_lease("sbx-disk")
+        if lease is None:
+            manager.state.allocate_ip("sbx-disk", "tap-test")
+            lease = manager.state.get_ip_lease("sbx-disk")
+        assert lease is not None
+        host_port = manager.state.get_ssh_port("sbx-disk") or manager.state.reserve_ssh_port(
+            "sbx-disk"
+        )
+        manager.state.update_vm(
+            "sbx-disk",
+            network=NetworkConfig(
+                guest_ip=lease[0],
+                gateway_ip="172.16.0.1",
+                tap_device=lease[1],
+                guest_mac="AA:FC:00:00:00:01",
+                ssh_host_port=host_port,
+            ),
+        )
         manager.network.cleanup_nat_rules.side_effect = SmolVMError("no outbound interface")
 
         manager.delete("sbx-disk")


### PR DESCRIPTION
## What's wrong

A per-VM disk under `data_dir/disks` is only reachable through its row in the inventory. Once the row is gone, the file cannot be found by name again, nothing reports it, and no command removes it. On my laptop this reached **101 orphaned disks, 51 GB**, which had to be cleared with `rm`.

Three paths produce one. All three reproduce on `main` (`c28dcca`); scripts are at the end.

**A. A failing teardown step forfeits the disk.** `_cleanup_resources()` did all of its work inside one `try` with a single catch-all that only logged. The disk unlink was the last step, so any earlier failure — `get_ip_lease`, `cleanup_nat_rules`, `cleanup_tap`, `release_ip`, `release_ssh_port`, `_unlink_socket` — skipped it. Both callers then dropped the row regardless (`delete()`, and the `create()` rollback). `delete()` reported success while leaking the disk.

This is not hypothetical: `smolvm sandbox create` with the firecracker backend and no passwordless sudo fails at TAP setup, and the rollback throws inside network teardown:

```
WARNING smolvm.vm: Error during cleanup for sbx-leak-fc: Could not detect default outbound network interface
rows : []
disks: sbx-leak-fc.ext4 419430400 bytes   <- leaked
```

Firecracker copies the whole rootfs, and each retry gets a fresh auto-generated name, so a handful of failed creates can cost gigabytes with nothing listed.

**B. Ctrl-C during create skips the rollback.** `create()` and `async_create()` rolled back on `except Exception`. `KeyboardInterrupt` is a `BaseException`, so an interrupt between writing the disk and writing the row skipped the rollback entirely. The image code already guards its staging directory exactly this way (`images/published.py`, `cli/image_transfer.py`: *"Ctrl-C and other non-Exception exits must not orphan the multi-GB staging directory"*); the per-VM disk path never got the same treatment.

**C. Nothing could reclaim one.** `sandbox list` does not show it, `sandbox delete <id>` failed with "not found" and left the file, `sandbox delete --all` saw nothing, `image prune` only touches the image cache. `delete()` already intends to handle this — it calls `_cleanup_resources()` for a missing row under the comment *"Best-effort cleanup of leaked artifacts"* — but that was a no-op for disks, because the lookup returns `None` as soon as the row is missing, even though the path is derivable from the VM ID.

## What this changes

- **Cleanup is split into host teardown and artifact removal.** A host failure can no longer skip the disk. The one failure that must still abort a delete — strict bridge teardown, where the row and disk have to survive for a retry — still propagates.
- **Each teardown step is isolated.** One failure no longer strands the leases and ports behind it, which were leaking the same way for the same reason.
- **Create rolls back on `BaseException`.** Ctrl-C or SIGTERM during materialization cannot leave an unreferenced disk.
- **Disk removal works without a row.** When the row is gone, the path is derived from the VM ID (constrained to the disk directory), so `smolvm sandbox delete <id>` reclaims a leaked disk and reports `deleted` instead of `failed`.
- **`<vm_id>.log` is removed with its sandbox.** Nothing ever unlinked it; my state directory still holds 100 of them.
- **New `smolvm sandbox prune`** for leftovers that already exist, with `--dry-run`, `--force`, `--include-saved` and `--json`.

### On `retain_disk_on_delete`

This was the open question in the report. A retained disk deliberately outlives its row, so on disk it is indistinguishable from a leaked one and a naive sweep would delete state the user asked to keep. Retained disks now get a `<disk>.retained` marker, written when the disk is kept and cleared when a VM row owns it again. The sweep skips marked disks unless `--include-saved` is passed. A marker file rather than a table because the failure mode being fixed is precisely the loss of the row.

Sandboxes started from an SDK script keep their inventory in memory, so their disks are not in the CLI database and would look like leftovers. The sweep also skips any disk whose path appears in a running process's command line, and prune requires confirmation.

## Verification

All four cases from the report, before and after:

| Case | Before | After |
| --- | --- | --- |
| A1 create fails at TAP setup | 400 MB disk, no row | no leftover |
| A2 `delete()` with a failing teardown step | disk left, `delete` says success | disk removed |
| B Ctrl-C during the disk copy | 212 MB partial disk, no row | no leftover |
| C reclaiming an existing leftover | no command finds it | `sandbox delete <id>` reclaims it; `sandbox prune` sweeps the rest, leaving live and saved disks alone |

21 new tests in `tests/test_disk_reclaim.py` and `tests/test_cleanup.py` cover each path, both sync and async, plus the retained-disk marker round trip, the in-use guard, and the strict-bridge contract that the refactor had to preserve.

`pytest`: 2001 passed. The 12 failures on my machine are pre-existing and unrelated (APFS sparse-file semantics and bash < 4.4 on macOS) — identical set before and after this change. `ruff check`, `ruff format --check` clean. `mypy src` goes from 183 to 181 errors (all pre-existing; 2 fewer in `vm.py`).

## Known limitation: disks saved before this change

Nothing here runs automatically on upgrade. Existing leftovers are reclaimed only when someone runs `smolvm sandbox prune`, or `smolvm sandbox delete <id>` for a leftover they can name.

That matters for one case. Disks kept with `retain_disk_on_delete` **before** this change carry no `.retained` marker, and nothing records which ones they were — the row that would have said so is exactly what a delete removes. So on an existing data directory, `smolvm sandbox prune` classifies those disks as leftovers and will delete them without `--include-saved`.

There is no way to backfill the marker after the fact. The mitigations are the confirmation prompt, `--dry-run`, and the fact that every disk saved from this change onward is marked at the moment it is kept. If you would rather be stricter, options are to have prune skip unmarked disks whose mtime predates the upgrade, or to require `--include-unknown` for any disk it cannot classify — happy to add either if you prefer it to a documented caveat.

<details>
<summary>Repro scripts</summary>

```python
# A2 — delete() leaks while reporting success. Any teardown step that can
# fail ahead of the disk unlink does this; one is forced here so the repro
# runs on any platform.
import os, sys
from pathlib import Path

data_dir = Path("/tmp/smolvm-leak-1")
work = Path("/tmp/smolvm-leak-1-fixtures")
work.mkdir(parents=True, exist_ok=True)
os.environ["SMOLVM_DATA_DIR"] = str(data_dir)

from smolvm.types import VMConfig
from smolvm.vm import SmolVMManager

rootfs, kernel = work / "rootfs.ext4", work / "vmlinux.bin"
for path, size in ((rootfs, 64 << 20), (kernel, 1 << 20)):
    if not path.exists():
        with path.open("wb") as fh:
            fh.truncate(size)

mgr = SmolVMManager()
info = mgr.create(VMConfig(vm_id="sbx-leak-delete", rootfs_path=rootfs,
                           rootfs_format="raw-ext4", kernel_path=kernel,
                           backend="qemu", disk_mode="isolated"))
print("after create ->", os.listdir(data_dir / "disks"))

def boom(*_a, **_k):
    raise OSError("host teardown failed")

mgr.state.release_ssh_port = boom
mgr.delete(info.vm_id)
print("after delete ->", os.listdir(data_dir / "disks"))
```

```python
# B — Ctrl-C during the disk copy. Same preamble; then:
os.environ["SMOLVM_DISABLE_NATIVE_DISK"] = "1"   # portable copy loop, slow enough to interrupt
# rootfs is 1 GiB of non-sparse data, config adds grow_filesystem=True so the
# rootfs stays raw and create copies it

def ctrl_c():
    time.sleep(0.1)
    os.kill(os.getpid(), signal.SIGINT)

threading.Thread(target=ctrl_c, daemon=True).start()
try:
    mgr.create(cfg)
except KeyboardInterrupt:
    print("interrupted")
print(sorted(p.name for p in (data_dir / "disks").iterdir()))
```

A1 is the same shape with `backend="firecracker"` and no patching at all: create fails at TAP setup, and the rollback throws in network teardown.

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `sandbox prune` to remove files left behind by deleted sandboxes.
  * Added dry-run, force, JSON output, and optional retained-file cleanup modes.
  * Reports reclaimed storage and lists files that could not be removed.
  * Preserves files still in use or explicitly retained.

* **Bug Fixes**
  * Improved cleanup reliability during sandbox deletion and interrupted creation.
  * Prevents disk loss when unrelated resource cleanup steps fail.

* **Documentation**
  * Documented orphaned disks, logs, dry-run behavior, and retained-file handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
